### PR TITLE
Change code for ipaddr2 address ranges

### DIFF
--- a/tests/sles4sap/cloud_netconfig/deploy.pm
+++ b/tests/sles4sap/cloud_netconfig/deploy.pm
@@ -17,7 +17,7 @@ single network interface.
 
 The created resources include:
 
-=over 4
+=over
 
 =item * A virtual machine (VM) to host the test.
 
@@ -27,7 +27,7 @@ The created resources include:
 
 =item * Three IP configurations associated with the single NIC:
 
-=over 2
+=over
 
 =item - The primary IP configuration with a public IP address.
 
@@ -43,7 +43,7 @@ The created resources include:
 
 =head1 VARIABLES
 
-=over 4
+=over
 
 =item B<PUBLIC_CLOUD_PROVIDER>
 

--- a/tests/sles4sap/ipaddr2/cluster_create.pm
+++ b/tests/sles4sap/ipaddr2/cluster_create.pm
@@ -69,7 +69,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
   ipaddr2_azure_resource_group
-);
+  ipaddr2_ip_get);
 
 sub run {
     my ($self) = @_;
@@ -80,6 +80,7 @@ sub run {
     select_serial_terminal;
 
     my $bastion_ip = ipaddr2_bastion_pubip();
+    my %ip = ipaddr2_ip_get(slot => get_var('WORKER_ID'));
 
     # Check if cloudinit is active or not. In case it is,
     # registration was eventually there and no need to per performed here.
@@ -88,6 +89,7 @@ sub run {
         my %web_install_args;
         $web_install_args{external_repo} = get_var('IPADDR2_NGINX_EXTREPO') if get_var('IPADDR2_NGINX_EXTREPO');
         $web_install_args{bastion_ip} = $bastion_ip;
+        $web_install_args{priv_ip_range} = $ip{priv_ip_range};
         foreach (1 .. 2) {
             $web_install_args{id} = $_;
             ipaddr2_configure_web_server(%web_install_args);
@@ -96,9 +98,10 @@ sub run {
 
     record_info("TEST STAGE", "Init and configure the Pacemaker cluster");
 
-    ipaddr2_cluster_check_version();
+    ipaddr2_cluster_check_version(priv_ip_range => $ip{priv_ip_range});
     ipaddr2_cluster_create(
         bastion_ip => $bastion_ip,
+        ip => \%ip,
         rootless => get_var('IPADDR2_ROOTLESS', '0'));
 }
 
@@ -109,7 +112,10 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
+    unless (check_var('IPADDR2_CLOUDINIT', 0)) {
+        my %ip = ipaddr2_ip_get(slot => get_var('WORKER_ID'));
+        ipaddr2_cloudinit_logs(priv_ip_range => $ip{priv_ip_range});
+    }
     if (my $ibsm_rg = get_var('IBSM_RG')) {
         qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
     }

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -65,7 +65,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_internal_key_accept
   ipaddr2_internal_key_gen
   ipaddr2_cloudinit_logs
-);
+  ipaddr2_ip_get);
 
 sub run {
     my ($self) = @_;
@@ -79,7 +79,8 @@ sub run {
     my $bastion_ip = ipaddr2_bastion_pubip();
     ipaddr2_bastion_key_accept(bastion_ip => $bastion_ip);
 
-    my %int_key_args = (bastion_ip => $bastion_ip);
+    my %ip = ipaddr2_ip_get(slot => get_var('WORKER_ID'));
+    my %int_key_args = (bastion_ip => $bastion_ip, priv_ip_range => $ip{priv_ip_range});
     # unsupported option "accept-new" for default ssh used in 12sp5
     $int_key_args{key_checking} = 'no' if (check_var('IPADDR2_KEYCHECK_OLD', '1'));
     ipaddr2_internal_key_accept(%int_key_args);
@@ -96,7 +97,10 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
+    unless (check_var('IPADDR2_CLOUDINIT', 0)) {
+        my %ip = ipaddr2_ip_get(slot => get_var('WORKER_ID'));
+        ipaddr2_cloudinit_logs(priv_ip_range => $ip{priv_ip_range});
+    }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -83,7 +83,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_deployment_sanity
   ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
-);
+  ipaddr2_ip_get);
 
 sub run {
     my ($self) = @_;
@@ -113,6 +113,7 @@ sub run {
         $os = $provider->get_image_id();
     }
 
+    my %ip = ipaddr2_ip_get(slot => get_var('WORKER_ID'));
     my %cloudinit_args;
     # This line of code is not really specific to cloud-init,
     # but it is used to ensure that registration code is available
@@ -126,6 +127,7 @@ sub run {
     $cloudinit_args{external_repo} = get_var('IPADDR2_NGINX_EXTREPO') if get_var('IPADDR2_NGINX_EXTREPO');
     my %deployment = (
         os => $os,
+        ip => \%ip,
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0));
     $deployment{trusted_launch} = 0 if (check_var('IPADDR2_TRUSTEDLAUNCH', 0));
 
@@ -147,7 +149,10 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
+    unless (check_var('IPADDR2_CLOUDINIT', 0)) {
+        my %ip = ipaddr2_ip_get(slot => get_var('WORKER_ID'));
+        ipaddr2_cloudinit_logs(priv_ip_range => $ip{priv_ip_range});
+    }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/ipaddr2/destroy.pm
+++ b/tests/sles4sap/ipaddr2/destroy.pm
@@ -65,7 +65,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
   ipaddr2_azure_resource_group
-);
+  ipaddr2_ip_get);
 
 sub run {
     my ($self) = @_;
@@ -78,6 +78,10 @@ sub run {
     if (my $ibsm_rg = get_var('IBSM_RG')) {
         qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
     }
+    unless (check_var('IPADDR2_CLOUDINIT', 0)) {
+        my %ip = ipaddr2_ip_get(slot => get_var('WORKER_ID'));
+        ipaddr2_cloudinit_logs(priv_ip_range => $ip{priv_ip_range});
+    }
     ipaddr2_infra_destroy();
 }
 
@@ -88,7 +92,10 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
+    unless (check_var('IPADDR2_CLOUDINIT', 0)) {
+        my %ip = ipaddr2_ip_get(slot => get_var('WORKER_ID'));
+        ipaddr2_cloudinit_logs(priv_ip_range => $ip{priv_ip_range});
+    }
     if (my $ibsm_rg = get_var('IBSM_RG')) {
         qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
     }

--- a/tests/sles4sap/ipaddr2/network_peering.pm
+++ b/tests/sles4sap/ipaddr2/network_peering.pm
@@ -66,12 +66,13 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_network_peering_create
   ipaddr2_repos_add_server_to_hosts
   ipaddr2_azure_resource_group
-);
+  ipaddr2_ip_get);
 
 sub run {
     my ($self) = @_;
 
     select_serial_terminal;
+    my %ip = ipaddr2_ip_get(slot => get_var('WORKER_ID'));
 
     # Create network peering
     ipaddr2_network_peering_create(ibsm_rg => get_required_var('IBSM_RG'));
@@ -79,7 +80,8 @@ sub run {
     ipaddr2_repos_add_server_to_hosts(
         ibsm_ip => get_required_var('IBSM_IP'),
         incident_repos => get_var('INCIDENT_REPO', ''),
-        repo_host => get_var('REPO_MIRROR_HOST', 'download.suse.de'));
+        repo_host => get_var('REPO_MIRROR_HOST', 'download.suse.de'),
+        priv_ip_range => $ip{priv_ip_range});
 }
 
 sub test_flags {
@@ -89,7 +91,10 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
+    unless (check_var('IPADDR2_CLOUDINIT', 0)) {
+        my %ip = ipaddr2_ip_get(slot => get_var('WORKER_ID'));
+        ipaddr2_cloudinit_logs(priv_ip_range => $ip{priv_ip_range});
+    }
     if (my $ibsm_rg = get_var('IBSM_RG')) {
         qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
     }

--- a/tests/sles4sap/ipaddr2/registration.pm
+++ b/tests/sles4sap/ipaddr2/registration.pm
@@ -69,7 +69,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_repo_refresh
   ipaddr2_repo_list
   ipaddr2_bastion_pubip
-);
+  ipaddr2_ip_get);
 
 sub run {
     my ($self) = @_;
@@ -77,6 +77,7 @@ sub run {
     select_serial_terminal;
 
     my $bastion_ip = ipaddr2_bastion_pubip();
+    my %ip = ipaddr2_ip_get(slot => get_var('WORKER_ID'));
 
     # Check if cloudinit is active or not. In case it is,
     # registration was eventually performed by the cloudinit script
@@ -88,6 +89,7 @@ sub run {
                 # Check if somehow the image is already registered or not
                 my $is_registered = ipaddr2_scc_check(
                     bastion_ip => $bastion_ip,
+                    priv_ip_range => $ip{priv_ip_range},
                     id => $_);
                 record_info('is_registered', "$is_registered");
                 # Conditionally register the SLES for SAP instance.
@@ -95,12 +97,14 @@ sub run {
                 # registration code ('SCC_REGCODE_SLES4SAP') is available.
                 ipaddr2_scc_register(
                     bastion_ip => $bastion_ip,
+                    priv_ip_range => $ip{priv_ip_range},
                     id => $_,
                     scc_code => get_required_var('SCC_REGCODE_SLES4SAP')) if ($is_registered ne 1);
             }
         }
         # Optionally register addons
         ipaddr2_scc_addons(
+            priv_ip_range => $ip{priv_ip_range},
             bastion_ip => $bastion_ip,
             scc_addons => get_required_var('SCC_ADDONS')
         ) if (get_var('SCC_ADDONS'));
@@ -108,8 +112,8 @@ sub run {
 
     foreach my $id (1 .. 2) {
         # refresh repo
-        ipaddr2_repo_refresh(id => $id, bastion_ip => $bastion_ip);
-        ipaddr2_repo_list(id => $id, bastion_ip => $bastion_ip);
+        ipaddr2_repo_refresh(id => $id, bastion_ip => $bastion_ip, priv_ip_range => $ip{priv_ip_range});
+        ipaddr2_repo_list(id => $id, bastion_ip => $bastion_ip, priv_ip_range => $ip{priv_ip_range});
     }
 }
 
@@ -120,7 +124,10 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
+    unless (check_var('IPADDR2_CLOUDINIT', 0)) {
+        my %ip = ipaddr2_ip_get(slot => get_var('WORKER_ID'));
+        ipaddr2_cloudinit_logs(priv_ip_range => $ip{priv_ip_range});
+    }
     ipaddr2_infra_destroy();
     $self->SUPER::post_fail_hook;
 }

--- a/tests/sles4sap/ipaddr2/sanity_cluster.pm
+++ b/tests/sles4sap/ipaddr2/sanity_cluster.pm
@@ -14,9 +14,12 @@ This module runs sanity checks specifically on the Pacemaker cluster created
 for the ipaddr2 test. It verifies the cluster's health, ensuring that it is
 properly configured and all resources are in the expected state.
 
-It primarily calls the C<ipaddr2_cluster_sanity> function from the shared
-library to perform the checks.
+It performs the following checks:
 
+- Verifies the overall cluster health using C<crm status>.
+- Ensures the cluster reports no issues via C<crm_mon>.
+- Confirms that exactly three primitive resources are configured.
+- Checks for the presence of the nginx resource agent and its corresponding package.
 
 =head1 VARIABLES
 
@@ -63,7 +66,7 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_infra_destroy
   ipaddr2_cloudinit_logs
   ipaddr2_azure_resource_group
-);
+  ipaddr2_ip_get);
 
 sub run {
     my ($self) = @_;
@@ -74,7 +77,9 @@ sub run {
     select_serial_terminal;
 
     my $bastion_ip = ipaddr2_bastion_pubip();
-    ipaddr2_cluster_sanity(bastion_ip => $bastion_ip);
+    my %ip = ipaddr2_ip_get(slot => get_var('WORKER_ID'));
+
+    ipaddr2_cluster_sanity(bastion_ip => $bastion_ip, priv_ip_range => $ip{priv_ip_range});
 }
 
 sub test_flags {
@@ -84,7 +89,10 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
+    unless (check_var('IPADDR2_CLOUDINIT', 0)) {
+        my %ip = ipaddr2_ip_get(slot => get_var('WORKER_ID'));
+        ipaddr2_cloudinit_logs(priv_ip_range => $ip{priv_ip_range});
+    }
     if (my $ibsm_rg = get_var('IBSM_RG')) {
         qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
     }


### PR DESCRIPTION
The ipaddr2 test has to extablish network peering the the Azure IBSm. The peering has to works for multiple jobs running in parallel. Each job has to use a different IP range when the peering has to be created. This commit is reworking an existing and functional implementation to:
- centralize the calculation of all the addresses and ranges in a single place.
- try as much as possible not to use values calculated at library load, try to keep th elibrary code as state-less as possible, try avoiding the read on WORKER_ID in the library.
- try to create an implementation that only use a different ip range for each job when the test needs also to create the peering
- convert more lib variables to constants, like `user`
- add more unit tests
- improve the documentation, fix typo, add more test modules POD descriptions.

I DO NOT PLAN TO MERGE IT. I CREATED THIS PR TO COLLECT SOME THE VRs

- Related ticket:

# Verification run:

- sle-15-SP5-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5-ipaddr2_azure_test_rootless@64bit -> http://openqaworker15.qa.suse.cz/tests/336227 :green_apple: 

 - sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5-ipaddr2_azure_test@64bit -> http://openqaworker15.qa.suse.cz/tests/336228 :green_apple: 