### PR TITLE
containers: Increase number of curl retries

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -82,7 +82,7 @@ sub build_and_run_image {
     assert_script_run("$runtime logs myapp");    # show logs for easier problem investigation
 
     # Test that the exported port is reachable
-    my $curl_opts = "--retry 10";
+    my $curl_opts = "--retry 50";
     assert_script_run("curl $curl_opts http://localhost:8888/ | grep 'The test shall pass'");
 
     # Cleanup

--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -85,7 +85,7 @@ sub run {
     systemctl '--now enable registry';
     systemctl 'status registry';
 
-    my $curl_opts = "--retry 10";
+    my $curl_opts = "--retry 50";
     assert_script_run "curl -s $curl_opts http://127.0.0.1:5000/v2/_catalog | grep repositories";
 
     my $engine = $self->containers_factory($runtime);


### PR DESCRIPTION
Increase number of curl retries.

The current number is not enough for FIPS tests and tests with only one vCPU

Failed tests:
- https://openqa.suse.de/tests/18568757#step/image_docker/233 (as usual a FIPS test.  It seems that Golang linked with OpenSSL as required by FIPS is VERY slow).
- https://openqa.opensuse.org/tests/5198859#step/docker_registry/17 (also needs `QEMUCPUS=2`)

Verification runs:
- https://openqa.suse.de/tests/18569474 (still failing).
- https://openqa.opensuse.org/tests/5199492