### PR TITLE
Fix for problems in sles_whole_disk_boot_unattended on aarch64

### DIFF
--- a/test_data/yam/whole_disk_and_boot_unattended_aarch64.yaml
+++ b/test_data/yam/whole_disk_and_boot_unattended_aarch64.yaml
@@ -1,0 +1,19 @@
+---
+disks:
+  - name: vdc
+    table_type: xfs
+    partitions:
+      # whole disk formatted
+      - name: vdc
+        fstype: xfs
+        type: disk
+  - name: vdd
+    table_type: gpt
+    partitions:
+      - name: vdd1
+        fstype: btrfs
+  - name: vda
+    table_type: gpt
+    partitions:
+      - name: vda1
+        fstype: vfat


### PR DESCRIPTION
- It lturned out that the disk device order on aarch64 differs from the one on x86_64, so we need an extra test_data file for the aarch64 architecture.
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/526
- VR: https://openqa.suse.de/tests/18524429
