### PR TITLE
openSUSE Welcome: Untick show-on-boot only if it is present

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -575,7 +575,12 @@ sub handle_welcome_screen {
     # The checkbox to start on boot is now dropped, but we need to care for it
     # in the case of older installs where the autostart is still there.
     check_screen('opensuse-welcome-show-on-boot');
-    untick_welcome_on_next_startup if match_has_tag('opensuse-welcome-show-on-boot');
+    if (match_has_tag('opensuse-welcome-show-on-boot')) {
+        untick_welcome_on_next_startup;
+    } else {
+        assert_and_click_until_screen_change('opensuse-welcome-close', 5, 5);
+        assert_screen("generic-desktop");
+    }
 }
 
 =head2 start_root_shell_in_xterm


### PR DESCRIPTION
With https://build.opensuse.org/requests/1297001 the autostart checkbox
is being dropped, however we need to still have the check in case of
older versions of leap that are still being tested or used in the
upgrade scenarios

VR:
- gnome - https://openqa.opensuse.org/tests/5250077
- kde - https://openqa.opensuse.org/tests/5250023
