### PR TITLE
Refine az_validate_uuid_pattern API

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -1514,11 +1514,25 @@ sub az_resource_list {
 
 =head2 az_validate_uuid_pattern
 
-    az_validate_uuid_pattern( uuid => $uuid_string )
+    my $is_valid = az_validate_uuid_pattern(uuid => $uuid_string);
 
-    Function checks input string against uuid pattern
-    which is commonly used as an identifier for Azure resources.
-    returns uuid (true) on match, 0 (false) on mismatch.
+    Validates if a given string matches the standard UUID pattern (e.g.,
+    C<xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx>). This is commonly used to verify
+    identifiers for Azure resources.
+
+B<Return value:>
+
+=over
+
+=item * On a successful match, returns the original B<scalar string> containing the UUID.
+This value is considered true in a boolean context.
+
+=item * On a failed match, returns B<undef>. This value is considered false in a
+boolean context.
+
+=back
+
+B<Arguments:>
 
 =over
 
@@ -1533,7 +1547,7 @@ sub az_validate_uuid_pattern {
     my $pattern = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
     return $args{uuid} if ($args{uuid} =~ /$pattern/i);
     diag("String did not match UUID pattern:\nString: '$args{uuid}'\nPattern: '$pattern'");
-    return 0;
+    return undef;
 }
 
 
@@ -1546,7 +1560,7 @@ sub az_validate_uuid_pattern {
 
 Uploads file to a storage container.
 
-=over 4
+=over
 
 =item B<container_name> Existing storage container name.
 
@@ -1578,20 +1592,32 @@ sub az_storage_blob_upload {
 
 =head2 az_storage_blob_lease_acquire
 
-    az_storage_blob_lease_acquire(
-        container_name=>'somecontainer',
-        storage_account_name=>'storageaccount',
-        blob_name => 'somefilename' [, lease_duration=>'42']
+    my $lease_id = az_storage_blob_lease_acquire(
+        container_name       => 'somecontainer',
+        storage_account_name => 'storageaccount',
+        blob_name            => 'somefilename',
+        lease_duration       => 60
     );
 
-Acquire a lease for a storage blob. Function returns UUID which is then required to modify the file and gives the
+Acquire a lease for a storage blob.
+The function returns a UUID which is then required to modify the file and gives the
 UUID owner exclusive rights.
-Optionally B<lease_duration> can be defined to limit this file lock up to 60s instead of infinity.
-In case of function returns nothing, the reasons may vary and it is up to caller to decide how to deal with the result.
-In that case
-Possible reasons are that there is already a lease present (az cli returns a message which is not a valid UUID)
 
-=over 4
+If the lease cannot be acquired (e.g., the blob is already leased by another
+process, or another Azure error occurs), the function will return C<undef>.
+
+B<Return value:>
+
+=over
+
+=item * On success, returns a B<scalar string> containing the lease UUID.
+
+=item * On failure, returns B<undef>. The reasons may vary and it is up to caller to decide how to deal with the result.
+        Possible reasons are that there is already a lease present (az cli returns a message which is not a valid UUID)
+
+=back
+
+=over
 
 =item B<container_name> Existing storage container name.
 
@@ -1599,7 +1625,9 @@ Possible reasons are that there is already a lease present (az cli returns a mes
 
 =item B<blob_name> Blob name to acquire lease for.
 
-=item B<lease_duration> Lease duration between 15-60s. Default: infinite
+=item B<lease_duration> Specifies the duration of the lease in seconds. A non-infinite
+                        lease can be between 15 and 60 seconds. A value of -1 indicates an infinite
+                        lease. Default: -1 (infinite).
 
 =back
 =cut
@@ -1625,7 +1653,9 @@ sub az_storage_blob_lease_acquire {
 
     my $lease_id = script_output($az_cmd, proceed_on_failure => 1);
     record_info('AZ CLI out', "AZ CLI returned output:\n $lease_id");
-    return ($lease_id) if az_validate_uuid_pattern(uuid => $lease_id);    # Return only valid output.
+    # Return a string if az_validate_uuid_pattern return "true"
+    # otherwise return undef, thanks to Perl's implicit return that get value from the if statement.
+    return $lease_id if (az_validate_uuid_pattern(uuid => $lease_id));
 }
 
 =head2 az_storage_blob_list
@@ -1637,7 +1667,7 @@ sub az_storage_blob_lease_acquire {
 
 List information about storage blob(s) specified by B<storage_account_name>, B<container_name> and B<query>.
 
-=over 3
+=over
 
 =item B<container_name> Existing storage container name.
 
@@ -1673,7 +1703,7 @@ sub az_storage_blob_list {
 
 Update properties of storage blob. Returns az cli command exit code.
 
-=over 4
+=over
 
 =item B<container_name> Existing resource group name.
 

--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -1544,7 +1544,7 @@ B<Arguments:>
 sub az_validate_uuid_pattern {
     my (%args) = @_;
     croak "Mandatory argument 'uuid' missing" unless $args{uuid};
-    my $pattern = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+    my $pattern = '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
     return $args{uuid} if ($args{uuid} =~ /$pattern/i);
     diag("String did not match UUID pattern:\nString: '$args{uuid}'\nPattern: '$pattern'");
     return undef;

--- a/lib/sles4sap/qesap/qesapdeployment.pm
+++ b/lib/sles4sap/qesap/qesapdeployment.pm
@@ -1951,7 +1951,7 @@ sub qesap_az_setup_native_fencing_permissions {
             "-n '$args{vm_name}'",
             "--query 'systemAssignedIdentity'",
             '-o tsv'));
-    die 'Returned output does not match ID pattern' if az_validate_uuid_pattern(uuid => $vm_id) eq 0;
+    die "Returned output '$vm_id' does not match ID pattern" if (!az_validate_uuid_pattern(uuid => $vm_id));
 
     # Assign role
     my $subscription_id = script_output('az account show --query "id" -o tsv');
@@ -1980,7 +1980,7 @@ sub qesap_az_get_tenant_id {
     my $az_cmd = "az account show --only-show-errors";
     my $az_cmd_args = "--subscription $subscription_id --query 'tenantId' -o tsv";
     my $tenant_id = script_output(join(' ', $az_cmd, $az_cmd_args));
-    croak 'Returned output does not match ID pattern' if az_validate_uuid_pattern(uuid => $tenant_id) eq 0;
+    die "Returned output '$tenant_id' does not match ID pattern" if (!az_validate_uuid_pattern(uuid => $tenant_id));
     return $tenant_id;
 }
 


### PR DESCRIPTION
Refine two azure_cli API: az_validate_uuid_pattern and az_storage_lease_acquire by defining some additional unit tests and improving the documentation. 

- Ticket [TEAM-10465](https://jira.suse.com/browse/TEAM-10465) - [SDAF] Fix network space assignment logic

# Verification

- sle-15-SP5-Azure-SDAF-PAYG-x86_64-Build15-SP5 -> https://openqaworker15.qa.suse.cz/tests/333702
- sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test_msi@64bit -> http://openqaworker15.qa.suse.cz/tests/333692
- sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2025-07-22T02:03:21Z-hanasr_azure_test_msi@az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/333693

