### PR TITLE
rabbitmq: Enable on SLE16 & update

### DIFF
--- a/schedule/functional/sle16/extra_tests_textmode2.yaml
+++ b/schedule/functional/sle16/extra_tests_textmode2.yaml
@@ -32,5 +32,6 @@ schedule:
     - console/orphaned_packages_check
     - console/consoletest_finish
     - console/zypper_log_packages
+    - console/rabbitmq
     - network/samba/samba_adcli
     - shutdown/shutdown

--- a/schedule/functional/stack_tests_python.yaml
+++ b/schedule/functional/stack_tests_python.yaml
@@ -23,7 +23,6 @@ conditional_schedule:
         - console/python_pycairo
         - console/django
         - '{{python_liblouis}}'
-        - console/rabbitmq
   version_specific:
     VERSION:
       15-SP7:
@@ -38,7 +37,6 @@ conditional_schedule:
         - console/python_pycairo
         - console/django
         - '{{python_liblouis}}'
-        - console/rabbitmq
       15-SP6:
         - console/python3_new_version_check
         - console/python3_setuptools
@@ -51,7 +49,6 @@ conditional_schedule:
         - console/python_pycairo
         - console/django
         - '{{python_liblouis}}'
-        - console/rabbitmq
       15-SP5:
         - console/python3_new_version_check
         - console/python3_setuptools
@@ -64,7 +61,6 @@ conditional_schedule:
         - console/python_pycairo
         - console/django
         - '{{python_liblouis}}'
-        - console/rabbitmq
       15-SP4:
         - console/python3_new_version_check
         - console/python3_setuptools
@@ -77,7 +73,6 @@ conditional_schedule:
         - console/python_pycairo
         - console/django
         - '{{python_liblouis}}'
-        - console/rabbitmq
       15-SP3:
         - console/python_flake8
         - console/django

--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -45,6 +45,7 @@ conditional_schedule:
   version_specific:
     VERSION:
       15-SP7:
+        - console/rabbitmq
         - console/chrony
         - console/openssl_nodejs
         - console/golang
@@ -53,6 +54,7 @@ conditional_schedule:
         - qe-core/systemd/journal_remote
         - '{{arch_specific}}'
       15-SP6:
+        - console/rabbitmq
         - console/chrony
         - console/openssl_nodejs
         - console/golang
@@ -61,6 +63,7 @@ conditional_schedule:
         - qe-core/systemd/journal_remote
         - '{{arch_specific}}'
       15-SP5:
+        - console/rabbitmq
         - console/chrony
         - console/openssl_nodejs
         - console/golang
@@ -68,6 +71,7 @@ conditional_schedule:
         - console/ansible
         - '{{arch_specific}}'
       15-SP4:
+        - console/rabbitmq
         - console/chrony
         - console/openssl_nodejs
         - console/golang
@@ -75,12 +79,14 @@ conditional_schedule:
         - console/ansible
         - '{{arch_specific}}'
       15-SP3:
+        - console/rabbitmq
         - console/chrony
         - console/openssl_nodejs
         - console/golang
         - console/redis
         - '{{arch_specific}}'
       15-SP2:
+        - console/rabbitmq
         - console/chrony
         - console/openssl_nodejs
         - console/golang


### PR DESCRIPTION
python3-pika not found on SLE16 https://dzedro.suse.cz/tests/2881#step/rabbitmq/23
-use serial terminal
-use go instead of python, python3-pika not found on SLE16
-no reason to schedule test on stack_tests_python with python3-pika or without

- Related ticket: https://progress.opensuse.org/issues/182075
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&build=jpupava_rabbitmq
