### PR TITLE
bats: Beautify JSON output through jq

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -345,9 +345,9 @@ sub bats_post_hook {
     script_run('tar zcf containers-conf.tgz $(find /etc/containers /usr/share/containers -type f)');
 
     for my $ip_version (4, 6) {
-        script_run("ip -j -$ip_version addr > ip$ip_version-addr.txt");
-        script_run("ip -j -$ip_version link > ip$ip_version-link.txt");
-        script_run("ip -j -$ip_version route > ip$ip_version-route.txt");
+        script_run("ip -j -$ip_version addr | jq -Mr > ip$ip_version-addr.txt");
+        script_run("ip -j -$ip_version link | jq -Mr > ip$ip_version-link.txt");
+        script_run("ip -j -$ip_version route | jq -Mr > ip$ip_version-route.txt");
     }
     script_run("iptables-save > iptables.txt");
     script_run("ip6tables-save > ip6tables.txt");


### PR DESCRIPTION
Beautify JSON output through jq.  The current output uses one line and is not fit for human consumption.
