### PR TITLE
containers: Drop soft-failure for bsc#1211058

### DIFF
--- a/tests/transactional/enable_selinux.pm
+++ b/tests/transactional/enable_selinux.pm
@@ -44,12 +44,6 @@ sub is_enforcing {
 sub run {
     select_console 'root-console';
 
-    # Until bsc#1211058 is resolved, we cannot enable SELinux via `transactional-update setup-selinux`.
-    if (is_sle_micro('=5.2')) {
-        record_soft_failure("bsc#1211058 Enabling SELinux broken via transactional-update setup-selinux");
-        return;
-    }
-
     my $trup_log = "/var/log/transactional-update.log";
 
     # auditd should be enabled


### PR DESCRIPTION
Drop soft-failure for https://bugzilla.suse.com/show_bug.cgi?id=1211058

NOTE: We need to move the `enable_selinux` module after `install_updates`

- Verification run: https://openqa.suse.de/tests/18626322