### PR TITLE
Add import_agama_profile  for agama custom registration test

### DIFF
--- a/schedule/yam/agama_rmt.yaml
+++ b/schedule/yam/agama_rmt.yaml
@@ -1,10 +1,11 @@
 ---
 name: agama_rmt
 description: >
-  Perform agama interactive installation with RMT registration
+  Perform agama interactive installation with custom registration
 schedule:
   - yam/agama/boot_agama
   - yam/agama/agama_arrange
+  - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama
   - installation/grub_test

--- a/schedule/yam/agama_rmt_s390x.yaml
+++ b/schedule/yam/agama_rmt_s390x.yaml
@@ -1,10 +1,11 @@
 ---
 name: agama_rmt_s390x
 description: >
-  Perform agama interactive installation with RMT registration
+  Perform agama interactive installation with custom registration
 schedule:
   - yam/agama/boot_agama
   - yam/agama/agama_arrange
+  - yam/agama/import_agama_profile
   - yam/agama/patch_agama_tests
   - yam/agama/agama
   - boot/reconnect_mgmt_console


### PR DESCRIPTION
##
### Add import_agama_profile for custom registration test
- Ticket: https://progress.opensuse.org/issues/185701
- Related PR: https://github.com/jknphy/agama-integration-test-webpack/pull/133
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/543/

- VR:
  - prod
    - [**sles_rmt_dev_2nd**](https://openqa.suse.de/tests/overview?distri=sle&build=hjluo%2Fos-autoinst-distri-opensuse%23custom_rmt_register&version=16.0)
 - regression:
   - [sles_default](https://openqa.suse.de/tests/18763453)
##