### PR TITLE
bats/netavark: Ignore 200-bridge-firewalld on SLES 15

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -73,15 +73,15 @@ netavark:
   sle-15-SP7:
     BATS_PATCHES:
     - 1191
-    BATS_SKIP: 250-bridge-nftables
+    BATS_SKIP: 200-bridge-firewalld 250-bridge-nftables
   sle-15-SP6:
     BATS_PATCHES:
     - 1191
-    BATS_SKIP: 250-bridge-nftables
+    BATS_SKIP: 200-bridge-firewalld 250-bridge-nftables
   sle-15-SP5:
     BATS_PATCHES:
     - 1191
-    BATS_SKIP: 250-bridge-nftables
+    BATS_SKIP: 200-bridge-firewalld 250-bridge-nftables
 podman:
   # Note on patches:
   # https://github.com/containers/podman/pull/21875 is needed for 060-mount


### PR DESCRIPTION
 Ignore 200-bridge-firewalld on SLES 15 until we find a better repo for ncat.

```
$ susebats notok https://openqa.suse.de/tests/18781068
    BATS_SKIP: 200-bridge-firewalld 250-bridge-nftables
$ susebats notok https://openqa.suse.de/tests/18781065
    BATS_SKIP: 200-bridge-firewalld 250-bridge-nftables
$ susebats notok https://openqa.suse.de/tests/18781060
    BATS_SKIP: 200-bridge-firewalld 250-bridge-nftables
$ susebats notok https://openqa.suse.de/tests/18781059
    BATS_SKIP: 200-bridge-firewalld 250-bridge-nftables
```


