### PR TITLE
Fix runc BATS tests on ppc64le & s390x

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -73,8 +73,11 @@ sub install_git {
     # We need git 2.47.0+ to use `--ours` with `git apply -3`
     if (is_sle) {
         my $version = get_var("VERSION");
-        $version =~ s/-SP/./;
-        run_command "sudo zypper addrepo https://download.opensuse.org/repositories/devel:/languages:/python:/backports/$version/devel:languages:python:backports.repo";
+        if (is_sle('<16')) {
+            $version =~ s/-/_/;
+            $version = "SLE_$version";
+        }
+        run_command "sudo zypper addrepo https://download.opensuse.org/repositories/Kernel:/tools/$version/Kernel:tools.repo";
     }
     run_command "sudo zypper --gpg-auto-import-keys -n install --allow-vendor-change git-core", timeout => 300;
 }

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -14,7 +14,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use containers::bats;
 use version_utils qw(is_tumbleweed);
-
+use Utils::Architectures qw(is_s390x);
 
 sub run_tests {
     my %params = @_;
@@ -54,6 +54,8 @@ sub run {
     # Compile helpers used by the tests
     my $cmds = script_output "find contrib/cmd tests/cmd -mindepth 1 -maxdepth 1 -type d -printf '%f ' || true";
     run_command "make $cmds || true";
+    # Skip this test on s390x due to https://bugzilla.suse.com/show_bug.cgi?id=1247567
+    run_command "rm -f tests/integration/seccomp.bats" if is_s390x;
 
     my $errors = run_tests(rootless => 1, skip_tests => 'BATS_SKIP_USER');
 

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -14,7 +14,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use containers::bats;
 use version_utils qw(is_tumbleweed);
-use Utils::Architectures qw(is_s390x);
+use Utils::Architectures qw(is_ppc64le is_s390x);
 
 sub run_tests {
     my %params = @_;
@@ -54,6 +54,8 @@ sub run {
     # Compile helpers used by the tests
     my $cmds = script_output "find contrib/cmd tests/cmd -mindepth 1 -maxdepth 1 -type d -printf '%f ' || true";
     run_command "make $cmds || true";
+    # Skip this test on s390x due to https://bugzilla.suse.com/show_bug.cgi?id=1247568
+    run_command "rm -f tests/integration/no_pivot.bats" if is_ppc64le;
     # Skip this test on s390x due to https://bugzilla.suse.com/show_bug.cgi?id=1247567
     run_command "rm -f tests/integration/seccomp.bats" if is_s390x;
 


### PR DESCRIPTION
This PR:
- Changes the OBS repo so we can get the latest git for ppc64le & s390x
- Fixes the runc test to work-around https://bugzilla.suse.com/show_bug.cgi?id=1247567
- Fixes the runc test to work-around https://bugzilla.suse.com/show_bug.cgi?id=1247568

Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2380

Verification runs:
- ppc64le:
  - sle-16.0: https://openqa.suse.de/tests/18673559
  - Tumbleweed: https://openqa.opensuse.org/tests/5221586
- s390x:
  - sle-16.0: https://openqa.suse.de/tests/18673480
  - sle-15-SP7: https://openqa.suse.de/tests/18673481
  - sle-15-SP6: https://openqa.suse.de/tests/18673482
  - sle-15-SP5:  https://openqa.suse.de/tests/18673484
  - sle-15-SP4: https://openqa.suse.de/tests/18673485
