### PR TITLE
Fix redirection_check 'Permission denied'

### DIFF
--- a/tests/sles4sap/redirection_tests/redirection_check.pm
+++ b/tests/sles4sap/redirection_tests/redirection_check.pm
@@ -22,7 +22,7 @@ sub run {
             my %host_data = %{$redirection_data{$instance_type}{$hostname}};
             record_info("Host: $hostname");
             connect_target_to_serial(
-                destination_ip => $host_data{ip_address}, ssh_user => $host_data{ssh_user});
+                destination_ip => $host_data{ip_address}, ssh_user => $host_data{ssh_user}, switch_root => 1);
 
             # Check if hostnames matches with what is expected
             # Check API calls: script_output, assert_script_run


### PR DESCRIPTION
Fix redirection_check 'Permission denied' error when doing connect_target_to_serial()

- Related ticket: [TEAM-10594](https://jira.suse.com/browse/TEAM-10594) - [SDAF] test module 'redirection_check' execution takes much longer than before
- Verification run (the cleanup failure is known):
http://openqaworker15.qa.suse.cz/tests/337828#step/redirection_check/1 (Test module redirection_check takes 5m)
http://openqaworker15.qa.suse.cz/tests/337827#step/redirection_check/1 (Test module redirection_check takes 5m)

Original job without this PR
http://openqaworker15.qa.suse.cz/tests/337727#step/redirection_check/1 (Test module redirection_check takes 23m)
http://openqaworker15.qa.suse.cz/tests/337732#step/redirection_check/1 (Test module redirection_check takes 23m)