### PR TITLE
Fix possible precedence problem in conditions

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -136,7 +136,7 @@ sub setup_console_in_grub {
         die "Host Hypervisor is not xen or kvm";
     }
 
-    if (!script_run('grep HPE /sys/class/dmi/id/board_vendor') == 0) {
+    if (script_run('grep HPE /sys/class/dmi/id/board_vendor') != 0) {
         $cmd = "sed -ri '/^terminal.*\$/ {:mylabel; n; s/^terminal.*\$//;b mylabel;}' $grub_cfg_file";
         assert_script_run($cmd);
         $cmd = "sed -ri '/^[[:space:]]*\$/d' $grub_cfg_file";

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -222,7 +222,7 @@ sub have_addn_repos {
       !get_var("NET")
       && !get_var("EVERGREEN")
       && get_var("SUSEMIRROR")
-      && !get_var("FLAVOR", '') =~ m/^Staging2?[\-]DVD$/;
+      && get_var("FLAVOR", '') !~ m/^Staging2?[\-]DVD$/;
 }
 
 sub is_livesystem {

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -1054,7 +1054,7 @@ sub process_modules {
     if (check_var('SCC_REGISTER', 'installation') || check_var('SCC_REGISTER', 'yast') || check_var('SCC_REGISTER', 'console')) {
         process_scc_register_addons;
     }
-    elsif (!get_var('SCC_REGISTER', '') =~ /addon|network/) {
+    elsif (get_var('SCC_REGISTER', '') !~ /addon|network/) {
         send_key $cmd{next};
     }
 }


### PR DESCRIPTION
Perl 5.42 introduces new warnings about possible precedence problems. It
seems we have three such cases where unusual combination of operators
were used. This commit uses common negative comparison operators instead
of negating the value of one comparison value in an equality or regex
check.