### PR TITLE
Bump timeout for check_screen on  Agama aarch64 bootup

### DIFF
--- a/lib/Yam/Agama/Pom/GrubMenuAgamaPage.pm
+++ b/lib/Yam/Agama/Pom/GrubMenuAgamaPage.pm
@@ -21,7 +21,7 @@ sub new {
 
 sub expect_is_shown {
     my ($self) = @_;
-    send_key_until_needlematch($self->{tag_agama_installer_highlighted}, 'down') unless check_screen($self->{tag_agama_installer_highlighted}, 5);
+    send_key_until_needlematch($self->{tag_agama_installer_highlighted}, 'down') unless check_screen($self->{tag_agama_installer_highlighted}, 10);
     assert_screen($self->{tag_agama_installer_highlighted}, 60);
 }
 


### PR DESCRIPTION
##
### Bump timeout for check_screen on  Agama aarch64 bootup

- We need to wait more time for check_screen when we check needle `agama_installer_highlighted` on aarch64, cause it's cost more time for Aarch64 boot into Grub menu.

- Related ticket: Quick PR
- Needles: N/A
- Verification run: 
  - pro
    - [10 seconds X 10 => ALL PASSED](https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=hjluo_sles_use_existing_md_raid_statistic)
    - [9 seconds X 10 => 4/10 FAILED](https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=hjluo_sles_use_existing_md_raid_wait_9_seconds)

  - Dev
    - https://openqa.suse.de/tests/18753083

##