### PR TITLE
Use PackageHub in BATS tests again

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -171,7 +171,7 @@ sub enable_modules {
     add_suseconnect_product(get_addon_fullname('desktop'));
     add_suseconnect_product(get_addon_fullname('sdk'));
     add_suseconnect_product(get_addon_fullname('python3')) if is_sle('>=15-SP4');
-    # Needed for criu & fakeroot
+    # Needed for criu, fakeroot & qemu-linux-user
     add_suseconnect_product(get_addon_fullname('phub'));
 }
 

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -171,6 +171,8 @@ sub enable_modules {
     add_suseconnect_product(get_addon_fullname('desktop'));
     add_suseconnect_product(get_addon_fullname('sdk'));
     add_suseconnect_product(get_addon_fullname('python3')) if is_sle('>=15-SP4');
+    # Needed for criu & fakeroot
+    add_suseconnect_product(get_addon_fullname('phub'));
 }
 
 sub patch_logfile {

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -73,7 +73,7 @@ sub run {
     select_serial_terminal;
 
     my @pkgs = qw(buildah docker git-daemon glibc-devel-static go1.24 jq libgpgme-devel libseccomp-devel make openssl podman selinux-tools);
-    push @pkgs, "qemu-linux-user" if (is_tumbleweed || is_sle('>=16'));
+    push @pkgs, "qemu-linux-user" if (is_tumbleweed || is_sle('>=15-SP6'));
 
     $self->bats_setup(@pkgs);
 

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -14,7 +14,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use Utils::Architectures qw(is_x86_64);
 use containers::bats;
-use version_utils qw(is_tumbleweed);
+use version_utils qw(is_sle);
 
 
 sub run_tests {
@@ -41,9 +41,7 @@ sub run {
     select_serial_terminal;
 
     my @pkgs = qw(apache2-utils jq openssl podman squashfs skopeo);
-    # This package is only available on Tumbleweed and is needed
-    # only for the SIF image test in systemtest/020-copy.bats
-    push @pkgs, "fakeroot" if is_tumbleweed;
+    push @pkgs, "fakeroot" unless is_sle('>=16.0');
 
     $self->bats_setup(@pkgs);
 


### PR DESCRIPTION
If we drop the `qemu-linux-user` dependency for the buildah upstream tests, then we would have to ignore the [bud](https://github.com/containers/buildah/blob/main/tests/bud.bats) test and this is something we can't afford given that it's the one of the most important tests.

