### PR TITLE
bats: Use BATS_IGNORE instead of BATS_SKIP

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -5,83 +5,83 @@ aardvark-dns:
   opensuse-Tumbleweed:
     BATS_PATCHES:
     - 619
-    BATS_SKIP:
+    BATS_IGNORE:
   sle-16.0:
     BATS_PATCHES:
     - 619
-    BATS_SKIP:
+    BATS_IGNORE:
   sle-15-SP7:
     BATS_PATCHES:
     - 519
-    BATS_SKIP: 100-basic-name-resolution
+    BATS_IGNORE: 100-basic-name-resolution
   sle-15-SP6:
     BATS_PATCHES:
     - 519
-    BATS_SKIP: 100-basic-name-resolution
+    BATS_IGNORE: 100-basic-name-resolution
   sle-15-SP5:
     BATS_PATCHES:
     - 519
-    BATS_SKIP: 100-basic-name-resolution
+    BATS_IGNORE: 100-basic-name-resolution
 buildah:
   # Note on patches:
   # https://github.com/containers/buildah/pull/6226 is needed for bud & run
   opensuse-Tumbleweed:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP:
-    BATS_SKIP_ROOT:
-    BATS_SKIP_USER:
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT:
+    BATS_IGNORE_USER:
   sle-16.0:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP:
-    BATS_SKIP_ROOT: bud
-    BATS_SKIP_USER:
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT: bud
+    BATS_IGNORE_USER:
   sle-15-SP7:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP:
-    BATS_SKIP_ROOT: bud run
-    BATS_SKIP_USER:
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT: bud run
+    BATS_IGNORE_USER:
   sle-15-SP6:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP:
-    BATS_SKIP_ROOT: bud run
-    BATS_SKIP_USER:
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT: bud run
+    BATS_IGNORE_USER:
   sle-15-SP5:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP: bud
-    BATS_SKIP_ROOT: run
-    BATS_SKIP_USER:
+    BATS_IGNORE: bud
+    BATS_IGNORE_ROOT: run
+    BATS_IGNORE_USER:
   sle-15-SP4:
     BATS_PATCHES:
     - 6226
-    BATS_SKIP: bud
-    BATS_SKIP_ROOT: run
-    BATS_SKIP_USER:
+    BATS_IGNORE: bud
+    BATS_IGNORE_ROOT: run
+    BATS_IGNORE_USER:
 netavark:
   # Note on patches:
   # https://github.com/containers/netavark/pull/1191 is needed for 001-basic
   opensuse-Tumbleweed:
-    BATS_SKIP:
+    BATS_IGNORE:
   sle-16.0:
     BATS_PATCHES:
     - 1191
-    BATS_SKIP:
+    BATS_IGNORE:
   sle-15-SP7:
     BATS_PATCHES:
     - 1191
-    BATS_SKIP: 200-bridge-firewalld 250-bridge-nftables
+    BATS_IGNORE: 200-bridge-firewalld 250-bridge-nftables
   sle-15-SP6:
     BATS_PATCHES:
     - 1191
-    BATS_SKIP: 200-bridge-firewalld 250-bridge-nftables
+    BATS_IGNORE: 200-bridge-firewalld 250-bridge-nftables
   sle-15-SP5:
     BATS_PATCHES:
     - 1191
-    BATS_SKIP: 200-bridge-firewalld 250-bridge-nftables
+    BATS_IGNORE: 200-bridge-firewalld 250-bridge-nftables
 podman:
   # Note on patches:
   # https://github.com/containers/podman/pull/21875 is needed for 060-mount
@@ -98,11 +98,11 @@ podman:
     - 25942
     - 26017
     - 26798
-    BATS_SKIP:
-    BATS_SKIP_ROOT_LOCAL: 200-pod
-    BATS_SKIP_ROOT_REMOTE:
-    BATS_SKIP_USER_LOCAL: 252-quadlet
-    BATS_SKIP_USER_REMOTE: 130-kill
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT_LOCAL: 200-pod
+    BATS_IGNORE_ROOT_REMOTE:
+    BATS_IGNORE_USER_LOCAL: 252-quadlet
+    BATS_IGNORE_USER_REMOTE: 130-kill
   sle-16.0:
     BATS_PATCHES:
     - 25792
@@ -111,95 +111,95 @@ podman:
     - 25942
     - 26017
     - 26798
-    BATS_SKIP:
-    BATS_SKIP_ROOT_LOCAL: 200-pod
-    BATS_SKIP_ROOT_REMOTE:
-    BATS_SKIP_USER_LOCAL:
-    BATS_SKIP_USER_REMOTE: 130-kill
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT_LOCAL: 200-pod
+    BATS_IGNORE_ROOT_REMOTE:
+    BATS_IGNORE_USER_LOCAL:
+    BATS_IGNORE_USER_REMOTE: 130-kill
   sle-15-SP7:
     BATS_PATCHES:
     - 21875
     - 24068
     - 25792
     - 25942
-    BATS_SKIP:
-    BATS_SKIP_ROOT_LOCAL:
-    BATS_SKIP_ROOT_REMOTE:
-    BATS_SKIP_USER_LOCAL:
-    BATS_SKIP_USER_REMOTE:
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT_LOCAL:
+    BATS_IGNORE_ROOT_REMOTE:
+    BATS_IGNORE_USER_LOCAL:
+    BATS_IGNORE_USER_REMOTE:
   sle-15-SP6:
     BATS_PATCHES:
     - 21875
     - 24068
     - 25792
     - 25942
-    BATS_SKIP:
-    BATS_SKIP_ROOT_LOCAL:
-    BATS_SKIP_ROOT_REMOTE:
-    BATS_SKIP_USER_LOCAL:
-    BATS_SKIP_USER_REMOTE:
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT_LOCAL:
+    BATS_IGNORE_ROOT_REMOTE:
+    BATS_IGNORE_USER_LOCAL:
+    BATS_IGNORE_USER_REMOTE:
 runc:
   # Note on patches:
   # https://github.com/opencontainers/runc/pull/4825 is needed for cgroups
   opensuse-Tumbleweed:
     BATS_PATCHES:
     - 4825
-    BATS_SKIP:
-    BATS_SKIP_ROOT:
-    BATS_SKIP_USER:
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT:
+    BATS_IGNORE_USER:
   sle-16.0:
     BATS_PATCHES:
     - 4825
-    BATS_SKIP:
-    BATS_SKIP_ROOT:
-    BATS_SKIP_USER:
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT:
+    BATS_IGNORE_USER:
   sle-15-SP7:
     BATS_PATCHES:
     - 4825
-    BATS_SKIP:
-    BATS_SKIP_ROOT:
-    BATS_SKIP_USER: run userns
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT:
+    BATS_IGNORE_USER: run userns
   sle-15-SP6:
     BATS_PATCHES:
     - 4825
-    BATS_SKIP:
-    BATS_SKIP_ROOT:
-    BATS_SKIP_USER: run userns
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT:
+    BATS_IGNORE_USER: run userns
   sle-15-SP5:
     BATS_PATCHES:
     - 4825
-    BATS_SKIP:
-    BATS_SKIP_ROOT:
-    BATS_SKIP_USER: run userns
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT:
+    BATS_IGNORE_USER: run userns
   sle-15-SP4:
     BATS_PATCHES:
     - 4825
-    BATS_SKIP:
-    BATS_SKIP_ROOT:
-    BATS_SKIP_USER: run userns
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT:
+    BATS_IGNORE_USER: run userns
 skopeo:
   opensuse-Tumbleweed:
-    BATS_SKIP:
-    BATS_SKIP_ROOT:
-    BATS_SKIP_USER:
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT:
+    BATS_IGNORE_USER:
   sle-16.0:
-    BATS_SKIP:
-    BATS_SKIP_ROOT:
-    BATS_SKIP_USER:
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT:
+    BATS_IGNORE_USER:
   sle-15-SP7:
-    BATS_SKIP:
-    BATS_SKIP_ROOT:
-    BATS_SKIP_USER:
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT:
+    BATS_IGNORE_USER:
   sle-15-SP6:
-    BATS_SKIP:
-    BATS_SKIP_ROOT:
-    BATS_SKIP_USER:
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT:
+    BATS_IGNORE_USER:
   sle-15-SP5:
-    BATS_SKIP:
-    BATS_SKIP_ROOT:
-    BATS_SKIP_USER:
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT:
+    BATS_IGNORE_USER:
   sle-15-SP4:
-    BATS_SKIP:
-    BATS_SKIP_ROOT:
-    BATS_SKIP_USER:
+    BATS_IGNORE:
+    BATS_IGNORE_ROOT:
+    BATS_IGNORE_USER:
 

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -420,7 +420,7 @@ sub bats_tests {
 
     unless (get_var("BATS_TESTS")) {
         $skip_tests = get_var($skip_tests, $settings->{$skip_tests});
-        my @skip_tests = split(/\s+/, join(' ', get_var('BATS_SKIP', $settings->{BATS_SKIP}), $skip_tests));
+        my @skip_tests = split(/\s+/, join(' ', get_var('BATS_IGNORE', $settings->{BATS_IGNORE}), $skip_tests));
         patch_logfile($log_file, @skip_tests);
     }
 

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -33,19 +33,19 @@ NOTES
 - `BATS_TEST_PACKAGES` may be used to test candidate kernels (KOTD, PTF, etc) and other packages.
 - `BATS_TEST_REPOS` may be used to test candidate packages outside the usual maintenance workflow.
 
-### Summary of the `BATS_SKIP` variables
+### Summary of the `BATS_IGNORE` variables
 
 These are defined in [skip.yaml](data/containers/bats/skip.yaml)
 
 | variable | description | aardvark | buildah | netavark | podman | runc | skopeo |
 |---|---|:---:|:---:|:---:|:---:|:---:|:---:|
-| `BATS_SKIP` | Skip tests on ALL scenarios              |✅|✅|✅|✅|✅|✅|
-| `BATS_SKIP_ROOT` | Skip tests for root user            |  |✅|  |  |✅|✅|
-| `BATS_SKIP_USER` | Skip tests for rootless             |  |✅|  |  |✅|✅|
-| `BATS_SKIP_ROOT_LOCAL` | Skip tests for root / local   |  |  |  |✅|  |  |
-| `BATS_SKIP_ROOT_REMOTE` | Skip tests for root / remote |  |  |  |✅|  |  |
-| `BATS_SKIP_USER_LOCAL` | Skip tests for user / local   |  |  |  |✅|  |  |
-| `BATS_SKIP_USER_REMOTE` | Skip tests for user / remote |  |  |  |✅|  |  |
+| `BATS_IGNORE` | Skip tests on ALL scenarios              |✅|✅|✅|✅|✅|✅|
+| `BATS_IGNORE_ROOT` | Skip tests for root user            |  |✅|  |  |✅|✅|
+| `BATS_IGNORE_USER` | Skip tests for rootless             |  |✅|  |  |✅|✅|
+| `BATS_IGNORE_ROOT_LOCAL` | Skip tests for root / local   |  |  |  |✅|  |  |
+| `BATS_IGNORE_ROOT_REMOTE` | Skip tests for root / remote |  |  |  |✅|  |  |
+| `BATS_IGNORE_USER_LOCAL` | Skip tests for user / local   |  |  |  |✅|  |  |
+| `BATS_IGNORE_USER_REMOTE` | Skip tests for user / remote |  |  |  |✅|  |  |
 
 NOTES
  - The special value `all` may be used to skip all tests.

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -96,11 +96,11 @@ sub run {
     my $helpers = script_output 'echo $(grep ^all: Makefile | grep -o "bin/[a-z]*" | grep -v bin/buildah)';
     run_command "make $helpers", timeout => 600;
 
-    my $errors = run_tests(rootless => 1, skip_tests => 'BATS_SKIP_USER');
+    my $errors = run_tests(rootless => 1, skip_tests => 'BATS_IGNORE_USER');
 
     switch_to_root;
 
-    $errors += run_tests(rootless => 0, skip_tests => 'BATS_SKIP_ROOT');
+    $errors += run_tests(rootless => 0, skip_tests => 'BATS_IGNORE_ROOT');
 
     die "buildah tests failed" if ($errors);
 }

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -99,18 +99,18 @@ sub run {
     run_command "make podman-testing || true", timeout => 600;
 
     # user / local
-    my $errors = run_tests(rootless => 1, remote => 0, skip_tests => 'BATS_SKIP_USER_LOCAL');
+    my $errors = run_tests(rootless => 1, remote => 0, skip_tests => 'BATS_IGNORE_USER_LOCAL');
 
     # user / remote
-    $errors += run_tests(rootless => 1, remote => 1, skip_tests => 'BATS_SKIP_USER_REMOTE');
+    $errors += run_tests(rootless => 1, remote => 1, skip_tests => 'BATS_IGNORE_USER_REMOTE');
 
     switch_to_root;
 
     # root / local
-    $errors += run_tests(rootless => 0, remote => 0, skip_tests => 'BATS_SKIP_ROOT_LOCAL');
+    $errors += run_tests(rootless => 0, remote => 0, skip_tests => 'BATS_IGNORE_ROOT_LOCAL');
 
     # root / remote
-    $errors += run_tests(rootless => 0, remote => 1, skip_tests => 'BATS_SKIP_ROOT_REMOTE');
+    $errors += run_tests(rootless => 0, remote => 1, skip_tests => 'BATS_IGNORE_ROOT_REMOTE');
 
     die "podman tests failed" if ($errors);
 }

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -61,11 +61,11 @@ sub run {
         run_command "rm -f tests/integration/seccomp.bats" if is_s390x;
     }
 
-    my $errors = run_tests(rootless => 1, skip_tests => 'BATS_SKIP_USER');
+    my $errors = run_tests(rootless => 1, skip_tests => 'BATS_IGNORE_USER');
 
     switch_to_root;
 
-    $errors += run_tests(rootless => 0, skip_tests => 'BATS_SKIP_ROOT');
+    $errors += run_tests(rootless => 0, skip_tests => 'BATS_IGNORE_ROOT');
 
     die "runc tests failed" if ($errors);
 }

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -54,11 +54,11 @@ sub run {
     my $goarch = script_output "podman version -f '{{.OsArch}}' | cut -d/ -f2";
     run_command "sed -i 's/arch=.*/arch=$goarch/' systemtest/010-inspect.bats";
 
-    my $errors = run_tests(rootless => 1, skip_tests => 'BATS_SKIP_USER');
+    my $errors = run_tests(rootless => 1, skip_tests => 'BATS_IGNORE_USER');
 
     switch_to_root;
 
-    $errors += run_tests(rootless => 0, skip_tests => 'BATS_SKIP_ROOT');
+    $errors += run_tests(rootless => 0, skip_tests => 'BATS_IGNORE_ROOT');
 
     die "skopeo tests failed" if ($errors);
 }


### PR DESCRIPTION
Since we don't really skip any tests specified in this variable but ignore their failures instead, change their names to reflect the actual usage.  Also, BATS tests have their own own concept of skipped tests using "# skip $reason" in the TAP logs.

This change is also needed because we're updating the susebats tool to track the tests internally skipped by bats.

No VR needed as I did a simple `sed -i s/BATS_SKIP/BATS_IGNORE/g $(grep -rl BATS_SKIP)`