### PR TITLE
add a new test to verify tcpdump

### DIFF
--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -200,4 +200,5 @@ schedule:
     - console/coredump_collect
     - console/valgrind
     - console/sssd_389ds_functional
+    - console/tcpdump
     - console/zypper_log_packages

--- a/schedule/functional/sle16/extra_tests_textmode.yaml
+++ b/schedule/functional/sle16/extra_tests_textmode.yaml
@@ -105,4 +105,5 @@ schedule:
     - console/coredump_collect
     - console/valgrind
     - console/sssd_389ds_functional
+    - console/tcpdump
     - console/zypper_log_packages

--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -39,6 +39,7 @@ schedule:
   - console/cpio
   - console/tar
   - console/ruby
+  - console/tcpdump
   - '{{version_specific}}'
   - console/coredump_collect
 conditional_schedule:

--- a/tests/console/tcpdump.pm
+++ b/tests/console/tcpdump.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: tcpdump
+# Summary: test tcpdump by pinging a localhost and dumping with an icmp filter
+# Maintainer: QE Core <qe-core@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use serial_terminal 'select_serial_terminal';
+
+sub run {
+    my ($self) = @_;
+    my $tcpdump_log_file = "/tmp/tcpdump.log";
+    my $pid_file = '/tmp/tcpdump.pid';
+
+    select_serial_terminal;
+
+    zypper_call "in tcpdump";
+    # Start tcpdump to sniff only icmp loclhost packets in background and do ping
+    script_run("tcpdump -i lo icmp and src localhost -vv > $tcpdump_log_file 2>&1 & echo \$! > $pid_file & sleep 4");
+    assert_script_run("ping -c4 localhost -4 & sleep 4");
+
+    assert_script_run("kill \$(cat $pid_file)");
+    record_info("TEST LOG", script_output("cat $tcpdump_log_file"));
+    validate_script_output("cat $tcpdump_log_file", sub { m/0 packets dropped by kernel/ });
+}
+1;


### PR DESCRIPTION
Verify tcpdump by pinging a localhost and dumping with an icmp filter.

- Related ticket: https://progress.opensuse.org/issues/183911
- Needles: No
- Verification run: 
   15-SP7: [x86_64](http://openqa.suse.de/tests/18604395#step/tcpdump/5) | [s390x](http://openqa.suse.de/tests/18604562#step/tcpdump/5) | [aarch64](http://openqa.suse.de/tests/18604561#step/tcpdump/5)
   15-SP6:  [x86_64](http://openqa.suse.de/tests/18604567#step/tcpdump/5) | [s390x](http://openqa.suse.de/tests/18604566#step/tcpdump/5) | [aarch64](http://openqa.suse.de/tests/18604563#step/tcpdump/5)
    15-SP5:  [x86_64](http://openqa.suse.de/tests/18604572#step/tcpdump/5) | [s390x](http://openqa.suse.de/tests/18604571#step/tcpdump/5) | [aarch64](http://openqa.suse.de/tests/18604568#step/tcpdump/5)
    15-SP4:[x86_64](http://openqa.suse.de/tests/18605428#step/tcpdump/5) | [s390x](http://openqa.suse.de/tests/18604571#step/tcpdump/5) | [aarch64](http://openqa.suse.de/tests/18604568#step/tcpdump/5)
    15-SP3:[x86_64](http://openqa.suse.de/tests/18605432#step/tcpdump/5) | [s390x](http://openqa.suse.de/tests/18605431#step/tcpdump/5) | [aarch64](http://openqa.suse.de/tests/18605426#step/tcpdump/5)
     15-SP2: [x86_64](http://openqa.suse.de/tests/18605433#step/tcpdump/5) 
     12-SP3: [x86_64](http://openqa.suse.de/tests/18605434#step/tcpdump/5)
     16: [x86_64](http://openqa.suse.de/tests/18613536#step/tcpdump/5)
tw: https://openqa.opensuse.org/tests/5212839