### PR TITLE
Support kubevirt tests on sle16

### DIFF
--- a/schedule/virt_autotest/kubevirt-tests-sle16.yaml
+++ b/schedule/virt_autotest/kubevirt-tests-sle16.yaml
@@ -1,0 +1,27 @@
+name:           kubevirt-tests
+description:    >
+    Maintainer: Nan Zhang <nan.zhang@suse.com> qe-virt@suse.de
+    Run kubevirt tests on sle16
+vars:
+    MAX_JOB_TIME: 72000
+schedule:
+    - '{{barrier_setup}}'
+    - '{{bootup_and_install}}'
+    - '{{kubevirt_tests}}'
+conditional_schedule:
+    barrier_setup:
+        SERVICE:
+            rke2-server:
+                - virt_autotest/kubevirt_barriers
+    bootup_and_install:
+        RUN_TEST_ONLY:
+            0:
+                - installation/ipxe_install
+                - installation/agama_reboot
+                - virt_autotest/login_console
+    kubevirt_tests:
+        SERVICE:
+            rke2-server:
+                - virt_autotest/kubevirt_tests_server
+            rke2-agent:
+                - virt_autotest/kubevirt_tests_agent

--- a/tests/virt_autotest/kubevirt_tests_agent.pm
+++ b/tests/virt_autotest/kubevirt_tests_agent.pm
@@ -48,8 +48,8 @@ sub rke2_agent_setup {
 
     record_info('RKE2 Agent Setup', '');
     unless (is_transactional) {
-        disable_and_stop_service('apparmor.service');
-        disable_and_stop_service('firewalld.service');
+        disable_and_stop_service('apparmor.service') if (script_run('systemctl is-active apparmor') == 0);
+        disable_and_stop_service('firewalld.service') if (script_run('systemctl is-active firewalld') == 0);
     }
     # Enable NTP service
     systemctl('enable --now chronyd', timeout => 180);

--- a/tests/virt_autotest/kubevirt_tests_server.pm
+++ b/tests/virt_autotest/kubevirt_tests_server.pm
@@ -98,8 +98,8 @@ sub rke2_server_setup {
 
     record_info('RKE2 Server Setup', '');
     unless (is_transactional) {
-        disable_and_stop_service('apparmor.service');
-        disable_and_stop_service('firewalld.service');
+        disable_and_stop_service('apparmor.service') if (script_run('systemctl is-active apparmor') == 0);
+        disable_and_stop_service('firewalld.service') if (script_run('systemctl is-active firewalld') == 0);
     }
     # Enable NTP service
     systemctl('enable --now chronyd', timeout => 180);


### PR DESCRIPTION
Create a yaml file to support kubevirt tests running on sle16.

- Related ticket: https://progress.opensuse.org/issues/185920
- Verification run: https://openqa.suse.de/tests/18558237, https://openqa.suse.de/tests/18753078
