### PR TITLE
Minor BATS fixes

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -22,13 +22,13 @@ buildah:
     BATS_PATCHES:
     - 6226
     BATS_SKIP:
-    BATS_SKIP_ROOT: bud namespaces run
+    BATS_SKIP_ROOT: bud run
     BATS_SKIP_USER:
   sle-15-SP6:
     BATS_PATCHES:
     - 6226
     BATS_SKIP:
-    BATS_SKIP_ROOT: bud namespaces run
+    BATS_SKIP_ROOT: bud run
     BATS_SKIP_USER:
   sle-15-SP5:
     BATS_PATCHES:

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -90,7 +90,7 @@ Please add this warning on each bug report you open when adding instructions on 
 | SLES 16.0             | [![logo]][s16_a]   | [![logo]][s16_b]   | [![logo]][s16_n]   | [![logo]][s16_p]   | [![logo]][s16_r]   | [![logo]][s16_s]   |
 | SLES 16.0 (aarch64)   | [![logo]][s16a_a]  |                    | [![logo]][s16a_n]  | [![logo]][s16a_p]  | [![logo]][s16a_r]  | [![logo]][s16a_s]  |
 | SLES 15 SP7           |                    | [![logo]][sp7_b]   | [![logo]][sp7_n]   | [![logo]][sp7_p]   | [![logo]][sp7_r]   | [![logo]][sp7_s]   |
-| SLES 15 SP7 (aarch64) |                    |                    | [![logo]][sp7a_n   | [![logo]][sp7a_p]  | [![logo]][sp7a_r]  | [![logo]][sp7a_s]  |
+| SLES 15 SP7 (aarch64) |                    |                    | [![logo]][sp7a_n]  | [![logo]][sp7a_p]  | [![logo]][sp7a_r]  | [![logo]][sp7a_s]  |
 | SLES 15 SP6           |                    | [![logo]][sp6_b]   | [![logo]][sp6_n]   | [![logo]][sp6_p]   | [![logo]][sp6_r]   | [![logo]][sp6_s]   |
 | SLES 15 SP6 (aarch64) |                    |                    | [![logo]][sp6a_n]  | [![logo]][sp6a_p]  | [![logo]][sp6a_r]  | [![logo]][sp6a_s]  |
 | SLES 15 SP5           |                    | [![logo]][sp5_b]   | [![logo]][sp5_n]   |                    | [![logo]][sp5_r]   | [![logo]][sp5_s]   |
@@ -193,8 +193,8 @@ Complete list found in [skip.yaml](data/containers/bats/skip.yaml)
 
 | test | reason |
 | --- | --- |
-| [130-kill] | flaky test that fails on user/remote scenario |
-| [200-pod] | flaky test that fails on root/local scenario |
+| [130-kill] | flaky test |
+| [200-pod] | flaky test |
 | [252-quadlet] | unknown |
 | [505-networking-pasta] | https://bugs.passt.top/show_bug.cgi?id=49 |
 


### PR DESCRIPTION
- Fix README
- Unignore `namespaces` test for buildah as it's passing in [15-SP6](https://openqa.suse.de/tests/18503622#step/buildah/402) & [15-SP7](https://openqa.suse.de/tests/18503369#step/buildah/396)

