### PR TITLE
bats/podman: Backport PR#26794 to fix pasta tests

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -91,16 +91,18 @@ podman:
   # https://github.com/containers/podman/pull/25918 is needed for 195-run-namespaces
   # https://github.com/containers/podman/pull/25942 is needed for 252-quadlet
   # https://github.com/containers/podman/pull/26017 is needed for 030-run
+  # https://github.com/containers/podman/pull/26794 is needed for 505-networking-pasta
   opensuse-Tumbleweed:
     BATS_PATCHES:
     - 25918
     - 25942
     - 26017
+    - https://github.com/containers/podman/pull/26794.patch
     BATS_SKIP:
     BATS_SKIP_ROOT_LOCAL: 200-pod
     BATS_SKIP_ROOT_REMOTE:
-    BATS_SKIP_USER_LOCAL: 252-quadlet 505-networking-pasta
-    BATS_SKIP_USER_REMOTE: 130-kill 505-networking-pasta
+    BATS_SKIP_USER_LOCAL: 252-quadlet
+    BATS_SKIP_USER_REMOTE: 130-kill
   sle-16.0:
     BATS_PATCHES:
     - 25792
@@ -108,11 +110,12 @@ podman:
     - 25918
     - 25942
     - 26017
+    - https://github.com/containers/podman/pull/26794.patch
     BATS_SKIP:
     BATS_SKIP_ROOT_LOCAL: 200-pod
     BATS_SKIP_ROOT_REMOTE:
-    BATS_SKIP_USER_LOCAL: 505-networking-pasta
-    BATS_SKIP_USER_REMOTE: 130-kill 505-networking-pasta
+    BATS_SKIP_USER_LOCAL:
+    BATS_SKIP_USER_REMOTE: 130-kill
   sle-15-SP7:
     BATS_PATCHES:
     - 21875


### PR DESCRIPTION
Backport https://github.com/containers/podman/pull/26794 to fix pasta tests.

The above PR:
- Fixes an issue with ipv4_get_addr_global & ipv4_get_addr_global
- Will correctly detect if IPv6 is supported (not the case with o3) and skip IPv6 tests.

Verification runs:
  - opensuse-Tumbleweed aarch64 (crun): https://openqa.opensuse.org/tests/5232655
  - opensuse-Tumbleweed aarch64 (runc): https://openqa.opensuse.org/tests/5232656
  - opensuse-Tumbleweed x86_64 (crun): https://openqa.opensuse.org/tests/5232657
  - opensuse-Tumbleweed x86_64 (runc): https://openqa.opensuse.org/tests/5232658
  - sle-16.0 aarch64: https://openqa.suse.de/tests/18738166
  - sle-16.0 ppc64le-p10: https://openqa.suse.de/tests/18738164
  - sle-16.0 s390x-kvm: https://openqa.suse.de/tests/18738165 (FAILING)
  - sle-16.0 x86_64: https://openqa.suse.de/tests/18738168

TODO
- Add final patch as file.