### PR TITLE
Run kdump-cli tests in MinimalVM 16+

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1664,6 +1664,10 @@ sub load_extra_tests_perl_bootloader {
 }
 
 sub load_extra_tests_kdump {
+    if (is_jeos && is_sle('16.0+')) {
+        loadtest "kernel/kdump";
+        return;
+    }
     return unless kdump_is_applicable;
     loadtest "console/kdump_and_crash";
 }


### PR DESCRIPTION
YaST has been deprecated, therefore the kdump tests were not executing the main test module. Now there is kdump module that uses the kdump cli tooling

- Verification run: http://kepler.suse.cz/tests/25090#
