### PR TITLE
podman IPv6: Get rid of script_retry '!curl...'

### DIFF
--- a/tests/containers/podman_ipv6.pm
+++ b/tests/containers/podman_ipv6.pm
@@ -48,7 +48,7 @@ sub run {
     assert_script_run("iptables -A OUTPUT -d $registry_ipv4 -j DROP");
     validate_script_output('iptables -L OUTPUT', sub { m/$registry_ipv4/g });
     # Test that access to openSUSE registry no longer works via IPv4
-    script_retry("!curl -sSf4 https://registry.opensuse.org/v2/", delay => 25, retry => 4);
+    assert_script_run("!curl -sSf4 https://registry.opensuse.org/v2/");
     # Test that access to openSUSE registry still works (IPv6 should work)
     script_retry('curl -sSf https://registry.opensuse.org/v2/', delay => 25, retry => 4);
     # Pull image from openSUSE registry (over IPv6 now)


### PR DESCRIPTION
- Related thread: [Slack](https://suse.slack.com/archives/C02CGKBCGT1/p1753172902071949)
- Verification runs:
[Buildsixt](https://pdostal-server.suse.cz/tests/overview?build=sixt&distri=sle&version=15-SP7) of sle-15-SP7-EC2-Updates.x86_64	  [sixt@64bit](https://pdostal-server.suse.cz/tests/9306)
[Buildsixt](https://pdostal-server.suse.cz/tests/overview?build=sixt&distri=sle&version=15-SP7) of sle-15-SP7-GCE-BYOS-Updates.x86_64	  [sixt@64bit](https://pdostal-server.suse.cz/tests/9304)
[Buildsixt](https://pdostal-server.suse.cz/tests/overview?build=sixt&distri=sle&version=15-SP7) of sle-15-SP7-EC2-BYOS-Updates.aarch64	  [sixt@64bit](https://pdostal-server.suse.cz/tests/9305)
[Buildsixt](https://pdostal-server.suse.cz/tests/overview?build=sixt&distri=sle&version=15-SP7) of sle-15-SP7-GCE-Updates.aarch64	  [sixt@64bit](https://pdostal-server.suse.cz/tests/9302)
[Buildsixt](https://pdostal-server.suse.cz/tests/overview?build=sixt&distri=sle&version=15-SP7) of sle-15-SP7-GCE-Updates.aarch64	  [sixt@64bit](https://pdostal-server.suse.cz/tests/9301)