### PR TITLE
Fix helm chart scheduling for SPR

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -322,12 +322,11 @@ sub load_container_tests {
     ## Helm chart tests. Add your individual helm chart tests here.
     if (my $chart = get_var('HELM_CHART')) {
         set_var('K3S_ENABLE_COREDNS', 1);
-
-        if ($chart eq 'helm' || $chart =~ m/rmt-helm$/) {
+        if ($chart =~ m/rmt-helm$/) {
             loadtest 'containers/charts/rmt';
-        } elsif ($chart =~ m/private-registry/ && check_var('HOST_VERSION', '15-SP7')) {
+        } elsif ($chart =~ m/private-registry/) {
             set_var('K3S_ENABLE_TRAEFIK', 1);
-            loadtest 'containers/charts/privateregistry';
+            loadtest 'containers/charts/privateregistry' if (check_var('HOST_VERSION', '15-SP7'));
         }
         else {
             die "Unsupported HELM_CHART value or HOST_VERSION";


### PR DESCRIPTION
The initial design of the Helm Chart testing had the `if / elsif / else` logic, where if the `HELM_CHART` variable didn't match any of the `if / elsif` statements, the entire test would fail with and error about the `HELM_CHART` value. 

With our new approach of testing some charts on certain versions and excluding other versions, the current logic does not work and ends up with a ton of errors. 

This PR removes tweaks the loadtest section to only trigger the tests we need.

- Verification runs:
  -  http://dirtman.qe.prg2.suse.org/tests/59 - This test is a clone of https://openqa.suse.de/tests/18803092 and shows that it `privateregistry` correctly does _NOT_ get scheduled and there is no error.
  - http://dirtman.qe.prg2.suse.org/tests/58 - clone of https://openqa.suse.de/tests/18803093 - no error and no test scheduled..
  - http://dirtman.qe.prg2.suse.org/tests/63 - clone of https://openqa.suse.de/tests/18803075. The test is correctly scheduled. 
  
