### PR TITLE
containers: Tweak curl retry options to give containers time to start

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -82,7 +82,7 @@ sub build_and_run_image {
     assert_script_run("$runtime logs myapp");    # show logs for easier problem investigation
 
     # Test that the exported port is reachable
-    my $curl_opts = "--retry 6 --retry-delay 30";
+    my $curl_opts = "--retry 6 --retry-all-errors";
     assert_script_run("curl $curl_opts http://localhost:8888/ | grep 'The test shall pass'");
 
     # Cleanup


### PR DESCRIPTION
Tweak curl retry options to give containers time to start

- Related ticket: https://progress.opensuse.org/issues/186185
- Failed test: https://openqa.suse.de/tests/18533509/modules/image_docker/steps/233
- Verification run: https://openqa.suse.de/tests/18534068