### PR TITLE
Allow single-application helm chart image overrides

### DIFF
--- a/lib/containers/helm.pm
+++ b/lib/containers/helm.pm
@@ -73,13 +73,20 @@ sub helm_configure_values {
 
     if (my $image = get_var('CONTAINER_IMAGE_TO_TEST')) {
         my ($repository, $tag) = split(':', $image, 2);
-        my $helm_values_image_path = get_required_var('HELM_VALUES_IMAGE_PATH');
+        my $helm_values_image_path = get_var('HELM_VALUES_IMAGE_PATH') || '';
 
         # Add space before appending if $set_options already has content
         $set_options .= " " if $set_options ne "";
 
-        # Charts by design have the image-related settings under `image.`. We only need to provide the path until that point via the variable.
-        $set_options .= "--set $helm_values_image_path.image.repository=$repository --set $helm_values_image_path.image.tag=$tag";
+        # Charts by design have the image-related settings under `image.`
+        #We only need to provide the path until that point via the variable.
+        if ($helm_values_image_path == '') {
+          $set_options .= "--set image.repository=$repository --set image.tag=$tag";
+        } else {
+          # If containing more than 1 application, the path would be app-specific
+          $set_options .= "--set $helm_values_image_path.image.repository=$repository --set $helm_values_image_path.image.tag=$tag";
+        }
+
     }
 
     # Enable debug logs

--- a/lib/containers/helm.pm
+++ b/lib/containers/helm.pm
@@ -80,7 +80,7 @@ sub helm_configure_values {
 
         # Charts by design have the image-related settings under `image.`
         #We only need to provide the path until that point via the variable.
-        if ($helm_values_image_path == '') {
+        if ($helm_values_image_path eq '') {
           $set_options .= "--set image.repository=$repository --set image.tag=$tag";
         } else {
           # If containing more than 1 application, the path would be app-specific


### PR DESCRIPTION
Follow up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22953. 

This PR adds logic to handle Helm Charts that have a single application and as such, the `image` key is at the top-level. i.e. We need to set `image.repository` instead of `app.image.repository`. 

- Verification run:
  - Checking if the existing logic still works. `HELM_VALUES_IMAGE_PATH="nginx"` - http://dirtman.qe.prg2.suse.org/tests/21#step/privateregistry/47 
  - Checking if empty string is handled correctly. `HELM_VALUES_IMAGE_PATH=""` - http://dirtman.qe.prg2.suse.org/tests/22#step/privateregistry/47
  - Checking if undefined is handled correctly. - http://dirtman.qe.prg2.suse.org/tests/23#step/privateregistry/47
