### PR TITLE
Add uname and other information requested by upstream

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -300,7 +300,7 @@ sub collect_coredumps {
     script_run('coredumpctl list > coredumpctl.txt');
 
     # Get PID and executable for all dumps
-    my @lines = split /\n/, script_output(q{coredumpctl --no-pager --no-legend | awk '$9 == "present" { print $5, $10 }'});
+    my @lines = split /\n/, script_output(q{coredumpctl --no-pager --no-legend | awk '$9 == "present" { print $5, $10 }'}, proceed_on_failure => 1);
 
     foreach my $line (@lines) {
         my ($pid, $exe) = split /\s+/, $line;

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -325,12 +325,15 @@ sub bats_post_hook {
     script_run('df -h > df-h.txt');
     script_run('dmesg > dmesg.txt');
     script_run('findmnt > findmnt.txt');
+    script_run('free -h > free.txt');
+    script_run('lscpu > lscpu.txt');
     script_run('lsmod > lsmod.txt');
     script_run('rpm -qa | sort > rpm-qa.txt');
     script_run('sysctl -a > sysctl.txt');
     script_run('systemctl > systemctl.txt');
     script_run('systemctl status > systemctl-status.txt');
     script_run('systemctl list-unit-files > systemctl_units.txt');
+    script_run('uname -a > uname.txt');
     script_run('journalctl -b > journalctl-b.txt', timeout => 120);
     script_run('tar zcf containers-conf.tgz $(find /etc/containers /usr/share/containers -type f)');
 


### PR DESCRIPTION
Add uname and other information requested by upstream

Also use `proceed_on_failure` when using `script_output` on commands that may fail.

VR: https://openqa.opensuse.org/tests/5225136#downloads (additional logs added).