### PR TITLE
Exclude SELINUX from supportconfig logs

### DIFF
--- a/data/virt_autotest/virt_logs_collector.sh
+++ b/data/virt_autotest/virt_logs_collector.sh
@@ -105,7 +105,7 @@ while { \${retry_times} > 0 } {
          expect -re "~( |\\\])#"
          if { \${extra_logs} == {support_config} } {
             send "rm -f -r \${logs_folder}/*supportconfig*\r"
-            send "supportconfig -y -A -x aFSLIST,AUDIT -t \${logs_folder} -B guest_\${guest_transformed}_supportconfig_\\\${time_stamp}\r"
+            send "supportconfig -y -A -x aFSLIST,AUDIT,SELINUX -t \${logs_folder} -B guest_\${guest_transformed}_supportconfig_\\\${time_stamp}\r"
          }
          if { \${extra_logs} == {sos_report} } {
             send "rm -f -r \${logs_folder}/*sosreport*\r"
@@ -200,7 +200,7 @@ function collect_system_log_and_diagnosis() {
     	      local time_stamp=`date '+%Y%m%d%H%M%S'`
 	      ${sshpass_ssh_cmd} rm -f -r ${logs_folder}/*supportconfig*
 	      echo -e "${sshpass_ssh_cmd} supportconfig -y -A -x aFSLIST,AUDIT -t ${logs_folder} -B ${target_type}_${target_transformed}_supportconfig_${time_stamp}"
-	      ${sshpass_ssh_cmd} supportconfig -y -A -x aFSLIST,AUDIT -t ${logs_folder} -B ${target_type}_${target_transformed}_supportconfig_${time_stamp}
+	      ${sshpass_ssh_cmd} supportconfig -y -A -x aFSLIST,AUDIT,SELINUX -t ${logs_folder} -B ${target_type}_${target_transformed}_supportconfig_${time_stamp}
 	   fi
 	   ret_result=$?
 	   if [[ ${ret_result} -eq 0 ]];then


### PR DESCRIPTION
* **SELINUX** causes extreme long time of logs collecting by supportconfig, which further leads to timed-out logs collecting. 

* **Excluding** SELINUX from logs collecting is better for test runs.
  * [successful run](https://openqa.suse.de/tests/18603819)
  * [failed run/selinux skipped during logs collecting](https://openqa.suse.de/tests/18603409)

