### PR TITLE
Hotfix ensa2 test to use rsync and a bigger timeout to get assets

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -1162,7 +1162,7 @@ sub prepare_swpm {
     my $sapinst_executable = "$target_path/sapinst";
 
     assert_script_run("mkdir -p $target_path");
-    assert_script_run("cp $sar_archives_dir/* $target_path/");
+    assert_script_run("rsync -azr --info=progress2 --stats $sar_archives_dir/* $target_path/", 600);
     assert_script_run("cd $target_path; $sapcar_bin_path -xvf ./$swpm_sar_filename");
     my $swpm_dir_content = script_output("ls -alitr $target_path");
     record_info("SWPM dir", "$swpm_dir_content");


### PR DESCRIPTION
The ENSA2 test downloads the NW installation files from the NFS server defined in the job group settings. Sometimes the NFS server can get overloaded so we need at a minimum to increase the time out.

- Related Ticket: TEAM-10504
- Verification run: https://openqaworker15.qa.suse.cz/tests/333562#