### PR TITLE
Fix: add "sle-micro: 6.2" in bug_ref for dracut-no-logger

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -908,7 +908,8 @@
         "description": "No '\/dev\/log' or 'logger' included for syslog logging",
         "products": {
             "opensuse": ["Tumbleweed"],
-            "microos":  ["Tumbleweed"]
+            "microos":  ["Tumbleweed"],
+            "sle-micro": ["6.2"]
         },
         "type": "ignore"
     },


### PR DESCRIPTION
- Verification run: [slem_migration_6.1_to_6.2](https://openqa.suse.de/tests/overview?build=leo-test-2025-07-25)
