### PR TITLE
Use the default variable VMWARE_HOST in workerconf for MU test

### DIFF
--- a/lib/virt_autotest/esxi_utils.pm
+++ b/lib/virt_autotest/esxi_utils.pm
@@ -30,7 +30,7 @@ our @EXPORT = qw(
   revert_vm_timesync_setting
 );
 
-my $hypervisor = get_var('HYPERVISOR') // get_var('VMWARE_SERVER');
+my $hypervisor = get_var('HYPERVISOR') // get_var('VMWARE_HOST');
 
 sub esxi_vm_get_vmid {
     my $vm_name = shift;

--- a/tests/virtualization/external/prepare.pm
+++ b/tests/virtualization/external/prepare.pm
@@ -23,7 +23,7 @@ sub run {
 
     # Fill the current pairs of hostname & address into /etc/hosts file
     if (get_var("REGRESSION", '') =~ /vmware/) {
-        my $vmware_server = get_required_var('VMWARE_SERVER');
+        my $vmware_server = get_required_var('VMWARE_HOST');
         foreach my $guest (keys %virt_autotest::common::guests) {
             my $ip = script_output(qq(ssh -o StrictHostKeyChecking=no root\@$vmware_server "vim-cmd vmsvc/get.guest \\`vim-cmd vmsvc/getallvms | grep -w $guest|cut -d ' ' -f1\\`|grep -A 1 hostName|grep ipAddress|cut -d '\\"' -f2"));
             record_info("$guest: $ip");


### PR DESCRIPTION
To unify variable names used for vmware tests between development and maintenance test, it will use VMWARE_HOST instead of VMWARE_SERVER.

- Related ticket: https://progress.opensuse.org/issues/183518
- Verification run: 
