### PR TITLE
bats/podman: Backport PR#26799 to unignore 252-quadlet

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -92,12 +92,14 @@ podman:
   # https://github.com/containers/podman/pull/25942 is needed for 252-quadlet
   # https://github.com/containers/podman/pull/26017 is needed for 030-run
   # https://github.com/containers/podman/pull/26798 is needed for 505-networking-pasta
+  # https://github.com/containers/podman/pull/26799 is needed for 252-quadlet
   opensuse-Tumbleweed:
     BATS_PATCHES:
     - 25918
     - 25942
     - 26017
     - 26798
+    - https://github.com/containers/podman/pull/26799.patch
     BATS_SKIP:
     BATS_SKIP_ROOT_LOCAL: 200-pod
     BATS_SKIP_ROOT_REMOTE:


### PR DESCRIPTION
DO NOT MERGE

Backport https://github.com/containers/podman/pull/26799 to unignore 252-quadlet

Verification runs (Tumbleweed) FAILED
- aarch64 (crun): https://openqa.opensuse.org/tests/5233551
- aarch64 (runc): https://openqa.opensuse.org/tests/5233552
- x86_64 (crun): https://openqa.opensuse.org/tests/5233549
- x86_64 (runc): https://openqa.opensuse.org/tests/5233550