### PR TITLE
Skip cdn.opensuse.org on Slowroll

### DIFF
--- a/tests/console/opensuse_repos.pm
+++ b/tests/console/opensuse_repos.pm
@@ -39,8 +39,8 @@ sub run {
     }
 
     zypper_call("refresh-services");
-    assert_script_run "zypper lr --uri | grep cdn.opensuse.org";
-    assert_script_run "zypper lr --uri | grep download.nvidia.com" if (is_x86_64 || is_aarch64);
+    validate_script_output("zypper lr --uri", qr/cdn.opensuse.org/, fail_message => "cdn.opensuse.org not present in repositories") unless (is_slowroll);
+    validate_script_output("zypper lr --uri", qr/download.nvidia.com/, fail_message => "download.nvidia.com not present in repositories") if (is_x86_64 || is_aarch64);
 
     # removing the distro package, removes the NVIDIA service too if it was installed
     zypper_call("rm $pkgname");


### PR DESCRIPTION
Slowroll is not using cdn.opensuse.org, so this test should not be run there.

- Related failure: https://openqa.opensuse.org/tests/5218315#step/opensuse_repos/20

## Verification runs

* [Tumbleweed](https://openqa.opensuse.org/tests/5219805)
* [Slowroll](https://openqa.opensuse.org/tests/5219806)
