### PR TITLE
containers: Drop soft-failure for bsc#1211774

### DIFF
--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -70,9 +70,6 @@ sub is_container_running {
     foreach my $cont (@containers) {
         if ($out =~ m/$cont/) {
             next;
-        } elsif (is_sle_micro) {
-            record_soft_failure('bsc#1211774 - podman fails to start container with SELinux');
-            return 0;
         } else {
             die "Container $cont is not running!";
         }


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1211774 was fixed exactly 1 year ago and no soft-failure is seen on SLEM 5.1:

https://openqa.suse.de/tests/overview?distri=sle-micro&version=5.1&build=20250731-1&groupid=420