### PR TITLE
containers: Schedule podmansh test only on Tumbleweed

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -168,6 +168,7 @@ sub load_host_tests_podman {
     load_compose_tests($run_args);
     loadtest('containers/seccomp', run_args => $run_args, name => $run_args->{runtime} . "_seccomp") unless is_sle('<15');
     loadtest('containers/isolation', run_args => $run_args, name => $run_args->{runtime} . "_isolation") unless (is_public_cloud || is_transactional);
+    loadtest('containers/podmansh') if (is_tumbleweed && !is_staging && !is_transactional);
 }
 
 sub load_host_tests_docker {

--- a/tests/containers/podmansh.pm
+++ b/tests/containers/podmansh.pm
@@ -8,6 +8,8 @@
 # - validates login through sudo, su, ssh and tty prompt
 # Maintainer: QE-C team <qa-c@suse.de>
 
+use strict;
+use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal qw(select_serial_terminal select_user_serial_terminal);


### PR DESCRIPTION
Re-schedule podmansh test only on Tumbleweed.  This module was de-scheduled in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21941 due to the number of changes needed and problems in other products.  

- Verification run: https://openqa.opensuse.org/tests/5188900
