### PR TITLE
Revert "Enable SaltBundle on SLES12-SP5"

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -53,20 +53,20 @@ sub packages_to_install {
         push @packages, ('python3-virtualenv') if ($bci_virtualenv);
     } elsif ($host_distri eq 'sles' || $host_distri =~ /leap/) {
         my $version = "$version.$sp";
+        push @packages, ('python3-virtualenv') if ($bci_virtualenv);
         if ($version =~ /12\./) {
             script_retry("SUSEConnect --auto-agree-with-licenses -p sle-sdk/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
             # PackageHub is needed for jq
             script_retry("SUSEConnect -p PackageHub/12.5/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
             script_retry('zypper -n in jq', retry => 3);
-            assert_script_run("zypper ar -f http://download.suse.de/ibs/SUSE:/SLE-12:/Update:/Products:/SaltBundle:/Update/standard/ saltbundle");
-            assert_script_run("zypper -n install venv-salt-minion");
+            # Note tox is not available on SLES12
+            push @packages, qw(python36-pip);
+            die "virtualenv is not supported on 12-SP5" if ($bci_virtualenv);
         } elsif ($version =~ /15\.[1-3]/) {
-            push @packages, ('python3-virtualenv') if ($bci_virtualenv);
             push @packages, ('skopeo');
         } else {
             script_retry("SUSEConnect -p sle-module-python3/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout) if ($host_distri =~ /sles/);
             push @packages, qw(python311 skopeo python311-pip python311-tox);
-            push @packages, ('python3-virtualenv') if ($bci_virtualenv);
         }
     } elsif ($host_distri =~ /opensuse/) {
         push @packages, qw(skopeo python3-pip python3-tox);
@@ -129,18 +129,10 @@ sub run {
         foreach my $pkg (@packages) {
             zypper_call("--quiet in $pkg", timeout => 300);
         }
-        if (is_sle('=12-SP5')) {
-            assert_script_run('source /usr/lib/venv-salt-minion/bin/activate');
+        activate_virtual_env if ($bci_virtualenv);
+        if (!grep(/-tox/, @packages)) {
             assert_script_run('pip --quiet install --upgrade pip', timeout => 600);
-            assert_script_run('pip --quiet install tox', timeout => 600);
-            $bci_virtualenv = 1;
-        }
-        else {
-            activate_virtual_env if ($bci_virtualenv);
-            if (!grep(/-tox/, @packages)) {
-                assert_script_run('pip --quiet install --upgrade pip', timeout => 600);
-                assert_script_run("pip --quiet install tox --ignore-installed six", timeout => 600);
-            }
+            assert_script_run("pip --quiet install tox --ignore-installed six", timeout => 600);
         }
     } else {
         die "Unexpected distribution ($host_distri) has been used";

--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -23,7 +23,7 @@ use serial_terminal 'select_serial_terminal';
 use containers::utils qw(reset_container_network_if_needed);
 use File::Basename;
 use utils qw(systemctl);
-use version_utils qw(get_os_release check_version is_sle);
+use version_utils qw(get_os_release check_version);
 
 my $error_count;
 
@@ -137,7 +137,6 @@ sub run {
     reset_container_network_if_needed($engine);
 
     assert_script_run('source bci/bin/activate') if ($bci_virtualenv);
-    assert_script_run('source /usr/lib/venv-salt-minion/bin/activate') if (is_sle('=12-SP5'));
 
     record_info('Run', "Starting the tests for the following environments:\n$test_envs");
     assert_script_run("cd /root/BCI-tests && git fetch && git reset --hard $bci_tests_branch");
@@ -159,7 +158,7 @@ sub run {
         $self->run_tox_cmd($env);
     }
 
-    assert_script_run('deactivate') if ($bci_virtualenv || is_sle('=12-SP5'));
+    assert_script_run('deactivate') if ($bci_virtualenv);
 
     # Mark the job as failed if any of the tests failed
     die("$error_count tests failed.") if ($error_count > 0);


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#22704 because it causing regression
Failed job : https://openqa.suse.de/tests/18737483#step/bci_prepare/60

VR: http://openqa.suse.de/tests/18754265