### PR TITLE
containers: Support all curl versions with dynamic option lookup

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -82,12 +82,12 @@ sub build_and_run_image {
     assert_script_run("$runtime logs myapp");    # show logs for easier problem investigation
 
     # Test that the exported port is reachable
-    my $curl_opts = "--retry 6 --retry-all-errors";
-    if (is_sle("<15-SP4") || is_sle_micro("<5.3")) {
-        # --retry-all-errors is not available on curl < 7.71.0
-        $curl_opts = "--retry 10";
-    }
-    assert_script_run("curl $curl_opts http://localhost:8888/ | grep 'The test shall pass'");
+    # --retry-all-errors is not available on curl < 7.71.0
+    assert_script_run(qq( <<EOF
+      curl_opts=$(curl --help all | grep -q retry-all-errors && echo "--retry 6 --retry-all-errors" || echo "--retry 10")
+      curl $curl_opts http://localhost:8888/ | grep 'The test shall pass'
+EOF
+));
 
     # Cleanup
     assert_script_run("$runtime stop myapp");


### PR DESCRIPTION
This is based on a proposal from schlad in
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22766#issuecomment-3110601614
to check for the version of curl just adapted to check the actually
mentioned supported options in the help output of curl.