### PR TITLE
Pubcloud wait_for_ssh fix IP-CHANGED condition block

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -410,8 +410,8 @@ sub wait_for_ssh {
         # skip SLES4SAP as incompatible with get_public_ip
         if (($duration >= $args{timeout} - 30) and (!get_var('PUBLIC_CLOUD_SLES4SAP'))) {
             my $public_ip_from_provider = $self->provider->get_public_ip();
-            if ($args{public_ip} eq $public_ip_from_provider) {
-                record_info('IP CHANGED', printf("The address we know is %s but provider returns %s", $args{public_ip}, $public_ip_from_provider));
+            if ($args{public_ip} ne $public_ip_from_provider) {
+                record_info('IP CHANGED', "The address we know is $args{public_ip} but provider returns $public_ip_from_provider");
             }
         }
 


### PR DESCRIPTION
Set not-equal in if-expression and correctly print internal message of record_info

- Related ticket: https://progress.opensuse.org/issues/186717

- Verification run: see PR posts
