### PR TITLE
bats/netavark: Backport PR#1287 to drop dependency on ncat

### DIFF
--- a/data/containers/bats/patches/netavark/1283.patch
+++ b/data/containers/bats/patches/netavark/1283.patch
@@ -1,0 +1,311 @@
+From 047ef70345caa092654a3f029d1a66420c166a40 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Wed, 16 Jul 2025 17:20:23 +0200
+Subject: [PATCH 1/5] change exec_netns macro to return result
+
+When I added it orignally I didn't really know how to return a proper
+result. It makes no real sense to pass the result var as third argument.
+
+Now just return the result directly so it works like a normal function
+does.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ src/network/bridge.rs     |  6 ++----
+ src/network/core_utils.rs | 13 ++++++-------
+ src/network/vlan.rs       |  3 +--
+ 3 files changed, 9 insertions(+), 13 deletions(-)
+
+diff --git a/src/network/bridge.rs b/src/network/bridge.rs
+index 5651de316..6e4090fbc 100644
+--- a/src/network/bridge.rs
++++ b/src/network/bridge.rs
+@@ -818,7 +818,7 @@ fn create_veth_pair<'fd>(
+     }
+ 
+     if let BridgeMode::Managed = data.mode {
+-        exec_netns!(hostns_fd, netns_fd, res, {
++        exec_netns!(hostns_fd, netns_fd, {
+             disable_ipv6_autoconf(&data.container_interface_name)?;
+             if data.ipam.ipv6_enabled {
+                 //  Disable dad inside the container too
+@@ -838,9 +838,7 @@ fn create_veth_pair<'fd>(
+             let rp_filter = format!("net/ipv4/conf/{}/rp_filter", &data.container_interface_name);
+             sysctl::apply_sysctl_value(rp_filter, "2")?;
+             Ok::<(), NetavarkError>(())
+-        });
+-        // check the result and return error
+-        res?;
++        })?;
+ 
+         if data.ipam.ipv6_enabled {
+             let host_veth = host.get_link(netlink::LinkID::ID(host_link))?;
+diff --git a/src/network/core_utils.rs b/src/network/core_utils.rs
+index a30829da6..28e96350f 100644
+--- a/src/network/core_utils.rs
++++ b/src/network/core_utils.rs
+@@ -263,11 +263,12 @@ pub fn join_netns<Fd: AsFd>(fd: Fd) -> NetavarkResult<()> {
+ /// executed in the ns.
+ #[macro_export]
+ macro_rules! exec_netns {
+-    ($host:expr, $netns:expr, $result:ident, $exec:expr) => {
++    ($host:expr, $netns:expr, $exec:expr) => {{
+         join_netns($netns)?;
+-        let $result = $exec;
++        let result = $exec;
+         join_netns($host)?;
+-    };
++        result
++    }};
+ }
+ 
+ pub struct NamespaceOptions {
+@@ -284,14 +285,12 @@ pub fn open_netlink_sockets(
+     let hostns = open_netlink_socket("/proc/self/ns/net").wrap("open host netns")?;
+ 
+     let host_socket = netlink::Socket::new().wrap("host netlink socket")?;
+-    exec_netns!(
++    let netns_sock = exec_netns!(
+         hostns.as_fd(),
+         netns.as_fd(),
+-        res,
+         netlink::Socket::new().wrap("netns netlink socket")
+-    );
++    )?;
+ 
+-    let netns_sock = res?;
+     Ok((
+         NamespaceOptions {
+             file: hostns,
+diff --git a/src/network/vlan.rs b/src/network/vlan.rs
+index d86d57e5d..99aa697b2 100644
+--- a/src/network/vlan.rs
++++ b/src/network/vlan.rs
+@@ -331,8 +331,7 @@ fn setup(
+         }
+     }
+ 
+-    exec_netns!(hostns_fd, netns_fd, res, { disable_ipv6_autoconf(if_name) });
+-    res?; // return autoconf sysctl error
++    exec_netns!(hostns_fd, netns_fd, { disable_ipv6_autoconf(if_name) })?;
+ 
+     let dev = netns
+         .get_link(netlink::LinkID::Name(if_name.to_string()))
+
+From 38cbf3a83cbb738f70f4f5b6336f573be9f6b5f6 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Wed, 16 Jul 2025 17:29:05 +0200
+Subject: [PATCH 2/5] bridge: early break out of loop
+
+When we look for the path name we can break once we got the name and set
+the sysctl here as we don't do anything else.
+Same when we check the mac address.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ src/network/bridge.rs | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/network/bridge.rs b/src/network/bridge.rs
+index 6e4090fbc..b402d0d95 100644
+--- a/src/network/bridge.rs
++++ b/src/network/bridge.rs
+@@ -703,6 +703,7 @@ fn create_interfaces(
+                 for nla in link.attributes.into_iter() {
+                     if let LinkAttribute::Address(addr) = nla {
+                         mac = Some(addr);
++                        break;
+                     }
+                 }
+                 if mac.is_none() {
+@@ -848,6 +849,7 @@ fn create_veth_pair<'fd>(
+                     //  Disable dad inside on the host too
+                     let disable_dad_in_container = format!("net/ipv6/conf/{name}/accept_dad");
+                     sysctl::apply_sysctl_value(disable_dad_in_container, "0")?;
++                    break;
+                 }
+             }
+         }
+
+From fbedef911f24557020e670efdf56553e23137c34 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Wed, 16 Jul 2025 18:21:57 +0200
+Subject: [PATCH 3/5] make get_default_route_interface return the full
+ LinkMessage
+
+Both callers use the name again to lookup the link again which is just a
+wasted netlink roundtrip. Make it return the full LinkMessage so the
+callers can just use that for the mtu or link index.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ src/network/bridge.rs     |  6 +++---
+ src/network/core_utils.rs | 22 ++++++----------------
+ src/network/vlan.rs       |  6 ++----
+ 3 files changed, 11 insertions(+), 23 deletions(-)
+
+diff --git a/src/network/bridge.rs b/src/network/bridge.rs
+index b402d0d95..1189a4cc0 100644
+--- a/src/network/bridge.rs
++++ b/src/network/bridge.rs
+@@ -661,13 +661,13 @@ fn create_interfaces(
+                 let mut mtu = data.mtu;
+                 if mtu == 0 {
+                     // if we have a default route, use its mtu as default
+-                    if let Ok(iface_name) = get_default_route_interface(host) {
+-                        match core_utils::get_mtu_from_iface(host, &iface_name) {
++                    if let Ok(link) = get_default_route_interface(host) {
++                        match core_utils::get_mtu_from_iface_attributes(&link.attributes) {
+                             Ok(iface_mtu) => {
+                                 mtu = iface_mtu;
+                             },
+                             Err(e) => debug!(
+-                                "failed to get mtu for default interface {iface_name}: {e}, using kernel default",
++                                "failed to get mtu for default interface {}: {e}, using kernel default", link.header.index
+                             ),
+                         }
+                     }
+diff --git a/src/network/core_utils.rs b/src/network/core_utils.rs
+index 28e96350f..7aa6cdd01 100644
+--- a/src/network/core_utils.rs
++++ b/src/network/core_utils.rs
+@@ -2,7 +2,7 @@ use crate::error::{ErrorWrap, NetavarkError, NetavarkResult};
+ use crate::network::{constants, internal_types, types};
+ use crate::wrap;
+ use ipnet::IpNet;
+-use netlink_packet_route::link::{IpVlanMode, MacVlanMode};
++use netlink_packet_route::link::{IpVlanMode, LinkMessage, MacVlanMode};
+ use nix::sched;
+ use sha2::{Digest, Sha512};
+ use std::collections::HashMap;
+@@ -398,7 +398,8 @@ pub fn is_using_systemd() -> bool {
+     Path::new("/run/systemd/system").exists()
+ }
+ 
+-pub fn get_default_route_interface(host: &mut netlink::Socket) -> NetavarkResult<String> {
++/// Returns the *first* interface with a default route or an error if no default route interface exists.
++pub fn get_default_route_interface(host: &mut netlink::Socket) -> NetavarkResult<LinkMessage> {
+     let routes = host.dump_routes().wrap("dump routes")?;
+ 
+     for route in routes {
+@@ -416,25 +417,14 @@ pub fn get_default_route_interface(host: &mut netlink::Socket) -> NetavarkResult
+         // if there is no dest we have a default route
+         // return the output interface for this route
+         if !dest && out_if > 0 {
+-            let link = host.get_link(netlink::LinkID::ID(out_if))?;
+-            let name = link.attributes.iter().find_map(|nla| {
+-                if let LinkAttribute::IfName(name) = nla {
+-                    Some(name)
+-                } else {
+-                    None
+-                }
+-            });
+-            if let Some(name) = name {
+-                return Ok(name.to_owned());
+-            }
++            return host.get_link(netlink::LinkID::ID(out_if));
+         }
+     }
+     Err(NetavarkError::msg("failed to get default route interface"))
+ }
+ 
+-pub fn get_mtu_from_iface(host: &mut netlink::Socket, iface_name: &str) -> NetavarkResult<u32> {
+-    let link = host.get_link(netlink::LinkID::Name(iface_name.to_string()))?;
+-    for nla in link.attributes.iter() {
++pub fn get_mtu_from_iface_attributes(attributes: &[LinkAttribute]) -> NetavarkResult<u32> {
++    for nla in attributes.iter() {
+         if let LinkAttribute::Mtu(mtu) = nla {
+             return Ok(*mtu);
+         }
+diff --git a/src/network/vlan.rs b/src/network/vlan.rs
+index 99aa697b2..489aaa46c 100644
+--- a/src/network/vlan.rs
++++ b/src/network/vlan.rs
+@@ -243,13 +243,11 @@ fn setup(
+     netns_fd: BorrowedFd<'_>,
+     kind_data: &KindData,
+ ) -> NetavarkResult<String> {
+-    let primary_ifname = match data.host_interface_name.as_ref() {
++    let link = match data.host_interface_name.as_ref() {
+         "" => get_default_route_interface(host)?,
+-        host_name => host_name.to_string(),
++        host_name => host.get_link(netlink::LinkID::Name(host_name.to_string()))?,
+     };
+ 
+-    let link = host.get_link(netlink::LinkID::Name(primary_ifname))?;
+-
+     let opts = match kind_data {
+         KindData::IpVlan { mode } => {
+             let mut opts = CreateLinkOptions::new(if_name.to_string(), InfoKind::IpVlan);
+
+From 57e37bbe8e854ee841fe4748704f850eefbaf471 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Wed, 16 Jul 2025 18:30:15 +0200
+Subject: [PATCH 4/5] get_mtu_from_iface_attributes: return error without mtu
+
+The kernel currently always includes the MTU attribute[1] so raise a
+warning if we actually don't see it in the response becuase that likely
+indicates something is wrong with the netlink message or the kernel.
+
+[1] https://elixir.bootlin.com/linux/v6.15.6/source/net/core/rtnetlink.c#L2055
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ src/network/bridge.rs     | 2 +-
+ src/network/core_utils.rs | 7 ++++---
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/src/network/bridge.rs b/src/network/bridge.rs
+index 1189a4cc0..718cdf2eb 100644
+--- a/src/network/bridge.rs
++++ b/src/network/bridge.rs
+@@ -666,7 +666,7 @@ fn create_interfaces(
+                             Ok(iface_mtu) => {
+                                 mtu = iface_mtu;
+                             },
+-                            Err(e) => debug!(
++                            Err(e) => log::warn!(
+                                 "failed to get mtu for default interface {}: {e}, using kernel default", link.header.index
+                             ),
+                         }
+diff --git a/src/network/core_utils.rs b/src/network/core_utils.rs
+index 7aa6cdd01..b2495bca8 100644
+--- a/src/network/core_utils.rs
++++ b/src/network/core_utils.rs
+@@ -429,7 +429,8 @@ pub fn get_mtu_from_iface_attributes(attributes: &[LinkAttribute]) -> NetavarkRe
+             return Ok(*mtu);
+         }
+     }
+-    // It is possible that the interface has no MTU set, in this case the kernel will use the default.
+-    // We return 0 to signal this, which netavark uses to mean "kernel default".
+-    Ok(0)
++    // It should be impossible that the interface has no MTU set, so return an error in such case.
++    Err(NetavarkError::msg(
++        "no MTU attribute in netlink message, possible kernel issue",
++    ))
+ }
+
+From 2fee8443a5dc28d7bc89a31a4e0003811e20203e Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Wed, 16 Jul 2025 18:36:39 +0200
+Subject: [PATCH 5/5] log default route mtu
+
+So we can easily see what mtu was picked up by us.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ src/network/bridge.rs | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/network/bridge.rs b/src/network/bridge.rs
+index 718cdf2eb..0a4ef72fc 100644
+--- a/src/network/bridge.rs
++++ b/src/network/bridge.rs
+@@ -664,6 +664,7 @@ fn create_interfaces(
+                     if let Ok(link) = get_default_route_interface(host) {
+                         match core_utils::get_mtu_from_iface_attributes(&link.attributes) {
+                             Ok(iface_mtu) => {
++                                debug!("Using mtu {iface_mtu} from default route interface for the network");
+                                 mtu = iface_mtu;
+                             },
+                             Err(e) => log::warn!(

--- a/data/containers/bats/patches/netavark/1287.patch
+++ b/data/containers/bats/patches/netavark/1287.patch
@@ -1,0 +1,573 @@
+From c984a9fdad342d91e39e3278f4adb3533a8fd59e Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Fri, 18 Jul 2025 17:26:42 +0200
+Subject: [PATCH 1/3] add .cargo/config.toml to runs tests via unshare -rn
+
+Out test don't actually need root, we only care about the ability to
+create a private netns in src/test/netlink.rs. This can be done via a
+user namespace as well. So configure cargo to run the tests via
+unshare -rn which creates a private userns and netns. That way devs can
+run cargo test rootless on the system.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ .cargo/config.toml | 2 ++
+ 1 file changed, 2 insertions(+)
+ create mode 100644 .cargo/config.toml
+
+diff --git a/.cargo/config.toml b/.cargo/config.toml
+new file mode 100644
+index 000000000..6a827c170
+--- /dev/null
++++ b/.cargo/config.toml
+@@ -0,0 +1,2 @@
++[target.'cfg(linux)']
++runner = 'unshare -rn'
+
+From dbc9200302a142cd3d5d1ff41529150c3fad24a1 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Mon, 21 Jul 2025 17:12:59 +0200
+Subject: [PATCH 2/3] test: add new test program for connection checks
+
+Use this to replace ncat. ncat is flaky and harder to use and with
+the latest version it seems they broke us in a way that makes the flags
+we use incompatible[1].
+
+As a nice benefit this makes the test code itself simpler and faster as
+we get rid of the is port bound polling/sleeps.
+
+[1] https://github.com/containers/netavark/pull/1282
+
+Fixes: #1076
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ Cargo.toml                    |   8 +-
+ Makefile                      |   1 +
+ src/test/main.rs              | 181 ++++++++++++++++++++++++++++++++
+ test/100-bridge-iptables.bats |   2 +-
+ test/README.md                |   1 -
+ test/helpers.bash             | 188 +++-------------------------------
+ 6 files changed, 204 insertions(+), 177 deletions(-)
+ create mode 100644 src/test/main.rs
+
+diff --git a/Cargo.toml b/Cargo.toml
+index e578ceb99..33dd3d8de 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -21,10 +21,16 @@ tier = "2"
+ name = "netavark"
+ path = "src/main.rs"
+ 
++
++# Only used for testing, do not ship to end users.
+ [[bin]]
+ name = "netavark-dhcp-proxy-client"
+ path = "src/dhcp_proxy_client/client.rs"
+ 
++[[bin]]
++name = "netavark-connection-tester"
++path = "src/test/main.rs"
++
+ # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+ [dependencies]
+ anyhow = "1.0.93"
+@@ -37,7 +43,7 @@ log = "0.4.27"
+ serde = { version = "1.0.219", features = ["derive"] }
+ serde_json = "1.0.141"
+ zbus = { version = "5.9.0" }
+-nix = { version = "0.30.1", features = ["sched", "signal", "user"] }
++nix = { version = "0.30.1", features = ["net", "sched", "signal", "socket", "user"] }
+ rand = "0.9.2"
+ sha2 = "0.10.9"
+ netlink-packet-route = "0.23.0"
+diff --git a/Makefile b/Makefile
+index 1b3321c72..1b5b3e208 100644
+--- a/Makefile
++++ b/Makefile
+@@ -58,6 +58,7 @@ bin/netavark: $(SOURCES) bin $(CARGO_TARGET_DIR)
+ 	$(CARGO) build $(release)
+ 	cp $(CARGO_TARGET_DIR)/$(profile)/netavark bin/netavark
+ 	cp $(CARGO_TARGET_DIR)/$(profile)/netavark-dhcp-proxy-client bin/netavark-dhcp-proxy-client
++	cp $(CARGO_TARGET_DIR)/$(profile)/netavark-connection-tester bin/netavark-connection-tester
+ 
+ 
+ .PHONY: examples
+diff --git a/src/test/main.rs b/src/test/main.rs
+new file mode 100644
+index 000000000..9b4d6d227
+--- /dev/null
++++ b/src/test/main.rs
+@@ -0,0 +1,181 @@
++//! Test program only, unsupported outside of our test suite.
++use std::{
++    io::Read,
++    os::fd::{AsRawFd, OwnedFd},
++};
++
++use netavark::exec_netns;
++use netavark::network::core_utils::join_netns;
++use nix::sys::socket;
++
++fn main() -> Result<(), Box<dyn std::error::Error>> {
++    let mut args = std::env::args();
++    _ = args.next(); // skip argv0
++
++    let mut i = 0;
++    let mut netns = String::new();
++    let mut connect = String::new();
++    let mut listen = String::new();
++
++    let mut sock_type = socket::SockType::Stream;
++    let mut protocol = socket::SockProtocol::Tcp;
++
++    for arg in args {
++        match arg.as_str() {
++            "--tcp" => {
++                protocol = socket::SockProtocol::Tcp;
++                sock_type = socket::SockType::Stream;
++            }
++            "--udp" => {
++                protocol = socket::SockProtocol::Udp;
++                sock_type = socket::SockType::Datagram;
++            }
++            "--sctp" => {
++                protocol = socket::SockProtocol::Sctp;
++                sock_type = socket::SockType::Stream;
++            }
++            _ => {
++                match i {
++                    0 => netns = arg,
++                    1 => connect = arg,
++                    2 => listen = arg,
++                    _ => {
++                        eprintln!("To many arguments\nUsage: NETNS CONNECT_ADDRESS LISTEN_PORT");
++                        std::process::exit(1)
++                    }
++                };
++                i += 1;
++            }
++        }
++    }
++
++    let hostns = std::fs::File::open("/proc/self/ns/net").expect("open host netns");
++    let containerns = std::fs::File::open(netns).expect("open netns");
++
++    let connect_addr: std::net::SocketAddr =
++        connect.parse().expect("failed to parse connect address");
++
++    let listen_port: u16 = listen.parse().expect("parse listne port");
++
++    let (address_family, listen_addr) = match connect_addr {
++        std::net::SocketAddr::V4(_) => (
++            socket::AddressFamily::Inet,
++            std::net::SocketAddr::V4(std::net::SocketAddrV4::new(
++                std::net::Ipv4Addr::UNSPECIFIED,
++                listen_port,
++            )),
++        ),
++        std::net::SocketAddr::V6(_) => (
++            socket::AddressFamily::Inet6,
++            std::net::SocketAddr::V6(std::net::SocketAddrV6::new(
++                std::net::Ipv6Addr::UNSPECIFIED,
++                listen_port,
++                0,
++                0,
++            )),
++        ),
++    };
++
++    // create socket in namespace
++    let listen_sock = exec_netns!(&hostns, &containerns, {
++        let listen_sock = socket::socket(
++            address_family,
++            sock_type,
++            socket::SockFlag::empty(),
++            Some(protocol),
++        )
++        .expect("listen socket");
++
++        socket::bind(
++            listen_sock.as_raw_fd(),
++            &socket::SockaddrStorage::from(listen_addr),
++        )
++        .expect("bind listen socket");
++
++        listen_sock
++    });
++
++    let connect_sock = socket::socket(
++        address_family,
++        sock_type,
++        socket::SockFlag::empty(),
++        Some(protocol),
++    )
++    .expect("connect socket");
++
++    let mut send_buf = Vec::new();
++    std::io::stdin()
++        .read_to_end(&mut send_buf)
++        .expect("read stdin");
++
++    match sock_type {
++        socket::SockType::Stream => stream_test(listen_sock, connect_sock, connect_addr, &send_buf),
++        socket::SockType::Datagram => {
++            datagram_test(listen_sock, connect_sock, connect_addr, &send_buf)
++        }
++        _ => unreachable!(),
++    }
++
++    Ok(())
++}
++
++fn stream_test(
++    listen_sock: OwnedFd,
++    connect_sock: OwnedFd,
++    connect_addr: std::net::SocketAddr,
++    buf: &[u8],
++) {
++    socket::listen(&listen_sock, socket::Backlog::new(5).unwrap()).expect("listen on socket");
++
++    socket::connect(
++        connect_sock.as_raw_fd(),
++        &socket::SockaddrStorage::from(connect_addr),
++    )
++    .expect("connect to remote socket");
++
++    let conn = socket::accept4(listen_sock.as_raw_fd(), socket::SockFlag::empty())
++        .expect("accept connection");
++
++    let peer_addr = socket::getpeername::<socket::SockaddrStorage>(conn).expect("getpeername");
++    println!("Peer address: {peer_addr}");
++
++    socket::send(connect_sock.as_raw_fd(), buf, socket::MsgFlags::empty()).expect("send msg");
++
++    let mut read_buf = vec![0; buf.len()];
++
++    let len = socket::recv(conn, &mut read_buf, socket::MsgFlags::empty()).expect("recv msg");
++
++    println!(
++        "Message: {}",
++        std::str::from_utf8(&read_buf[..len]).expect("parse msg")
++    );
++}
++
++fn datagram_test(
++    listen_sock: OwnedFd,
++    connect_sock: OwnedFd,
++    connect_addr: std::net::SocketAddr,
++    buf: &[u8],
++) {
++    socket::sendto(
++        connect_sock.as_raw_fd(),
++        buf,
++        &socket::SockaddrStorage::from(connect_addr),
++        socket::MsgFlags::empty(),
++    )
++    .expect("sendto msg");
++
++    let mut read_buf = vec![0; buf.len()];
++
++    let (len, peer_addr) =
++        socket::recvfrom::<socket::SockaddrStorage>(listen_sock.as_raw_fd(), &mut read_buf)
++            .expect("recvfrom msg");
++
++    let peer_addr = peer_addr.expect("no peer address");
++    println!("Peer address: {peer_addr}");
++
++    println!(
++        "Message: {}",
++        std::str::from_utf8(&read_buf[..len]).expect("parse msg")
++    );
++}
+diff --git a/test/100-bridge-iptables.bats b/test/100-bridge-iptables.bats
+index 6aee41a98..68b245e38 100644
+--- a/test/100-bridge-iptables.bats
++++ b/test/100-bridge-iptables.bats
+@@ -590,7 +590,7 @@ fw_driver=iptables
+     assert "2" "rp_filter eth1 interface"
+ 
+     # Important: Use the "host" ip here and not localhost or bridge ip.
+-    run_nc_test "0" "tcp" 8080 "10.0.0.1" 8080
++    run_connection_test "0" "tcp" 8080 "10.0.0.1" 8080
+ }
+ 
+ @test "bridge ipam none" {
+diff --git a/test/README.md b/test/README.md
+index 203aeb353..ab6e1345a 100644
+--- a/test/README.md
++++ b/test/README.md
+@@ -14,4 +14,3 @@ The tests need root privileges to create network namespaces, so you either have
+ - iptables
+ - firewalld
+ - dbus-daemon
+-- ncat (NMAP)
+diff --git a/test/helpers.bash b/test/helpers.bash
+index 116f0fe31..c782982b1 100644
+--- a/test/helpers.bash
++++ b/test/helpers.bash
+@@ -2,6 +2,7 @@
+ 
+ # Netavark binary to run
+ NETAVARK=${NETAVARK:-./bin/netavark}
++NETAVARK_CONNECTION_TESTER=${NETAVARK_CONNECTION_TESTER:-./bin/netavark-connection-tester}
+ 
+ TESTSDIR=${TESTSDIR:-$(dirname ${BASH_SOURCE})}
+ 
+@@ -398,7 +399,7 @@ function assert_json() {
+ #     hostport=$port the port which is binded on the host
+ #     containerport=$port the port which is binded in the container
+ #     range=$num >=1 specify a port range which will forward hostport+range ports
+-#     connectip=$ip the ip which is used to connect to in the ncat test
++#     connectip=$ip the ip which is used to connect to in the connection test
+ #     firewalld_reload={false,true} call firewall-cmd --reload to check for port rules
+ #
+ function test_port_fw() {
+@@ -567,7 +568,7 @@ EOF
+                     fi
+                 fi
+ 
+-                run_nc_test "0" "$proto" $cport $connect_ip $hport
++                run_connection_test "0" "$proto" $cport $connect_ip $hport
+             fi
+ 
+ 
+@@ -579,7 +580,7 @@ EOF
+                     fi
+                 fi
+ 
+-                run_nc_test "0" "$proto" $cport $connect_ip $hport
++                run_connection_test "0" "$proto" $cport $connect_ip $hport
+             fi
+ 
+             ((i = i + 1))
+@@ -610,64 +611,27 @@ function is_ipv4() {
+ }
+ 
+ #################
+-#  run_nc_test  # run ncat connection test between the namespaces
++#  run_connection_test  # run connection test between the namespaces with our test helper
+ #################
+-# $1 == common nc args which are added to both the server and client nc command
+-# $2 == container port, the nc server will listen on it in the container ns
+-# $3 == connection ip, the ip address which is used by the client nc to connect to the server
+-# $4 == host port, the nc client will connect to this port
+-function run_nc_test() {
++# $1 == contianer ns number
++# $2 == protocol (tcp, udp, sctp)
++# $3 == container port, the server will listen on it in the container ns
++# $4 == connection ip, the ip address which is used by the client to connect to the server
++# $5 == host port, the client will connect to this port
++function run_connection_test() {
+     local container_ns=$1
+     local proto=$2
+     local container_port=$3
+     local connect_ip=$4
+     local host_port=$5
+ 
+-    local nc_common_args=""
+-    exec {stdin}<>/dev/null
+-
+-    case $proto in
+-    tcp) ;; # nothing to do (default)
+-    udp) nc_common_args=--udp ;;
+-    sctp)
+-        nc_common_args=--sctp
+-        # For some reason we have to attach a empty STDIN (not /dev/null and not something with data in it)
+-        # to the server only for the sctp proto otherwise it will just exit for weird reasons.
+-        # As such create a empty anonymous pipe to work around that.
+-        # https://github.com/nmap/nmap/issues/2829
+-        exec {stdin}<> <(:)
+-        ;;
+-    *) die "unknown port proto '$proto'" ;;
+-    esac
+-
+-    if is_ipv4 "$connect_ip"; then
+-        nc_common_args="-4 $nc_common_args"
+-    fi
+     if is_ipv6 "$connect_ip"; then
+-        nc_common_args="-6 $nc_common_args"
+-    fi
+-
+-    nsenter -n -t "${CONTAINER_NS_PIDS[$container_ns]}" timeout --foreground -v --kill=10 5 \
+-        ncat $nc_common_args -l -p $container_port &>"$NETAVARK_TMPDIR/nc-out" <&$stdin &
+-
+-    # make sure to wait until port is bound otherwise test can flake
+-    # https://github.com/containers/netavark/issues/433
+-    if [ "$proto" = "tcp" ] || [ "$proto" = "udp" ]; then
+-        wait_for_port "${CONTAINER_NS_PIDS[$container_ns]}" $container_port $proto
+-    else
+-        # TODO add support for sctp port reading from /proc/net/sctp/eps,
+-        # for now just sleep
+-        sleep 0.5
++        connect_ip="[$connect_ip]"
+     fi
+ 
+     data=$(random_string)
+-    run_in_host_netns ncat $nc_common_args $connect_ip $host_port <<<"$data"
+-
+-    got=$(cat "$NETAVARK_TMPDIR/nc-out")
+-    assert "$got" == "$data" "ncat received data"
+-
+-    # close the fd
+-    exec {stdin}>&-
++    run_in_host_netns $NETAVARK_CONNECTION_TESTER --$proto  "$(get_container_netns_path $container_ns)" "$connect_ip:$host_port" $container_port <<<"$data"
++    assert "${lines[1]}" == "Message: $data" "Logged message"
+ }
+ 
+ #################
+@@ -763,127 +727,3 @@ function add_dummy_interface_on_host() {
+     fi
+     run_in_host_netns ip link set "$name" up
+ }
+-
+-
+-### Below functions are taken from podman system tests,
+-### see Stefano Brivio's commit  https://github.com/containers/podman/pull/16141/commits/ea4f168b3a6603991f2cbdc2dcfe6268a46bf1ba
+-
+-# ipv6_to_procfs() - RFC 5952 IPv6 address text representation to procfs format
+-# $1:	Address in any notation described by RFC 5952
+-function ipv6_to_procfs() {
+-    local addr="${1}"
+-
+-    # Add leading zero if missing
+-    case ${addr} in
+-        "::"*) addr=0"${addr}" ;;
+-    esac
+-
+-    # Double colon can mean any number of all-zero fields. Expand to fill
+-    # as many colons as are missing. (This will not be a valid IPv6 form,
+-    # but we don't need it for long). E.g., 0::1 -> 0:::::::1
+-    case ${addr} in
+-        *"::"*)
+-            # All the colons in the address
+-            local colons
+-            colons=$(tr -dc : <<<$addr)
+-            # subtract those from a string of eight colons; this gives us
+-            # a string of two to six colons...
+-            local pad
+-            pad=$(sed -e "s/$colons//" <<<":::::::")
+-            # ...which we then inject in place of the double colon.
+-            addr=$(sed -e "s/::/::$pad/" <<<$addr)
+-            ;;
+-    esac
+-
+-    # Print as a contiguous string of zero-filled 16-bit words
+-    # (The additional ":" below is needed because 'read -d x' actually
+-    # means "x is a TERMINATOR, not a delimiter")
+-    local group
+-    while read -d : group; do
+-        printf "%04X" "0x${group:-0}"
+-    done <<<"${addr}:"
+-}
+-
+-# __ipv4_to_procfs() - Print bytes in hexadecimal notation reversing arguments
+-# $@:	IPv4 address as separate bytes
+-function __ipv4_to_procfs() {
+-    printf "%02X%02X%02X%02X" ${4} ${3} ${2} ${1}
+-}
+-
+-# ipv4_to_procfs() - IPv4 address representation to big-endian procfs format
+-# $1:	Text representation of IPv4 address
+-function ipv4_to_procfs() {
+-    IFS='.' __ipv4_to_procfs ${1}
+-}
+-
+-# port_is_bound() - Check if TCP or UDP port is bound for a given address
+-# $1:   Netns PID
+-# $2:	Port number
+-# $3:	Optional protocol, or optional IPv4 or IPv6 address, default: tcp
+-# $4:	Optional IPv4 or IPv6 address, or optional protocol, default: any
+-function port_is_bound() {
+-    local pid=$1
+-    local port=${2?Usage: port_is_bound PORT [tcp|udp] [ADDRESS]}
+-
+-    if   [ "${3}" = "tcp" ] || [ "${3}" = "udp" ]; then
+-        local address="${4}"
+-        local proto="${3}"
+-    elif [ "${4}" = "tcp" ] || [ "${4}" = "udp" ]; then
+-        local address="${3}"
+-        local proto="${4}"
+-    else
+-        local address="${3}"	# Might be empty
+-        local proto="tcp"
+-    fi
+-
+-    port=$(printf %04X ${port})
+-    case "${address}" in
+-    *":"*)
+-        nsenter -n -t $pid grep -e "^[^:]*: $(ipv6_to_procfs "${address}"):${port} .*" \
+-             -e "^[^:]*: $(ipv6_to_procfs "::0"):${port} .*"        \
+-             -q "/proc/net/${proto}6"
+-        ;;
+-    *"."*)
+-        nsenter -n -t $pid grep -e "^[^:]*: $(ipv4_to_procfs "${address}"):${port}"    \
+-             -e "^[^:]*: $(ipv4_to_procfs "0.0.0.0"):${port}"       \
+-             -q "/proc/net/${proto}"
+-        ;;
+-    *)
+-        # No address: check both IPv4 and IPv6, for any bound address
+-        nsenter -n -t $pid grep "^[^:]*: [^:]*:${port} .*" -q "/proc/net/${proto}6" || \
+-        nsenter -n -t $pid grep "^[^:]*: [^:]*:${port} .*" -q "/proc/net/${proto}"
+-        ;;
+-    esac
+-}
+-
+-# port_is_free() - Check if TCP or UDP port is free to bind for a given address
+-# $1:   Netns PID
+-# $2:	Port number
+-# $3:	Optional protocol, or optional IPv4 or IPv6 address, default: tcp
+-# $4:	Optional IPv4 or IPv6 address, or optional protocol, default: any
+-function port_is_free() {
+-    ! port_is_bound ${@}
+-}
+-
+-# wait_for_port() - Return when port is binded
+-# $1:   Netns PID
+-# $2:	Port number
+-# $3:	Optional protocol, or optional IPv4 or IPv6 address, default: tcp
+-# $4:	Optional IPv4 or IPv6 address, or optional protocol, default: any
+-# $5:	Optional timeout, 5 seconds if not given
+-function wait_for_port() {
+-    local pid=$1
+-    local port=$2
+-    local proto=$3
+-    local host=$4
+-    local _timeout=${5:-5}
+-
+-    # Wait
+-    while [ $_timeout -gt 0 ]; do
+-        port_is_bound ${pid} ${port} ${proto} ${host} && return
+-        sleep 1
+-        _timeout=$(( $_timeout - 1 ))
+-    done
+-
+-    die "Timed out waiting for $host:$port"
+-}
+
+From f7c388309b131ba19d4af7475da64ba1de632d94 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Mon, 21 Jul 2025 18:21:02 +0200
+Subject: [PATCH 3/3] exec_netns macro: update comment
+
+Follow up to commit 047ef70345 which removed the third argument.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ src/network/core_utils.rs | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/network/core_utils.rs b/src/network/core_utils.rs
+index b2495bca8..ed1c1b9f9 100644
+--- a/src/network/core_utils.rs
++++ b/src/network/core_utils.rs
+@@ -259,8 +259,7 @@ pub fn join_netns<Fd: AsFd>(fd: Fd) -> NetavarkResult<()> {
+ 
+ /// safe way to join the namespace and join back to the host after the task is done
+ /// This first arg should be the hostns fd, the second is the container ns fd.
+-/// The third is the result variable name and the last the closure that should be
+-/// executed in the ns.
++/// The third and last the closure that should be executed in the ns.
+ #[macro_export]
+ macro_rules! exec_netns {
+     ($host:expr, $netns:expr, $exec:expr) => {{

--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -64,6 +64,7 @@ buildah:
 netavark:
   # Note on patches:
   # https://github.com/containers/netavark/pull/1191 is needed for 001-basic
+  # https://github.com/containers/netavark/pull/1283 is needed to drop ncat dependency
   # https://github.com/containers/netavark/pull/1287 is needed to drop ncat dependency
   opensuse-Tumbleweed:
     BATS_SKIP:
@@ -74,16 +75,19 @@ netavark:
   sle-15-SP7:
     BATS_PATCHES:
     - 1191
+    - 1283
     - 1287
     BATS_SKIP: 250-bridge-nftables
   sle-15-SP6:
     BATS_PATCHES:
     - 1191
+    - 1283
     - 1287
     BATS_SKIP: 250-bridge-nftables
   sle-15-SP5:
     BATS_PATCHES:
     - 1191
+    - 1283
     - 1287
     BATS_SKIP: 250-bridge-nftables
 podman:

--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -64,6 +64,7 @@ buildah:
 netavark:
   # Note on patches:
   # https://github.com/containers/netavark/pull/1191 is needed for 001-basic
+  # https://github.com/containers/netavark/pull/1287 is needed to drop ncat dependency
   opensuse-Tumbleweed:
     BATS_SKIP:
   sle-16.0:
@@ -73,14 +74,17 @@ netavark:
   sle-15-SP7:
     BATS_PATCHES:
     - 1191
+    - 1287
     BATS_SKIP: 250-bridge-nftables
   sle-15-SP6:
     BATS_PATCHES:
     - 1191
+    - 1287
     BATS_SKIP: 250-bridge-nftables
   sle-15-SP5:
     BATS_PATCHES:
     - 1191
+    - 1287
     BATS_SKIP: 250-bridge-nftables
 podman:
   # Note on patches:

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -29,7 +29,7 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    my @pkgs = qw(aardvark-dns cargo firewalld iproute2 jq make ncat protobuf-devel netavark);
+    my @pkgs = qw(aardvark-dns cargo firewalld iproute2 jq make protobuf-devel netavark);
     if (is_tumbleweed || is_sle('>=16.0')) {
         push @pkgs, qw(dbus-1-daemon);
     } elsif (is_sle) {
@@ -51,6 +51,8 @@ sub run {
 
     # Compile helpers & patch tests
     run_command "make examples", timeout => 600;
+    run_command "cargo build --release --bin netavark-connection-tester", timeout => 300;
+    run_command "cp targets/release/netavark-connection-tester bin/";
     unless (get_var("BATS_TESTS")) {
         run_command "rm -f test/100-bridge-iptables.bats" if ($firewalld_backend ne "iptables");
     }


### PR DESCRIPTION
Backport https://github.com/containers/netavark/pull/1287 to drop dependency on ncat.

Verification runs:
 - sle-15-SP5 aarch64: https://openqa.suse.de/tests/18785304
 - sle-15-SP5 x86_64: https://openqa.suse.de/tests/18785305
 - sle-15-SP6 aarch64: https://openqa.suse.de/tests/18785306
 - sle-15-SP6 x86_64: https://openqa.suse.de/tests/18785307
 - sle-15-SP7 aarch64: https://openqa.suse.de/tests/18785311
 - sle-15-SP7 x86_64: https://openqa.suse.de/tests/18785310
