### PR TITLE
SDAF Show terraform version

### DIFF
--- a/tests/sles4sap/sap_deployment_automation_framework/configure_deployer.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/configure_deployer.pm
@@ -52,6 +52,9 @@ sub run {
     my $subscription_id = az_login();
     set_common_sdaf_os_env(subscription_id => $subscription_id);
     prepare_sdaf_project();
+    my $tf_version_out = script_output('terraform -v');
+    $tf_version_out =~ /Terraform\s(v\.*)/;
+    record_info("Terraform $1", $tf_version_out);
     record_info('Jumphost ready');
 
     # Do not leave connection hanging around between modules.


### PR DESCRIPTION
Current tests lack screen which would present terraform version being used. This PR adds a 'record_info' screen showing it in results.

Ticket: https://jira.suse.com/browse/TEAM-10523

Verification run: 
https://openqaworker15.qa.suse.cz/tests/334968#step/configure_deployer/299


