### PR TITLE
bats: Use .txt extension to make TAP files browser-friendly 

### DIFF
--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -56,7 +56,7 @@ NOTES
 - To debug SELinux issues you may check the audit log & clone a job with `ENABLE_SELINUX=0`
 - To debug individual tests you may clone a job with `BATS_TESTS`
 - You can also test individual tests from the latest version in the `main` branch with `BATS_URL=main`
-- The BATS output is collected in the log files with the `.tap` extension
+- The BATS output is collected in the log files with the `.tap.txt` extension
 - The commands are collected in a log file ending with `-commands.txt`
 
 ## Adding patches to `BATS_PATCHES`

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -168,6 +168,7 @@ Please add this warning on each bug report you open when adding instructions on 
 [s16s_r]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Online&version=16.0&arch=s390x&test=runc_testsuite
 [s16s_s]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Online&version=16.0&arch=s390x&test=skopeo_testsuite
 
+[sp7_a]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP7&arch=x86_64&test=aardvark_testsuite
 [sp7_b]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP7&arch=x86_64&test=buildah_testsuite
 [sp7_n]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP7&arch=x86_64&test=netavark_testsuite
 [sp7_p]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP7&arch=x86_64&test=podman_testsuite
@@ -183,6 +184,7 @@ Please add this warning on each bug report you open when adding instructions on 
 [sp7s_r]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP7&arch=s390x&test=runc_testsuite
 [sp7s_s]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP7&arch=s390x&test=skopeo_testsuite
 
+[sp6_a]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP6&arch=x86_64&test=aardvark_testsuite
 [sp6_b]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP6&arch=x86_64&test=buildah_testsuite
 [sp6_n]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP6&arch=x86_64&test=netavark_testsuite
 [sp6_p]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP6&arch=x86_64&test=podman_testsuite
@@ -198,6 +200,7 @@ Please add this warning on each bug report you open when adding instructions on 
 [sp6s_r]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP6&arch=s390x&test=runc_testsuite
 [sp6s_s]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP6&arch=s390x&test=skopeo_testsuite
 
+[sp5_a]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP5&arch=x86_64&test=aardvark_testsuite
 [sp5_b]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP5&arch=x86_64&test=buildah_testsuite
 [sp5_n]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP5&arch=x86_64&test=netavark_testsuite
 [sp5_r]: https://openqa.suse.de/tests/latest?distri=sle&flavor=Server-DVD-Updates&version=15-SP5&arch=x86_64&test=runc_testsuite

--- a/tests/containers/bats/aardvark.pm
+++ b/tests/containers/bats/aardvark.pm
@@ -25,7 +25,7 @@ sub run_tests {
         NETAVARK => $netavark,
     );
 
-    my $log_file = "aardvark.tap";
+    my $log_file = "aardvark.tap.txt";
 
     return bats_tests($log_file, \%env, "");
 }

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -34,7 +34,7 @@ sub run_tests {
         STORAGE_DRIVER => $storage_driver,
     );
 
-    my $log_file = "buildah-" . ($rootless ? "user" : "root") . ".tap";
+    my $log_file = "buildah-" . ($rootless ? "user" : "root") . ".tap.txt";
 
     my $ret = bats_tests($log_file, \%env, $skip_tests);
 

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -22,7 +22,7 @@ sub run_tests {
         NETAVARK => $netavark,
     );
 
-    my $log_file = "netavark.tap";
+    my $log_file = "netavark.tap.txt";
 
     return bats_tests($log_file, \%env, "");
 }

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -32,7 +32,7 @@ sub run_tests {
         QUADLET => $quadlet,
     );
 
-    my $log_file = "bats-" . ($rootless ? "user" : "root") . "-" . ($remote ? "remote" : "local") . ".tap";
+    my $log_file = "bats-" . ($rootless ? "user" : "root") . "-" . ($remote ? "remote" : "local") . ".tap.txt";
 
     run_command "podman system service --timeout=0 &" if ($remote);
 

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -27,7 +27,7 @@ sub run_tests {
         RUNC => "/usr/bin/runc",
     );
 
-    my $log_file = "runc-" . ($rootless ? "user" : "root") . ".tap";
+    my $log_file = "runc-" . ($rootless ? "user" : "root") . ".tap.txt";
 
     return bats_tests($log_file, \%env, $skip_tests);
 }

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -31,7 +31,7 @@ sub run_tests {
         SKOPEO_TEST_REGISTRY_FQIN => $registry,
     );
 
-    my $log_file = "skopeo-" . ($rootless ? "user" : "root") . ".tap";
+    my $log_file = "skopeo-" . ($rootless ? "user" : "root") . ".tap.txt";
 
     return bats_tests($log_file, \%env, $skip_tests);
 }


### PR DESCRIPTION
Use `.txt` extension to make TAP files browser-friendly.

No need to download `.tap` files anymore as they're just one click away.

- Verification run: https://openqa.opensuse.org/tests/5238544/logfile?filename=aardvark-aardvark.tap.txt
