### PR TITLE
P.C. wait_for_ssh: remove the threshold limiting the IP check

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -408,10 +408,10 @@ sub wait_for_ssh {
         last if (not isok($exit_code) and $args{wait_stop});    # ssh port closed ok
 
         # skip SLES4SAP as incompatible with get_public_ip
-        if (($duration >= $args{timeout} - 30) and (!get_var('PUBLIC_CLOUD_SLES4SAP'))) {
+        unless (get_var('PUBLIC_CLOUD_SLES4SAP')) {
             my $public_ip_from_provider = $self->provider->get_public_ip();
             if ($args{public_ip} ne $public_ip_from_provider) {
-                record_info('IP CHANGED', "The address we know is $args{public_ip} but provider returns $public_ip_from_provider");
+                record_info('IP CHANGED', "The address we know is $args{public_ip} but provider returns $public_ip_from_provider", result => 'fail');
             }
         }
 


### PR DESCRIPTION
Publiccloud instances in the phase checking VM that is up, remove the threshold limiting the expected-IP check to be triggered 30sec before timeout only: now it is always performed.

See also the note in https://progress.opensuse.org/issues/186717#note-5

Also, in case of IP **different**, a **red** box is reported in the job details boxes.

- Related ticket: poo#[186717](https://progress.opensuse.org/issues/186717)
- Verification run: TBD