### PR TITLE
bats: Use xz to compress coredump and use a prefix for the name

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -253,6 +253,8 @@ sub bats_setup {
     if ($oci_runtime && !grep { $_ eq $oci_runtime } @pkgs) {
         push @pkgs, $oci_runtime;
     }
+    # We use xz to compress core files
+    push @pkgs, "xz";
     run_command "zypper --gpg-auto-import-keys -n install @pkgs", timeout => 300;
 
     configure_oci_runtime $oci_runtime;
@@ -304,11 +306,12 @@ sub collect_coredumps {
 
     foreach my $line (@lines) {
         my ($pid, $exe) = split /\s+/, $line;
-        my $core = basename($exe) . ".$pid.core";
+        $exe = basename($exe);
+        my $core = "core.$exe.$pid.core";
 
         # Dumping and compressing coredumps may take some time
         script_run("coredumpctl -o $core dump $pid", 300);
-        script_run("gzip -v $core", 300);
+        script_run("xz -9v $core", 300);
     }
 }
 


### PR DESCRIPTION
Since the introduction of `collect_coredumps` we notice that some tests are generating core files, which needs investigation, and they take up some storage space.  Use `xz` instead of `gzip` to do faster multi-threaded compression and achieve 20% size reduction in core files.  Also use a predictable `core` prefix to easily find them in the `Logs & Assets` tab.

