### PR TITLE
autoyast/mini: ensure system reboots at the end of the installation

### DIFF
--- a/data/autoyast/mini.xml
+++ b/data/autoyast/mini.xml
@@ -37,4 +37,9 @@
       <username>root</username>
     </user>
   </users>
+  <general>
+    <mode>
+      <final_reboot config:type="boolean">true</final_reboot>
+    </mode>
+  </general>
 </profile>


### PR DESCRIPTION
- Related ticket: bsc#1231522, which requested the default to not reboot
- Needles: N/A
- Verification run: CI job
