### PR TITLE
Schedule valkey test on sle15sp6 and sle15sp7

### DIFF
--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -46,6 +46,7 @@ conditional_schedule:
         - console/nginx
         - '{{arch_specific}}'
         - console/valgrind
+        - console/valkey
         - '{{arch_specific15_sp5plus}}'
       15-SP6:
         - console/curl_ipv6
@@ -59,6 +60,7 @@ conditional_schedule:
         - console/nginx
         - '{{arch_specific}}'
         - console/valgrind
+        - console/valkey
         - '{{arch_specific15_sp5plus}}'
       15-SP5:
         - console/curl_ipv6

--- a/tests/console/valkey.pm
+++ b/tests/console/valkey.pm
@@ -30,7 +30,7 @@ sub run {
     assert_script_run('cd valkey/tls');
     # CA
     assert_script_run('openssl genrsa -out ca.key 4096');
-    assert_script_run('openssl req -new -x509 -days 3650 -key ca.key -out ca.crt -subj "/"');
+    assert_script_run('openssl req -new -x509 -nodes -days 3650 -key ca.key -out ca.crt -subj "/C=DE/ST=Nueremberg/L=Nueremberg/O=QA/OU=core/CN=susetest.example.com"');
     # Master
     assert_script_run('openssl genrsa -out server/valkey.key 2048');
     assert_script_run('openssl req -new -key server/valkey.key -out server/valkey.csr -subj "/"');


### PR DESCRIPTION
https://progress.opensuse.org/issues/182654

1. Add coverage for sle15sp6/sp7
2. Add some required parameters when generating the ca cert file. [or the cert file is not recognized on sle15sp6]

- Verification run: 
[sle15sp6/sp7](https://openqa.suse.de/tests/overview?build=rfan0725&distri=sle)
[sle16](http://openqa.suse.de/tests/18576941)
[tw](https://openqa.opensuse.org/tests/5203046)