### PR TITLE
Revert "Only schedule openSUSE repos test for TW and leap16+"

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1211,7 +1211,7 @@ sub load_consoletests {
             loadtest "console/installation_snapshots" unless get_var('FLAVOR') =~ /OpenStack-Cloud/;
         }
     }
-    loadtest "console/opensuse_repos" if (is_tumbleweed || is_leap('16.0+'));
+    loadtest "console/opensuse_repos" if is_opensuse && !(is_staging || is_updates_tests);
     loadtest "console/zypper_lr";
     # Enable installation repo from the usb, unless we boot from USB, but don't use it
     # for the installation, like in case of LiveCDs and when using http/smb/ftp mirror


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#22724 as #22726 has a fix for original repos being removed