### PR TITLE
Add selinux pattern in agama jsonnet file because of bsc#1247046

### DIFF
--- a/data/autoyast_hanaperf/agama-config.jsonnet
+++ b/data/autoyast_hanaperf/agama-config.jsonnet
@@ -11,7 +11,7 @@
     sshPublicKey: 'enable ssh',
   },
   software: {
-    patterns: ['sles_sap_HADB', 'sles_sap_HAAPP', 'sles_sap_DB', 'sles_sap_APP'],
+    patterns: ['sles_sap_HADB', 'sles_sap_HAAPP', 'sles_sap_DB', 'sles_sap_APP', 'selinux'],
   },
   product: {
     id: '{{AGAMA_PRODUCT_ID}}',


### PR DESCRIPTION
there is a incorrect kernel cmdline "security=" when NOT installing `selinux` pattern, here is the issue:
http://openqa.qa2.suse.asia/tests/85640#step/install_qatestset/10

for the details, please refer to
https://bugzilla.suse.com/show_bug.cgi?id=1247046#c20
https://bugzilla.suse.com/show_bug.cgi?id=1247046#c21

this comment explained why we need to add selinux pattern in agama jsonnet:
https://bugzilla.suse.com/show_bug.cgi?id=1247046#c5

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1247046
- Needles: None
- Verification run:
    http://openqa.qa2.suse.asia/tests/86016