### PR TITLE
Add workaround for grub install entry

### DIFF
--- a/lib/Yam/Agama/Pom/GrubMenuAgamaPage.pm
+++ b/lib/Yam/Agama/Pom/GrubMenuAgamaPage.pm
@@ -10,6 +10,7 @@ package Yam::Agama::Pom::GrubMenuAgamaPage;
 use strict;
 use warnings;
 use testapi;
+use Utils::Architectures qw(is_aarch64);
 
 sub new {
     my ($class, $args) = @_;
@@ -21,7 +22,7 @@ sub new {
 
 sub expect_is_shown {
     my ($self) = @_;
-    send_key_until_needlematch($self->{tag_agama_installer_highlighted}, 'down');
+    send_key_until_needlematch($self->{tag_agama_installer_highlighted}, 'down') unless check_screen($self->{tag_agama_installer_highlighted}, 5);
     assert_screen($self->{tag_agama_installer_highlighted}, 60);
 }
 


### PR DESCRIPTION
To make the grub menu install entry suitable for production and development group, need check whether the first entry is for installation.

- Related ticket: https://progress.opensuse.org/issues/186702
- Needles: N/A
- Verification run: 
production:
https://openqa.suse.de/tests/18673007#details  x86_64
https://openqa.suse.de/tests/18673006  aarch64
development:
https://openqa.suse.de/tests/18673008#details  x86_64
https://openqa.suse.de/tests/18673009   aarch64