### PR TITLE
containers: Extend podman-remote test on SLES & Tumbleweed

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -161,7 +161,7 @@ sub load_host_tests_podman {
     # exclude rootless podman on public cloud because of cgroups2 special settings
     unless (is_openstack || is_public_cloud) {
         loadtest 'containers/rootless_podman';
-        loadtest 'containers/podman_remote' if is_sle_micro('5.5+');
+        loadtest 'containers/podman_remote' if (is_sle('>=15-SP3') || is_sle_micro('5.5+') || is_tumbleweed);
     }
     # Buildah is not available in SLE Micro, MicroOS and staging projects
     load_buildah_tests($run_args) unless (is_sle('<15') || is_sle_micro || is_microos || is_leap_micro || is_staging);


### PR DESCRIPTION
Extend podman-remote test to SLES & Tumbleweed.  This package is available on SLES 15-SP3+

This module was limited to only SLEM 5.5+ likely by accident on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19697/

Verification runs:
- Tumbleweed: https://openqa.opensuse.org/tests/5188842
- SLES 16.0: https://openqa.suse.de/tests/18508849
- SLES 15-SP3: https://openqa.suse.de/tests/18508854