### PR TITLE
Fix qnetd/qdevice test on powervm

### DIFF
--- a/schedule/ha/bv/pvm_ha_qdevice_node.yaml
+++ b/schedule/ha/bv/pvm_ha_qdevice_node.yaml
@@ -5,7 +5,7 @@ description:    >
   Schedule for qdevice/qnetd test cluster nodes. Use HA_CLUSTER_INIT setting
   in the job group so the schedule loads the tests for a node running
   ha-cluster-init or for nodes running ha-cluster-join. Cluster nodes must be
-  run along a support server and a qnetd server. Some settings are defined
+  run along a qnetd server. Some settings are defined
   here in the schedule, while others are required outside the schedule.
 
   The following settings must be defined outside of the schedule, either in
@@ -21,7 +21,7 @@ description:    >
 vars:
   DESKTOP: textmode
   HA_CLUSTER: "1"
-  # Number of nodes. This setting must match CLUSTER_INFOS in the support server job
+  # Number of nodes.
   NUM_NODES: "2"
   QDEVICE: "1"
   # qdevice test role is client in the cluster nodes and qnetd_server in the server
@@ -32,6 +32,7 @@ schedule:
   - installation/agama_reboot
   - installation/first_boot
   - console/system_prepare
+  - ha/check_hae_active.py
   - console/consoletest_setup
   - console/check_os_release
   - console/hostname
@@ -59,4 +60,5 @@ conditional_schedule:
   boot:
     HA_CLUSTER_INIT:
       no:
-        - boot/boot_to_desktop
+        - boot/reconnect_mgmt_console
+        - installation/first_boot

--- a/schedule/ha/bv/pvm_ha_qnetd_server.yaml
+++ b/schedule/ha/bv/pvm_ha_qnetd_server.yaml
@@ -19,7 +19,7 @@ vars:
   DESKTOP: textmode
   HA_CLUSTER: "1"
   HOSTNAME: "%CLUSTER_NAME%-node03"
-  # Number of nodes. This setting is required here and in the support server job
+  # Number of nodes.
   NUM_NODES: "2"
   # qdevice test role is qnetd_server here and client in the cluster nodes
   QDEVICE_TEST_ROLE: qnetd_server
@@ -32,4 +32,5 @@ schedule:
   - console/check_os_release
   - console/hostname
   - ha/firewall_disable
+  - ha/setup_hosts_and_luns
   - ha/qnetd

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -37,9 +37,13 @@ sub run {
             # modules use them, we create them here as well for the scenarios without supportserver
             mutex_create($_) foreach ('iscsi', 'support_server_ready');
             barrier_create("BARRIER_HA_$cluster_name", $num_nodes);
-            barrier_create("BARRIER_HA_NFS_SUPPORT_DIR_SETUP_$cluster_name", $num_nodes);
-            barrier_create("BARRIER_HA_HOSTS_FILES_READY_$cluster_name", $num_nodes);
-            barrier_create("BARRIER_HA_LUNS_FILES_READY_$cluster_name", $num_nodes);
+            # For the qnetd/qdevice test without support-server scenario (e.g. on powervm),
+            # we need to run 'setup_hosts_and_luns' on the qnetd server node as well,
+            # so an extra barrier is needed.
+            my $qnetd_num_nodes = get_var('QDEVICE') ? $num_nodes + 1 : $num_nodes;
+            barrier_create("BARRIER_HA_NFS_SUPPORT_DIR_SETUP_$cluster_name", $qnetd_num_nodes);
+            barrier_create("BARRIER_HA_HOSTS_FILES_READY_$cluster_name", $qnetd_num_nodes);
+            barrier_create("BARRIER_HA_LUNS_FILES_READY_$cluster_name", $qnetd_num_nodes);
             barrier_create("BARRIER_HA_NONSS_FILES_SYNCED_$cluster_name", $num_nodes);
         }
         else {


### PR DESCRIPTION
For the qnetd/qdevice test, all previous tests are run with support server.

On SLE16, for ppc64, we are using powervm instead of qemu, so we are using QE-SAP infra instead of support server for NFS/iscsi.

In ha_cluster_init test, we can not get the IP of qnetd server, because we do not have DHCP from support server, unlike previous test scenarios.

We can solve this issue by scheduling test `setup_hosts_and_luns` for the qnetd server as well, so that the qnetd server IP is written to /etc/hosts and synced to all nodes.

- Related ticket: https://jira.suse.com/browse/TEAM-10546
- Needles: none
- Verification run: https://openqa.suse.de/tests/18654758#step/ha_cluster_init/32
(The test used to fail at this step, now it passes.  The test still fails at the last step `check_after_reboot`, but that is due to a different issue.)