### PR TITLE
Test agama with FIPS ker mode installation

### DIFF
--- a/schedule/security/sle16/agama.yaml
+++ b/schedule/security/sle16/agama.yaml
@@ -2,6 +2,8 @@
 name: agama
 description: >
   Perform interactive installation with agama.
+  If `FIPS_INSTALLATION` is set to 1, the test also checks if FIPS in enabled.
+  FIPS can be set up during installation in kernel mode by setting `BOOTPARAMS` to `fips=1`.
 schedule:
   - yam/agama/boot_agama
   - yam/agama/agama_arrange
@@ -13,6 +15,12 @@ schedule:
   - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
   - console/validate_repos
+  - '{{fips_installation}}'
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+conditional_schedule:
+  fips_installation:
+    FIPS_INSTALLATION:
+      1:
+        - fips/fips_setup


### PR DESCRIPTION
https://progress.opensuse.org/issues/186125

This change enables installation with FIPS in kernel mode when `FIPS_INSTALLATION` is set to 1 and `BOOTPARAMS` to `fips=1`. This adds the `fips=1` kernel parameter during installer boot and checks if FIPS is enabled in the installed system.

- Related ticket: https://progress.opensuse.org/issues/186125
- Verification run: https://openqa.suse.de/tests/18765895
