### PR TITLE
Use non-emulated power workers in sle-micro testing

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -50,7 +50,6 @@ sub load_config_tests {
 
 sub load_boot_from_disk_tests {
     loadtest 'microos/disk_boot' if (check_var('MACHINE', 'ppc64le-p10-virtio') && !check_var('FIRST_BOOT_CONFIG', 'wizard'));
-    return if is_ppc64le && get_var('MACHINE') !~ /ppc64le-emu/i && !(is_sle_micro('=5.5') && check_var('FLAVOR', 'Container-Image-Updates'));
     # add additional image handling module for svirt workers
     if (is_s390x()) {
         loadtest 'installation/bootloader_start';


### PR DESCRIPTION
Dropping a workaround that was introduced to test sle-micro on emulated workers. Now we can use POWER8 and POWER10 according to product specification.

- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
