### PR TITLE
New regkey in autounattend to disable 'Welcome to Edge' screen

### DIFF
--- a/data/wsl/Autounattend_UEFI.xml
+++ b/data/wsl/Autounattend_UEFI.xml
@@ -393,6 +393,11 @@
           <Order>67</Order>
           <Path>powershell.exe -NoProfile -Command "sc.exe create "openqa-agent" type= own start= auto binPath= 'C:\Program Files\openqa-agent.exe'"</Path>
         </RunSynchronousCommand>
+        <!-- This Registry key disables the infamous 'Welcome to Edge' popup -->
+        <RunSynchronousCommand wcm:action="add">
+          <Order>68</Order>
+          <Path>%windir%\System32\reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Edge" /v HideFirstRunExperience /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
   </settings>


### PR DESCRIPTION
There's a new "experience" called 'Welcome to Edge' that is shown up the first time you open the Microsoft Edge explorer. Nevertheless, Microsoft has decided to show this screen also the first time we open our WSL distro, so we will disable it via Registry Keys

- Related ticket: https://progress.opensuse.org/issues/186290
- Verification run: (tried on my own VM)
<img width="1223" height="764" alt="image" src="https://github.com/user-attachments/assets/49dfc9c3-c819-49c2-ac47-6e5abcd47356" />

