### PR TITLE
Add BIOS info during sev-snp testing

### DIFF
--- a/tests/virt_autotest/prepare_non_transactional_server.pm
+++ b/tests/virt_autotest/prepare_non_transactional_server.pm
@@ -39,7 +39,12 @@ sub run {
 sub prepare_networks {
     my $self = shift;
 
-    virt_autotest::virtual_network_utils::create_host_bridge_nm;
+    # Skip br0 bridge creation if SKIP_HOST_BRIDGE_SETUP is set
+    if (get_var('SKIP_HOST_BRIDGE_SETUP')) {
+        record_info("Host bridge preparation skipped", "Host bridge preparation skipped due to SKIP_HOST_BRIDGE_SETUP setting");
+    } else {
+        virt_autotest::virtual_network_utils::create_host_bridge_nm;
+    }
 }
 
 sub prepare_ground {

--- a/tests/virt_autotest/sev_snp_validation.pm
+++ b/tests/virt_autotest/sev_snp_validation.pm
@@ -144,6 +144,9 @@ sub check_sev_snp_on_host {
     my $cpu_info = script_output("grep -m1 'model name' /proc/cpuinfo");
     record_info('CPU Info', "CPU: $cpu_info");
 
+    # Display system information
+    $self->display_system_info();
+
     # Check architecture
     unless (is_x86_64) {
         record_info('Architecture', 'Non-x86_64 architecture detected, SEV-SNP is not supported', result => 'fail');
@@ -200,6 +203,25 @@ sub check_sev_snp_on_host {
     # Check SEV-SNP capability
     $self->check_sev_snp_host_capability();
 
+    return $self;
+}
+
+=head2 display_system_info
+
+  display_system_info($self)
+
+Display system information including BIOS, system details,
+and hardware capabilities relevant for SEV-SNP verification.
+This provides better visibility into the test environment and helps
+with debugging hardware compatibility issues.
+
+=cut
+
+sub display_system_info {
+    my $self = shift;
+
+    record_info('BIOS Information', script_output("dmidecode -t bios", proceed_on_failure => 1));
+    record_info('System Information', script_output("dmidecode -t system", proceed_on_failure => 1));
     return $self;
 }
 


### PR DESCRIPTION
Add BIOS info ans machine info during sev-snp testing
Skip br0 creation during sev-snp and sev-es testing

- Related ticket: https://progress.opensuse.org/issues/187104
- Needles: n/a
- Verification run: 
          [BIOS info display](https://openqa.oqa.prg2.suse.org/tests/18932843#step/sev_snp_validation/45)
          [Machine info display](https://openqa.oqa.prg2.suse.org/tests/18932843#step/sev_snp_validation/48)
          [Skip br0 creation](https://openqa.oqa.prg2.suse.org/tests/18941700#step/prepare_non_transactional_server/32)
