### PR TITLE
bats/podman: Use a proper repo with ncat 7.95 for PowerPC

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -91,8 +91,7 @@ sub install_ncat {
         if (is_aarch64) {
             run_command "zypper addrepo http://download.opensuse.org/ports/aarch64/tumbleweed/repo/non-oss/ non-oss";
         } elsif (is_ppc64le) {
-            # This should be temporary until ncat 7.95 is published for Tumbleweed
-            run_command "zypper addrepo https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0:/NonFree/standard/openSUSE:Leap:16.0:NonFree.repo";
+            run_command "zypper addrepo https://download.opensuse.org/repositories/openSUSE:/Factory:/PowerPC:/NonFree/standard/openSUSE:Factory:PowerPC:NonFree.repo";
         } elsif (is_s390x) {
             run_command "zypper addrepo http://download.opensuse.org/ports/zsystems/tumbleweed/repo/non-oss/ non-oss";
         } else {


### PR DESCRIPTION
Use a proper repo with ncat 7.95 for PowerPC

Related PR: https://github.com/os-autoinst/opensuse-jobgroups/pull/704

Verification runs:
- podman with runc: https://openqa.opensuse.org/tests/5242648
- podman with crun: https://openqa.opensuse.org/tests/5242649