### PR TITLE
Revert "SLE16 container host tests fix grub-missing screen"

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -919,9 +919,6 @@ sub wait_boot {
     # SLE-16 boot on ppc64le results too quick to be captured, from grub2 to login prompt
     elsif (get_var('OFW') && is_sle('16+') && is_ppc64le && (check_screen('linux-login', 10))) {
     }
-    # SLE-16 on aarch64 login prompt needs more time to be detected, before to continue.
-    elsif (is_sle('16+') && is_aarch64 && (check_screen('linux-login', 30))) {
-    }
     elsif (is_bootloader_grub2) {
         assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu pxe-menu)], 600) if (uses_qa_net_hardware() || get_var("PXEBOOT"));
         $self->handle_grub(bootloader_time => $bootloader_time, in_grub => $in_grub);


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#22703

The changes in `opensusebasetest::wait_boot()` break reboot in kernel tests. In the correct control flow, the test is supposed to wait for GRUB menu and select a specific boot option based on job settings:
https://openqa.suse.de/tests/18472498#step/install_ltp/2

After the change, kernel tests expect login prompt instead of GRUB menu and the login needle matches *before* the reboot even starts because the old login prompt from the first boot is still visible on screen:
https://openqa.suse.de/tests/18520914#step/install_ltp/1