### PR TITLE
containers: Remove soft-failure for bsc#1196801

### DIFF
--- a/tests/containers/multi_runtime.pm
+++ b/tests/containers/multi_runtime.pm
@@ -114,7 +114,6 @@ sub run {
     # - https://fedoraproject.org/wiki/Changes/NetavarkNftablesDefault#Known_Issue_with_docker
     # - https://docs.docker.com/engine/network/packet-filtering-firewalls/#docker-on-a-router
     if (script_run("iptables -L -v | grep -q DOCKER") == 0) {
-        record_soft_failure("bsc#1196801");
         script_run "iptables -I DOCKER-USER -j ACCEPT";
         script_run "ip6tables -I DOCKER-USER -j ACCEPT";
     }


### PR DESCRIPTION
Remove soft-failure for https://bugzilla.suse.com/show_bug.cgi?id=1196801

This bug is fixed and it never made sense to add a soft-failure for it.