### PR TITLE
Use ADDONS_REGCODE to get the variable name

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -21,7 +21,7 @@ use testapi;
 use utils;
 use version_utils qw(is_sle is_public_cloud get_version_id is_transactional is_openstack is_sle_micro check_version);
 use transactional qw(reboot_on_changes trup_call process_reboot);
-use registration qw(get_addon_fullname add_suseconnect_product);
+use registration qw(get_addon_fullname add_suseconnect_product %ADDONS_REGCODE);
 use maintenance_smelt qw(is_embargo_update);
 
 # Indicating if the openQA port has been already allowed via SELinux policies
@@ -136,7 +136,8 @@ sub register_addon {
     assert_script_run 'source /tmp/os-release';
 
     if ($addon =~ /ltss/) {
-        ssh_add_suseconnect_product($remote, get_addon_fullname($addon), program => $program, version => '${VERSION_ID}', arch => $arch, params => "-r " . get_required_var('SCC_REGCODE_LTSS'), timeout => $timeout, retries => $retries, delay => $delay);
+        my $name = get_addon_fullname($addon);
+        ssh_add_suseconnect_product($remote, $name, program => $program, version => '${VERSION_ID}', arch => $arch, params => "-r " . $ADDONS_REGCODE{$name}, timeout => $timeout, retries => $retries, delay => $delay);
     } elsif (is_ondemand) {
         record_info($addon, 'This is on demand image, we will not register this addon.');
         return;


### PR DESCRIPTION
Use the table from registration library to get the name of the variable that is supposed to store the registration code associated to the selected addons.


- Related ticket: https://jira.suse.com/browse/TEAM-10547

# Verification run:

 - sle-15-SP5-Azure-BYOS-Hardened-Incidents-Ext-x86_64-Build:39880:cloud-regionsrv-client-publiccloud_img_proof az_Standard_B2s -> http://openqaworker15.qa.suse.cz/tests/335668

## SLES4SAP

### 12sp5

sle-12-SP5-Azure-SAP-BYOS-Incidents-saptune-x86_64-Build:39881:cloud-regionsrv-client-sles4sap_gnome_saptune_delete_rename az_Standard_E4s_v3  with `PUBLIC_CLOUD_SCC_ENDPOINT=SUSEConnect` and LTSS-ES
- http://openqaworker15.qa.suse.cz/tests/335296 :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/335660 registration command is at http://openqaworker15.qa.suse.cz/tests/335660#step/registration/22 and http://openqaworker15.qa.suse.cz/tests/335660#step/registration/39 :green_circle:  (job failure is not related to the PR change)

sle-12-SP5-Azure-SAP-PAYG-Incidents-saptune-x86_64-Build:39881:cloud-regionsrv-client-sles4sap_gnome_saptune_delete_rename az_Standard_E4s_v3 it is LTSS
 -  http://openqaworker15.qa.suse.cz/tests/335659 :green_circle:  http://openqaworker15.qa.suse.cz/tests/335659#step/registration/24


### 15sp7 

https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=15-SP7&build=%3A39611%3Asystemd&groupid=62 :green_circle: 