### PR TITLE
bats/aardvark-dns: Backport PR#619 to fix dnsmasq issue

### DIFF
--- a/data/containers/bats/patches/aardvark-dns/619.patch
+++ b/data/containers/bats/patches/aardvark-dns/619.patch
@@ -1,0 +1,24 @@
+From 254c6d1188ca27d67161207619767051b9c640d6 Mon Sep 17 00:00:00 2001
+From: Ricardo Branco <rbranco@suse.de>
+Date: Sat, 9 Aug 2025 10:36:49 +0200
+Subject: [PATCH] test: Remove empty user= directive in dnsmasq.conf to avoid
+ SIGSEGV
+
+Signed-off-by: Ricardo Branco <rbranco@suse.de>
+---
+ test/dnsmasq.conf | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/test/dnsmasq.conf b/test/dnsmasq.conf
+index b000d3d8..72859da3 100644
+--- a/test/dnsmasq.conf
++++ b/test/dnsmasq.conf
+@@ -6,8 +6,6 @@ no-resolv
+ 
+ log-queries
+ 
+-user=
+-
+ # aone and bone should return NXDOMAIN, by default dnsmasq returns REFUSED
+ address=/aone/
+ address=/bone/

--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -1,8 +1,14 @@
 aardvark-dns:
+  # Note on patches:
+  # https://github.com/containers/aardvark-dns/pull/619 is needed for dnsmasq issue
   opensuse-Tumbleweed:
-    BATS_SKIP: 100-basic-name-resolution 200-two-networks 300-three-networks
+    BATS_PATCHES:
+    - 619
+    BATS_SKIP:
   sle-16.0:
-    BATS_SKIP: 100-basic-name-resolution 200-two-networks 300-three-networks
+    BATS_PATCHES:
+    - 619
+    BATS_SKIP:
 buildah:
   # Note on patches:
   # https://github.com/containers/buildah/pull/6226 is needed for bud & run

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -221,12 +221,6 @@ Please add this warning on each bug report you open when adding instructions on 
 
 Complete list found in [skip.yaml](data/containers/bats/skip.yaml)
 
-### aardvark-dns
-
-| tests | reason |
-| --- | --- |
-| half of them | [aardvark-dns upstream tests make dnsmasq dump core](https://bugzilla.opensuse.org/show_bug.cgi?id=1247812) |
-
 ## Tools
 
 - [susebats](https://github.com/ricardobranco777/susebats)


### PR DESCRIPTION
Backport https://github.com/containers/aardvark-dns/pull/619 to address https://github.com/containers/aardvark-dns/issues/618

Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1247812
Verification runs:
- Tumbleweed:
  - aarch64: https://openqa.opensuse.org/tests/5231401
  - x86_64: https://openqa.opensuse.org/tests/5231402
- SLE 16.0:
  - aarch64: https://openqa.suse.de/tests/18737148
  - ppc64le: https://openqa.suse.de/tests/18737149
  - s390x: https://openqa.suse.de/tests/18737150
  - x86_64: https://openqa.suse.de/tests/18737151