### PR TITLE
Add support for multiple repo hosts in IBSM jobs

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -2019,9 +2019,10 @@ sub ipaddr2_add_server_repos_to_hosts {
     my (%args) = @_;
     croak 'Missing mandatory argument < ibsm_ip >' unless $args{ibsm_ip};
     $args{bastion_ip} //= ipaddr2_bastion_pubip();
+    my $repo_host = get_var('REPO_MIRROR_HOST', 'download.suse.de');
     foreach my $id (1 .. 2) {
         ipaddr2_ssh_internal(id => $id,
-            cmd => "echo \"$args{'ibsm_ip'} download.suse.de\" | sudo tee -a /etc/hosts",
+            cmd => "echo \"$args{'ibsm_ip'} $repo_host\" | sudo tee -a /etc/hosts",
             bastion_ip => $args{bastion_ip});
     }
 

--- a/tests/sles4sap/cloud_zypper_patch/add_repo.pm
+++ b/tests/sles4sap/cloud_zypper_patch/add_repo.pm
@@ -20,8 +20,9 @@ sub run {
     select_serial_terminal;
 
     zp_ssh_connect();
+    my $repo_host = get_var('REPO_MIRROR_HOST', 'download.suse.de');
     zp_add_repos(ip => get_required_var('IBSM_IP'),
-        name => 'download.suse.de',
+        name => $repo_host,
         repos => get_var('INCIDENT_REPO'));
 }
 

--- a/tests/sles4sap/publiccloud/add_server_to_hosts.pm
+++ b/tests/sles4sap/publiccloud/add_server_to_hosts.pm
@@ -21,8 +21,9 @@ sub run {
         next if ($instance->{'instance_id'} !~ m/vmhana/);
         record_info("$instance");
 
+        my $repo_host = get_var('REPO_MIRROR_HOST', 'download.suse.de');
         my $ibsm_ip = get_required_var('IBSM_IP');
-        $instance->run_ssh_command(cmd => "echo \"$ibsm_ip download.suse.de\" | sudo tee -a /etc/hosts", username => 'cloudadmin');
+        $instance->run_ssh_command(cmd => "echo \"$ibsm_ip $repo_host\" | sudo tee -a /etc/hosts", username => 'cloudadmin');
         $instance->run_ssh_command(cmd => 'cat /etc/hosts', username => 'cloudadmin');
     }
 }


### PR DESCRIPTION
This ticket adds support for dynamic repo hostname resolution at runtime (using the `REPO_MIRROR_HOST` variable) instead of the hardcoded approach used until now.

- Related ticket: https://jira.suse.com/browse/TEAM-10558
- Verification run: https://openqa.suse.de/tests/18674707
