### PR TITLE
Add real esxi_open_vm_tools test to 12-SP5-ES

### DIFF
--- a/tests/virt_autotest/esxi_open_vm_tools.pm
+++ b/tests/virt_autotest/esxi_open_vm_tools.pm
@@ -29,7 +29,7 @@ sub run {
     elsif (is_qemu) {
         my $host_os_ver = get_var('DISTRI') . "s" . lc(get_var('VERSION') =~ s/-//r);
         foreach my $guest (keys %virt_autotest::common::guests) {
-            run_tests($guest) if ($guest eq $host_os_ver || $guest eq "${host_os_ver}TD" || $guest eq "${host_os_ver}PV" || $guest eq "${host_os_ver}HVM");
+            run_tests($guest) if ($guest eq $host_os_ver || $guest eq "${host_os_ver}TD" || $guest eq "${host_os_ver}PV" || $guest eq "${host_os_ver}HVM" || $guest eq "${host_os_ver}ES");
         }
     }
 }


### PR DESCRIPTION
Add real esxi_open_vm_tools test 12-SP5 ES

openQA test in scenario sle-12-SP5-Server-DVD-Incidents-VIRT-Vmware-ES-x86_64-mau-extratests-virt-vmware@64bit does not execute real open_vm_tools steps [esxi_open_vm_tools] and quit immediately. We should run the test for ES guests too.

- Related ticket: https://progress.opensuse.org/issues/179936
- 
- Verification run: https://openqa.suse.de/tests/18833706#step/esxi_open_vm_tools/201
