### PR TITLE
containers: Avoid --retry-all-errors on SLES < 15-SP4

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -83,6 +83,10 @@ sub build_and_run_image {
 
     # Test that the exported port is reachable
     my $curl_opts = "--retry 6 --retry-all-errors";
+    if (is_sle("<15-SP4")) {
+        # --retry-all-errors is not available on curl < 7.71.0
+        $curl_opts = "--retry 10";
+    }
     assert_script_run("curl $curl_opts http://localhost:8888/ | grep 'The test shall pass'");
 
     # Cleanup


### PR DESCRIPTION
Avoid --retry-all-errors on SLES < 15-SP4

`curl: option --retry-all-errors: is unknown`.

Failed test: https://openqa.suse.de/tests/18540048#step/podman/296

