### PR TITLE
io_uring: Print the last commit

### DIFF
--- a/tests/kernel/io_uring.pm
+++ b/tests/kernel/io_uring.pm
@@ -47,6 +47,7 @@ sub run {
     assert_script_run("git clone --no-single-branch $repository");
     assert_script_run("cd liburing");
     assert_script_run("git checkout $version");
+    record_info("test version", script_output("git log -1 --oneline"));
     assert_script_run("./configure");
     assert_script_run("make -C src");
     assert_script_run("make -C test");

--- a/tests/kernel/io_uring.pm
+++ b/tests/kernel/io_uring.pm
@@ -92,7 +92,7 @@ sub run {
         record_info(
             "Timeout",
             $lines[0],
-            result => 'softfail'
+            result => 'fail'
         );
     }
 

--- a/tests/kernel/io_uring.pm
+++ b/tests/kernel/io_uring.pm
@@ -30,6 +30,7 @@ sub run {
     my @lines;
     my $out;
 
+    record_info('KERNEL', script_output('rpm -qi kernel-default'));
     # check if liburing2 is installed and eventually install it
     $pkgs .= " liburing2" if script_run('rpm -q liburing2');
 


### PR DESCRIPTION
A few minor enhancements plus a fix for the timeouts which should not softfail but fail instead. 

- Related ticket: https://progress.opensuse.org/issues/186405
- Verification run: 
sle16: passing: https://openqa.suse.de/tests/18577954
sle15sp7: https://openqa.suse.de/tests/18577976 - with catching the failed tests
TW: https://openqa.opensuse.org/tests/5203956 - with catching the failed tests

I know those  2 lops     # search for timed out tests and     # search for failed tests and known issues are awfully similar. If you prefer I can try to move it to  a function or combine it into a single loop searching for both failed tests and timeouts but I simply kept the original code just fixed the issues.
