### PR TITLE
xfstests: Add NFS with krb5 tests

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -480,7 +480,7 @@ Variable        | Type      | Default value | Details
 XFSTEST_MKFS_OPTION | string | | BTRFS only, value=<options-in-mkfs>. Set the options in mkfs.btrfs. And also set it in xfstests runtime option BTRFS_MKFS_OPTIONS.
 XFSTESTS_LOGDEV | boolean | 0 | XFS only, value=0/1. enable log device in testing xfs
 XFSTESTS_XFS_REPAIR | boolean | 0 | XFS only, value=0/1. enable TEST_XFS_REPAIR_REBUILD=1 in xfstests log file local.config
-XFSTESTS_NFS_VERSION | string | 4.1 | NFS only, version of test target NFS
+XFSTESTS_NFS_VERSION | string | 4.1 | NFS only, version of test target NFS. What's special is that set it with TLS-<nfsversion> will enable NFS over kTLS. And set it with krb5[pi]-<nfsversion> will enable NFS with kerberos5 mount option during tests
 XFSTESTS_NFS_SERVER | boolean | | NFS multimation test only, mandatory. To tag this test job for NFS server in a NFS multimachine test. NFS test in a multimachine test either a client or a server.
 NFS_GRACE_TIME | integer | 15 | NFS only, set the nlm_grace_period in /etc/modprobe.d/lockd.conf used in NFS test.
 PARALLEL_WITH | string | | NFS multimation test only, value=<set-the-parent-job-name>. To set the NFS server job name in NFS client job in a NFS multimachine test. e.g. xfstests_nfs4.1-server


### PR DESCRIPTION
Add NFS with kerberos settings. The mount option could be sec=krb5:krb5i:krb5p, the setting similar to NFS over TLS, could be set with XFSTESTS_NFS_VERSION=[krb5:krb5i:krb5p]-<nfsversion> to enable, e.g:XFSTESTS_NFS_VERSION=krb5-4.2

- Related ticket: https://progress.opensuse.org/issues/177672
- Verification run: https://openqa.suse.de/tests/18753089
