### PR TITLE
Accept Promoted/Unpromoted in drbd_passive test module

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -1185,6 +1185,11 @@ C<script_output_retry_check> also defined in this library.
 =cut
 
 sub collect_sbd_delay_parameters {
+    # Depending on when this function is executed, the cmap API may not be ready
+    # (for example, after a fence). Since corosync-cmapctl is used to get some
+    # of the params below, lets first confirm cmap API is ready
+    script_retry('corosync-cmapctl', delay => 30, timeout => $default_timeout, fail_message => 'cmap API not ready');
+
     # all commands below ($corosync_token, $corosync_consensus...) are defined and exported at the beginning of the library
     my %params = (
         'corosync_token' =>

--- a/tests/ha/iscsi_client_setup.pm
+++ b/tests/ha/iscsi_client_setup.pm
@@ -3,7 +3,7 @@
 # Copyright 2016-2020 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Package: iscsi-client-sles-16
+# Package: open-iscsi, iscsiuio
 # Summary: Configure iSCSI target for HA tests
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
@@ -17,11 +17,74 @@ use hacluster;
 use serial_terminal qw(select_serial_terminal);
 use version_utils qw(is_sle package_version_cmp);
 
+=head1 NAME
+
+ha/iscsi_client_setup.pm - Add iSCSI targets to the System Under Test
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=head1 DESCRIPTION
+
+Configure iSCSI targets from a known iSCSI server in the System Under Test using CLI commands.
+
+B<The key tasks performed by this module include:>
+
+=over
+
+=item * Verify the test module runs in SLES 16 or older. Skip in older versions.
+
+=item * Restart C<systemd-udevd> service.
+
+=item * Verify the iSCSI server is reachable.
+
+=item * Record iSCSI initiator value.
+
+=item * Install C<open-iscsi> and C<iscsiuio>
+
+=item * Generate a new initiator
+
+=item * Enable and start C<iscsid> service.
+
+=item * Query a list of IQN nodes from the iSCSI server, and select one that matches to the C<openqa> string.
+
+=item * Change the startup of the IQN node name from C<manual> to C<automatic> in the C<default>
+configuration file generated after discovery.
+
+=item * Start a new session to the IQN node name in the iSCSI server.
+
+=item * Restart C<iscsid> and C<iscsi> services.
+
+=item * Verify there are new block devices starting with the text C<ip-> in the SUT.
+
+=back
+
+=head1 OPENQA SETTINGS
+
+=over
+
+=item * USE_SUPPORT_SERVER: indicates whether test runs in a Multi Machine scenario with a Support Server.
+
+=item * ISCSI_SERVER: IP address or FQHN of the iSCSI server.
+
+=back
+
+=cut
+
 sub run {
     return record_info('Skip iscsi_client_setup', 'Module skipped on older versions of SLES. Use ha/iscsi_client instead') if (is_sle('<16'));
     my $iscsi_server = get_var('USE_SUPPORT_SERVER') ? 'ns' : get_required_var('ISCSI_SERVER');
 
     select_serial_terminal;
+
+    # Restart udevd in SLES 16, as it comes configured with
+    # ProtectHostname=yes, meaning that the hostname seen by
+    # udevd and the one configured in the system may differ in
+    # scenarios where console/hostname is also scheduled which
+    # can lead to issues later with some HA resources. We need to
+    # do this before iSCSI and watchdog setup
+    systemctl 'restart systemd-udevd.service';
 
     # Perform a ping size check to several hosts which need to be accessible while
     # running this module


### PR DESCRIPTION
Recent versions of crmsh have replaced the terms Master/Slave with Promoted/Unpromoted. The `ha/drbd_passive` test module fails as it tries to confirm the `ms_drbd_passive` resource is started and running in the first node by looking for `Master` in the output of `crm resource status`. This commit makes it so both `Master` and `Promoted` are accepted.

Also included in the commit is an added command in `ha/iscsi_client_setup` to restart `systemd-udevd` before iSCSI configuration in SLES 16, as now udev comes configured with `ProtectHostname=yes` and without restarting udev or the node, it's possible that the hostname seen by udev and the one configured in the system do not match, leading to problems later in the test.

Additionally, also included in the commit is a call to `corosync-cmapctl` added with `script_retry` in
`hacluster::collect_sbd_delay_parameters` as the function requires the cmap API to be ready. Retrying the command before attemtpting to collect the SBD params allows us to check whether the cmap API did start.

- Related Ticket: https://bugzilla.suse.com/show_bug.cgi?id=1247534
- Needles: N/A
- Verification run: http://mango.qe.nue2.suse.org/tests/7089 & http://mango.qe.nue2.suse.org/tests/7090
