### PR TITLE
Update leftovers from #22809

### DIFF
--- a/tests/console/zypper_ar.pm
+++ b/tests/console/zypper_ar.pm
@@ -19,7 +19,7 @@ sub run {
     select_console 'root-console';
     # Trying to switch to more scalable solution with updated rsync.pl
     if (my $urlprefix = get_var('MIRROR_PREFIX')) {
-        my @repos_to_add = qw(OSS NON_OSS OSS_DEBUG LEAP_MICRO LEAP_OSS LEAP_OSS_DEBUG);
+        my @repos_to_add = qw(OSS NON_OSS OSS_DEBUG LEAP_MICRO);
         my $repourl;
         foreach (@repos_to_add) {
             next unless get_var("REPO_$_");    # Skip repo if not defined

--- a/tests/console/zypper_ar.pm
+++ b/tests/console/zypper_ar.pm
@@ -19,7 +19,7 @@ sub run {
     select_console 'root-console';
     # Trying to switch to more scalable solution with updated rsync.pl
     if (my $urlprefix = get_var('MIRROR_PREFIX')) {
-        my @repos_to_add = qw(OSS NON_OSS OSS_DEBUGINFO LEAP_MICRO LEAP_OSS LEAP_OSS_DEBUG);
+        my @repos_to_add = qw(OSS NON_OSS OSS_DEBUG LEAP_MICRO LEAP_OSS LEAP_OSS_DEBUG);
         my $repourl;
         foreach (@repos_to_add) {
             next unless get_var("REPO_$_");    # Skip repo if not defined


### PR DESCRIPTION
Follows #22809
- **Update leftover OSS_DEBUGINFO to OSS_DEBUG**
- **Sync Leap and Factory variables**

Needs to be merged with https://github.com/os-autoinst/openqa-trigger-from-obs/pull/311

VR (manually set REPO_OSS_DEBUG): https://openqa.opensuse.org/tests/5207495#step/kdump_and_crash/8
