### PR TITLE
SDAF remove dependency from inventory file

### DIFF
--- a/lib/sles4sap/console_redirection/redirection_data_tools.pm
+++ b/lib/sles4sap/console_redirection/redirection_data_tools.pm
@@ -1,0 +1,82 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+package sles4sap::console_redirection::redirection_data_tools;
+use Mojo::Base -base;
+use strict;
+use warnings FATAL => 'all';
+use testapi;
+
+
+=head1 SYNOPSIS
+
+Library with helper tools to extract and manipulate data from data structure used in redirection tests.
+For more details about structure format and redirection tests check B<tests/sles4sap/redirection_tests/README.md>
+
+B<Usage example:>
+C<use sles4sap::console_redirection::redirection_data_tools;>
+C<my $redirection = sles4sap::console_redirection::redirection_data_tools->new($run_args->{redirection_data});>
+C<my %nw_hosts = %{$redirection->get_nw_hosts};>
+
+=cut
+
+=head2 get_databases
+
+    get_databases();
+
+Returns B<ARRAYREF> containing only HANA database connection data
+B<Example:>
+{
+    hostname_a => {ip_address => '192.168.0.2', ssh_user => 'username'}
+    hostname_b => {ip_address => '192.168.0.2', ssh_user => 'username'}
+};
+
+=cut
+
+sub get_databases {
+    my $self = shift;
+    return $self->{db_hana};
+}
+
+=head2 get_ensa2_hosts
+
+    get_ensa2_hosts();
+
+Returns B<ARRAYREF> containing only ENSA2 cluster connection data
+B<Example:>
+{
+    hostname_a => {ip_address => '192.168.0.2', ssh_user => 'username'}
+    hostname_b => {ip_address => '192.168.0.2', ssh_user => 'username'}
+};
+
+=cut
+
+sub get_ensa2_hosts {
+    my $self = shift;
+    my %result = map { %{$_} } ($self->{nw_ascs}, $self->{nw_ers});
+    return \%result;
+}
+
+=head2 get_nw_hosts
+
+    get_nw_hosts();
+
+Returns B<ARRAYREF> containing only ENSA2 cluster connection data
+B<Example:>
+{
+    hostname_a => {ip_address => '192.168.0.2', ssh_user => 'username'}
+    hostname_b => {ip_address => '192.168.0.2', ssh_user => 'username'}
+};
+
+=cut
+
+sub get_nw_hosts {
+    my $self = shift;
+    my %result = map { %{$_} } ($self->{nw_ascs}, $self->{nw_ers}, $self->{nw_pas}, $self->{nw_aas});
+    return \%result;
+}
+
+1;

--- a/lib/sles4sap/database_hana.pm
+++ b/lib/sles4sap/database_hana.pm
@@ -16,6 +16,7 @@ use sles4sap::sapcontrol;
 
 our @EXPORT = qw(
   hdb_stop
+  hdb_info
   wait_for_failed_resources
   wait_for_takeover
   register_replica
@@ -67,6 +68,30 @@ sub hdb_stop {
     # Wait Hana processes to stop
     sapcontrol_process_check(instance_id => $args{instance_id}, expected_state => 'stopped', wait_for_state => 'yes', timeout => $stop_timeout);
     record_info('DB stopped');
+}
+
+=head2 hdb_info
+
+    hdb_info([switch_user=>'sidadm']);
+
+List hana database processes using C<HDB info> command. Returns command output.
+Function expects to be executed as sidadm, however you can use B<switch_user> to execute command using C<sudo su ->
+as a different user.
+
+=over
+
+=item * B<switch_user>: Execute command as specified user with help of C<sudo su ->. Default: undef
+
+=item * B<quiet>: Execute C<script_output> with quiet=>'true'. Default: undef
+
+=back
+
+=cut
+
+sub hdb_info {
+    my (%args) = @_;
+    my $cmd = $args{switch_user} ? qq/sudo su - $args{switch_user} -c "HDB info"/ : 'HDB info';
+    return script_output($cmd, quiet => $args{quiet});
 }
 
 =head2 wait_for_failed_resources

--- a/lib/sles4sap/sap_host_agent.pm
+++ b/lib/sles4sap/sap_host_agent.pm
@@ -12,6 +12,7 @@ use warnings;
 use testapi;
 use Carp qw(croak);
 use Exporter qw(import);
+use sles4sap::sapcontrol qw(get_instance_type);
 
 our @EXPORT = qw(
   parse_instance_name
@@ -78,7 +79,9 @@ sub saphostctrl_list_instances {
         my @instance_data = split(/\s:\s|\s-\s/, $instance);
         push(@instances, {
                 sap_sid => $instance_data[1],
+                sidadm => lc($instance_data[1]) . 'adm',
                 instance_id => $instance_data[2],
+                instance_type => get_instance_type(local_instance_id => $instance_data[2]),
                 hostname => $instance_data[3],
                 nw_release => $instance_data[4]
         });

--- a/schedule/sles4sap/sap_deployment_automation_framework/sdaf_deployment.yml
+++ b/schedule/sles4sap/sap_deployment_automation_framework/sdaf_deployment.yml
@@ -2,6 +2,8 @@
 name: sap_deployment_automation_framework
 description: |
   Deploy SAP Hana SR scenario using 'SAP deployment automation framework'
+vars:
+  TEST_CONTEXT: 'OpenQA::Test::RunArgs'
 schedule:
   - boot/boot_to_desktop
   - sles4sap/sap_deployment_automation_framework/create_deployer_vm
@@ -10,3 +12,7 @@ schedule:
   - sles4sap/sap_deployment_automation_framework/deploy_workload_zone
   - sles4sap/sap_deployment_automation_framework/deploy_sap_systems
   - sles4sap/sap_deployment_automation_framework/execute_playbooks
+  - sles4sap/sap_deployment_automation_framework/prepare_ssh_config
+  - sles4sap/redirection_tests/check_hana_database
+  - sles4sap/redirection_tests/check_ensa2_cluster
+  - sles4sap/redirection_tests/check_netweaver

--- a/t/20_sdaf_deployment_library.t
+++ b/t/20_sdaf_deployment_library.t
@@ -498,34 +498,6 @@ subtest '[playbook_settings] Verify playbook order' => sub {
     is $playbook_list[10], 'playbook_05_03_sap_app_install.yaml', 'Playbook #11 must be: playbook_05_03_sap_app_install.yaml';
 };
 
-subtest '[ansible_show_status] HanaSR status commands' => sub {
-    my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
-    my @commands;
-    $ms_sdaf->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', $_[0], ':', $_[1])); });
-    $ms_sdaf->redefine(ansible_execute_command => sub { push @commands, @_; return $_[1] });
-    $ms_sdaf->redefine(record_soft_failure => sub { return; });
-    $ms_sdaf->redefine(get_sdaf_instance_id => sub { return '00'; });
-    ansible_show_status(sdaf_config_root_dir => '/config/dir', sap_sid => 'abc', scenarios => ['db_install', 'db_ha']);
-
-    ok(grep(/cat \/etc\/os-release/, @commands), 'Execute os-release command');
-    ok(grep(/crm status full/, @commands), 'Show full cluster status');
-    ok(grep(/sudo SAPHanaSR-showAttr/, @commands), 'Show HanaSR status');
-};
-
-subtest '[ansible_show_status] ENSA2 status commands' => sub {
-    my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
-    my @commands;
-    $ms_sdaf->redefine(record_soft_failure => sub { return; });
-    $ms_sdaf->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', $_[0], ':', $_[1])); });
-    $ms_sdaf->redefine(ansible_execute_command => sub { push @commands, @_; return $_[1] });
-    $ms_sdaf->redefine(get_sdaf_instance_id => sub { return '00'; });
-    ansible_show_status(sdaf_config_root_dir => '/config/dir', sap_sid => 'abc', scenarios => ['db_install', 'db_ha', 'nw_pas', 'nw_aas', 'nw_ensa']);
-
-    ok(grep(/cat \/etc\/os-release/, @commands), 'Execute os-release command');
-    ok(grep(/crm status full/, @commands), 'Show full cluster status');
-    ok(grep(/ps -ef | grep sap/, @commands), 'Netweaver processes');
-};
-
 subtest '[register_byos] Test exceptions' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
     $ms_sdaf->redefine(ansible_execute_command => sub { return; });

--- a/t/31_sap_host_agent.t
+++ b/t/31_sap_host_agent.t
@@ -21,4 +21,34 @@ subtest '[parse_instance_name] Exceptions' => sub {
     dies_ok { parse_instance_name('POO0.') } 'Instance name contains any non-word characters';
 };
 
+subtest '[saphostctrl_list_instances] Command composition' => sub {
+    my $saphostagent = Test::MockModule->new('sles4sap::sap_host_agent', no_auto => 1);
+    my $mock_data = ' Inst Info : HDB - 00 - qesdhdb01l000 - 753, patch 1236, changelist 2222163';
+    my @cmd_args;
+    $saphostagent->redefine(script_output => sub { @cmd_args = @_; return $mock_data; });
+    $saphostagent->redefine(get_instance_type => sub { return 'ERS'; });
+
+    saphostctrl_list_instances();
+    note("\n  -->  " . join("\n  -->  ", @cmd_args));
+    ok((grep /\/usr\/sap\/hostctrl\/exe\/saphostctrl/, @cmd_args), 'Base saphostctrl command');
+    ok((grep /-function/, @cmd_args), 'Add "-function" argument');
+    ok((grep /ListInstances/, @cmd_args), 'Execute "ListInstances" function');
+    ok((grep /| grep 'Inst Info'/, @cmd_args), 'Filter out instance info');
+};
+
+subtest '[saphostctrl_list_instances] Command composition - switch user' => sub {
+    my $saphostagent = Test::MockModule->new('sles4sap::sap_host_agent', no_auto => 1);
+    my $mock_data = ' Inst Info : HDB - 00 - qesdhdb01l000 - 753, patch 1236, changelist 2222163';
+    my @cmd_args;
+    $saphostagent->redefine(script_output => sub { @cmd_args = @_; return $mock_data; });
+    $saphostagent->redefine(get_instance_type => sub { return 'ERS'; });
+
+    saphostctrl_list_instances();
+    note("\n  -->  " . join("\n  -->  ", @cmd_args));
+    ok((grep /\/usr\/sap\/hostctrl\/exe\/saphostctrl/, @cmd_args), 'Base saphostctrl command');
+    ok((grep /-function/, @cmd_args), 'Add "-function" argument');
+    ok((grep /ListInstances/, @cmd_args), 'Execute "ListInstances" function');
+    ok((grep /| grep 'Inst Info'/, @cmd_args), 'Filter out instance info');
+};
+
 done_testing;

--- a/t/36_redirection_data_tools.t
+++ b/t/36_redirection_data_tools.t
@@ -1,0 +1,77 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+use Test::MockModule;
+use List::MoreUtils qw(all);
+use List::Util qw(any);
+use Data::Dumper;
+use testapi;
+use sles4sap::console_redirection::redirection_data_tools;
+
+my $mock_data = {
+    db_hana => {
+        hanadb_a => {
+            ip_address => '192.168.1.3',
+            ssh_user => 'hanaadmin'
+        },
+        hanadb_b => {
+            ip_address => '192.168.1.4',
+            ssh_user => 'hanaadmin'
+        }
+    },
+    nw_pas => {
+        nw_pas => {
+            ip_address => '192.168.1.6',
+            ssh_user => 'hanaadmin'
+        }
+    },
+    nw_aas => {
+        nw_aas_01 => {
+            ip_address => '192.168.1.7',
+            ssh_user => 'hanaadmin'
+        }
+    },
+    nw_ascs => {
+        nw_ascs_01 => {
+            ip_address => '192.168.1.9',
+            ssh_user => 'hanaadmin'
+        }
+    },
+    nw_ers => {
+        nw_ers_02 => {
+            ip_address => '192.168.1.10',
+            ssh_user => 'hanaadmin'
+        }
+    }
+};
+
+subtest '[get_databases]' => sub {
+    my $mockObject = sles4sap::console_redirection::redirection_data_tools->new($mock_data);
+    my %dbs = %{$mockObject->get_databases()};
+    note('Databases found: ' . join(' ', keys %dbs));
+    ok((any { /hanadb_a/ } %dbs and any { /hanadb_b/ } %dbs), 'Get correct list of databases');
+};
+
+subtest '[get_ensa2_hosts]' => sub {
+    my $mockObject = sles4sap::console_redirection::redirection_data_tools->new($mock_data);
+    my %ensa2 = %{$mockObject->get_ensa2_hosts()};
+    my @expected_hosts = qw(nw_ascs_01 nw_ers_02);
+    note('ENSA2 hosts found: ' . join(' ', keys %ensa2));
+    for my $host (@expected_hosts) {
+        ok(grep(/$host/, keys(%ensa2)), "ENSA2 list contains host '$host'");
+    }
+};
+
+subtest '[get_nw_hosts]' => sub {
+    my $mockObject = sles4sap::console_redirection::redirection_data_tools->new($mock_data);
+    my %nw_hosts = %{$mockObject->get_nw_hosts()};
+    my @expected_hosts = qw(nw_ascs_01 nw_ers_02 nw_aas_01 nw_pas);
+    note('NW hosts found: ' . join(' ', keys %nw_hosts));
+    for my $host (@expected_hosts) {
+        ok(grep(/$host/, keys(%nw_hosts)), "NW list contains host '$host'");
+    }
+};
+
+done_testing();

--- a/tests/sles4sap/redirection_tests/check_ensa2_cluster.pm
+++ b/tests/sles4sap/redirection_tests/check_ensa2_cluster.pm
@@ -1,0 +1,116 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Post deployment screens and checks for ENSA2 cluster
+
+use parent 'sles4sap::sap_deployment_automation_framework::basetest';
+
+package check_ensa2_cluster;
+use strict;
+use warnings FATAL => 'all';
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use sles4sap::console_redirection;
+use sles4sap::console_redirection::redirection_data_tools;
+use hacluster qw(wait_for_idle_cluster check_cluster_state);
+use sles4sap::sap_host_agent qw(saphostctrl_list_instances);
+use hacluster qw($crm_mon_cmd);
+use sles4sap::sapcontrol qw(sapcontrol);
+
+=head1 NAME
+
+sles4sap/redirection_tests/check_ensa2_cluster.pm - Perform checks and display status screens for ENSA2 cluster.
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=head1 DESCRIPTION
+
+Module executes checks and provides status screens for ENSA2 cluster. It is intended to be used on a healthy
+cluster, for example after a deployment is finished or at the end of a test sequence. In case of unhealthy cluster,
+test will fail.
+
+B<The key tasks performed by this module include:>
+
+=over
+
+=item * Collects connection data to all ENSA2 cluster nodes required for console redirection
+
+=item * Connect to each cluster node in a loop
+
+=item * Wait for cluster to become idle
+
+=item * Collect data about  instances using sapcontrol
+
+=item * Collect output from sapcontrol using B<HACheckConfig> webmethod
+
+=item * Collect output from sapcontrol using B<HACheckFailoverConfig> webmethod
+
+=item * Check cluster state
+
+=item * Disconnect from instance node
+
+=item * Display collected outputs using B<record_info> API call
+
+=back
+
+=head1 OPENQA SETTINGS
+
+Test module does not use any OpenQA settings
+
+=cut
+
+
+sub run {
+    my ($self, $run_args) = @_;
+    my $redirection_data = sles4sap::console_redirection::redirection_data_tools->new($run_args->{redirection_data});
+    my %ensa2_hosts = %{$redirection_data->get_ensa2_hosts};
+    unless ($redirection_data->{nw_ers}) {
+        record_info('N/A', 'ENSA2 deployment not detected, skipping.');
+        return;
+    }
+    my %results;
+
+    # ENSA2 cluster result collection
+    for my $host (keys(%ensa2_hosts)) {
+        # Everything is now executed on SUT, not worker VM
+        my $ip_addr = $ensa2_hosts{$host}{ip_address};
+        my $user = $ensa2_hosts{$host}{ssh_user};
+        my %instance_results;
+        die "Redirection data missing. Got:\nIP: $ip_addr\nUSER: $user\n" unless $ip_addr and $user;
+
+        connect_target_to_serial(destination_ip => $ip_addr, ssh_user => $user, switch_root => 'yes');
+        wait_for_idle_cluster();
+
+        my $instance_data = saphostctrl_list_instances(as_root => 'yes', running => 'yes');
+        # loop commands
+        $instance_results{'CRM status'} = script_output($crm_mon_cmd, quiet => 1);
+        $instance_results{'HA Check Config'} = sapcontrol(
+            webmethod => 'HACheckConfig',
+            instance_id => $instance_data->[0]{instance_id},
+            sidadm => $instance_data->[0]{sap_sid},
+            return_output => 'yes');
+        $instance_results{'HA Failover Config'} = sapcontrol(
+            webmethod => 'HACheckFailoverConfig',
+            instance_id => $instance_data->[0]{instance_id},
+            sidadm => $instance_data->[0]{sap_sid},
+            return_output => 'yes');
+
+        $results{$host} = \%instance_results;
+        check_cluster_state();
+        disconnect_target_from_serial();
+    }
+
+    record_info('RESULTS');
+    for my $host (keys(%results)) {
+        record_info("Host: $host");
+        my %host_results = %{$results{$host}};
+        # Loop over result title and command output
+        record_info($_, $host_results{$_}) foreach keys(%host_results);
+    }
+}
+
+1;

--- a/tests/sles4sap/redirection_tests/check_hana_database.pm
+++ b/tests/sles4sap/redirection_tests/check_hana_database.pm
@@ -1,0 +1,112 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Post deployment screens and checks
+
+use parent 'sles4sap::sap_deployment_automation_framework::basetest';
+
+package check_hana_database;
+use strict;
+use warnings FATAL => 'all';
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use sles4sap::console_redirection;
+use sles4sap::console_redirection::redirection_data_tools;
+use hacluster qw(wait_for_idle_cluster check_cluster_state);
+use sles4sap::database_hana qw(hdb_info);
+use sles4sap::sap_host_agent qw(saphostctrl_list_instances);
+use hacluster qw($crm_mon_cmd);
+
+=head1 NAME
+
+sles4sap/redirection_tests/check_hana_database.pm - Perform checks and display status screens for HANA DB cluster.
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=head1 DESCRIPTION
+
+Module executes checks and provides status screens for HANA database cluster. It is intended to be used on a healthy
+cluster, for example after a deployment is finished or at the end of a test sequence. In case of unhealthy cluster,
+test will fail.
+
+B<The key tasks performed by this module include:>
+
+=over
+
+=item * Collects connection data to Hana database nodes required for console redirection
+
+=item * Connect to each Hana database node in a loop
+
+=item * Wait for cluster to become idle
+
+=item * Collect data about database instances
+
+=item * Collect content from file B</etc/os-release>
+
+=item * Collect B<SAPHanaSR-showAttr> command output
+
+=item * Collect B<crm_mon> command output
+
+=item * Collect B<HDB info> command output
+
+=item * Check cluster state
+
+=item * Disconnect from database node
+
+=item * Display collected outputs using B<record_info> API call
+
+=back
+
+=head1 OPENQA SETTINGS
+
+Test module does not use any OpenQA settings
+
+=cut
+
+sub run {
+    my ($self, $run_args) = @_;
+    my $redirection_data = sles4sap::console_redirection::redirection_data_tools->new($run_args->{redirection_data});
+    my %database_hosts = %{$redirection_data->get_databases};
+    if (!%database_hosts) {
+        record_info('N/A', 'Database deployment not detected, skipping.');
+        return;
+    }
+    my %results;
+
+    # DB cluster result collection
+    for my $host (keys(%database_hosts)) {
+        # Everything is now executed on SUT, not worker VM
+        my $ip_addr = $database_hosts{$host}{ip_address};
+        my $user = $database_hosts{$host}{ssh_user};
+        my %instance_results;
+        die "Redirection data missing. Got:\nIP: $ip_addr\nUSER: $user\n" unless $ip_addr and $user;
+
+        connect_target_to_serial(destination_ip => $ip_addr, ssh_user => $user, switch_root => 'yes');
+        wait_for_idle_cluster();
+
+        my $instance_data = saphostctrl_list_instances(as_root => 'yes', running => 'yes');
+
+        # Collected results will be displayed at the end of the module
+        $instance_results{Release} = script_output('cat /etc/os-release', quiet => 1);
+        $instance_results{'System Replication'} = script_output('SAPHanaSR-showAttr', quiet => 1);
+        $instance_results{'CRM status'} = script_output($crm_mon_cmd, quiet => 1);
+        $instance_results{'HDB info'} = hdb_info(switch_user => $instance_data->[0]{sidadm}, quiet => 'true');
+        $results{$host} = \%instance_results;
+
+        check_cluster_state();
+        disconnect_target_from_serial();
+    }
+    record_info('RESULTS');
+    for my $host (keys(%results)) {
+        record_info("Host: $host");
+        my $host_results = $results{$host};
+        # Loop over result title and command output
+        record_info($_, $host_results->{$_}) foreach keys(%{$host_results});
+    }
+}
+
+1;

--- a/tests/sles4sap/redirection_tests/check_netweaver.pm
+++ b/tests/sles4sap/redirection_tests/check_netweaver.pm
@@ -1,0 +1,107 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Post deployment screens and checks
+
+use parent 'sles4sap::sap_deployment_automation_framework::basetest';
+
+package check_netweaver;
+use strict;
+use warnings FATAL => 'all';
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use sles4sap::console_redirection;
+use sles4sap::console_redirection::redirection_data_tools;
+use hacluster qw(wait_for_idle_cluster check_cluster_state);
+use sles4sap::sap_host_agent qw(saphostctrl_list_instances);
+use hacluster qw($crm_mon_cmd);
+use sles4sap::sapcontrol qw(sapcontrol);
+
+=head1 NAME
+
+sles4sap/redirection_tests/check_netweaver.pm - Perform checks and display status screens for netweaver instances.
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=head1 DESCRIPTION
+
+Module executes checks and provides status screens for Netweaver instances.
+
+B<The key tasks performed by this module include:>
+
+=over
+
+=item * Collects connection data to all Netweaver instance nodes required for console redirection
+
+=item * Connect to each instance node in a loop
+
+=item * Collect data about Netweaver instances using sapcontrol
+
+=item * Collect SAP related processes using B<ps -ef> command
+
+=item * Collect output from sapcontrol using B<GetProcessList> webmethod
+
+=item * Collect output from sapcontrol using B<GetSystemInstanceList> webmethod
+
+=item * Disconnect from instance node
+
+=item * Display collected outputs using B<record_info> API call
+
+=back
+
+=head1 OPENQA SETTINGS
+
+Test module does not use any OpenQA settings
+
+=cut
+
+sub run {
+    my ($self, $run_args) = @_;
+    my $redirection_data = sles4sap::console_redirection::redirection_data_tools->new($run_args->{redirection_data});
+    my %nw_hosts = %{$redirection_data->get_nw_hosts};
+    if (!%nw_hosts) {
+        record_info('N/A', 'Netweaver deployment not detected, skipping.');
+        return;
+    }
+    my %results;
+
+    # ENSA2 cluster result collection
+    for my $host (keys(%nw_hosts)) {
+        # Everything is now executed on SUT, not worker VM
+        my $ip_addr = $nw_hosts{$host}{ip_address};
+        my $user = $nw_hosts{$host}{ssh_user};
+        my %instance_results;
+        die "Redirection data missing. Got:\nIP: $ip_addr\nUSER: $user\n" unless $ip_addr and $user;
+
+        connect_target_to_serial(destination_ip => $ip_addr, ssh_user => $user, switch_root => 'yes');
+        my $instance_data = saphostctrl_list_instances(as_root => 'yes', running => 'yes');
+        # loop commands
+        $instance_results{'OS proc'} = script_output('ps -ef| grep sap', quiet => 1);
+        $instance_results{'Process list'} = sapcontrol(
+            webmethod => 'GetProcessList',
+            instance_id => $instance_data->[0]{instance_id},
+            sidadm => $instance_data->[0]{sap_sid},
+            return_output => 'yes');
+        $instance_results{'System instances'} = sapcontrol(
+            webmethod => 'GetSystemInstanceList',
+            instance_id => $instance_data->[0]{instance_id},
+            sidadm => $instance_data->[0]{sap_sid},
+            return_output => 'yes');
+
+        $results{$host} = \%instance_results;
+        disconnect_target_from_serial();
+    }
+    record_info('RESULTS');
+    for my $host (keys(%results)) {
+        record_info("Host: $host");
+        my %host_results = %{$results{$host}};
+        # Loop over result title and command output
+        record_info($_, $host_results{$_}) foreach keys(%host_results);
+    }
+}
+
+1;

--- a/tests/sles4sap/sap_deployment_automation_framework/execute_playbooks.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/execute_playbooks.pm
@@ -110,10 +110,6 @@ sub run {
         }
 
     }
-
-    # Display deployment information
-    ansible_show_status(sdaf_config_root_dir => $sdaf_config_root_dir, scenarios => \@setup);
-
     disconnect_target_from_serial();
     serial_console_diag_banner('Module sdaf_deploy_hanasr.pm : stop');
 }


### PR DESCRIPTION
Test modules use currently data from inventory file which is not a source with current data. This PR moves data sourcing from actual system information instead.

**Ticket:** https://jira.suse.com/browse/TEAM-10470
**Verification run:** 
**HanaSR:**  https://openqaworker15.qa.suse.cz/tests/336018#step/check_hana_database/161
**HanaSR SBD:** https://openqaworker15.qa.suse.cz/tests/336029#step/check_hana_database/168
**ENSA2:** https://openqaworker15.qa.suse.cz/tests/336209#step/check_ensa2_cluster/231
**ENSA2 SBD:** https://openqaworker15.qa.suse.cz/tests/336212#step/check_netweaver/261

