### PR TITLE
containers: Skip rootless_docker on public cloud

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -197,7 +197,8 @@ sub load_host_tests_docker {
     # The docker-rootless-extras package is only available on SLES 15-SP4+
     # while the docker-stable-rootless-extras is available on SLES 16.0+
     if (is_tumbleweed || is_leap || is_sle && (is_sle('>=16') || is_sle('>=15-SP4') && !check_var("CONTAINERS_DOCKER_FLAVOUR", "stable"))) {
-        loadtest 'containers/rootless_docker';
+        # select_user_serial_terminal is broken on public cloud
+        loadtest 'containers/rootless_docker' unless (is_public_cloud);
     }
     # Expected to work anywhere except of real HW backends, PC and Micro
     unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro || (is_sle('=12-SP5') && is_aarch64)) {


### PR DESCRIPTION
Reverting https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22863

Skip rootless_docker on public cloud.

Failing test: https://openqa.suse.de/tests/18679773#step/rootless_docker/79
