### PR TITLE
lib/main_micro_alp.pm: Fix host_config missing from selfinstall jobs

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -158,6 +158,7 @@ sub load_selfinstall_boot_tests {
     if (check_var('FIRST_BOOT_CONFIG', 'wizard')) {
         loadtest 'jeos/firstrun';
     }
+    loadtest 'transactional/host_config';
     replace_opensuse_repos_tests if is_repo_replacement_required;
 }
 


### PR DESCRIPTION
That case was missed in a previous commit.

Relevant ticket: https://progress.opensuse.org/issues/187398
Failure: https://openqa.suse.de/tests/18824709
Verification run: https://openqa.suse.de/tests/18826362