### PR TITLE
Add a new test for Apache FastCGI and PHP-FPM

### DIFF
--- a/data/php/mod_fcgid.conf
+++ b/data/php/mod_fcgid.conf
@@ -1,0 +1,24 @@
+################################################################################
+##
+## Sample config for apache2_mod-fcgid
+##
+## Most lines, that are commented out, reflect the default values.
+##
+## See http://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html for the real documentation
+##
+
+<IfModule fcgid_module>
+FcgidIPCDir /var/lib/apache2/fcgid/
+FcgidProcessTableFile /var/lib/apache2/fcgid/shm
+DirectoryIndex index.php
+<FilesMatch "\.php$">
+#    AddHandler fcgid-script .php
+    SetHandler "proxy:fcgi://127.0.0.1:9000/"
+    #CGIPassAuth on
+</FilesMatch>
+</IfModule>
+# End of <IfModule fcgid_module>
+
+##
+################################################################################
+

--- a/schedule/functional/extra_tests_textmode.yaml
+++ b/schedule/functional/extra_tests_textmode.yaml
@@ -205,4 +205,5 @@ schedule:
     - console/valgrind
     - console/sssd_389ds_functional
     - console/tcpdump
+    - console/apache2_php_fpm
     - console/zypper_log_packages

--- a/schedule/qam/15-SP7/mau-extratests-phub.yaml
+++ b/schedule/qam/15-SP7/mau-extratests-phub.yaml
@@ -11,6 +11,7 @@ schedule:
   # - console/python_flake8 Removed due to bsc#1209609
   - console/vmstat
   - console/systemd_rpm_macros
+  - console/apache2_php_fpm
   - console/coredump_collect
 conditional_schedule:
   sle15_x86_64:

--- a/schedule/qam/common/stack_tests_php.yaml
+++ b/schedule/qam/common/stack_tests_php.yaml
@@ -6,11 +6,11 @@ schedule:
   - boot/boot_to_desktop
   - console/prepare_test_data
   - console/php_version
-  - '{{version_specific}}'
   - console/php_pcre
   - console/php_mysql
   - console/php_postgresql
   - console/php_timezone
+  - '{{version_specific}}'
 conditional_schedule:
   version_specific:
     VERSION:
@@ -22,3 +22,5 @@ conditional_schedule:
         - console/php_composer
       15-SP4:
         - console/php_composer
+      '16.0':
+        - console/apache2_php_fpm

--- a/tests/console/apache2_php_fpm.pm
+++ b/tests/console/apache2_php_fpm.pm
@@ -1,0 +1,109 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: apache2_mod_fcgid php8-fpm
+# Summary: Install and configure Apache FastCGI and PHP-FPM
+# Verify the Apache server is working with php-fmp.service
+# Maintainer: QE Core <qe-core@suse.com>
+
+use base "consoletest";
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils;
+use version_utils qw(is_sle is_leap php_version);
+use registration qw(add_suseconnect_product get_addon_fullname);
+
+sub run {
+    select_serial_terminal;
+    my ($php, $php_pkg, $php_ver) = php_version();
+    record_info("PHP version", $php_pkg);
+
+    if (is_sle(">=16.0")) {
+        if (check_var('BETA', '1')) {
+            my $VERSION = get_required_var('VERSION');
+            my $ARCH = get_required_var('ARCH');
+            zypper_call("--no-gpg-checks ar -f http://updates.suse.de/SUSE/Backports/SLE-${VERSION}_${ARCH}/standard/ 'Backport_${VERSION}'");
+            zypper_call("--gpg-auto-import-keys ref", 300);
+        }
+        else {
+            add_suseconnect_product("PackageHub", undef, undef, undef, 300, 1);
+        }
+    }
+    zypper_call("in $php_pkg apache2-mod_$php_pkg");
+    # Disable apache2-mod_php8
+    assert_script_run "a2dismod $php_pkg";
+    # Install and enable apache2-mod_fcgid and php8-fpm
+    zypper_call("in apache2-mod_fcgid $php_pkg-fpm $php_pkg-pear");
+    assert_script_run 'a2enmod proxy';
+    assert_script_run 'a2enmod proxy_fcgi';
+    assert_script_run 'a2enmod setenvif';
+    assert_script_run 'a2enmod fcgid';
+
+    # Edit Apache FastCGI configuration
+    my $mod_fcgi_conf_file = '/etc/apache2/conf.d/mod_fcgid.conf';
+    assert_script_run("curl " . data_url("php/mod_fcgid.conf") . " -o $mod_fcgi_conf_file");
+    systemctl("restart apache2");
+
+    # Configure php_fpm
+    my $php_fpm_configuration_file = "/etc/$php_pkg/fpm/php-fpm.d/www.conf";
+    my $conf = <<EOF;
+[www]
+user = wwwrun
+group = www
+listen = /run/php-fpm/php-fpm.sock
+listen.owner = wwwrun
+listen.group = www
+listen.mode = 0660
+EOF
+    script_output("echo '$conf' >> $php_fpm_configuration_file");
+
+    # Create Apache Config for PHP-FPM
+    my $apache_config_file = '/etc/apache2/conf.d/php-fpm.conf';
+    $conf = <<EOF;
+<FilesMatch \\.php\$>
+  SetHandler \"proxy:unix:/run/php-fpm/php-fpm.sock|fcgi://localhost\"
+</FilesMatch>
+EOF
+    script_output("echo '$conf' >> $apache_config_file");
+
+    # create a php test file test.php
+    my $php_test_file = '/srv/www/htdocs/test.php';
+    $conf = <<EOF;
+<?php phpinfo(); ?> 
+EOF
+    script_output("echo '$conf' >> $php_test_file");
+    # Start php-fpm and apache2 service
+    systemctl("restart php-fpm");
+
+    # Add appArmor allow rule /srv/www/htdocs/* r, to the php-fpm profile
+    # and reload the profile
+    if (is_sle("=15-sp7")) {
+        my $rule = "/srv/www/htdocs/* r,";
+        assert_script_run('sed -i  \'s/^}/   \/srv\/www\/htdocs\/*  r,\n}/\' /etc/apparmor.d/php-fpm');
+        assert_script_run("apparmor_parser -r /etc/apparmor.d/php-fpm");
+    }
+
+    validate_script_output("ls -l /run/php-fpm", sub { m/php-fpm.sock/ });
+    systemctl("restart apache2");
+
+    my $php_version = script_output("rpm -q $php_pkg --qf '%{VERSION}'");
+    record_info("PHP version", $php_version);
+    # Verify the test.php
+    validate_script_output("wget -qO- http://localhost/test.php", sub { m/PHP Version $php_version/ });
+    cleanup();
+}
+
+sub post_fail_hook {
+    cleanup();
+}
+
+sub cleanup {
+    my ($php, $php_pkg, $php_ver) = php_version();
+    zypper_call("rm $php_pkg apache2-mod_$php_pkg apache2-mod_fcgid");
+    script_run("rm -f /srv/www/htdocs/test.php /etc/apache2/conf.d/php-fpm.conf /etc/apache2/conf.d/mod_fcgid.conf");
+    # Disable PHP-FPM configuration
+    assert_script_run 'a2dismod proxy_fcgi';
+}
+1;


### PR DESCRIPTION
Install and configure Apache FastCGI and PHP-FPM based on SLES 15 SP7/SLES 16 and openSUSE Tumbleweed
 check that Apache server is working with php-fmp.service

- Related ticket: https://progress.opensuse.org/issues/179705
- Needles: No
- Verification run: 
   15-SP7: [x86_64](http://openqa.suse.de/tests/18826883#step/apache2_php_fpm/85)
   Tumbleweed:  [x86_64](https://openqa.opensuse.org/tests/5251629#step/apache2_php_fpm/72)
    SLE-16.0: [x86_64](http://openqa.suse.de/tests/18886870#step/apache2_php_fpm/75)| [s390x](http://openqa.suse.de/tests/18886873#step/apache2_php_fpm/75) | [ppc64le](http://openqa.suse.de/tests/18886872#step/apache2_php_fpm/75) | 
