### PR TITLE
Add validation for /etc/SUSEConnect using inst.register_url

### DIFF
--- a/schedule/yam/agama_rmt_unattended.yaml
+++ b/schedule/yam/agama_rmt_unattended.yaml
@@ -8,3 +8,4 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - console/validate_repos
+  - yam/validate/validate_suseconnect_register_url

--- a/schedule/yam/agama_rmt_unattended_ppc64le.yaml
+++ b/schedule/yam/agama_rmt_unattended_ppc64le.yaml
@@ -9,3 +9,4 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - console/validate_repos
+  - yam/validate/validate_suseconnect_register_url

--- a/schedule/yam/agama_rmt_unattended_s390x.yaml
+++ b/schedule/yam/agama_rmt_unattended_s390x.yaml
@@ -9,3 +9,4 @@ schedule:
   - boot/reconnect_mgmt_console
   - installation/first_boot
   - console/validate_repos
+  - yam/validate/validate_suseconnect_register_url

--- a/tests/yam/validate/validate_suseconnect_register_url.pm
+++ b/tests/yam/validate/validate_suseconnect_register_url.pm
@@ -1,0 +1,24 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Validate SUSEConnect after using "inst.register_url".
+
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    select_console 'root-console';
+    my $suse_connect = script_output("cat /etc/SUSEConnect");
+    record_info("cat /etc/SUSEConnect", $suse_connect);
+    my $scc_url = get_var('SCC_URL', 'https://scc.suse.com');
+    validate_script_output("cat /etc/SUSEConnect", sub { m/\b$scc_url\b/ });
+}
+
+1;


### PR DESCRIPTION
- Related ticket: [poo#184474](https://progress.opensuse.org/issues/184474)
- Verification run: [Online|agama-installer](https://openqa.suse.de/tests/overview?build=issues-184474)
