### PR TITLE
Fix failure in desktopapps-firefox on sle16

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -16,7 +16,7 @@ use autotest;
 use utils;
 use wicked::TestContext;
 use Utils::Architectures;
-use version_utils qw(:VERSION :BACKEND :SCENARIO is_community_jeos is_public_cloud);
+use version_utils qw(:VERSION :BACKEND :SCENARIO is_community_jeos is_public_cloud is_leap is_sle);
 use Utils::Backends;
 use data_integrity_utils 'verify_checksum';
 use bmwqemu ();
@@ -2094,7 +2094,7 @@ sub load_x11_webbrowser {
     loadtest "x11/firefox/firefox_html5";
     loadtest "x11/firefox/firefox_developertool";
     loadtest "x11/firefox/firefox_ssl";
-    loadtest "x11/firefox/firefox_emaillink";
+    loadtest "x11/firefox/firefox_emaillink" if (is_sle('<16') || is_leap('<16.0'));
     loadtest "x11/firefox/firefox_plugins";
     loadtest "x11/firefox/firefox_extcontent";
     if (!get_var("OFW") && is_qemu) {

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -522,7 +522,7 @@ Turns off the screensaver depending on desktop environment
 sub turn_off_screensaver {
     return turn_off_kde_screensaver if check_var('DESKTOP', 'kde');
     die "Unsupported desktop '" . get_var('DESKTOP', '') . "'" unless check_var('DESKTOP', 'gnome');
-    x11_start_program('xterm');
+    x11_start_program(default_gui_terminal());
     turn_off_gnome_screensaver;
     script_run 'exit', 0;
 }

--- a/tests/x11/firefox/firefox_extcontent.pm
+++ b/tests/x11/firefox/firefox_extcontent.pm
@@ -22,12 +22,13 @@ use warnings;
 use base "x11test";
 use testapi;
 use version_utils 'is_sle';
+use x11utils 'default_gui_terminal';
 
 sub run {
     my ($self) = @_;
 
     $self->start_firefox_with_profile;
-    x11_start_program('xterm');
+    x11_start_program(default_gui_terminal());
     my $host = script_run('ping -c1 mirror.suse.cz') == 0 ? 'mirror.suse.cz' : 'ibs-mirror.prv.suse.net';
     send_key 'ctrl-d';
     wait_still_screen 2;

--- a/tests/x11/firefox/firefox_extensions.pm
+++ b/tests/x11/firefox/firefox_extensions.pm
@@ -63,6 +63,7 @@ sub run {
     $self->firefox_open_url('opensuse.org', assert_loaded_url => 'firefox-extensions-show_flag');
 
     send_key "alt-2";
+    assert_and_click("firefox-extensions-tab");
     wait_still_screen 2, 4;
     assert_and_click('firefox-extensions-menu-icon') if check_screen('firefox-extensions-menu-icon');
     assert_and_click('firefox-extensions-remove');

--- a/tests/x11/firefox/firefox_html5.pm
+++ b/tests/x11/firefox/firefox_html5.pm
@@ -17,12 +17,13 @@ use warnings;
 use base "x11test";
 use testapi;
 use utils;
+use x11utils 'default_gui_terminal';
 
 sub run {
     my ($self) = @_;
     $self->start_firefox_with_profile;
 
-    x11_start_program('xterm');
+    x11_start_program(default_gui_terminal());
     script_run('cd ~/data/testwebsites');
     enter_cmd('python3 -m http.server 48080 &');
     # curl provides an adequate time window for the server to run
@@ -30,6 +31,6 @@ sub run {
     send_key 'alt-tab';    #Switch to firefox
     $self->firefox_open_url('http://localhost:48080/html5_video', assert_loaded_url => 'firefox-testvideo');
     $self->exit_firefox;
-    enter_cmd('exit');
+    send_key_until_needlematch("generic-desktop", "alt-f4", 6, 5);
 }
 1;

--- a/tests/x11/firefox/firefox_pagesaving.pm
+++ b/tests/x11/firefox/firefox_pagesaving.pm
@@ -21,6 +21,7 @@ use strict;
 use warnings;
 use base "x11test";
 use testapi;
+use x11utils 'default_gui_terminal';
 
 sub run {
     my ($self) = @_;
@@ -36,7 +37,7 @@ sub run {
     # Exit
     $self->exit_firefox;
 
-    x11_start_program('xterm');
+    x11_start_program(default_gui_terminal());
     send_key "ctrl-l";
     wait_still_screen 3;
     # look for file name "Internet for people, not profit",

--- a/tests/x11/firefox/firefox_passwd.pm
+++ b/tests/x11/firefox/firefox_passwd.pm
@@ -74,7 +74,10 @@ sub run {
     $self->firefox_preferences;
     assert_and_click('firefox-passwd-security');
     send_key_until_needlematch([qw(firefox-primary-passwd-selected firefox-passwd-master_setting)], 'alt-shift-u', 4, 2);
-    send_key 'spc' unless check_screen('firefox-passwd-master_setting', 3);
+    if (check_screen('firefox-passwd-master_setting', 3)) {
+        assert_and_click('firefox-passwd-master_setting');
+    }
+    assert_and_click("firefox-enter-new-password");
     # We should use strong password due to bsc#1208951
     type_string $masterpw, 150;
     send_key "tab";
@@ -91,7 +94,7 @@ sub run {
     type_string "squiddy";
     send_key "tab";
     type_string "calamari";
-    send_key "ret";
+    assert_and_click('firefox-passwd-login');
     wait_still_screen(2);
     assert_and_click('firefox-passwd-confirm_remember');
     confirm_master_pw;


### PR DESCRIPTION
Fix failures in disable_screensaver and firefox_*
SLE16 doesn't have evolution so we will not run firefox_emaillink on SLE16
Some minor code changes were added to make the test cases more robust.

- Related ticket: https://progress.opensuse.org/issues/185446
- Needles: already added when debugging on osd
- Verification run: 
> SLE16 https://openqa.suse.de/tests/18546394
> SLE15 SP7 https://openqa.suse.de/tests/18546291
