### PR TITLE
nfs: Add NFS mm tests on bare metal servers

### DIFF
--- a/schedule/storage/nfs_baremetal.yaml
+++ b/schedule/storage/nfs_baremetal.yaml
@@ -1,7 +1,7 @@
 ---
 name: NFS testing on Baremetal
 description:    >
-    Maintainer: mmoese
+    Maintainer: mmoese, schlad
     Tests creating NFS set-up and testing NFS itself with focus on various
     versions, features etc. on baremetal.
 vars:
@@ -50,4 +50,4 @@ schedule:
     - kernel/mellanox_config
     - kernel/before_nfs_test
     - '{{nfstest}}'
-    - kernel/nfs_stress_ng
+    #- kernel/nfs_stress_ng


### PR DESCRIPTION
This is the resurrection of the bare metal NFS set-up to utilize nfs_server and nfs_client tests on the real servers

- Related ticket: https://progress.opensuse.org/issues/186341
- Verification run: tbd
