### PR TITLE
Access REPO_MIRROR_HOST in the test module

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -2011,6 +2011,8 @@ Add download.suse.de server to hosts by specifying IBSM address
 
 =item B<incident_repo> - Comma separated list of incident repos
 
+=item B<repo_host> - host name of the repo server. Default is download.suse.de.
+
 =back
 
 =cut
@@ -2019,10 +2021,10 @@ sub ipaddr2_add_server_repos_to_hosts {
     my (%args) = @_;
     croak 'Missing mandatory argument < ibsm_ip >' unless $args{ibsm_ip};
     $args{bastion_ip} //= ipaddr2_bastion_pubip();
-    my $repo_host = get_var('REPO_MIRROR_HOST', 'download.suse.de');
+    $args{repo_host} //= 'download.suse.de';
     foreach my $id (1 .. 2) {
         ipaddr2_ssh_internal(id => $id,
-            cmd => "echo \"$args{'ibsm_ip'} $repo_host\" | sudo tee -a /etc/hosts",
+            cmd => "echo \"$args{'ibsm_ip'} $args{repo_host}\" | sudo tee -a /etc/hosts",
             bastion_ip => $args{bastion_ip});
     }
 

--- a/tests/sles4sap/ipaddr2/network_peering.pm
+++ b/tests/sles4sap/ipaddr2/network_peering.pm
@@ -29,7 +29,8 @@ sub run {
 
     ipaddr2_add_server_repos_to_hosts(
         ibsm_ip => get_required_var('IBSM_IP'),
-        incident_repo => get_var('INCIDENT_REPO', ''));
+        incident_repo => get_var('INCIDENT_REPO', ''),
+        repo_host => get_var('REPO_MIRROR_HOST', 'download.suse.de'));
 }
 
 sub test_flags {


### PR DESCRIPTION
Move where the ipaddr2 test is reading REPO_MIRROR_HOST from the lib to the test module.

- Related ticket: https://jira.suse.com/browse/TEAM-10558

VR:

 - sle-15-SP6-Azure-SAP-PAYG-Incidents-x86_64-Build:39691:fence-agents-ipaddr2@64bit -> http://openqaworker15.qa.suse.cz/tests/335877