### PR TITLE
Remove sles_or_sled selection check from WSL TW and Leap

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -277,9 +277,9 @@ sub run {
     # Enter password & Confirm
     enter_root_passwd;
 
-    # In WSL: Choose SLES or SLED
+    # In sle WSL: Choose SLES or SLED
     # And register via SCC
-    if (get_var('WSL_VERSION')) {
+    if (is_sle && get_var('WSL_VERSION')) {
         wsl_choose_sles;
         register_via_scc;
     }


### PR DESCRIPTION
jeos-firstrun asks whether we will choose sles or sled installation. Logically, this should not be checked for in TW and Leap.

- Related ticket: https://progress.opensuse.org/issues/186645

- Verification run: 


