### PR TITLE
Fix code for SLE16 container host ppc64le create_hdd test

### DIFF
--- a/tests/yam/agama/agama_auto.pm
+++ b/tests/yam/agama/agama_auto.pm
@@ -22,7 +22,7 @@ sub run {
 
     $self->upload_agama_logs() unless is_hyperv();
 
-    (is_s390x() || is_pvm() || is_vmware()) ?
+    (is_s390x() || is_ppc64le() || is_pvm() || is_vmware()) ?
       # reboot via console
       power_action('reboot', keepconsole => 1, first_reboot => 1) :
       # graphical reboot


### PR DESCRIPTION
Fix code for SLE16 container host ppc64le create_hdd test, restoring the ppc64le condition, removed in PR#22611

- Related ticket: https://progress.opensuse.org/issues/185995

- Verification run: 
  - create_hdd_agama_containers for ppc64le:
    https://openqa.suse.de/tests/18509318
  - sles_default_unattended__TEST__:
    https://openqa.suse.de/tests/18473925
