### PR TITLE
Drop test build of multipath-tools for Tumbleweed

### DIFF
--- a/tests/console/systemd_rpm_macros.pm
+++ b/tests/console/systemd_rpm_macros.pm
@@ -5,7 +5,7 @@
 
 # Summary: systemd-rpm-macros test
 #          - call a list of macros to make sure they are available (list taken from manual testing report)
-#          - if Tumbleweed or SLE >= 15, also download sources and install multipath-tools to run some macros
+#          - SLE >= 15, also download sources and install multipath-tools to run some macros
 #
 # Maintainer: QE Core <qe-core@suse.de>
 
@@ -42,10 +42,6 @@ sub run {
         zypper_call("--gpg-auto-import-keys ref", 300) if (get_var('FIPS') || get_var('FIPS_ENABLED'));
         build_mt();
         assert_script_run(q(zypper mr -d $(zypper lr|awk '/Basesystem.*Source/ {print$5}')));
-    } elsif (is_tumbleweed) {
-        zypper_call("ar -f http://download.opensuse.org/source/tumbleweed/repo/oss/ my-source-repo");
-        build_mt();
-        zypper_call("rr my-source-repo");
     }
 }
 1;


### PR DESCRIPTION
In factory only few sources are synced but moreover the coverage
provided by the test is already sufficient to know that RPM is able to
expand systemd macros

Pulling assets from already published assets instead of the assets to be tested is also problematic

Failure: https://openqa.opensuse.org/tests/5195001#step/systemd_rpm_macros/27
