### PR TITLE
Extend podman artifact test to SLE 16.0

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -137,7 +137,7 @@ sub load_host_tests_podman {
     load_rt_workload($run_args) if is_rt;
     load_container_engine_privileged_mode($run_args);
     # podman artifact needs podman 5.4.0
-    loadtest 'containers/podman_artifact' if is_tumbleweed;
+    loadtest 'containers/podman_artifact' if (is_sle('>=16.0') || is_tumbleweed);
     loadtest 'containers/podman_bci_systemd';
     loadtest 'containers/podman_pods';
     # CNI is the default network backend on SLEM<6 and SLES<15-SP6. It is still available on later products as a dependency for docker.

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -138,6 +138,11 @@ sub load_host_tests_podman {
     load_container_engine_privileged_mode($run_args);
     # podman artifact needs podman 5.4.0
     loadtest 'containers/podman_artifact' if (is_sle('>=16.0') || is_tumbleweed);
+    # The registry module contains further tests for podman artifact pull/push
+    # The distribution-registry package is only available on Tumbleweed & SLES 15-SP4
+    unless (is_staging || is_transactional || is_sle("<15-sp4")) {
+        loadtest('containers/registry', run_args => $run_args, name => $run_args->{runtime} . "_registry");
+    }
     loadtest 'containers/podman_bci_systemd';
     loadtest 'containers/podman_pods';
     # CNI is the default network backend on SLEM<6 and SLES<15-SP6. It is still available on later products as a dependency for docker.
@@ -175,8 +180,9 @@ sub load_host_tests_docker {
     load_container_engine_privileged_mode($run_args);
     # Firewall is not installed in Public Cloud, JeOS OpenStack and MicroOS but it is in SLE Micro
     load_firewall_test($run_args);
+    # The distribution-registry package is only available on Tumbleweed & SLES 15-SP4
     unless (is_staging || is_transactional || is_sle("<15-sp4")) {
-        loadtest 'containers/registry';
+        loadtest('containers/registry', run_args => $run_args, name => $run_args->{runtime} . "_registry");
     }
     # Skip this test on docker-stable due to https://bugzilla.opensuse.org/show_bug.cgi?id=1239596
     unless (is_transactional || is_public_cloud || is_sle('<15-SP4') || check_var("CONTAINERS_DOCKER_FLAVOUR", "stable")) {

--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -71,7 +71,9 @@ sub registry_push_pull {
 }
 
 sub run {
-    my ($self) = @_;
+    my ($self, $args) = @_;
+    my $runtime = $args->{runtime};
+
     select_serial_terminal;
 
     # Install and check that it's running
@@ -86,16 +88,10 @@ sub run {
     script_retry 'curl http://127.0.0.1:5000/v2/_catalog', delay => 3, retry => 10;
     assert_script_run 'curl -s http://127.0.0.1:5000/v2/_catalog | grep repositories';
 
-    # Run docker tests
-    my $docker = $self->containers_factory('docker');
+    my $engine = $self->containers_factory($runtime);
     my $image = 'registry.opensuse.org/opensuse/busybox';
-    registry_push_pull(image => $image, runtime => $docker);
-    $docker->cleanup_system_host();
-
-    # Run podman tests
-    my $podman = $self->containers_factory('podman');
-    registry_push_pull(image => $image, runtime => $podman);
-    $podman->cleanup_system_host();
+    registry_push_pull(image => $image, runtime => $engine);
+    $engine->cleanup_system_host();
 }
 
 1;


### PR DESCRIPTION
This PR:
- Extends the podman artifact test to SLE 16.0 which uses podman 5.4.2
- Makes the registry module use only one engine instead of running both docker & podman

Verification runs:
- Tumbleweed docker: https://openqa.opensuse.org/tests/5188561
- Tumbleweed podman: https://openqa.opensuse.org/tests/5188545
- SLES 16.0 docker: https://openqa.suse.de/tests/18508182
- SLES 16.0 podman: https://openqa.suse.de/tests/18508116