### PR TITLE
Unschedule test_console_redirection

### DIFF
--- a/schedule/sles4sap/qesapdeploy/qesap.yml
+++ b/schedule/sles4sap/qesapdeploy/qesap.yml
@@ -12,5 +12,4 @@ schedule:
     - sles4sap/qesapdeployment/test_cluster
     - sles4sap/qesapdeployment/test_mirror
     - sles4sap/qesapdeployment/test_crash
-    - sles4sap/qesapdeployment/test_console_redirection
     - sles4sap/qesapdeployment/destroy


### PR DESCRIPTION
Temporary unschedule this test as it fails frequently in GCP resulting in many leftover resources.

- Related ticket: [TEAM-10520](https://jira.suse.com/browse/TEAM-10520) [TEAM-10525](https://jira.suse.com/browse/TEAM-10525)
