### PR TITLE
Kselftests: Improvements for -t native flag as well as known_issues

### DIFF
--- a/tests/kernel/run_kselftests.pm
+++ b/tests/kernel/run_kselftests.pm
@@ -94,9 +94,10 @@ sub postprocess_kselftest_results {
                 arch => get_var('ARCH', ''),
             };
 
-            if ($whitelist->find_whitelist_entry($env, $suite, $test_name)) {
+            my $sanitized_suite_name = (split(':', $suite))[0];
+            if ($whitelist->find_whitelist_entry($env, $sanitized_suite_name, $test_name)) {
                 $self->{result} = 'softfail';
-                record_info("Known issue", "$suite:$test_name marked as softfail");
+                record_info("Known issue", "$sanitized_suite_name:$test_name marked as softfail");
             }
         }
     }


### PR DESCRIPTION
Initial idea was simple: use known_issues approach from the LTP. Specifically: lib/WhiteList.pm.

There are however very specific caveats when it comes to the kernel selftests.

Kernel selftests do not support test exclusion. Basically there are following options in the upstream:
```
  -t | --test COLLECTION:TEST	Run TEST from COLLECTION
  -c | --collection COLLECTION	Run all tests from COLLECTION
```

Tests are often compiled binaries. Those are called TEST looking at the example above. So COLLECTION:TEST is - for instance - cgroup:test_core where test_core is a binary containing 12 individual tests
Openqa kselftestrunner works in the way that the tap output file is parsed and KTAP.pm parser is used to produce the openQA result view for each individual test however runner can't run COLLECTION:TEST:single_test.
This means we can only postprocess the tap output and change is using known_issues/WhiteList.pm

Also the objective is to have reliable test reporting. This means, is the test is known to fail, we should exclude it or report known_issues; basically we do not want to have "red bubbles/failing tests" in the "production" if those tests are known to be faulty and there is no esy fix in sight.

We could exclude the entire COLLECTION:TEST but that would be bad since often times there is a single faulty test and number of other good tests in a given TEST.

All in all in the PR I propose to:
* implement known_issues coming from WhiteList.pm
* enhance the runner to support for -t and -c options so that - if needed - only whitelisted COLLECTION:TEST can be scheduled
* postprocess the tap output so the individual tests for COLLECTION:TEST can be updated with TAP supported TODO keyword 

The above also means that the KTAP.pm parser will need to be updated to recognize TODO keyword (I am on that)

- Related ticket: https://progress.opensuse.org/issues/182363
- Verification run: 
VR for the -t option, so we run whitelisted COLLECTION:TEST. KSELFTESTS_SUITE set to: cgroup:test_core,cgroup:test_zswap -> https://openqa.suse.de/tests/18605391
VR for the -c option, so we run COLLECTION, KSELFTESTS_SUITE set to: cgroup -> https://openqa.suse.de/tests/18605395
VR for the -c option, KSELFTESTS_SUITE set to: cgroup:test_core,cgroup:test_zswap but the known_issue file updated, so all zswap tests prone to fail should be marked with the keyword TODO: https://openqa.suse.de/tests/18605408