### PR TITLE
Schedule SPR on SP7 or newer

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -325,12 +325,12 @@ sub load_container_tests {
 
         if ($chart eq 'helm' || $chart =~ m/rmt-helm$/) {
             loadtest 'containers/charts/rmt';
-        } elsif ($chart =~ m/private-registry/) {
+        } elsif ($chart =~ m/private-registry/ && check_var('HOST_VERSION', '15-SP7')) {
             set_var('K3S_ENABLE_TRAEFIK', 1);
             loadtest 'containers/charts/privateregistry';
         }
         else {
-            die "Unsupported HELM_CHART value";
+            die "Unsupported HELM_CHART value or HOST_VERSION";
         }
         return;
     }


### PR DESCRIPTION
This PR schedules the SUSE Private Registry helm chart tests only for SP7 to avoid unnecessary duplication.

- Related ticket: https://progress.opensuse.org/issues/186465
- Verification run:[ openqa.mypersonalinstance.de/tests/xyz#step/module/x](http://dirtman.qe.prg2.suse.org/tests/46#)
