### PR TITLE
zypper_in: Don't schedule broken opensuse_repos on maintenance

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1210,7 +1210,7 @@ sub load_consoletests {
             loadtest "console/installation_snapshots" unless get_var('FLAVOR') =~ /OpenStack-Cloud/;
         }
     }
-    loadtest "console/opensuse_repos" if is_opensuse && !(is_staging);
+    loadtest "console/opensuse_repos" if is_opensuse && !(is_staging || is_updates_tests);
     loadtest "console/zypper_lr";
     # Enable installation repo from the usb, unless we boot from USB, but don't use it
     # for the installation, like in case of LiveCDs and when using http/smb/ftp mirror


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22675

- Related ticket: https://progress.opensuse.org/issues/185974
- Verification run: https://openqa.suse.de/tests/18507016