### PR TITLE
Ensure creation of the "after install" snapshot was removed

### DIFF
--- a/schedule/yam/agama.yaml
+++ b/schedule/yam/agama.yaml
@@ -13,4 +13,5 @@ schedule:
   - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
   - yam/validate/validate_hostname
+  - yam/validate/validate_snapshot
   - console/validate_repos

--- a/schedule/yam/agama_unattended.yaml
+++ b/schedule/yam/agama_unattended.yaml
@@ -11,6 +11,7 @@ schedule:
   - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
   - yam/validate/validate_hostname
+  - yam/validate/validate_snapshot
   - console/validate_repos
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown

--- a/tests/yam/validate/validate_snapshot.pm
+++ b/tests/yam/validate/validate_snapshot.pm
@@ -1,0 +1,24 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Validate that the snapshot "after install" is not present.
+
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    select_console 'root-console';
+
+    my $snapper_description = script_output("snapper list --columns description");
+    if ($snapper_description =~ /after\sinstallation/) {
+        die "After installation snapshot is present, check log";
+    }
+}
+
+1;


### PR DESCRIPTION
We have added a validation that check if after install snapshot is present or not.

- Related ticket: https://progress.opensuse.org/issues/185356
- Needles: N/A
- Verification run: 
  - unattended: https://openqa.suse.de/tests/18604767
  - interactive: https://openqa.suse.de/tests/18604770
