### PR TITLE
bats/runc: Skip cgroups tests on ppc64le due to issue 4841

### DIFF
--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -54,6 +54,8 @@ sub run {
     # Compile helpers used by the tests
     my $cmds = script_output "find contrib/cmd tests/cmd -mindepth 1 -maxdepth 1 -type d -printf '%f ' || true";
     run_command "make $cmds || true";
+    # Skip this test due to https://github.com/opencontainers/runc/issues/4841
+    run_command "rm -f tests/integration/cgroups.bats" if is_ppc64le;
     # Skip this test due to https://bugzilla.suse.com/show_bug.cgi?id=1247568
     run_command "rm -f tests/integration/no_pivot.bats" if is_ppc64le;
     # Skip this test due to https://bugzilla.suse.com/show_bug.cgi?id=1247567


### PR DESCRIPTION
Skip cgroups tests on ppc64le due to issue 4841
