### PR TITLE
Remove jeos-locale needle check for WSL Tumbleweed

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -243,8 +243,8 @@ sub run {
 
     # kiwi-templates-JeOS images except of 12sp5 and community jeos are build w/o translations
     # jeos-firstboot >= 0.0+git20200827.e920a15 locale warning dialog has been removed
-    # system locale is present in WSL with jeos-firstboot
-    if (is_community_jeos || is_sle('=12-sp5') || get_var('WSL_VERSION')) {
+    # system locale is present in WSL with jeos-firstboot except in WSL Tumbleweed
+    if (is_community_jeos || is_sle('=12-sp5') || (!is_tumbleweed && get_var('WSL_VERSION'))) {
         assert_screen 'jeos-locale', 300;
         send_key_until_needlematch "jeos-system-locale-$lang", $locale_key{$lang}, 51;
         send_key 'ret';


### PR DESCRIPTION
WSL Tumbleweed contains only glibc-locale-base locale package, which only contains English locale, and therefore we have no locale choices during installation.
We need to remove jeos-locale checks for Tumblweed installations to allow the tests to proceed.

- Related ticket: https://progress.opensuse.org/issues/186552

- Verification run: 

✅ Leap: Checks for system locale  https://openqa.opensuse.org/tests/5209641#step/firstrun/7
✅ TW:  Does not check for system locale https://openqa.opensuse.org/tests/5209642#step/firstrun/6
✅ SLES: Checks for system locale https://openqa.suse.de/tests/18613747#step/firstrun/5
✅ Minimal VM jeos-main: works as expected:  https://openqa.suse.de/tests/18613929
