### PR TITLE
bats/podman: Unignore 505-networking-pasta

### DIFF
--- a/data/containers/bats/patches/podman/26798.patch
+++ b/data/containers/bats/patches/podman/26798.patch
@@ -1,0 +1,115 @@
+From 6c360f6ece30c4db736f5ed255ea17ee650da763 Mon Sep 17 00:00:00 2001
+From: Ricardo Branco <rbranco@suse.de>
+Date: Sun, 10 Aug 2025 14:18:14 +0200
+Subject: [PATCH] tests: Fix network test helpers
+
+Fixes ipv4_get_addr_global & ipv6_get_addr_global by skipping
+link-local IPv4/IPv6 addresses as they are not globally routable.
+
+Uses a trick from Richard W. Stevens's "Unix Network Programming" book
+to get the default global IPv4 & IPv6 address that doesn't need a target
+IP host to be connected at all to the Internet.
+
+Signed-off-by: Ricardo Branco <rbranco@suse.de>
+---
+ test/system/helpers.network.bash | 63 +++++++++++++++++++++++++++-----
+ 1 file changed, 54 insertions(+), 9 deletions(-)
+
+diff --git a/test/system/helpers.network.bash b/test/system/helpers.network.bash
+index 0ffcabc576..4695eef3cb 100644
+--- a/test/system/helpers.network.bash
++++ b/test/system/helpers.network.bash
+@@ -4,14 +4,45 @@ _cached_has_slirp4netns=
+ 
+ ### Feature Checks #############################################################
+ 
++function ip_get_addr_global() {
++    # Google DNS servers
++    if [ "$1" = "-6" ]; then
++        address="2001:4860:4860::8888"
++    else
++        address="8.8.8.8"
++    fi
++    # According to Richard W. Stevens's UNIX Network Programming Vol. 1 3rd Ed:
++    # "Calling connect on a UDP socket does not send anything to that host;
++    # it is entirely a local operation that saves the peer's IP address and port.
++    # We also see that calling connect on an unbound UDP socket also assigns an
++    # ephemeral port to the socket."
++    python_script='
++import socket, sys
++
++family = socket.AF_INET if sys.argv[1] == "-4" else socket.AF_INET6
++ipport = socket.getaddrinfo(sys.argv[2], 53, family=family, type=socket.SOCK_DGRAM)[0][4]
++
++with socket.socket(family, socket.SOCK_DGRAM) as s:
++    try:
++        s.connect(ipport)
++    except OSError:
++        sys.exit(1)
++    print(s.getsockname()[0])'
++
++    python3 -c "$python_script" "$1" "$address"
++}
++
+ # has_ipv4() - Check if one default route is available for IPv4
+ function has_ipv4() {
+-    [ -n "$(ip -j -4 route show | jq -rM '.[] | select(.dst == "default")')" ]
++    local expr='[.[].addr_info[] | select(.scope=="global") | select(.local | test("^169\\.254\\.") | not)] | .[0].local'
++    echo "${1:-$(ip -j -4 address show)}" | jq -rM "${expr}"
+ }
+ 
+ # has_ipv6() - Check if one default route is available for IPv6
+ function has_ipv6() {
+-    [ -n "$(ip -j -6 route show | jq -rM '.[] | select(.dst == "default")')" ]
++    # Require both global IPv6 addresses AND a default route for true IPv6 connectivity
++    ip -j -6 addr show | jq -e '[.[].addr_info[] | select(.scope == "global")] | length > 0' >/dev/null &&
++    ip -j -6 route show | jq -e 'any(.dst == "default")' >/dev/null
+ }
+ 
+ # skip_if_no_ipv4() - Skip current test if IPv4 traffic can't be routed
+@@ -101,15 +132,25 @@ function ipv4_to_procfs() {
+ # ipv4_get_addr_global() - Print first global IPv4 address reported by netlink
+ # $1:	Optional output of 'ip -j -4 address show' from a different context
+ function ipv4_get_addr_global() {
+-    local expr='[.[].addr_info[] | select(.scope=="global")] | .[0].local'
+-    echo "${1:-$(ip -j -4 address show)}" | jq -rM "${expr}"
++    if [ -n "$1" ]; then
++        # Skip RFC 3927 link-local IPv4 addresses in 169.254.0.0/16 as they are not globally routable
++        local expr='[.[].addr_info[] | select(.scope=="global") | select(.local | test("^169\\.254\\.") | not)] | .[0].local'
++        echo "$1" | jq -rM "${expr}"
++    else
++        ip_get_addr_global -4
++    fi
+ }
+ 
+ # ipv6_get_addr_global() - Print first global IPv6 address reported by netlink
+ # $1:	Optional output of 'ip -j -6 address show' from a different context
+ function ipv6_get_addr_global() {
+-    local expr='[.[].addr_info[] | select(.scope=="global")] | .[0].local'
+-    echo "${1:-$(ip -j -6 address show)}" | jq -rM "${expr}"
++    if [ -n "$1" ]; then
++        # Skip RFC 4291 link-local IPv6 addresses in fe80::/10 as they are not globally routable
++        local expr='[.[].addr_info[] | select(.scope=="global") | select(.local | test("^fe[89ab][0-9a-f]:") | not)] | (map(select(.mngtmpaddr == true)) + map(select(.mngtmpaddr != true))) | .[0].local'
++        echo "$1" | jq -rM "${expr}"
++    else
++        ip_get_addr_global -6
++    fi
+ }
+ 
+ # random_rfc1918_subnet() - Pseudorandom unused subnet in 172.16/12 prefix
+@@ -444,8 +485,12 @@ function default_ifname() {
+ 
+ function default_addr() {
+     local ip_ver="${1}"
+-    local ifname="${2:-$(default_ifname "${ip_ver}")}"
+ 
+-    local expr='[.[0].addr_info[] | select(.deprecated != true)][0].local'
+-    ip -j -"${ip_ver}" addr show "${ifname}" | jq -rM "${expr}"
++    if [ -n "$2" ] ; then
++        local ifname="${2:-$(default_ifname "${ip_ver}")}"
++        local expr='[.[0].addr_info[] | select(.deprecated != true)][0].local'
++        ip -j -"${ip_ver}" addr show "${ifname}" | jq -rM "${expr}"
++    else
++        ip_get_addr_global -"${ip_ver}"
++    fi
+ }

--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -99,8 +99,8 @@ podman:
     BATS_SKIP:
     BATS_SKIP_ROOT_LOCAL: 200-pod
     BATS_SKIP_ROOT_REMOTE:
-    BATS_SKIP_USER_LOCAL: 252-quadlet 505-networking-pasta
-    BATS_SKIP_USER_REMOTE: 130-kill 505-networking-pasta
+    BATS_SKIP_USER_LOCAL: 252-quadlet
+    BATS_SKIP_USER_REMOTE: 130-kill
   sle-16.0:
     BATS_PATCHES:
     - 25792
@@ -111,8 +111,8 @@ podman:
     BATS_SKIP:
     BATS_SKIP_ROOT_LOCAL: 200-pod
     BATS_SKIP_ROOT_REMOTE:
-    BATS_SKIP_USER_LOCAL: 505-networking-pasta
-    BATS_SKIP_USER_REMOTE: 130-kill 505-networking-pasta
+    BATS_SKIP_USER_LOCAL:
+    BATS_SKIP_USER_REMOTE: 130-kill
   sle-15-SP7:
     BATS_PATCHES:
     - 21875

--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -91,11 +91,13 @@ podman:
   # https://github.com/containers/podman/pull/25918 is needed for 195-run-namespaces
   # https://github.com/containers/podman/pull/25942 is needed for 252-quadlet
   # https://github.com/containers/podman/pull/26017 is needed for 030-run
+  # https://github.com/containers/podman/pull/26798 is needed for 505-networking-pasta
   opensuse-Tumbleweed:
     BATS_PATCHES:
     - 25918
     - 25942
     - 26017
+    - 26798
     BATS_SKIP:
     BATS_SKIP_ROOT_LOCAL: 200-pod
     BATS_SKIP_ROOT_REMOTE:
@@ -108,6 +110,7 @@ podman:
     - 25918
     - 25942
     - 26017
+    - 26798
     BATS_SKIP:
     BATS_SKIP_ROOT_LOCAL: 200-pod
     BATS_SKIP_ROOT_REMOTE:


### PR DESCRIPTION
Backport https://github.com/containers/podman/pull/26798 to fix pasta tests

Verification runs:
 - Tumbleweed aarch64 (crun): https://openqa.opensuse.org/tests/5232829
 - Tumbleweed aarch64 (runc): https://openqa.opensuse.org/tests/5232830
 - Tumbleweed x86_64 (crun): https://openqa.opensuse.org/tests/5232831
 - Tumbleweed x86_64 (runc): https://openqa.opensuse.org/tests/5232832
 - sle-16.0 aarch64: https://openqa.suse.de/tests/18739145
 - sle-16.0 ppc64le-p10: https://openqa.suse.de/tests/18739146
 - sle-16.0 s390x-kvm: https://openqa.suse.de/tests/18739147
 - sle-16.0 x86_64: https://openqa.suse.de/tests/18739148
