### PR TITLE
kdump_utils: Clear screen before system crash

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -361,6 +361,8 @@ sub kdump_is_active {
 }
 
 sub do_kdump {
+    # clear screen
+    assert_script_run "reset";
     # get dump
     script_run "echo c > /proc/sysrq-trigger", 0;
 }


### PR DESCRIPTION
Clear the screen to ensure proper needle matching during boot on slower systems.

- Related ticket: none
- Needles: none
- Verification run: 
Micro: https://openqa.suse.de/tests/18613269#step/kdump/44
TW:
SLE16:
SLE15:
