### PR TITLE
containers: Drop curl --retry-all-errors option

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -82,11 +82,7 @@ sub build_and_run_image {
     assert_script_run("$runtime logs myapp");    # show logs for easier problem investigation
 
     # Test that the exported port is reachable
-    my $curl_opts = "--retry 6 --retry-all-errors";
-    if (is_sle("<15-SP4") || is_sle_micro("<5.3")) {
-        # --retry-all-errors is not available on curl < 7.71.0
-        $curl_opts = "--retry 10";
-    }
+    my $curl_opts = "--retry 10";
     assert_script_run("curl $curl_opts http://localhost:8888/ | grep 'The test shall pass'");
 
     # Cleanup

--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -85,7 +85,7 @@ sub run {
     systemctl '--now enable registry';
     systemctl 'status registry';
 
-    my $curl_opts = "--retry 10 --retry-all-errors";
+    my $curl_opts = "--retry 10";
     assert_script_run "curl -s $curl_opts http://127.0.0.1:5000/v2/_catalog | grep repositories";
 
     my $engine = $self->containers_factory($runtime);


### PR DESCRIPTION
Drop curl `--retry-all-errors` option.

This option is not available in older curl versions and `--retry 10` has been working fine on older SLES & SLEM.

Supersedes https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22774