### PR TITLE
bats: Use --quiet with coredumpctl

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -307,7 +307,7 @@ sub collect_coredumps {
     script_run('coredumpctl list > coredumpctl.txt');
 
     # Get PID and executable for all dumps
-    my @lines = split /\n/, script_output(q{coredumpctl --no-pager --no-legend | awk '$9 == "present" { print $5, $10 }'}, proceed_on_failure => 1);
+    my @lines = split /\n/, script_output(q{coredumpctl -q --no-pager --no-legend | awk '$9 == "present" { print $5, $10 }'}, proceed_on_failure => 1);
 
     foreach my $line (@lines) {
         my ($pid, $exe) = split /\s+/, $line;


### PR DESCRIPTION
Use `--quiet` with coredumpctl.  Otherwise we get `"No coredumps found."` and we loop on this.

Failed test:
https://openqa.opensuse.org/tests/5240079#step/podman/553

Tested locally.