### PR TITLE
SDAF extend delay between cleanup retries

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -759,7 +759,7 @@ sub sdaf_execute_remover {
         upload_logs($output_log_file, log_name => $output_log_file);
 
         last unless $rc;
-        sleep 30;
+        sleep 120;
         record_info("SDAF destroy retry $attempt_no", "destroy of '$args{deployment_type}' exited with RC '$rc', retrying ...");
         $attempt_no++;
     }


### PR DESCRIPTION
There are sporadic issues in cleanup module happening on Azure. According to MS, those are caused by Azure infrastructure as such and they recommended increasing sleep between cleanup retriess. This PR increases sleep to 2 min.

Ticket: No ticket
Original failure:
https://openqaworker15.qa.suse.cz/tests/336143/#step/cleanup/164

VR: https://openqaworker15.qa.suse.cz/tests/336215#live