### PR TITLE
Revert "containers: Temporarily exclude rootless_docker test on PC"

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -197,8 +197,7 @@ sub load_host_tests_docker {
     # The docker-rootless-extras package is only available on SLES 15-SP4+
     # while the docker-stable-rootless-extras is available on SLES 16.0+
     if (is_tumbleweed || is_leap || is_sle && (is_sle('>=16') || is_sle('>=15-SP4') && !check_var("CONTAINERS_DOCKER_FLAVOUR", "stable"))) {
-        # Public Cloud repos have unmatching versions of the docker & extras packages
-        loadtest 'containers/rootless_docker' unless (is_public_cloud);
+        loadtest 'containers/rootless_docker';
     }
     # Expected to work anywhere except of real HW backends, PC and Micro
     unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro || (is_sle('=12-SP5') && is_aarch64)) {


### PR DESCRIPTION
This reverts commit dbb4a1dda244c2dcd728174cc54855cf2c65a73b.

Needed CONTM repositories added to PC jobs

- Related ticket: https://progress.opensuse.org/issues/185512
- Verification run: TBD
