### PR TITLE
containers: Fix container pull on slow network transfers

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -233,7 +233,7 @@ sub check_containers_connectivity {
     my $container_name = 'sut_container';
     my $image = "registry.opensuse.org/opensuse/busybox:latest";
 
-    script_retry "$runtime pull $image", retry => 3, delay => 120;
+    script_retry "$runtime pull $image", timeout => 300, retry => 3, delay => 120;
     assert_script_run "$runtime run -id --rm --name $container_name -p 1234:1234 $image sleep infinity";
     my $container_ip = container_ip $container_name, $runtime;
 


### PR DESCRIPTION
It is reasonable to assume that a container image pull can take longer
than the default 30s timeout. This was observed in at least one case
where the download was only finished by about 30% during a time when SLE
aggregate tests were running in a bunch explaining the slower download
speed.

Related progress issue: https://progress.opensuse.org/issues/186555