### PR TITLE
Fix screen freeze in ppc64le Power10

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -854,6 +854,7 @@ sub activate_console {
         else {
             # on s390x we need to login here by providing a password
             handle_password_prompt if is_s390x;
+            send_key_until_needlematch('inst-console', 'ret') if is_ppc64le && is_agama;
             assert_screen "inst-console";
         }
     }


### PR DESCRIPTION
We have added a minor fix (Include a return carriage key push) to avoid screen freeze in power 10 tests.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/18605536 (agama_arrange passed the screen)
  - https://openqa.suse.de/tests/18605860 (another try)
