### PR TITLE
Fix combustion in powerPC test

### DIFF
--- a/schedule/jeos/sle/minimalvm-main.yaml
+++ b/schedule/jeos/sle/minimalvm-main.yaml
@@ -25,6 +25,8 @@ conditional_schedule:
                 - installation/bootloader_uefi
             'aarch64':
                 - installation/bootloader_uefi
+            'ppc64le-p10':
+                - installation/bootloader_uefi
     efi:
         UEFI:
             '1':
@@ -41,6 +43,8 @@ conditional_schedule:
                 - installation/first_boot
                 - console/system_prepare
             'combustion':
+                - installation/first_boot
+                - jeos/host_config
                 - microos/verify_setup
                 - microos/image_checks
 schedule:
@@ -49,7 +53,6 @@ schedule:
     - jeos/image_info
     - jeos/record_machine_id
     - console/force_scheduled_tasks
-    - jeos/host_config
     - jeos/diskusage
     - jeos/build_key
     - console/prjconf_excluded_rpms

--- a/tests/jeos/host_config.pm
+++ b/tests/jeos/host_config.pm
@@ -19,7 +19,7 @@ use Utils::Architectures qw(is_s390x);
 use version_utils qw(is_sle);
 
 sub run {
-    select_serial_terminal;
+    select_console('root-console');
 
     set_grub_gfxmode;
     ensure_serialdev_permissions;

--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -12,7 +12,7 @@ use warnings;
 use testapi;
 use version_utils qw(is_microos is_sle_micro is_jeos is_leap_micro);
 use Utils::Backends 'is_pvm';
-use Utils::Architectures qw(is_aarch64);
+use Utils::Architectures qw(is_aarch64 is_ppc64le);
 
 sub run {
     select_console 'root-console';
@@ -42,7 +42,7 @@ sub run {
         $left_sectors = 4062;
     } elsif ((is_sle_micro("5.4+") || is_leap_micro("5.4+")) && is_aarch64 && get_var('FLAVOR', '') !~ m/qcow|SelfInstall/) {
         $left_sectors = 2048;
-    } elsif (is_sle_micro("6.0+") && get_required_var('FLAVOR') =~ /ppc-4096/) {
+    } elsif ((is_sle_micro("6.0+") && get_required_var('FLAVOR') =~ /ppc-4096/) || is_jeos && is_ppc64le) {
         $left_sectors = 1792;
     }
 


### PR DESCRIPTION
Introduce combustion testsuite for powerPC.
Adding first_boot.pm after bootloader handler helps to avoid first
console login issues. The problem was that tty1 stayed and the
consecutive select console did not switch to expected tty6.
The jeos/host_config ensures that serial console configuration will take
place at an early stage of the test job.

- ticket: [[Minimal-VM][ppc64le] minimalvm-main-combustion test fails in verify_setup likely due to missing serial terminal](https://progress.opensuse.org/issues/186281)

- Verification run: https://openqa.suse.de/tests/18753648#
