### PR TITLE
Force get_test_repos() to return unique values

### DIFF
--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -14,7 +14,7 @@ use Exporter;
 use testapi;
 use utils qw(zypper_call handle_screen zypper_repos upload_y2logs);
 use JSON;
-use List::Util qw(max);
+use List::Util qw(max uniq);
 use version_utils qw(is_sle is_transactional);
 
 our @EXPORT
@@ -267,7 +267,7 @@ sub get_test_repos {
             push @repos, split(/,/, $value);
         }
     }
-    return @repos;
+    return uniq @repos;
 }
 
 1;

--- a/t/33_qam.t
+++ b/t/33_qam.t
@@ -3,7 +3,7 @@ use warnings;
 use Test::More;
 use Test::Warnings;
 use Test::MockModule;
-use List::Util qw(any none);
+use List::Util qw(any none uniq);
 use testapi;
 use qam;
 
@@ -17,18 +17,27 @@ sub undef_vars {
 subtest '[get_test_repos]' => sub {
     set_var('BALAMB_TEST_REPOS', 'Squall,Seifer');
     set_var('WINHILL_TEST_REPOS', 'Quistis,Rinoa');
-
     my $qam_mock = Test::MockModule->new('qam', no_auto => 1);
-    $qam_mock->redefine('set_var', sub { return; });
+    $qam_mock->noop('set_var');
 
     my @repos = get_test_repos();
-
     undef_vars();
 
     ok((any { /Squall/ } @repos), 'Got "Squall" from BALAMB_TEST_REPOS');
     ok((any { /Seifer/ } @repos), 'Got "Seifer" from BALAMB_TEST_REPOS');
     ok((any { /Quistis/ } @repos), 'Got "Quistis" from WINHILL_TEST_REPOS');
     ok((any { /Rinoa/ } @repos), 'Got "Rinoa" from WINHILL_TEST_REPOS');
+};
+
+subtest '[get_test_repos] Test repo deduplicaton' => sub {
+    set_var('BALAMB_TEST_REPOS', 'Squall,Seifer');
+    set_var('WINHILL_TEST_REPOS', 'Quistis,Rinoa,Seifer');
+    my $qam_mock = Test::MockModule->new('qam', no_auto => 1);
+    $qam_mock->noop('set_var');
+
+    my @repos = get_test_repos();
+    undef_vars();
+    is scalar @repos, scalar(uniq @repos), 'returned list is unique';
 };
 
 done_testing;


### PR DESCRIPTION
Change `get_test_repos` function to filter out duplicates before returning, to avoid duplicate repo lists.

- Related ticket: https://jira.suse.com/browse/TEAM-10505
- Verification run: https://openqa.suse.de/tests/18475307
(failure unrelated to current pr, is due to https://jira.suse.com/browse/TEAM-10484 which will be fixed in a different pr). Check the serial terminal log and search for `-e repos`: unlike previous runs, repos appear only once.
