### PR TITLE
containers: Use --retry-all-errors with curl

### DIFF
--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -85,7 +85,7 @@ sub run {
     systemctl '--now enable registry';
     systemctl 'status registry';
 
-    my $curl_opts = "--retry 10 --retry-delay 3";
+    my $curl_opts = "--retry 10 --retry-all-errors";
     assert_script_run "curl -s $curl_opts http://127.0.0.1:5000/v2/_catalog | grep repositories";
 
     my $engine = $self->containers_factory($runtime);


### PR DESCRIPTION
Avoid specifying small delay inherited by blind translation of script_retry arguments

Failed tests:
- docker: https://openqa.opensuse.org/tests/5192519#step/docker_registry/14
- podman: https://openqa.opensuse.org/tests/5192524#step/podman_registry/1

Verification runs:
- docker: https://openqa.opensuse.org/tests/5193065
- podman: https://openqa.opensuse.org/tests/5193066

