### PR TITLE
Add method for image override in Helm Chart tests

### DIFF
--- a/lib/containers/helm.pm
+++ b/lib/containers/helm.pm
@@ -73,10 +73,13 @@ sub helm_configure_values {
 
     if (my $image = get_var('CONTAINER_IMAGE_TO_TEST')) {
         my ($repository, $tag) = split(':', $image, 2);
+        my $helm_values_image_path = get_required_var('HELM_VALUES_IMAGE_PATH');
 
         # Add space before appending if $set_options already has content
         $set_options .= " " if $set_options ne "";
-        $set_options .= "--set app.image.repository=$repository --set app.image.tag=$tag";
+
+        # Charts by design have the image-related settings under `image.`. We only need to provide the path until that point via the variable.
+        $set_options .= "--set $helm_values_image_path.image.repository=$repository --set $helm_values_image_path.image.tag=$tag";
     }
 
     # Enable debug logs


### PR DESCRIPTION
Introduces new logic when testing a new container image (`CONTAINER_IMAGE_TO_TEST`). It takes the value of `HELM_VALUES_IMAGE_PATH` and overrides the image repository and tag to the correct ones for the image under testing. 

This allows us to test the new images with the Helm Chart test. 

- Related ticket: https://progress.opensuse.org/issues/186465
- Verification run: [openqa.mypersonalinstance.de/tests/xyz#step/module/x](http://dirtman.qe.prg2.suse.org/tests/16#step/privateregistry/47) ( the VR is for the substitution, the test fails for other reasons).
