### PR TITLE
bats/aardvark: Use netcat-openbsd for SLES < 16

### DIFF
--- a/tests/containers/bats/aardvark.pm
+++ b/tests/containers/bats/aardvark.pm
@@ -33,7 +33,12 @@ sub run {
     select_serial_terminal;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns firewalld iproute2 jq ncat netavark podman);
+    my @pkgs = qw(aardvark-dns firewalld iproute2 jq netavark podman);
+    if (is_sle("<16")) {
+        push @pkgs, qw(netcat-openbsd);
+    } else {
+        push @pkgs, qw(ncat);
+    }
     if (is_tumbleweed || is_sle('>=16.0')) {
         push @pkgs, qw(dbus-1-daemon);
     } elsif (is_sle) {


### PR DESCRIPTION
Use netcat-openbsd instead of ncat on SLES < 16.
    
The original aardvark-dns tests used netcat-openbsd (nc) and they worked.  Later they migrated to Nmap's ncat and they break on versions different than 7.92, 7.94 & 7.95.  We also depend on repos for ncat that disappear.

Issue opened upstream to migrate away from ncat: https://github.com/containers/aardvark-dns/issues/622

Failed jobs: https://openqa.suse.de/tests/18781071#step/aardvark/101

Verification runs:
 - sle-15-SP5 aarch64: https://openqa.suse.de/tests/18782411
 - sle-15-SP5 x86_64: https://openqa.suse.de/tests/18782412
 - sle-15-SP6 aarch64: https://openqa.suse.de/tests/18782414
 - sle-15-SP6 x86_64: https://openqa.suse.de/tests/18782415
 - sle-15-SP7 aarch64: https://openqa.suse.de/tests/18782416
 - sle-15-SP7 x86_64: https://openqa.suse.de/tests/18782417