### PR TITLE
Use br123 for SLE16 guest installation

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
@@ -20,7 +20,7 @@
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-suse-4m-code.bin,loader.readonly=yes,loader.type=pflash,nvram.template=/usr/share/qemu/ovmf-x86_64-suse-4m-vars.bin,hd,bootmenu.enable=yes,menu=on</guest_boot_settings>
     <guest_xpath/>
     <guest_installation_automation_method>autoagama</guest_installation_automation_method>
-    <guest_installation_automation_platform></guest_installation_automation_platform>
+    <guest_installation_automation_platform/>
     <guest_installation_automation_file>sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet</guest_installation_automation_file>
     <guest_installation_method>directkernel</guest_installation_method>
     <guest_installation_extra_args/>
@@ -42,7 +42,7 @@
     <guest_storage_backing_format/>
     <guest_storage_others>driver.name=qemu,target.dev=vda,target.bus=virtio,bus=virtio,cache=none</guest_storage_others>
     <guest_network_type>bridge</guest_network_type>
-    <guest_network_mode>host</guest_network_mode>
+    <guest_network_mode>bridge</guest_network_mode>
     <guest_network_device/>
     <guest_network_others/>
     <guest_netaddr/>


### PR DESCRIPTION
* **Use** br123 for SLE16 guest installation

* **I** had not changed this settings back in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22656. It is for testing purpose only.

* **Looks** like current environment is not stable enough, so better use br123.
