### PR TITLE
containers: Use serial terminal instead of console to fix poo#186669

### DIFF
--- a/tests/containers/rootless_docker.pm
+++ b/tests/containers/rootless_docker.pm
@@ -18,7 +18,7 @@ use strict;
 use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
-use serial_terminal 'select_serial_terminal';
+use serial_terminal;
 use utils;
 use containers::common;
 use containers::docker;
@@ -55,7 +55,7 @@ sub run {
     # already exists owned by root
     assert_script_run 'rm -rf /tmp/script*';
     ensure_serialdev_permissions;
-    select_console "user-console";
+    select_user_serial_terminal;
 
     # https://docs.docker.com/engine/security/rootless/
     assert_script_run "dockerd-rootless-setuptool.sh install";


### PR DESCRIPTION
Use serial terminal instead of console.

- Related ticket: https://progress.opensuse.org/issues/186669
- Failed job: https://openqa.suse.de/tests/18612550#step/rootless_docker/155
- Verification run: https://openqa.suse.de/tests/18625001