### PR TITLE
Kselftests: Install SUSE certificate

### DIFF
--- a/tests/kernel/run_kselftests.pm
+++ b/tests/kernel/run_kselftests.pm
@@ -56,6 +56,10 @@ sub prepare_kselftests_from_ibs
 {
     my ($root) = @_;
 
+    zypper_call("in curl");
+    assert_script_run("curl -k https://ca.suse.de/certificates/ca/SUSE_Trust_Root.crt -o /etc/pki/trust/anchors/SUSE_Trust_Root.crt");
+    assert_script_run("update-ca-certificates");
+
     my $repo = get_var('KSELFTESTS_REPO', '');
     zypper_call("ar -f $repo kselftests");
     zypper_call("--gpg-auto-import-keys ref");


### PR DESCRIPTION
When using custom repositories, we might need SUSE's root certificate.

- Related ticket: https://progress.opensuse.org/issues/131180
- Verification runs:

(Failing to add repo from IBS) https://rmarliere-openqa.qe.prg2.suse.org/tests/1301#step/run_kselftests/85
(Adding repo from IBS successfully) https://rmarliere-openqa.qe.prg2.suse.org/tests/1297#step/run_kselftests/33
