### PR TITLE
Add verbose and timer to unit-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ tidy-full: tools/tidy
 
 .PHONY: unit-test
 unit-test:
-	prove -l -Ios-autoinst/ t/
+	prove --verbose --timer -l -Ios-autoinst/ t/
 
 .PHONY: test-compile
 test-compile: check-links


### PR DESCRIPTION
Introduce `--verbose` and `--timer` options to `prove` command line for enhanced debugging and performance analysis.
verbose is useful to get note to be printed out
timeout can give a glimpse on test implemented without using Test::Mock::Time

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
