### PR TITLE
Remove variables from schedules for InfiniBand tests

### DIFF
--- a/schedule/kernel/agama_ibtest-master.yaml
+++ b/schedule/kernel/agama_ibtest-master.yaml
@@ -5,8 +5,6 @@ vars:
     INST_AUTO: agama_auto/sle_default_ipmi.jsonnet
     DESKTOP: textmode
     IBTESTS: 1
-    IBTEST_GITBRANCH: master
-    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_MASTER
     MLX_PROTOCOL: 1
 schedule:

--- a/schedule/kernel/agama_ibtest-slave.yaml
+++ b/schedule/kernel/agama_ibtest-slave.yaml
@@ -5,8 +5,6 @@ vars:
     INST_AUTO: agama_auto/sle_default_ipmi.jsonnet
     DESKTOP: textmode
     IBTESTS: 1
-    IBTEST_GITBRANCH: master
-    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_SLAVE
     MLX_PROTOCOL: 1
     PARALLEL_WITH: ibtest-master

--- a/schedule/kernel/ibtest-master-autoyast.yaml
+++ b/schedule/kernel/ibtest-master-autoyast.yaml
@@ -6,8 +6,6 @@ vars:
     AUTOYAST_PREPARE_PROFILE: 1
     GRUB_TIMEOUT: 300
     IBTESTS: 1
-    IBTEST_GITBRANCH: master
-    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_MASTER
     IPXE: 1
     IPXE_CONSOLE: ttyS1,115200

--- a/schedule/kernel/ibtest-master-rdma-next.yaml
+++ b/schedule/kernel/ibtest-master-rdma-next.yaml
@@ -5,8 +5,6 @@ vars:
     DESKTOP: textmode
     GRUB_TIMEOUT: 300
     IBTESTS: 1
-    IBTEST_GITBRANCH: master
-    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_MASTER
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de

--- a/schedule/kernel/ibtest-master-tumbleweed.yaml
+++ b/schedule/kernel/ibtest-master-tumbleweed.yaml
@@ -5,8 +5,6 @@ vars:
     DESKTOP: textmode
     DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/openSUSE_Tumbleweed/devel:tools.repo
     IBTESTS: 1
-    IBTEST_GITBRANCH: master
-    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_MASTER
     PATTERNS: base,minimal
     ROOTONLY: 1

--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -8,8 +8,6 @@ vars:
     DESKTOP: textmode
     GRUB_TIMEOUT: 300
     IBTESTS: 1
-    IBTEST_GITBRANCH: master
-    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_MASTER
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de

--- a/schedule/kernel/ibtest-slave-autoyast.yaml
+++ b/schedule/kernel/ibtest-slave-autoyast.yaml
@@ -7,8 +7,6 @@ vars:
     DEVEL_TOOLS_REPO: https://download.opensuse.org/repositories/home:/MMoese:/branches:/devel:/tools/SLE_12_SP4/home:MMoese:branches:devel:tools.repo
     GRUB_TIMEOUT: 300
     IBTESTS: 1
-    IBTEST_GITBRANCH: master
-    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_SLAVE
     IPXE: 1
     IPXE_CONSOLE: ttyS1,115200

--- a/schedule/kernel/ibtest-slave-rdma-next.yaml
+++ b/schedule/kernel/ibtest-slave-rdma-next.yaml
@@ -5,8 +5,6 @@ vars:
     DESKTOP: textmode
     GRUB_TIMEOUT: 300
     IBTESTS: 1
-    IBTEST_GITBRANCH: master
-    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_SLAVE
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de

--- a/schedule/kernel/ibtest-slave-tumbleweed.yaml
+++ b/schedule/kernel/ibtest-slave-tumbleweed.yaml
@@ -5,8 +5,6 @@ vars:
     DESKTOP: textmode
     EVEL_TOOLS_REPO: https://download.opensuse.org/repositories/devel:/tools/openSUSE_Tumbleweed/devel:tools.repo
     IBTESTS: 1
-    IBTEST_GITBRANCH: master
-    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_SLAVE
     ROOTONLY: 1
     SCC_ADDONS: sdk

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -8,8 +8,6 @@ vars:
     DESKTOP: textmode
     GRUB_TIMEOUT: 300
     IBTESTS: 1
-    IBTEST_GITBRANCH: master
-    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_SLAVE
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de


### PR DESCRIPTION
We have a default value in the code, no use to repeat this in the schedules. Plus, if we have it in the schedules we cannot override it in a clone or post command.

- Related ticket: https://progress.opensuse.org/issues/183164

