### PR TITLE
P.C. system restart: WAIT CHECK highlights eventual failures

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -494,7 +494,7 @@ sub wait_for_ssh {
       ", $instance_msg, Duration: $duration sec.\nResult: $sshout";
     $instance_msg .= $sysout if defined($sysout);
     $instance_msg .= "\nRetries on failure: $retry" if ($retry);
-    record_info("WAIT CHECK", $instance_msg);
+    record_info("WAIT CHECK", $instance_msg, result => ($sysout =~ m/\sfailed\s/ ? "fail" : "ok"));
     # OK
     return $duration if (isok($exit_code) and not $args{wait_stop});
     # FAIL


### PR DESCRIPTION
In `wait_for_ssh` a systemctl check returning **`degraded`** after startup, implies more checks to extract the output of eventual failures. 

The `$sysout` string contains the full `systemctl` output, then also eventual failed message, that detected, we format the record_info result to be 'fail' otherwise normal, ok.

`WAIT CHECK` record_info now points out issue in RED/fail outline, for eventual post-failure analysis, if the test fails.

This feature can be explained with this _failed_ test (from [1247382](https://bugzilla.suse.com/show_bug.cgi?id=1247382)): 
if we had this feature active in  [prepare_instance/367](https://openqa.suse.de/tests/18598767#step/prepare_instance/367) (that is [L452](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/ed30102466309b90e6720b192b357b0aebc32244/lib/publiccloud/instance.pm#L452)), we could have detected earlier the problem in [next step](https://openqa.suse.de/tests/18598767#step/prepare_instance/415), 
from a _red_ [Wait Check red outline](https://openqa.suse.de/tests/18598767#step/prepare_instance/392).


Note: 
detecting the '`failed`' string from systemctl output can help to address more checks, but considering this string itself not a fully necessary-&-sufficient condition, preferable is avoiding `die` test, leaving the final check as post-failure analysis, if then it does.

- Related ticket: https://progress.opensuse.org/issues/186819#note-4

- Verification run: see PR threads
