### PR TITLE
Minor BATS enhancements

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -345,8 +345,9 @@ sub bats_post_hook {
     script_run('tar zcf containers-conf.tgz $(find /etc/containers /usr/share/containers -type f)');
 
     for my $ip_version (4, 6) {
-        script_run("ip -$ip_version addr > ip$ip_version-addr.txt");
-        script_run("ip -$ip_version route > ip$ip_version-route.txt");
+        script_run("ip -j -$ip_version addr > ip$ip_version-addr.txt");
+        script_run("ip -j -$ip_version link > ip$ip_version-link.txt");
+        script_run("ip -j -$ip_version route > ip$ip_version-route.txt");
     }
     script_run("iptables-save > iptables.txt");
     script_run("ip6tables-save > ip6tables.txt");

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -19,7 +19,7 @@ sub run_tests {
     my %params = @_;
     my ($rootless, $skip_tests) = ($params{rootless}, $params{skip_tests});
 
-    return if check_var($skip_tests, "all");
+    return 0 if check_var($skip_tests, "all");
 
     my $storage_driver = $rootless ? "vfs" : script_output("buildah info --format '{{ .store.GraphDriverName }}'");
     $storage_driver = get_var("BUILDAH_STORAGE_DRIVER", $storage_driver);

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -22,7 +22,7 @@ sub run_tests {
     my %params = @_;
     my ($rootless, $remote, $skip_tests) = ($params{rootless}, $params{remote}, $params{skip_tests});
 
-    return if check_var($skip_tests, "all");
+    return 0 if check_var($skip_tests, "all");
 
     my $quadlet = script_output "rpm -ql podman | grep podman/quadlet";
 

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -20,7 +20,7 @@ sub run_tests {
     my %params = @_;
     my ($rootless, $skip_tests) = ($params{rootless}, $params{skip_tests});
 
-    return if check_var($skip_tests, "all");
+    return 0 if check_var($skip_tests, "all");
 
     my %env = (
         RUNC_USE_SYSTEMD => "1",

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -21,7 +21,7 @@ sub run_tests {
     my %params = @_;
     my ($rootless, $skip_tests) = ($params{rootless}, $params{skip_tests});
 
-    return if check_var($skip_tests, "all");
+    return 0 if check_var($skip_tests, "all");
 
     # Default quay.io/libpod/registry:2 image used by the test only has amd64 image
     my $registry = is_x86_64 ? "" : "docker.io/library/registry:2";


### PR DESCRIPTION
- Use JSON on `ip -$ip_version` commands. 
- Use `return 0` on early skip.
