### PR TITLE
Ipaddr2 move ssh args to constants

### DIFF
--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -311,7 +311,6 @@ subtest '[ipaddr2_cluster_check_version]' => sub {
     ok((any { /ssh.*\.41.*rpm.*qf.*which crm/ } @calls), "Get rpm crm");
     ok((any { /ssh.*\.41.*crm --version/ } @calls), "Get crm --version");
     ok((any { /ssh.*\.41.*zypper se.*crmsh/ } @calls), "Get installed crmsh zypper package");
-
 };
 
 subtest '[ipaddr2_deployment_sanity] Pass' => sub {


### PR DESCRIPTION
Move some ssh arguments, mostly about verbosity and logging, to some constants.
Drop a too small internal function.
Small fixed in the POD documentation.

Related ticket: https://jira.suse.com/browse/TEAM-10500

refinement of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22893

# Verification run:
 - sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5-ipaddr2_azure_test -> http://openqaworker15.qa.suse.cz/tests/336223 :green_apple: 
 
 - sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5-ipaddr2_azure_test_cloud_init -> http://openqaworker15.qa.suse.cz/tests/336224 :green_apple: 
 
- sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5-ipaddr2_azure_test_root -> http://openqaworker15.qa.suse.cz/tests/336225 :green_apple: 

 - sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5-ipaddr2_azure_test_rootless -> http://openqaworker15.qa.suse.cz/tests/336226 :green_apple: 
