### PR TITLE
publiccloud: Fix run_ltp for build-less tests

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -232,7 +232,7 @@ sub gen_ltp_env {
     my ($instance, $ltp_pkg) = @_;
     my $environment = {
         product => get_required_var('DISTRI') . ':' . get_required_var('VERSION'),
-        revision => get_required_var('BUILD'),
+        revision => get_var('BUILD', ''),
         arch => get_var('PUBLIC_CLOUD_ARCH', get_required_var("ARCH")),
         kernel => $instance->run_ssh_command(cmd => 'uname -r'),
         backend => get_required_var('BACKEND'),


### PR DESCRIPTION
Trying to call openqa-investigate from
https://github.com/os-autoinst/scripts/blob/master/openqa-investigate I
encountered failed openQA jobs merely for the reason that the BUILD
variable is unset so that openQA investigation jobs outside production
job history can be created. This commit replaces the unnecessarily
restrictive "get_required_var" with a sane default value of an empty
string for the build value which is only used to print for debugging
purposes anyway.

Verification run:
```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22834 https://openqa.suse.de/tests/18753449
```

* https://openqa.suse.de/tests/18768501

Related progress issue: https://progress.opensuse.org/issues/186648