### PR TITLE
Test alert informing the user that Agama could not fetch the profile

### DIFF
--- a/schedule/yam/agama_alert_popup.yaml
+++ b/schedule/yam/agama_alert_popup.yaml
@@ -1,0 +1,9 @@
+---
+name: agama_alert_popup
+description: >
+  Verify alert popup shown with invalid profile url.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_arrange
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama

--- a/tests/yam/agama/agama.pm
+++ b/tests/yam/agama/agama.pm
@@ -10,6 +10,7 @@ use strict;
 use warnings;
 use Carp qw(croak);
 use testapi qw(
+  check_var
   diag
   get_var
   get_required_var
@@ -62,7 +63,7 @@ sub run {
         my $svirt = console('svirt')->change_domain_element(os => boot => {dev => 'hd'});
     }
 
-    (is_s390x() || is_pvm() || is_headless_installation()) ?
+    (is_s390x() || is_pvm() || is_headless_installation() || check_var('AGAMA_ALERT_POPUP', 'invalid_profile')) ?
       # reboot via console
       power_action('reboot', keepconsole => 1, first_reboot => 1) :
       # graphical reboot

--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -104,7 +104,7 @@ sub run {
     $grub_entry_edition->boot();
 
     return if check_var('AGAMA_GRUB_SELECTION', 'rescue_system');
-    if (get_var('EXTRABOOTPARAMS', '') =~ /systemd.unit=multi-user.target/) {
+    if (get_var('EXTRABOOTPARAMS', '') =~ /systemd.unit=multi-user.target/ || check_var('AGAMA_ALERT_POPUP', 'invalid_profile')) {
         wait_serial('Connect to the Agama installer using these URLs:', 300) || die "Agama installer didn't start";
     } else {
         $agama_up_an_running->expect_is_shown();


### PR DESCRIPTION
Add test in puppeteer to verify the alert popup shown.

- Related ticket: https://progress.opensuse.org/issues/185704
- Related PR: https://github.com/jknphy/agama-integration-test-webpack/pull/124
- Needles: N/A
- Verification run: 
  https://openqa.suse.de/tests/18546327#details x86_64
  https://openqa.suse.de/tests/18546326#details aarch64