### PR TITLE
bats: Install ncat only when required by package module

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -234,6 +234,12 @@ sub bats_setup {
 
     enable_modules if is_sle;
 
+    my $install_ncat = 0;
+    if (grep { $_ eq "ncat" } @pkgs) {
+        $install_ncat = 1;
+        @pkgs = grep { $_ ne "ncat" } @pkgs;
+    }
+
     # Install tests dependencies
     my $oci_runtime = get_var("OCI_RUNTIME", "");
     if ($oci_runtime && !grep { $_ eq $oci_runtime } @pkgs) {
@@ -243,7 +249,7 @@ sub bats_setup {
 
     configure_oci_runtime $oci_runtime;
 
-    install_ncat if (get_required_var("BATS_PACKAGE") =~ /^aardvark-dns|netavark|podman$/);
+    install_ncat if $install_ncat;
 
     install_git;
 

--- a/tests/containers/bats/aardvark.pm
+++ b/tests/containers/bats/aardvark.pm
@@ -35,7 +35,7 @@ sub run {
     select_serial_terminal;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns firewalld iproute2 jq netavark podman);
+    my @pkgs = qw(aardvark-dns firewalld iproute2 jq ncat netavark podman);
     if (is_tumbleweed || is_sle('>=16.0')) {
         push @pkgs, qw(dbus-1-daemon);
     } elsif (is_sle) {

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -31,7 +31,7 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    my @pkgs = qw(aardvark-dns cargo firewalld iproute2 jq make protobuf-devel netavark);
+    my @pkgs = qw(aardvark-dns cargo firewalld iproute2 jq make ncat protobuf-devel netavark);
     if (is_tumbleweed || is_sle('>=16.0')) {
         push @pkgs, qw(dbus-1-daemon);
     } elsif (is_sle) {

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -51,7 +51,7 @@ sub run {
     select_serial_terminal;
 
     my @pkgs = qw(aardvark-dns apache2-utils buildah catatonit glibc-devel-static go1.24 gpg2 jq libgpgme-devel
-      libseccomp-devel make netavark openssl podman podman-remote python3-PyYAML skopeo socat sudo systemd-container xfsprogs);
+      libseccomp-devel make ncat netavark openssl podman podman-remote python3-PyYAML skopeo socat sudo systemd-container xfsprogs);
     push @pkgs, qw(criu libcriu2) if is_tumbleweed;
     # Needed for podman machine
     if (is_x86_64) {


### PR DESCRIPTION
Since https://github.com/containers/netavark/pull/1287 netavark (and perhaps aardvark-dns & podman) too will ditch Nmap's ncat for their own helper function.

We need to detect the package version from each package test module to add this ncat dependency on demand.

- Verification run: https://openqa.opensuse.org/tests/5216760