### PR TITLE
containers: Drop soft-failure for bsc#1211917

### DIFF
--- a/tests/transactional/enable_selinux.pm
+++ b/tests/transactional/enable_selinux.pm
@@ -58,11 +58,7 @@ sub run {
     # install and enable SELinux if not done by default
     if (!is_enforcing) {
         if (has_selinux_by_default) {
-            if (is_sle_micro('=5.4')) {
-                record_soft_failure("bsc#1211917 - SELinux not in enforcing mode on SLEM 5.4");
-            } else {
-                die("SELinux should be enabled by default on " . get_required_var("DISTRI") . " " . get_required_var("VERSION"));
-            }
+            die("SELinux should be enabled by default on " . get_required_var("DISTRI") . " " . get_required_var("VERSION"));
         }
 
         trup_call('setup-selinux');


### PR DESCRIPTION
Drop soft-failure for https://bugzilla.suse.com/show_bug.cgi?id=1211917 which is fixed for SLEM 5.4:
https://openqa.suse.de/tests/overview?distri=sle-micro&version=5.4&build=20250731-1&groupid=420