### PR TITLE
Adds Himmelblau tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1848,6 +1848,10 @@ sub load_rollback_tests {
     }
 }
 
+sub load_extra_tests_himmelblau {
+    loadtest("console/azure_himmelblau");
+}
+
 sub load_extra_tests_filesystem {
     loadtest "console/lsof";
     loadtest "console/autofs";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -999,7 +999,7 @@ elsif (get_var('LIBSOLV_INSTALLCHECK')) {
 elsif (get_var("EXTRATEST")) {
     boot_hdd_image;
     load_extra_tests();
-    loadtest "console/coredump_collect" unless (check_var('EXTRATEST', 'wicked') || get_var('PUBLIC_CLOUD') || is_jeos);
+    loadtest "console/coredump_collect" unless (get_var('EXTRATEST') =~ /wicked|himmelblau/ || get_var('PUBLIC_CLOUD') || is_jeos);
 }
 elsif (get_var("WINDOWS")) {
     loadtest "installation/win10_installation";

--- a/tests/console/azure_himmelblau.pm
+++ b/tests/console/azure_himmelblau.pm
@@ -1,0 +1,75 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Create VM in Azure using azure-cli binary
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use base 'opensusebasetest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils qw(zypper_call);
+
+sub configure_himmelblau {
+    # Allow login from users in the provided domain and groups.
+    # If users are provided directly (e.g. user@domain.com for `pam_allow_groups`) they will be allowed.
+    my ($allowed_domain, $allowed_user) = @_;
+    my $CONFIG_FILE = "/etc/himmelblau/himmelblau.conf";
+    my $ENABLE_DEBUG_LOGS = "true";
+
+    assert_script_run("sed -i -e 's/# domains =/domains = $allowed_domain/g' $CONFIG_FILE");
+    assert_script_run("sed -i -e 's/# pam_allow_groups =.*/pam_allow_groups = $allowed_user/g' $CONFIG_FILE");
+    assert_script_run("sed -i -e 's/# debug =.*/debug = $ENABLE_DEBUG_LOGS/g' $CONFIG_FILE");
+
+    record_info("Himmelblau configured");
+}
+
+sub configure_nss {
+    my $NSSWITCH_CONF_PATH = "/usr/etc/nsswitch.conf";
+
+    assert_script_run("sed -i -e '0,/passwd:.*/!{0,/passwd:.*/s/passwd:.*/passwd:    files systemd himmelblau/}' $NSSWITCH_CONF_PATH");
+    assert_script_run("sed -i -e '0,/group:.*/!{0,/group:.*/s/group:.*/group:    files systemd himmelblau/}' $NSSWITCH_CONF_PATH");
+    assert_script_run("sed -i -e '0,/shadow:.*/!{0,/shadow:.*/s/shadow:.*/shadow:   files himmelblau/}' $NSSWITCH_CONF_PATH");
+
+    record_info("NSS configured");
+}
+
+sub configure_pam {
+    assert_script_run('pam-config --add --himmelblau');
+    assert_script_run('sed -i -e "/account requisite pam_unix.so try_first_pass/account sufficient pam_unix.so try_first_pass/g" /etc/pam.d/common-account');
+    record_info("PAM configured");
+}
+
+sub run {
+    my ($self, $args) = @_;
+    my $allowed_domain = get_required_var('HIMMELBLAU_ALLOWED_DOMAINS');
+    my $allowed_user = get_required_var('HIMMELBLAU_ALLOWED_USERS');
+    my $user = "$allowed_user\@$allowed_domain";
+    select_serial_terminal;
+
+    # Install Himmelblau
+    zypper_call("update");
+    zypper_call("lr -U");
+    zypper_call("install himmelblau");
+
+    # Configure the relevant services
+    configure_himmelblau($allowed_domain, $user);
+    configure_nss();
+    configure_pam();
+
+    # Start Himmelblau
+    assert_script_run("systemctl enable himmelblaud himmelblaud-tasks --now");
+
+    # Test if Himmelblau can get the user and generate the /etc/passwd entry
+    validate_script_output("getent passwd $user", qr/\/home\/$user/);
+
+    # Test if Himmelblau can map the user from Azure Entra ID
+    validate_script_output("su -l $user -c whoami", qr/$allowed_user/);
+}
+
+1;


### PR DESCRIPTION
Implements a new Test for the Himmelblau IDM package (https://github.com/himmelblau-idm/himmelblau) . 

The test configures Himmelblau and runs a verification against Azure with a set user and domain. 

The test works as expected if it manages to connect to Azure and return a valid entry for the user.

- Related ticket: https://progress.opensuse.org/issues/183203
- Verification runs: 
  - SLE16 http://dirtman.qe.prg2.suse.org/tests/83#
  - Tumbleweed http://dirtman.qe.prg2.suse.org/tests/84#
