### PR TITLE
Adjust OpenVPN schedule and tests for s390x

### DIFF
--- a/schedule/security/create_fips_hdd.yaml
+++ b/schedule/security/create_fips_hdd.yaml
@@ -1,8 +1,16 @@
 name: create_fips_hdd
 description: >
-    This is used by the FIPS tests (kernel mode).
+  This is used by the FIPS tests (kernel mode).
 schedule:
-    - boot/boot_to_desktop
-    - console/consoletest_setup
-    - fips/fips_setup
-    - shutdown/shutdown
+  - '{{bootloader}}'
+  - boot/boot_to_desktop
+  - console/consoletest_setup
+  - fips/fips_setup
+  - shutdown/shutdown
+conditional_schedule:
+  bootloader:
+    ARCH:
+      s390x:
+        - installation/bootloader_zkvm
+      ppc64le:
+        - installation/bootloader

--- a/schedule/security/openvpn.yaml
+++ b/schedule/security/openvpn.yaml
@@ -3,11 +3,24 @@ description: >
   Maintainer: pdostal.
   openVPN test
 schedule:
+  - '{{bootloader}}'
   - boot/boot_to_desktop
-  - network/setup_multimachine
+  - '{{setup_multimachine}}'
   - '{{fips}}'
   - '{{openvpn}}'
 conditional_schedule:
+  bootloader:
+    ARCH:
+      s390x:
+        - installation/bootloader_zkvm
+      ppc64le:
+        - installation/bootloader
+  setup_multimachine:
+    ARCH:
+      aarch64:
+        - network/setup_multimachine
+      x86_64:
+        - network/setup_multimachine
   fips:
     FIPS_ENABLED:
       1:

--- a/tests/network/openvpn_client.pm
+++ b/tests/network/openvpn_client.pm
@@ -9,7 +9,7 @@
 #  * When connected, we perform the ping, disconnect and wait again
 #  * After server is done, we use SCP to download the root certificate, client certificate and key
 #  * When connected, we perform the ping, and finally disconnect.
-# Maintainer: Pavel Dostál <pdostal@suse.cz>
+# Maintainer: QE Security <none@suse.de>
 
 use base 'consoletest';
 use testapi;
@@ -21,14 +21,23 @@ use utils qw(systemctl zypper_call exec_and_insert_password script_retry);
 use version_utils 'is_sle';
 use strict;
 use warnings;
+use Utils::Architectures;
+use network_utils 'iface';
 
 sub run {
+    my $server_ip = get_var('SERVER_IP', '10.0.2.101');
+    my $client_ip = get_var('CLIENT_IP', '10.0.2.102');
     mutex_wait 'barrier_setup_done';
     barrier_wait 'SETUP_DONE';
     select_serial_terminal;
 
     # Install runtime dependencies
     zypper_call("in iputils");
+
+    # We don't run setup_multimachine in s390x, but we need to know the server and client's
+    # ip address, so we add a known ip to NETDEV
+    my $netdev = iface();
+    assert_script_run("ip addr add $client_ip/24 dev $netdev") if (is_s390x);
 
     # Install openvpn
     zypper_call('in openvpn');
@@ -37,15 +46,15 @@ sub run {
     # Wait for static key and write the client config
     mutex_wait 'OPENVPN_STATIC_KEY';
 
+    # Download key from the server
+    assert_script_run("curl -o static.key $server_ip:8008/static.key");
+    assert_script_run("cat /etc/openvpn/static.key");
+
     # Download the client config
     assert_script_run('curl -o static.conf ' . data_url('openvpn/static_client.conf'));
 
     # Remove unsupported configuration options on older SLE versions
     assert_script_run('sed -i "/^cipher/d; /^data-ciphers/d" static.conf') if (is_sle('<15-sp4'));
-
-    # Download key from the server
-    exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@10.0.2.101:/etc/openvpn/static.key /etc/openvpn/static.key");
-    assert_script_run("cat /etc/openvpn/static.key");
 
     # Start the client when also server is ready and test the connection
     systemctl('start openvpn@static');
@@ -70,15 +79,15 @@ sub run {
     mutex_wait 'OPENVPN_CA_KEYS';
 
     # Write the client config
-    assert_script_run('curl -o ca.conf ' . data_url('openvpn/ca_client.conf'));
+    assert_script_run('curl -o /etc/openvpn/ca.conf ' . data_url('openvpn/ca_client.conf'));
 
     # Remove unsupported configuration options on older SLE versions
     assert_script_run('sed -i "/^cipher/d; /^data-ciphers/d" ca.conf') if (is_sle('<15-sp4'));
 
     # Download key from the server
-    exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@10.0.2.101:/etc/openvpn/pki/ca.crt /etc/openvpn/ca.crt");
-    exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@10.0.2.101:/etc/openvpn/pki/issued/client.crt /etc/openvpn/client.crt");
-    exec_and_insert_password("scp -o StrictHostKeyChecking=no root\@10.0.2.101:/etc/openvpn/pki/private/client.key /etc/openvpn/client.key");
+    assert_script_run("curl -o ca.crt $server_ip:8008/pki/ca.crt");
+    assert_script_run("curl -o client.crt $server_ip:8008/pki/issued/client.crt");
+    assert_script_run("curl -o client.key $server_ip:8008/pki/private/client.key");
 
     # Start the client when also server is ready and test the connection
     systemctl('start openvpn@ca');
@@ -97,6 +106,9 @@ sub run {
     # Stop the client when also server is done
     barrier_wait 'OPENVPN_CA_FINISHED';
     systemctl('stop openvpn@ca');
+
+    # Delete the ip that we added if arch is s390x
+    assert_script_run("ip addr del $client_ip/24 dev $netdev") if (is_s390x);
 }
 
 1;


### PR DESCRIPTION
changes in order to work on s390x to the hdd creation and to the openvpn_client/server tests. Due to CC, port 22 is not possible to use. 

- Related ticket: https://progress.opensuse.org/issues/184249
- Verification run:  
  - Security maintenace:
      -  https://openqa.suse.de/tests/overview?distri=sle&version=15-SP7&build=20250727-1&groupid=611
      - https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&build=20250727-1&groupid=611
  - 16.0:
    - s390x: 
      - https://openqa.suse.de/tests/18577081
      - https://openqa.suse.de/tests/18577085
    - x86_64:
      - https://openqa.suse.de/tests/18552420
      - https://openqa.suse.de/tests/18552449
  - 15-SP7: s390x:
    - https://openqa.suse.de/tests/18481278
    - https://openqa.suse.de/tests/18538957