### PR TITLE
bats/skopeo: Limit fakeroot dependency to Tumbleweed

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -171,8 +171,6 @@ sub enable_modules {
     add_suseconnect_product(get_addon_fullname('desktop'));
     add_suseconnect_product(get_addon_fullname('sdk'));
     add_suseconnect_product(get_addon_fullname('python3')) if is_sle('>=15-SP4');
-    # Needed for criu & fakeroot
-    add_suseconnect_product(get_addon_fullname('phub'));
 }
 
 sub patch_logfile {

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -14,7 +14,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use Utils::Architectures qw(is_x86_64);
 use containers::bats;
-use version_utils qw(is_sle);
+use version_utils qw(is_tumbleweed);
 
 
 sub run_tests {
@@ -41,7 +41,9 @@ sub run {
     select_serial_terminal;
 
     my @pkgs = qw(apache2-utils jq openssl podman squashfs skopeo);
-    push @pkgs, "fakeroot" unless is_sle('>=16.0');
+    # This package is only available on Tumbleweed and is needed
+    # only for the SIF image test in systemtest/020-copy.bats
+    push @pkgs, "fakeroot" if is_tumbleweed;
 
     $self->bats_setup(@pkgs);
 


### PR DESCRIPTION
Limit fakeroot dependency to Tumbleweed so we can enable skopeo tests on ppc64le & s390x where these packages are not available on PackageHub.  Drop PackageHub as we don't really need this 3rd party repo that may pollute our tests.

Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2381

Verification runs:
- ppc64le:
  - SLES 16.0: https://openqa.suse.de/tests/18674706
  - Tumbleweed: https://openqa.opensuse.org/tests/5222260
- s390x:
  - SLES 16.0: https://openqa.suse.de/tests/18674700
  - SLES 15-SP7: https://openqa.suse.de/tests/18674701
  - SLES 15-SP6: https://openqa.suse.de/tests/18674702
  - SLES 15-SP5: https://openqa.suse.de/tests/18674727
  - SLES 15-SP4: https://openqa.suse.de/tests/18674704