### PR TITLE
Speed up script_retry test which takes 1s

### DIFF
--- a/t/05_utils_auxiliary.t
+++ b/t/05_utils_auxiliary.t
@@ -29,8 +29,7 @@ subtest 'script_retry' => sub {
     # This fails on first run but succeeds on second run. Test if we are actually retrying
     is script_retry('rm -f test', retry => 1, delay => 0, timeout => 1), 0, 'removing test file';
     is script_retry('bash -c "if [[ -f test ]]; then exit 0; else touch test; exit 1; fi"', retry => 2, delay => 0, timeout => 1, die => 0), 0, "script_retry - OK on second try";
-    # Note: This is the only test that waits for one second. Disable if time is crucial.
-    dies_ok { script_retry('sleep 10', retry => 1, delay => 0, timeout => 1) } 'script_retry(sleep) is expected to die';
+    dies_ok { script_retry('sleep 10', retry => 1, delay => 0, timeout => 0.1) } 'script_retry(sleep) is expected to die';
 };
 
 


### PR DESCRIPTION
As timeout accepts floating point number the timeout can be reduced by 90%. An additional safing time can be achieved by use floating number for sleep as well but 90% gain is quite enough.


before: `0.64s user 0.25s system 47% cpu 1.883 total`
after:     `0.66s user 0.27s system 91% cpu 1.021 total`