### PR TITLE
containers: Increase curl --retry for FIPS tests

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -82,7 +82,9 @@ sub build_and_run_image {
     assert_script_run("$runtime logs myapp");    # show logs for easier problem investigation
 
     # Test that the exported port is reachable
-    my $curl_opts = "--retry 50";
+    # FIPS libraries always check whether the host is in FIPS mode and must perform some initialization
+    # so it takes more time.
+    my $curl_opts = "--retry 500";
     assert_script_run("curl $curl_opts http://localhost:8888/ | grep 'The test shall pass'");
 
     # Cleanup

--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -85,7 +85,7 @@ sub run {
     systemctl '--now enable registry';
     systemctl 'status registry';
 
-    my $curl_opts = "--retry 50";
+    my $curl_opts = "--retry 500";
     assert_script_run "curl -s $curl_opts http://127.0.0.1:5000/v2/_catalog | grep repositories";
 
     my $engine = $self->containers_factory($runtime);


### PR DESCRIPTION
Increase curl --retry for FIPS tests

- Related ticket: https://progress.opensuse.org/issues/186391
- Failed test: https://openqa.suse.de/tests/18575614#step/image_docker/233
- Verification runs:
  - https://openqa.suse.de/tests/18577925
  - https://openqa.opensuse.org/tests/5203959 (needs https://github.com/os-autoinst/opensuse-jobgroups/pull/697)