### PR TITLE
Add test for alert informing the user that Agama could not fetch profile

### DIFF
--- a/lib/Yam/Agama/Pom/AgamaUpAndRunningPage.pm
+++ b/lib/Yam/Agama/Pom/AgamaUpAndRunningPage.pm
@@ -19,6 +19,7 @@ sub new {
         tag_array_ref_any_first_screen_shown => [
             qw(agama-product-selection
               agama-configuring-the-product
+              agama-error-fetching-profile
               agama-unsupported-autoyast-elements
               agama-installing
               agama-sle-overview

--- a/tests/yam/agama/agama.pm
+++ b/tests/yam/agama/agama.pm
@@ -8,7 +8,6 @@
 use base Yam::Agama::agama_base;
 use Carp qw(croak);
 use testapi qw(
-  check_var
   diag
   get_var
   get_required_var
@@ -61,7 +60,7 @@ sub run {
         my $svirt = console('svirt')->change_domain_element(os => boot => {dev => 'hd'});
     }
 
-    (is_s390x() || is_pvm() || is_headless_installation() || check_var('AGAMA_ALERT_POPUP', 'invalid_profile')) ?
+    (is_s390x() || is_pvm() || is_headless_installation()) ?
       # reboot via console
       power_action('reboot', keepconsole => 1, first_reboot => 1) :
       # graphical reboot

--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -97,7 +97,7 @@ sub run {
     $grub_entry_edition->boot();
 
     return if check_var('AGAMA_GRUB_SELECTION', 'rescue_system');
-    if (get_var('EXTRABOOTPARAMS', '') =~ /systemd.unit=multi-user.target/ || check_var('AGAMA_ALERT_POPUP', 'invalid_profile')) {
+    if (get_var('EXTRABOOTPARAMS', '') =~ /systemd.unit=multi-user.target/) {
         wait_serial('Connect to the Agama installer using these URLs:', 300) || die "Agama installer didn't start";
     } else {
         $agama_up_an_running->expect_is_shown();


### PR DESCRIPTION
Enhance the test to avoid introducing fictitious variable.

- Related ticket: https://progress.opensuse.org/issues/185704
- Related PR: https://github.com/jknphy/agama-integration-test-webpack/pull/136
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/18915865#details