### PR TITLE
opensuse_repos: Simplify old repos restore

### DIFF
--- a/tests/console/opensuse_repos.pm
+++ b/tests/console/opensuse_repos.pm
@@ -45,7 +45,7 @@ sub run {
     # removing the distro package, removes the NVIDIA service too if it was installed
     zypper_call("rm $pkgname");
     # restore old repos which were replaced by openSUSE service
-    assert_script_run(q"pushd /etc/zypp/repos.d; for f in *; do mv $f $(echo $f|sed s'/.rpmsave//'); done; popd");
+    assert_script_run(q"rename .rpmsave '' /etc/zypp/repos.d/*.rpmsave");
 
     if (script_run("zypper lr --uri | grep -E 'cdn\.opensuse|download\.nvidia'") == 0) {
         die "Unexpected leftover repositories";


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22726

- Related ticket: https://progress.opensuse.org/issues/185974
- Verification run: https://dzedro.suse.cz/tests/2878