### PR TITLE
Change the fetch file playbook

### DIFF
--- a/data/sles4sap/fetch_file.yaml
+++ b/data/sles4sap/fetch_file.yaml
@@ -5,8 +5,18 @@
     local_path: '/tmp/ansible_fetch_output/'
     file: 'testout.txt'
   tasks:
-  - name: fetch
-    fetch:
-      flat: yes
+  - name: Get remote file size
+    stat:
+      path: "{{ remote_path }}{{ file }}"
+    register: logfile_stats
+
+  - name: Print remote file size
+    debug:
+      msg: "File size: {{ logfile_stats.stat.size }} bytes."
+
+  - name: Download the remote file
+    ansible.posix.synchronize:
+      mode: pull
       src: "{{ remote_path }}{{ file }}"
       dest: "{{ local_path }}"
+    delegate_to: localhost


### PR DESCRIPTION
Change the playbook used by qesap to download logs:
- Print the file size before to download it
- Download using ansible.posix.synchronize

- Related ticket: https://jira.suse.com/browse/TEAM-10543

# Verification run:
sle-15-SP7-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_7_PAYG-qesap_azure_saptune_test_msi
 - http://openqaworker15.qa.suse.cz/tests/335259 :green_circle: here how it looks like in action http://openqaworker15.qa.suse.cz/tests/335259/logfile?filename=serial_terminal.txt#line-28063
  
sle-15-SP6-HanaSr-Aws-Payg-x86_64-Build15-SP6_2025-08-01T02:03:22Z-hanasr_aws_test_fencing_native_baremetal ec2_r5b.metal
-  http://openqaworker15.qa.suse.cz/tests/335260