### PR TITLE
buildah: Try to fix timeouts on slow repo load

### DIFF
--- a/tests/containers/buildah.pm
+++ b/tests/containers/buildah.pm
@@ -41,7 +41,7 @@ sub run_tests {
     # network failure
     if ($runtime eq 'podman') {
         record_info('Test', "Install random package in the container");
-        assert_script_run("buildah run $container -- zypper in -y cowsay", timeout => 300);
+        assert_script_run("buildah run $container -- zypper in -y cowsay", timeout => 600);
         assert_script_run("buildah run $container -- cowsay hello world");
     }
 


### PR DESCRIPTION
As observed in two jobs of today refreshing repos and installing
packages can run into timeout while the operation is still ongoing. I
assume that a high workload in the overall system causes this when
multiple jobs run in parallel stressing the network infrastructure.

Related progress issue: https://progress.opensuse.org/issues/186522