### PR TITLE
bats/podman: Support BATS_IGNORE_{USER,ROOT}=all

### DIFF
--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -98,19 +98,23 @@ sub run {
     # Compile helpers used by the tests
     run_command "make podman-testing || true", timeout => 600;
 
-    # user / local
-    my $errors = run_tests(rootless => 1, remote => 0, skip_tests => 'BATS_IGNORE_USER_LOCAL');
+    unless (check_var("BATS_IGNORE_USER", "all")) {
+        # user / local
+        my $errors = run_tests(rootless => 1, remote => 0, skip_tests => 'BATS_IGNORE_USER_LOCAL');
 
-    # user / remote
-    $errors += run_tests(rootless => 1, remote => 1, skip_tests => 'BATS_IGNORE_USER_REMOTE');
+        # user / remote
+        $errors += run_tests(rootless => 1, remote => 1, skip_tests => 'BATS_IGNORE_USER_REMOTE');
+    }
 
     switch_to_root;
 
-    # root / local
-    $errors += run_tests(rootless => 0, remote => 0, skip_tests => 'BATS_IGNORE_ROOT_LOCAL');
+    unless (check_var("BATS_IGNORE_ROOT", "all")) {
+        # root / local
+        $errors += run_tests(rootless => 0, remote => 0, skip_tests => 'BATS_IGNORE_ROOT_LOCAL');
 
-    # root / remote
-    $errors += run_tests(rootless => 0, remote => 1, skip_tests => 'BATS_IGNORE_ROOT_REMOTE');
+        # root / remote
+        $errors += run_tests(rootless => 0, remote => 1, skip_tests => 'BATS_IGNORE_ROOT_REMOTE');
+    }
 
     die "podman tests failed" if ($errors);
 }


### PR DESCRIPTION
Support `BATS_IGNORE_USER=all` & `BATS_IGNORE_ROOT=all` to avoid having to use specify both the `_LOCAL` & `_REMOTE` variants when wanting to skip rootless or root.

Undocumented for now until we see whether it's worth it to extend it to have other values like other modules.