### PR TITLE
Adapt saptune/mr_test for SLES for SAP 16

### DIFF
--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -3,15 +3,41 @@
 # Copyright 2017-2018 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
+# Package: saptune
 # Summary: saptune availability test
 # Maintainer: QE-SAP <qe-sap@suse.de>, Alvaro Carvajal <acarvajal@suse.de>
 
 use base 'sles4sap';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use utils "zypper_call";
+use utils qw(systemctl zypper_call);
 use version_utils qw(is_sle is_upgrade);
 use Utils::Architectures;
+
+=head1 NAME
+
+sles4sap/saptune.pm - Smoke test for saptune package in SLES for SAP
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=head1 DESCRIPTION
+
+This module will check C<saptune> is installed, and it will also check if the
+corresponding service has been started in SLES for SAP 16 or newer.
+
+B<The key tasks performed by this module include:>
+
+=over
+
+=item * Check with C<systemctl> the status of the C<saptune> service on SLES for SAP 16 or newer.
+
+=item * Check C<saptune> is installed with C<saptune version> command.
+
+=back
+
+=cut
 
 sub run {
     select_serial_terminal;
@@ -20,9 +46,11 @@ sub run {
     return if is_upgrade();
 
     # saptune is not installed by default on SLES4SAP 12 on ppc64le
-    zypper_call "-n in saptune" if (is_ppc64le() and is_sle('<15'));
+    zypper_call '-n in saptune' if (is_ppc64le() and is_sle('<15'));
 
-    assert_script_run "saptune version";
+    systemctl 'status saptune' if is_sle('>=16');
+
+    assert_script_run 'saptune version';
 }
 
 1;


### PR DESCRIPTION
This commit includes changes on the test module `sles4sap/saptune/mr_test_run` so it is compatible with the changes in `saptune` on SLES for SAP Applications 16.

Changes include:

* Added a `saptune solution revert SAP_Base` at the start of the test as SLES for SAP 16 comes with a `SAP_Base` solution pre-configured. Without reverting, test would fail while applying the first solution. 12 & 15 do not come with a solution pre-configured.
* Removal of notes 1680803, 1771258, 1805750 on 16.
* Adding new notes 3565382 & 3577842 for 16.
* Replace note 2684254 for 3577842 on SLES 16.
* Removal of SAP-ASE solution on 16.
* The version header for saptune notes is no longer a single line starting with a pound (#) sign, but a multi-line variable/value list. This commit allows for this new format to be used in custom notes when running on SLES 16 while keeping the old one-line format in 12 & 15.
* Test module was reporting errors on `wait_serial` when creating custom notes with `assert_script_run` due to the commands containing strings separated by newlines (\n). Commit introduces a new method `wrap_assert_script_run_with_newlines()` in the module to handle these multi-line commands.
* Check saptune is started by default in SLES for SAP 16.

- Related Ticket: https://jira.suse.com/browse/TEAM-10430
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?version=16.0&build=team10430&distri=sle, http://mango.qe.nue2.suse.org/tests/7129#step/saptune/4
