### PR TITLE
Shutdown PVM setup when test completes

### DIFF
--- a/schedule/functional/sle16/agama-create-hdd-textmode_pvm.yaml
+++ b/schedule/functional/sle16/agama-create-hdd-textmode_pvm.yaml
@@ -8,3 +8,4 @@ schedule:
     - installation/grub_test
     - installation/first_boot
     - console/system_prepare
+    - shutdown/shutdown


### PR DESCRIPTION
https://progress.opensuse.org/issues/186459

- Verification run: https://openqa.suse.de/tests/18654402#

As discussed offline, I will file another PR for function `shutdown_pvm_hmc`, and this one should only focus on shutdown the setup after successfully run