### PR TITLE
kselftests: Use KTAP parser

### DIFF
--- a/tests/kernel/run_kselftests.pm
+++ b/tests/kernel/run_kselftests.pm
@@ -84,19 +84,16 @@ sub run
         foreach my $i (@kselftests_suite) {
             install_kselftest_suite($i);
             assert_script_run("cd ./tools/testing/selftests/kselftest_install");
-            #required by the TAP openQA parser
-            assert_script_run("echo t/$i.t .. > $i.tap");
             assert_script_run("./run_kselftest.sh -o $timeout -c $i >> $i.tap", 7200);
-            parse_extra_log(TAP => "$i.tap");
+            parse_extra_log(KTAP => "$i.tap");
             assert_script_run("cd -");
         }
     } else {
         prepare_kselftests_from_ibs("/usr/share/kselftests");
 
         foreach my $i (@kselftests_suite) {
-            assert_script_run("echo t/$i.t .. > $i.tap");
             assert_script_run("/usr/share/kselftests/run_kselftest.sh -o $timeout -c $i >> $i.tap", 7200);
-            parse_extra_log(TAP => "$i.tap");
+            parse_extra_log(KTAP => "$i.tap");
         }
     }
 }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/182360
- also: https://progress.opensuse.org/issues/186083
- Verification run:
initial: https://rmarliere-openqa.qe.prg2.suse.org/tests/1336
additional on OSD: https://openqa.suse.de/tests/18533847

This PR shall be merged only after this merged and deployed: 
https://github.com/os-autoinst/openQA/pull/6597
