### PR TITLE
Automate scenario to allow to use some RAIDs as if they were disks

### DIFF
--- a/schedule/yam/agama_raid_unattended_publish_image.yaml
+++ b/schedule/yam/agama_raid_unattended_publish_image.yaml
@@ -1,0 +1,13 @@
+---
+name: agama_raid_unattended_publish_image
+description: >
+  Perform unattended installation with RAID and publish image.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_md_raid
+  - console/validate_raid
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/schedule/yam/agama_raid_unattended_use_existing_md_raid.yaml
+++ b/schedule/yam/agama_raid_unattended_use_existing_md_raid.yaml
@@ -1,0 +1,12 @@
+---
+name: agama_raid_unattended_existing_md_raid
+description: >
+  Perform unattended installation with RAID and modify the RAID disk of swap.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - yam/agama/agama_boot_from_hdd
+  - installation/first_boot
+  - console/validate_md_raid
+  - console/validate_raid
+  - yam/validate/validate_raid_swap

--- a/tests/yam/validate/validate_raid_swap.pm
+++ b/tests/yam/validate/validate_raid_swap.pm
@@ -1,0 +1,22 @@
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Validate the /etc/fstab doesn't have md1 as swap but has md0 instead.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base 'y2_module_consoletest';
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    select_console 'root-console';
+
+    # Check that swap is on /dev/md0
+    assert_script_run 'swapon --summary | grep -q "^/dev/md0"';
+
+    # Ensure /dev/md1 is not used for swap
+    assert_script_run '! swapon --summary | grep -q "^/dev/md1"';
+}
+
+1;


### PR DESCRIPTION
After a long journey we completed the required restrictions to make RAID0, software RAID to work.
We have added a job to produce and publish RAID0 images configured with Agama, after that another job grab such images and install SLES16 over the RAID without creating a new one.
In addition, we could see that the swap partition changed in Agama installation (The RAID is modified but not recreated).

- Related ticket: https://progress.opensuse.org/issues/184273
- Needles: N/A
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/527
- Verification run: 
  - raid0_unattended (Original one): https://openqa.suse.de/tests/18524527
  - Related jobs: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=119.1&groupid=583
