### PR TITLE
Reset console for fencing

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -24,6 +24,7 @@ use network_utils qw(iface);
 use Carp qw(croak);
 use Data::Dumper;
 use XML::Simple;
+use Utils::Architectures;
 
 our @EXPORT = qw(
   $crm_mon_cmd
@@ -1605,6 +1606,7 @@ sub prepare_console_for_fencing {
     select_console 'root-console', await_console => 0;
     send_key 'ctrl-l';
     send_key 'ret';
+    reset_consoles if (is_ppc64le() and get_var('BACKEND', '') eq 'pvm_hmc');
     select_console 'root-console';
 }
 


### PR DESCRIPTION
SAP case run on ppc64le hmc backend sometimes failed in fencing module: https://openqa.suse.de/tests/18781760#step/fencing/4  The output is not write to serial, `reset_console` could fix this sporadic issue.

VR: https://openqa.suse.de/tests/overview?distri=sle&build=Amrysliu%2Fos-autoinst-distri-opensuse%23reset_console

