### PR TITLE
Changed Agama version conditional

### DIFF
--- a/tests/yam/agama/import_agama_profile.pm
+++ b/tests/yam/agama/import_agama_profile.pm
@@ -20,7 +20,7 @@ sub run {
     select_console 'install-shell';
 
     if (!check_var('AGAMA_PROFILE_LOAD', '0')) {
-        my $command = get_var('AGAMA_VERSION') == '16' ?
+        my $command = get_var('AGAMA_VERSION') >= '16' ?
           "agama config load $profile_url" : "agama profile import $profile_url";
 
         assert_script_run($command, timeout => 300);


### PR DESCRIPTION
We have changed the Agama version conditional from `==` to `>=` this will support Agama 17 and later updates.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/18546395
