### PR TITLE
containers: Use serial console to avoid poo#186561

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -107,7 +107,7 @@ sub install_docker_multiplatform {
 
     my $pkg_name = check_var("CONTAINERS_DOCKER_FLAVOUR", "stable") ? "docker-stable" : "docker";
     if (is_transactional) {
-        select_console 'root-console';
+        select_serial_terminal;
         trup_call("pkg install $pkg_name");
         check_reboot_changes;
         return;


### PR DESCRIPTION
Use serial terminal instead of root-console in container tests.

- Related ticket: https://progress.opensuse.org/issues/186561
- Verification run: https://openqa.suse.de/tests/18605717