### PR TITLE
PC: Get clean the serial terminal log

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -552,8 +552,7 @@ sub on_terraform_destroy_timeout {
     assert_script_run("az group delete --yes --no-wait --name $resgroup");
 }
 
-sub get_state_from_instance
-{
+sub get_state_from_instance {
     my ($self, $instance) = @_;
     my $id = $instance->instance_id();
     my $out = decode_azure_json(script_output("az vm get-instance-view --ids '$id' --query instanceView.statuses[1] --output json", quiet => 1));
@@ -568,12 +567,11 @@ sub get_public_ip {
     $instance_id =~ s/.*\/(.*)/$1/;
     my $resource_group = $self->get_terraform_output('.resource_group_name.value[0]');
 
-    my $out = decode_azure_json(script_output("az vm list-ip-addresses --name '$instance_id' --resource-group '$resource_group'", quiet => 1));
-    return $out->[0]->{virtualMachine}->{network}->{publicIpAddresses}->[0]->{ipAddress};
+    # asdf
+    return script_output("az vm list-ip-addresses --name '$instance_id' --resource-group '$resource_group' | jq -r '.[0].virtualMachine.network.publicIpAddresses[0].ipAddress'", quiet => 1);
 }
 
-sub stop_instance
-{
+sub stop_instance {
     my ($self, $instance) = @_;
     # We assume that the instance_id on azure is actually the name
     # which is equal to the resource group


### PR DESCRIPTION
In the serial terminal we sometimes print long json just to grep the VM name or its IP address. This makes the debugging difficult. Instead of that 'perl native' approach we should rather do `| jq` and make the serial terminal more readable as we use it for debugging.

- Verification runs:
[Buildpc_show](https://pdostal-server.suse.cz/tests/overview?build=pc_show&distri=sle&version=15-SP7) of sle-15-SP7-EC2-Updates.x86_64	  [pc_show@64bit](https://pdostal-server.suse.cz/tests/9324)
[Buildpc_show](https://pdostal-server.suse.cz/tests/overview?build=pc_show&distri=sle&version=12-SP5) of sle-12-SP5-EC2-Updates.x86_64	  [pc_show@64bit](https://pdostal-server.suse.cz/tests/9325)
[Buildpc_show](https://pdostal-server.suse.cz/tests/overview?build=pc_show&distri=sle&version=12-SP5) of sle-12-SP5-Azure-BYOS-Updates.x86_64	  [pc_show@64bit](https://pdostal-server.suse.cz/tests/9326)
[Buildpc_show](https://pdostal-server.suse.cz/tests/overview?build=pc_show&distri=sle&version=15-SP7) of sle-15-SP7-Azure-BYOS-Updates.aarch64	  [pc_show@64bit](https://pdostal-server.suse.cz/tests/9322)
[Buildpc_show](https://pdostal-server.suse.cz/tests/overview?build=pc_show&distri=sle&version=12-SP5) of sle-12-SP5-EC2-BYOS-Updates.x86_64	  [pc_show@64bit](https://pdostal-server.suse.cz/tests/9328)
[Buildpc_show](https://pdostal-server.suse.cz/tests/overview?build=pc_show&distri=sle&version=15-SP7) of sle-15-SP7-GCE-BYOS-Updates.aarch64	  [pc_show@64bit](https://pdostal-server.suse.cz/tests/9334)
[Buildpc_show](https://pdostal-server.suse.cz/tests/overview?build=pc_show&distri=sle&version=15-SP7) of sle-15-SP7-GCE-BYOS-Updates.aarch64	  [pc_show@64bit](https://pdostal-server.suse.cz/tests/9332)
[Buildpc_show](https://pdostal-server.suse.cz/tests/overview?build=pc_show&distri=sle&version=15-SP7) of sle-15-SP7-EC2-BYOS-Updates.x86_64	  [pc_show@64bit](https://pdostal-server.suse.cz/tests/9331)
[Buildpc_show](https://pdostal-server.suse.cz/tests/overview?build=pc_show&distri=sle&version=15-SP7) of sle-15-SP7-Azure-Basic-Updates.x86_64	  [pc_show@64bit](https://pdostal-server.suse.cz/tests/9330)
[Buildpc_show](https://pdostal-server.suse.cz/tests/overview?build=pc_show&distri=sle&version=15-SP7) of sle-15-SP7-GCE-BYOS-Updates.aarch64	  [pc_show@64bit](https://pdostal-server.suse.cz/tests/9335)
[Buildpc_show](https://pdostal-server.suse.cz/tests/overview?build=pc_show&distri=sle&version=15-SP7) of sle-15-SP7-Azure-BYOS-Updates.aarch64	  [pc_show@64bit](https://pdostal-server.suse.cz/tests/9327)
[Buildpc_show](https://pdostal-server.suse.cz/tests/overview?build=pc_show&distri=sle&version=15-SP7) of sle-15-SP7-EC2-BYOS-Updates.aarch64	  [pc_show@64bit](https://pdostal-server.suse.cz/tests/9329)
[Buildpc_show](https://pdostal-server.suse.cz/tests/overview?build=pc_show&distri=sle&version=15-SP7) of sle-15-SP7-GCE-Updates.aarch64	  [pc_show@64bit](https://pdostal-server.suse.cz/tests/9320)
[Buildpc_show](https://pdostal-server.suse.cz/tests/overview?build=pc_show&distri=sle&version=15-SP7) of sle-15-SP7-GCE-BYOS-Updates.aarch64	 [pc_show@64bit](https://pdostal-server.suse.cz/tests/9336)