### PR TITLE
Check crm list-options

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -1774,9 +1774,37 @@ sub crm_resource_meta_set {
 
 =head2 crm_list_options
 
-    crm_list_options();
+    my $ret = crm_list_options();
 
-Run various commands TBD
+Executes a series of C<crm> commands to list metadata options for different
+resource types (primitive, fencing, cluster attributes) and validates that their
+XML output is well-formed. This function is designed to test a new feature in
+C<crmsh> version 5.0.0 and newer, which provides a CLI interface to query
+resource meta-attributes.
+
+The function will execute the following commands:
+
+=over
+
+=item * C<crm_resource --list-options primitive --output-as xml>
+
+=item * C<crm_resource --list-options fencing --output-as xml>
+
+=item * C<crm_attribute --list-options cluster --all --output-as=xml>
+
+=back
+
+B<Return values:>
+
+=over
+
+=item * B<1>: All commands executed successfully and their XML output was valid.
+
+=item * B<0>: The installed C<crmsh> version is older than 5.0.0. The function performs no operation.
+
+=item * B<-1>: At least one of the commands produced output that was not valid XML.
+
+=back
 
 =cut
 

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -15,7 +15,7 @@ use warnings;
 use testapi;
 use serial_terminal qw(select_serial_terminal);
 use utils;
-use hacluster qw(get_hostname ha_export_logs save_state wait_until_resources_started script_output_retry_check);
+use hacluster qw(get_hostname ha_export_logs save_state wait_until_resources_started);
 use isotovideo;
 use ipmi_backend_utils;
 use x11utils qw(ensure_unlocked_desktop);

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -44,9 +44,7 @@ sub run {
     assert_script_run "iptables -F && iptables -X" if (is_node(1) && check_var('QDEVICE_TEST_ROLE', 'client') && !get_var('HA_UNICAST'));
 
     # Workaround network timeout issue during upgrade
-    if (get_var('HDDVERSION')) {
-        check_iscsi_failure;
-    }
+    check_iscsi_failure if (get_var('HDDVERSION'));
 
     # Check iSCSI server is connected
     my $ret = script_run 'ls /dev/disk/by-path/ip-*', $default_timeout;
@@ -83,7 +81,6 @@ sub run {
         systemctl 'status pacemaker';
     }
     systemctl 'list-units | grep iscsi', timeout => $default_timeout;
-
     if ((!defined $node_to_fence && check_var('HA_CLUSTER_INIT', 'yes')) || (defined $node_to_fence && get_hostname eq "$node_to_fence")) {
         my $sbd_delay = setup_sbd_delay();
         record_info("SBD delay $sbd_delay sec", "Calculated SBD start delay: $sbd_delay");

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -140,6 +140,8 @@ sub run {
     # And check for the state of the whole cluster
     check_cluster_state;
 
+    crm_list_options;
+
     if (check_var('CLUSTER_NAME', 'hana')) {
         'sles4sap'->check_replication_state;
         'sles4sap'->check_hanasr_attr;

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -3,9 +3,136 @@
 # Copyright 2018 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Package: yast2-iscsi-client pacemaker-cli
 # Summary: Check cluster status *after* reboot
-# Maintainer: QE-SAP <qe-sap@suse.de>, Loic Devulder <ldevulder@suse.com>
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+=head1 NAME
+
+ha/check_after_reboot.pm - Check cluster status after a reboot
+
+=head1 DESCRIPTION
+
+This module is responsible for verifying and restoring the cluster's health after a
+node has rebooted, typically as a result of a fencing operation. It performs a
+series of checks and recovery actions to ensure the cluster returns to a stable
+and operational state.
+
+The key tasks performed by this module include:
+
+=over
+
+=item * Ensuring the correct console is active, especially after a fencing event.
+
+=item * Re-establishing iSCSI connections if they were lost during the reboot.
+  Different methods are used for different SLES versions.
+
+=item * Clearing iptables rules in specific QDevice/QNetd scenarios to ensure
+  proper network communication after a reboot.
+
+=item * Respecting the SBD start delay to prevent a fenced node from rejoining
+  the cluster prematurely.
+
+=item * Verifying the integrity of MD RAID configurations and applying workarounds
+  for known issues.
+
+=item * Waiting for all cluster resources to start and then performing a
+  comprehensive health check of the entire cluster.
+
+=item * Performing specific checks for SLES for SAP HANA clusters, including
+  replication status and takeover handling.
+
+=back
+
+This module is designed following the multi-machine pattern. Its execution is
+going to sync with others test modules running in different openQA jobs. The list
+of synchronization points is:
+
+=over
+
+=item * C<CHECK_AFTER_REBOOT_BEGIN_${cluster_name}_NODE${node_index}>
+
+=item * C<SBD_START_DELAY_$cluster_name>
+
+=item * C<HANA_RA_RESTART_${cluster_name}_NODE${node_index}>
+
+=item * C<CHECK_AFTER_REBOOT_END_${cluster_name}_NODE${node_index}>
+
+=item * C<HAWK_FENCE_$cluster_name}>
+
+=item * C<QNETD_TESTS_DONE_$cluster_name}>
+
+=back
+
+=head1 VARIABLES
+
+This list only cites variables explicitly used in this module.
+Far more variables are used in the base class haclusterbasetest or in lib functions.
+
+=over
+
+=item B<AUTOMATED_REGISTER>
+
+Controls the behavior of HANA resource takeover. If set to 'false', a manual
+takeover might be initiated.
+
+=item B<CLUSTER_NAME>
+
+The name of the cluster. This is used for barrier synchronization and other
+cluster-wide operations. For SLES for SAP tests, it can also be 'hana' to
+trigger specific HANA-related checks.
+
+=item B<HA_CLUSTER_INIT>
+
+If set to 'yes', it indicates that this node is the one that initialized the
+cluster. This is used to determine which node was fenced when
+B<NODE_TO_FENCE> is not explicitly set.
+
+=item B<HA_UNICAST>
+
+If set, indicates that the cluster is configured to use unicast communication.
+This is used in conjunction with B<QDEVICE_TEST_ROLE> to decide whether to
+clear iptables.
+
+=item B<HAWKGUI_TEST_ROLE>
+
+If set to 'server', it indicates that this node is part of a HAWK GUI test
+scenario. This triggers a wait on a specific barrier to synchronize with the
+client-side test.
+
+=item B<HDDVERSION>
+
+If set, indicates that the test is part of an upgrade scenario. This triggers
+a workaround for potential network timeout issues.
+
+=item B<NODE_TO_FENCE>
+
+The hostname of the node that was previously fenced. If this variable is not
+defined, the module assumes the first node of the cluster (the one with
+B<HA_CLUSTER_INIT> set to 'yes') was fenced.
+
+=item B<QDEVICE_TEST_ROLE>
+
+If set to 'client', indicates that the test is part of a QDevice/QNetd
+scenario, which may trigger specific cleanup actions (e.g., clearing iptables).
+
+=item B<TAKEOVER_NODE>
+
+Specifies the target node for a HANA resource takeover.
+
+=item B<TIMEOUT_SCALE>
+
+A scaling factor for timeouts. It defaults to 2 and is used to adjust wait
+times, especially on slower architectures like ppc64le and aarch64, to
+prevent premature test failures.
+
+=back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=cut
+
 
 use base 'haclusterbasetest';
 use strict;


### PR DESCRIPTION
Create library function to test --list-options in crm_resource and crm_attribute.
Call the function as part of existing check_after_reboot test module.
The test will only taks place if the SUT has the supported crmsh installed, that is at least 5.0.0.
Add documentation and unit tests.

First commit only  changes arguments validation in hacluster, it not contain any functional changes.
It only has small cosmetic changes in hacluster lib and sles4sap. It removes importing of script_output_retry_check that is not used.


- Related ticket: https://jira.suse.com/browse/TEAM-10494


# Verification
sle-16.0-Online-x86_64-Build119.1-ha_3nodes_supportserver@64bit-4gbram -> http://openqaworker15.qa.suse.cz/tests/333003

sle-16.0-Online-x86_64-Build119.1-ha_3nodes_node01@64bit-4gbram -> http://openqaworker15.qa.suse.cz/tests/333005

1. crmsh version check http://openqaworker15.qa.suse.cz/tests/333005/logfile?filename=serial0.txt#line-3052
2. `crm_resource --list-options primitive` http://openqaworker15.qa.suse.cz/tests/333005/logfile?filename=serial0.txt#line-3080
3. `crm_resource --list-options fencing` http://openqaworker15.qa.suse.cz/tests/333005/logfile?filename=serial0.txt#line-3200
4. `crm_attribute --list-options cluster` http://openqaworker15.qa.suse.cz/tests/333005/logfile?filename=serial0.txt#line-3346

sle-16.0-Online-x86_64-Build119.1-ha_3nodes_node02@64bit-4gbram -> http://openqaworker15.qa.suse.cz/tests/333004

sle-16.0-Online-x86_64-Build119.1-ha_3nodes_node03@64bit-4gbram -> http://openqaworker15.qa.suse.cz/tests/333006


VR with only the first commit http://openqaworker15.qa.suse.cz/tests/332979#