### PR TITLE
microos: no longer expect issue-generator to be running

### DIFF
--- a/tests/microos/services_enabled.pm
+++ b/tests/microos/services_enabled.pm
@@ -14,7 +14,7 @@ use utils;
 use testapi;
 
 my %services_for = (
-    default => [qw(sshd issue-generator issue-add-ssh-keys transactional-update.timer)],
+    default => [qw(sshd transactional-update.timer)],
     cloud => [qw(cloud-init-local cloud-init cloud-config cloud-final)],
     cluster => [qw(chronyd)],
     admin => [qw(docker kubelet etcd)],


### PR DESCRIPTION
agetty gained the functionality to print issue files directly

- Related ticket: N/A (related to https://build.opensuse.org/requests/1296560)
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/5209953 ![VR](https://openqa.opensuse.org/tests/5209953/badge)
