### PR TITLE
Update autoyast profiles for Support Server

### DIFF
--- a/data/supportserver/autoyast_supportserver_non_x86.xml
+++ b/data/supportserver/autoyast_supportserver_non_x86.xml
@@ -61,8 +61,6 @@
 		<package>autofs</package>
 		<package>bind</package>
 		<package>atftp</package>
-		<package>yast2-iscsi-lio-server</package>
-		<package>tgt</package>
     </packages>
    <patterns config:type="list">
           <pattern>base</pattern>

--- a/data/supportserver/autoyast_supportserver_non_x86.xml
+++ b/data/supportserver/autoyast_supportserver_non_x86.xml
@@ -49,7 +49,6 @@
     </routing>
   </networking>
   <software>
-    <image/>
     <instsource/>
     <packages config:type="list">
 		<package>vim</package>
@@ -83,9 +82,4 @@
                       <user_password>{{PASSWORD}}</user_password>
           </user>
   </users>
-
-  <runlevel>
-    <default>3</default>
-  </runlevel>
-
 </profile>

--- a/data/supportserver/autoyast_supportserver_x86.xml
+++ b/data/supportserver/autoyast_supportserver_x86.xml
@@ -48,7 +48,6 @@
     </routing>
   </networking>
   <software>
-    <image/>
     <instsource/>
     <packages config:type="list">
       <package>vim</package>
@@ -83,9 +82,4 @@
       <user_password>{{PASSWORD}}</user_password>
     </user>
   </users>
-
-  <runlevel>
-    <default>3</default>
-  </runlevel>
-
 </profile>

--- a/data/supportserver/autoyast_supportserver_x86.xml
+++ b/data/supportserver/autoyast_supportserver_x86.xml
@@ -61,8 +61,6 @@
       <package>autofs</package>
       <package>bind</package>
       <package>atftp</package>
-      <package>yast2-iscsi-lio-server</package>
-      <package>tgt</package>
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>


### PR DESCRIPTION
The current autoyast profiles weren't passing validation by the installer https://openqa.opensuse.org/tests/5192549#step/installation/12

Additionally remove two packages that aren't present in the install-dvd: https://openqa.opensuse.org/tests/5194031#step/installation/10

VR: https://openqa.opensuse.org/tests/5194044 
