### PR TITLE
Automate configurable timeout for bootloader

### DIFF
--- a/data/yam/agama/auto/lib/base.libsonnet
+++ b/data/yam/agama/auto/lib/base.libsonnet
@@ -1,7 +1,4 @@
 {
-  bootloader: {
-    stopOnBootMenu: true
-  },
   files: [{
      destination: '/usr/local/share/dummy.xml',
      url: 'dummy.xml'
@@ -20,5 +17,14 @@
     [if password then 'password']: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
     [if password then 'hashedPassword']: true,
     sshPublicKey: 'fake public key to enable sshd and open firewall',
+  },
+}
+
+{
+  stop_timeout():: {
+    stopOnBootMenu: true,
+  },
+  timeout():: {
+    timeout: 15,
   },
 }

--- a/data/yam/agama/auto/template.libsonnet
+++ b/data/yam/agama/auto/template.libsonnet
@@ -9,7 +9,8 @@ local software_lib = import 'lib/software.libsonnet';
 local storage_lib = import 'lib/storage.libsonnet';
 local security_lib = import 'lib/security.libsonnet';
 
-function(bootloader=false,
+function(bootloader=true,
+         bootloader_timeout=false,
          dasd=false,
          extra_repositories=false,
          files=false,
@@ -30,7 +31,8 @@ function(bootloader=false,
          ssl_certificates=false,
          storage='',
          user=true) {
-  [if bootloader == true then 'bootloader']: base_lib['bootloader'],
+  [if bootloader then 'bootloader']: base_lib.stop_timeout(),
+  [if bootloader_timeout then 'bootloader']: base_lib.timeout(),
   [if dasd == true then 'dasd']: dasd_lib.dasd(),
   [if files == true then 'files']: base_lib['files'],
   [if iscsi == true then 'iscsi']: iscsi_lib.iscsi(),

--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -38,6 +38,7 @@ sub grub_test {
     # 60 due to rare slowness e.g. multipath poo#11908
     # 90 as a workaround due to the qemu backend fallout
     assert_screen(is_bootloader_grub2_bls ? 'grub2-bls' : 'grub2', $timeout);
+    assert_screen('grub2_timeout') if get_var('AGAMA_PROFILE_OPTIONS', '') =~ /bootloader_timeout/;
     stop_grub_timeout;
     boot_into_snapshot if get_var("BOOT_TO_SNAPSHOT");
     send_key_until_needlematch("bootmenu-xen-kernel", 'down', 11, 5) if get_var('XEN');


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/184073
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/545
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&build=lemon-suse%2Fos-autoinst-distri-opensuse%23check-agama-grub-timeout-shown&version=16.0

