### PR TITLE
Increase timeout for aarch64

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -188,7 +188,7 @@ sub add_file_in_csync {
 
     if (defined($conf_file) && defined($args{value})) {
         # Check if conf_file is a valid value
-        assert_script_run "[[ -w $conf_file ]]";
+        assert_script_run("[[ -w $conf_file ]]", 180);
 
         # Add the value in conf_file and sync on all nodes
         assert_script_run "grep -Fq $args{value} $conf_file || sed -i 's|^}\$|include $args{value};\\n}|' $conf_file";


### PR DESCRIPTION
Due to aarch64 performance issue, drbd_passive usually failed in timeout
issue, increase the timeout.
    
Failure: https://openqa.suse.de/tests/18715250#step/drbd_passive/89
    
VR: https://openqa.suse.de/tests/18720714#
