### PR TITLE
containers: Use serial terminal instead of console

### DIFF
--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 use Mojo::Base 'containers::basetest';
 use testapi;
-use serial_terminal 'select_serial_terminal';
+use serial_terminal;
 use utils;
 use containers::common;
 use containers::container_images;
@@ -98,7 +98,7 @@ sub run {
     # already exists owned by root
     assert_script_run 'rm -rf /tmp/script*';
     ensure_serialdev_permissions;
-    select_console "user-console";
+    select_user_serial_terminal;
 
     # By default the storage driver is set to btrfs if /var is in btrfs
     # but if the home partition is not btrfs podman commands will fail with


### PR DESCRIPTION
Use serial terminal instead of console.

We're purging all uses of `select_console` in containers tests as issues appear as we've doing in other places like `rootless_docker`: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22842

- Failing test: https://openqa.suse.de/tests/18667597#step/rootless_podman/222
- Verification run: https://openqa.suse.de/tests/18673470