### PR TITLE
containers: Use whole utils module

### DIFF
--- a/tests/containers/firewall.pm
+++ b/tests/containers/firewall.pm
@@ -12,7 +12,7 @@ use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use utils 'script_retry';
+use utils;
 use containers::common 'check_containers_connectivity';
 use Utils::Systemd 'systemctl';
 


### PR DESCRIPTION
Fix missing validate_script_output_retry

Failing test: https://openqa.suse.de/tests/18592773#step/podman_firewall/52