### PR TITLE
Fix boot grub entry issue on UEFI

### DIFF
--- a/lib/Yam/Agama/Pom/GrubMenuAgamaPage.pm
+++ b/lib/Yam/Agama/Pom/GrubMenuAgamaPage.pm
@@ -16,12 +16,14 @@ sub new {
     return bless {
         grub_menu_base => $args->{grub_menu_base},
         tag_agama_installer_highlighted => 'grub-menu-agama-installer-highlighted',
+        tag_agama_grub_menu_suse => 'grub-menu-agama-suse-brand',
     }, $class;
 }
 
 sub expect_is_shown {
     my ($self) = @_;
-    send_key_until_needlematch($self->{tag_agama_installer_highlighted}, 'down') unless check_screen($self->{tag_agama_installer_highlighted}, 5);
+    assert_screen($self->{tag_agama_grub_menu_suse}, 60);
+    send_key_until_needlematch($self->{tag_agama_installer_highlighted}, 'down');
     assert_screen($self->{tag_agama_installer_highlighted}, 60);
 }
 


### PR DESCRIPTION
Assert bootmenu suse brand to ensure enter page of boot menu to avoid send key too early issue to select the correct install grub entry.

- Related ticket:  N/A
- Needles: grub-menu-agama-suse-brand
- Verification run: 
https://openqa.suse.de/tests/overview?version=16.0&build=lemon-suse%2Fos-autoinst-distri-opensuse%23debug-boot-menu-sequence-issue&distri=sle
