### PR TITLE
Collect SELinux AVCs in HA tests

### DIFF
--- a/lib/haclusterbasetest.pm
+++ b/lib/haclusterbasetest.pm
@@ -17,6 +17,7 @@ use hacluster qw(ha_export_logs);
 use Utils::Logging qw(export_logs);
 use version_utils 'is_sle';
 use x11utils qw(ensure_unlocked_desktop);
+use Utils::Logging qw(record_avc_selinux_alerts);
 
 =head1 SYNOPSIS
 
@@ -54,6 +55,7 @@ sub post_run_hook {
     my ($self) = @_;
     record_info(__PACKAGE__ . ':' . 'post_run_hook' . ' ' . "prev_console=$prev_console");
 
+    $self->record_avc_selinux_alerts() if is_sle('16+');
     return unless ($prev_console);
     select_console($prev_console, await_console => 0);
     if ($prev_console eq 'x11') {


### PR DESCRIPTION
In 30e1f5ef9174569b3b40a9c9480eea5819480eca we introduced AVC collection on SLES for SAP and HA tests on SLE 16.0. This was however temporarily removed in f9c0378c9767f9e1ed47366a530b0ee2dd980606 for HA tests.

In the meantime, we introduced a base class for HA tests in bf9b2109cb50f6a11ad8c1f831cd3ba5c11aa2ae, so we can reeanable AVC collection in HA test more cleanly.

This commit does it.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.qe.nue2.suse.org/tests/7048, http://mango.qe.nue2.suse.org/tests/7047, http://mango.qe.nue2.suse.org/tests/7045, http://mango.qe.nue2.suse.org/tests/7044, http://mango.qe.nue2.suse.org/tests/7042, http://mango.qe.nue2.suse.org/tests/7050, http://mango.qe.nue2.suse.org/tests/7049
- P.S.: 2 node failure in `drbd_passive` is expected. It's part of the reason to re-enable AVC collection, as the previous 2 drbd_passive bugs were related to SELinux.
