### PR TITLE
LTP: Log network with ss

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -289,7 +289,7 @@ EOF
         script_run('ip6tables -S');
 
         # display various network configuration
-        script_run('netstat -nap');
+        script_run('ss -nap || netstat -nap');
 
         script_run('cat /etc/resolv.conf');
         script_run('f=/etc/nsswitch.conf; [ ! -f $f ] && f=/usr$f; cat $f');


### PR DESCRIPTION
`ss` is more modern tool than `netstat`, log network with it. Fallback to `netstat` (old systems or net-tools package not installed).

Verification run:
- https://openqa.suse.de/tests/overview?build=netstat-ss
- https://openqa.opensuse.org/tests/overview?build=netstat-ss
