### PR TITLE
SLE16 container host aarch64 create_hdd fix grub missing cases

### DIFF
--- a/data/containers/agama/sle_default.jsonnet
+++ b/data/containers/agama/sle_default.jsonnet
@@ -3,6 +3,9 @@
     id: '{{AGAMA_PRODUCT_ID}}',
     registrationCode: '{{SCC_REGCODE}}'
   },
+  bootloader: {
+    timeout: 30,
+  },
   user: {
     fullName: 'Bernhard M. Wiedemann',
     password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',


### PR DESCRIPTION
grub timeout managed in order to avoid cases when after reboot it is not visible anymore and needles expecting it make test fail.

Followup of issue in PR[22703](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22703), related to aarch64 create_hdd, then reverted in [22743](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22743)

- Verification run: https://openqa.suse.de/tests/18534085
