### PR TITLE
microos/disk_boot.pm: Use wait_boot_past_bootloader on OFW as well

### DIFF
--- a/tests/microos/disk_boot.pm
+++ b/tests/microos/disk_boot.pm
@@ -17,13 +17,12 @@ use transactional "record_kernel_audit_messages";
 use utils qw(is_uefi_boot);
 
 sub run {
-
     # default timeout in grub2 is set to 10s
     # Sometimes, machines tend to stall when trying to match grub2
     # this leads to test failures because openQA does not assert grub2 properly
     # KEEP_GRUB_TIMEOUT=0 will force the grub needle to match, useful when booting
     # pre-configured images with disabled timeout. See opensusebasetest::handle_grub
-    if ((is_uefi_boot || is_aarch64 || is_sle_micro('>=6.0')) && get_var('KEEP_GRUB_TIMEOUT', '1') && !main_micro_alp::is_dvd()) {
+    if ((is_uefi_boot || is_aarch64 || get_var('OFW') || is_sle_micro('>=6.0')) && get_var('KEEP_GRUB_TIMEOUT', '1') && !main_micro_alp::is_dvd()) {
         shift->wait_boot_past_bootloader(textmode => 1);
     } else {
         shift->wait_boot(bootloader_time => 300);


### PR DESCRIPTION
wait_boot is really broken in the OFW=1 case: To skip the grub2 match, it does check_screen('displaymanager', 5), which just wastes 15s and then fails: 'displaymanager' will never match on textmode images and ppc64le machine types have TIMEOUT_SCALE=3. This guarantees that it will both fail the check_screen as well as the subsequent handle_grub.

Bypass this absolute mess by using wait_boot_past_bootloader instead.

- Failure: https://openqa.opensuse.org/tests/5210737#step/disk_boot/1
- Verification run: https://openqa.opensuse.org/tests/5220025
