### PR TITLE
containers: Fix registry test

### DIFF
--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -85,8 +85,7 @@ sub run {
     systemctl '--now enable registry';
     systemctl 'status registry';
 
-    my $curl_opts = "--retry 500";
-    assert_script_run "curl -s $curl_opts http://127.0.0.1:5000/v2/_catalog | grep repositories";
+    validate_script_output_retry("curl -s http://127.0.0.1:5000/v2/_catalog", sub { m/repositories/ }, retry => 3, delay => 5, timeout => 300);
 
     my $engine = $self->containers_factory($runtime);
     my $image = 'registry.opensuse.org/opensuse/busybox';


### PR DESCRIPTION
Fix registry test

We can't rely on curl --retry because we can't use the more recent set of --retry-xxx options as they're not available on older products.

- Related ticket: https://progress.opensuse.org/issues/186391
- Failed test: https://openqa.suse.de/tests/18589675#step/docker_registry/17
- Verification run: https://openqa.suse.de/tests/18591171
