### PR TITLE
Generic code improvement in ipaddr2 lib

### DIFF
--- a/tests/sles4sap/ipaddr2/cluster_create.pm
+++ b/tests/sles4sap/ipaddr2/cluster_create.pm
@@ -24,7 +24,7 @@ Its primary tasks are:
 
 =head1 VARIABLES
 
-=over 4
+=over
 
 =item B<PUBLIC_CLOUD_PROVIDER>
 
@@ -64,6 +64,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_configure_web_server
   ipaddr2_bastion_pubip
   ipaddr2_cluster_create
+  ipaddr2_cluster_check_version
   ipaddr2_deployment_logs
   ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
@@ -94,7 +95,11 @@ sub run {
     }
 
     record_info("TEST STAGE", "Init and configure the Pacemaker cluster");
-    ipaddr2_cluster_create(bastion_ip => $bastion_ip, rootless => get_var('IPADDR2_ROOTLESS', '0'));
+
+    ipaddr2_cluster_check_version();
+    ipaddr2_cluster_create(
+        bastion_ip => $bastion_ip,
+        rootless => get_var('IPADDR2_ROOTLESS', '0'));
 }
 
 sub test_flags {

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -21,7 +21,7 @@ It performs the following key configuration steps:
 
 =head1 VARIABLES
 
-=over 4
+=over
 
 =item B<PUBLIC_CLOUD_PROVIDER>
 

--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -18,7 +18,7 @@ It creates the necessary resources in Azure, which includes:
 
 =head1 VARIABLES
 
-=over 4
+=over
 
 =item B<IPADDR2_CLOUDINIT>
 
@@ -100,7 +100,7 @@ sub run {
     # remove configuration file created by the PC factory
     # as it interfere with ssh behavior.
     # in particular it has setting about verbosity that
-    # break test steps that relay to remote ssh comman output
+    # break test steps that relay to remote ssh command output
     assert_script_run('rm ~/.ssh/config');
 
     my $os;

--- a/tests/sles4sap/ipaddr2/destroy.pm
+++ b/tests/sles4sap/ipaddr2/destroy.pm
@@ -1,8 +1,58 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# Summary: Check that deployed resource in the cloud are as expected
-# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+# Summary: Destroy the SUT for the ipaddr2 test
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+=head1 NAME
+
+ipaddr2/destroy.pm - Destroy the infrastructure for the ipaddr2 test
+
+=head1 DESCRIPTION
+
+This module is responsible for cleaning up and destroying all the Azure
+resources created for the ipaddr2 test.
+
+Its main tasks are:
+
+- If a network peering was established with an IBSm (Infrastructure Build and
+  Support mirror) environment, it deletes the peering connection.
+- It destroys the entire Azure Resource Group, which contains all VMs,
+  networks, and other resources created by the C<deploy.pm> module.
+
+This module is typically the last one to run in the test suite.
+
+=head1 VARIABLES
+
+=over
+
+=item B<PUBLIC_CLOUD_PROVIDER>
+
+Used to check the public cloud provider. Currently, only 'AZURE' is supported.
+
+=item B<IBSM_RG>
+
+The name of the Azure Resource Group for the IBSm (Infrastructure Build and
+Support mirror) environment. If this variable is set, it indicates that a
+network peering was established and needs to be cleaned up.
+
+=item B<IPADDR2_DIAGNOSTIC>
+
+If enabled (1), extended deployment logs (e.g., boot diagnostics) are
+collected on failure.
+
+=item B<IPADDR2_CLOUDINIT>
+
+This variable's state affects log collection on failure. If not set to 0
+(default is enabled), cloud-init logs are collected.
+
+=back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=cut
 
 use strict;
 use warnings;
@@ -38,7 +88,7 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs();
+    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
     if (my $ibsm_rg = get_var('IBSM_RG')) {
         qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
     }

--- a/tests/sles4sap/ipaddr2/network_peering.pm
+++ b/tests/sles4sap/ipaddr2/network_peering.pm
@@ -4,6 +4,55 @@
 # Summary: Create network peering with IBSm
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
+=head1 NAME
+
+ipaddr2/network_peering.pm - Create a network peering with an IBSm server
+
+=head1 DESCRIPTION
+
+This module establishes a network peering between the ipaddr2 test
+environment and an IBSm server.
+
+The module performs two main tasks:
+
+- It creates an Azure VNet peering between the test's virtual network and the
+  IBSm's virtual network.
+- It configures the SUT (System Under Test) VMs to use the IBSm for software
+  repositories by adding an entry to `/etc/hosts` and configuring any specified
+  incident repositories.
+
+=head1 VARIABLES
+
+=over
+
+=item B<IBSM_RG>
+
+The name of the Azure Resource Group for the IBSm environment. This is
+required to create the VNet peering.
+
+=item B<IBSM_IP>
+
+The IP address of the IBSm server. This is required to add an entry to the
+`/etc/hosts` file on the SUT VMs, redirecting repository traffic.
+
+=item B<INCIDENT_REPO>
+
+An optional, comma-separated list of incident-specific repository URLs. If provided,
+these repositories will be added to the SUTs' package manager configuration.
+
+=item B<REPO_MIRROR_HOST>
+
+The hostname of the repository server to be redirected to the IBSm.
+Defaults to `download.suse.de`.
+
+=back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=cut
+
 use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';
@@ -15,7 +64,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_cloudinit_logs
   ipaddr2_infra_destroy
   ipaddr2_network_peering_create
-  ipaddr2_add_server_repos_to_hosts
+  ipaddr2_repos_add_server_to_hosts
   ipaddr2_azure_resource_group
 );
 
@@ -27,9 +76,9 @@ sub run {
     # Create network peering
     ipaddr2_network_peering_create(ibsm_rg => get_required_var('IBSM_RG'));
 
-    ipaddr2_add_server_repos_to_hosts(
+    ipaddr2_repos_add_server_to_hosts(
         ibsm_ip => get_required_var('IBSM_IP'),
-        incident_repo => get_var('INCIDENT_REPO', ''),
+        incident_repos => get_var('INCIDENT_REPO', ''),
         repo_host => get_var('REPO_MIRROR_HOST', 'download.suse.de'));
 }
 

--- a/tests/sles4sap/ipaddr2/patch_system.pm
+++ b/tests/sles4sap/ipaddr2/patch_system.pm
@@ -21,7 +21,30 @@ consistent and up-to-date state for subsequent tests.
 =head1 VARIABLES
 
 This module does not require any specific configuration variables for its core functionality.
-It assumes that the system repositories are already configured and accessible.
+Some variables are needed for the correct execution of the post_fail_hook
+
+=over
+
+=item B<IPADDR2_CLOUDINIT>
+
+Enables or disables the use of cloud-init for SUT setup. Defaults to enabled (1).
+When enabled, cloud-init handles tasks such as image registration,
+installation of nginx and socat, and creation of a basic web page for SUT identification.
+
+=item B<IPADDR2_DIAGNOSTIC>
+
+Enable some diagnostic features as the additional deployment of some Azure resources needed
+to collect boot logs.
+
+=item B<IBSM_RG>
+
+The name of the Azure Resource Group for the IBSm (Infrastructure Build and Support mirror)
+environment. If this variable is set, it indicates that a network peering was
+established. This module uses it in the C<post_fail_hook> to clean up the
+peering connection if the test fails.
+
+=back
+
 
 =head1 MAINTAINER
 

--- a/tests/sles4sap/ipaddr2/registration.pm
+++ b/tests/sles4sap/ipaddr2/registration.pm
@@ -25,7 +25,7 @@ for both SUT VMs and lists them for logging purposes.
 
 =head1 VARIABLES
 
-=over 4
+=over
 
 =item B<IPADDR2_CLOUDINIT>
 
@@ -66,8 +66,8 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_scc_addons
   ipaddr2_scc_check
   ipaddr2_scc_register
-  ipaddr2_refresh_repo
-  ipaddr2_ssh_internal
+  ipaddr2_repo_refresh
+  ipaddr2_repo_list
   ipaddr2_bastion_pubip
 );
 
@@ -108,16 +108,8 @@ sub run {
 
     foreach my $id (1 .. 2) {
         # refresh repo
-        ipaddr2_refresh_repo(id => $id, bastion_ip => $bastion_ip);
-
-        # record repo lr
-        ipaddr2_ssh_internal(id => $id,
-            cmd => "sudo zypper lr",
-            bastion_ip => $bastion_ip);
-        # record repo ls
-        ipaddr2_ssh_internal(id => $id,
-            cmd => "sudo zypper ls",
-            bastion_ip => $bastion_ip);
+        ipaddr2_repo_refresh(id => $id, bastion_ip => $bastion_ip);
+        ipaddr2_repo_list(id => $id, bastion_ip => $bastion_ip);
     }
 }
 

--- a/tests/sles4sap/ipaddr2/sanity_cluster.pm
+++ b/tests/sles4sap/ipaddr2/sanity_cluster.pm
@@ -1,14 +1,55 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# Summary: Check that deployed resource in the cloud are as expected
-# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
-# Summary: Check that deployed resource in the cloud are as expected at OS level:
-#          Check packages, connectivity between nodes, network configuration
-#
-# This test module can be configured with these variables:
-#   - PUBLIC_CLOUD_PROVIDER: This setting is needed by other test modules usually scheduled with this one.
-#                            Variable here is only validated and only value 'AZURE' is supported at the moment.
+# Summary: Perform cluster sanity checks for the ipaddr2 test
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+=head1 NAME
+
+ipaddr2/sanity_cluster.pm - Perform cluster sanity checks for the ipaddr2 test
+
+=head1 DESCRIPTION
+
+This module runs sanity checks specifically on the Pacemaker cluster created
+for the ipaddr2 test. It verifies the cluster's health, ensuring that it is
+properly configured and all resources are in the expected state.
+
+It primarily calls the C<ipaddr2_cluster_sanity> function from the shared
+library to perform the checks.
+
+
+=head1 VARIABLES
+
+=over
+
+=item B<PUBLIC_CLOUD_PROVIDER>
+
+Specifies the public cloud provider. This module currently only supports 'AZURE'.
+
+=item B<IPADDR2_DIAGNOSTIC>
+
+If enabled (1), extended deployment logs (e.g., boot diagnostics) are
+collected on failure.
+
+=item B<IPADDR2_CLOUDINIT>
+
+This variable's state affects log collection on failure. If not set to 0
+(default is enabled), cloud-init logs are collected.
+
+=item B<IBSM_RG>
+
+The name of the Azure Resource Group for the IBSm (Infrastructure Build and
+Support mirror) environment. If this variable is set, the C<post_fail_hook>
+will clean up the network peering on failure.
+
+=back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=cut
+
 use strict;
 use warnings;
 use Mojo::Base 'publiccloud::basetest';

--- a/tests/sles4sap/ipaddr2/sanity_os.pm
+++ b/tests/sles4sap/ipaddr2/sanity_os.pm
@@ -1,8 +1,63 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# Summary: Check that deployed resource in the cloud are as expected
-# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+# Summary: Perform OS and cluster sanity checks for the ipaddr2 test
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+=head1 NAME
+
+ipaddr2/sanity_os - Perform OS and cluster sanity checks for the ipaddr2 test
+
+=head1 DESCRIPTION
+
+This module performs a series of sanity checks on the deployed infrastructure
+for the ipaddr2 test. It verifies both the operating system (OS) configuration
+of the SUT (System Under Test) VMs and the basic health of the Pacemaker cluster.
+
+The OS-level checks verify network configuration, connectivity between nodes,
+SSH key setup for the configured user, systemd state, and cloud-init status.
+
+The cluster-level checks validate the overall status of the Pacemaker cluster
+and ensure all configured resources are running as expected.
+
+=head1 VARIABLES
+
+=over
+
+=item B<PUBLIC_CLOUD_PROVIDER>
+
+Specifies the public cloud provider. This module currently only supports 'AZURE'.
+
+=item B<IPADDR2_ROOTLESS>
+
+Determines the user context for the SSH sanity checks. If set to 1, it validates
+the configuration for a rootless cluster setup (using the 'cloudadmin' user).
+If set to 0 or not defined (default), it validates the configuration for a
+cluster running as 'root'.
+
+=item B<IPADDR2_DIAGNOSTIC>
+
+If enabled (1), extended deployment logs (e.g., boot diagnostics) are collected on failure.
+
+=item B<IPADDR2_CLOUDINIT>
+
+This variable's state affects log collection on failure. If not set to 0 (default is enabled),
+cloud-init logs are collected, assuming it was used during deployment.
+
+=item B<IBSM_RG>
+
+The name of the Azure Resource Group for the IBSm (Infrastructure Build and Support mirror)
+environment. If this variable is set, it indicates that a network peering was
+established. This module uses it in the C<post_fail_hook> to clean up the
+peering connection if the test fails.
+
+=back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=cut
 
 use strict;
 use warnings;


### PR DESCRIPTION
Rename functions to all use same convention ipaddr2_<object>_verb Use constant for the user
Improve POD documentatio
Create cluster version function

- Related ticket: https://jira.suse.com/browse/TEAM-10496

# Verification run:

## Regression
sle-15-SP7-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_7-ipaddr2_azure_test_rootless
- https://openqaworker15.qa.suse.cz/tests/336017 :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/336041 :green_circle: 

sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-ipaddr2_azure_test
 - http://openqaworker15.qa.suse.cz/tests/336042 :green_circle: 

sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5-ipaddr2_azure_test_cloud_init
- http://openqaworker15.qa.suse.cz/tests/336027 :green_circle: 

sle-12-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE12_5_PAYG-ipaddr2_azure_test
 - http://openqaworker15.qa.suse.cz/tests/336043
 - http://openqaworker15.qa.suse.cz/tests/336056
 
## Maintenance
sle-12-SP5-Azure-SAP-BYOS-Incidents-x86_64-Build:38246:azure-cli-core-ipaddr2
- https://openqaworker15.qa.suse.cz/tests/336036 :green_circle: 


sle-12-SP5-Azure-SAP-PAYG-Incidents-x86_64-Build:38246:azure-cli-core-ipaddr2
- https://openqaworker15.qa.suse.cz/tests/336040 :green_circle: 



sle-15-SP6-Azure-SAP-BYOS-Incidents-x86_64-Build:40043:cluster-glue-ipaddr2
- https://openqaworker15.qa.suse.cz/tests/336052 :green_circle: 


sle-15-SP6-Azure-SAP-PAYG-Incidents-x86_64-Build:40043:cluster-glue-ipaddr2
- https://openqaworker15.qa.suse.cz/tests/336044 :green_circle: 
