### PR TITLE
containers: Use user-console on transactional systems

### DIFF
--- a/tests/containers/rootless_podman.pm
+++ b/tests/containers/rootless_podman.pm
@@ -101,7 +101,11 @@ sub run {
     # already exists owned by root
     assert_script_run 'rm -rf /tmp/script*';
     ensure_serialdev_permissions;
-    select_user_serial_terminal;
+    if (is_transactional) {
+        select_console "user-console";
+    } else {
+        select_user_serial_terminal();
+    }
 
     # By default the storage driver is set to btrfs if /var is in btrfs
     # but if the home partition is not btrfs podman commands will fail with


### PR DESCRIPTION
Use user-console on transactional systems like we do [here](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/containers/compose.pm#L94)

- Failing test: https://openqa.opensuse.org/tests/5223246#step/rootless_podman/77
- Verification run: https://openqa.opensuse.org/tests/5224240