### PR TITLE
Add a condition for sle16 ppc64le gnome testing

### DIFF
--- a/tests/yam/agama/agama_auto.pm
+++ b/tests/yam/agama/agama_auto.pm
@@ -22,7 +22,7 @@ sub run {
 
     $self->upload_agama_logs() unless is_hyperv();
 
-    (is_s390x() || is_ppc64le() || is_pvm() || is_vmware()) ?
+    (is_s390x() || (is_ppc64le() && check_var("DESKTOP", "textmode")) || is_pvm() || is_vmware()) ?
       # reboot via console
       power_action('reboot', keepconsole => 1, first_reboot => 1) :
       # graphical reboot


### PR DESCRIPTION
To fix issue: https://openqa.suse.de/tests/18605832#step/agama_auto/30
The issue is caused by the changes in [PR#22721](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22721/files), I add a condition for desktop setting.

Verification run:  
- sles_gnome_unattended: https://openqa.suse.de/tests/18624215
- create_hdd_textmode: https://openqa.suse.de/tests/18624216
- installation without DESKTOP setting:  https://openqa.suse.de/tests/18624219