### PR TITLE
Add Azure CLI functions for Azure Availability Sets

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -40,6 +40,8 @@ our @EXPORT = qw(
   az_network_lb_probe_create
   az_network_lb_rule_create
   az_vm_as_create
+  az_vm_as_list
+  az_vm_as_show
   az_img_from_vhd_create
   az_vm_create
   az_vm_list
@@ -640,9 +642,9 @@ Create an availability set. Later on VM can be assigned to it.
 
 =over
 
-=item B<resource_group> - existing resource group where to create the Availability set
+=item B<resource_group> - existing resource group where to create the availability set
 
-=item B<region> - region where to create the Availability set
+=item B<region> - region where to create the availability set
 
 =item B<name> - availability set name
 
@@ -663,6 +665,58 @@ sub az_vm_as_create {
         '-n', $args{name},
         '-l', $args{region},
         $fc_cmd);
+    assert_script_run($az_cmd);
+}
+
+=head2 az_vm_as_list
+
+    az_vm_as_list(resource_group => 'openqa-rg');
+
+List all availability set in a resource group.
+
+=over
+
+=item B<resource_group> - existing resource group where to create the availability set
+
+=back
+=cut
+
+sub az_vm_as_list {
+    my (%args) = @_;
+    croak("Argument < resource_group > missing") unless $args{resource_group};
+    my $az_cmd = join(' ', 'az vm availability-set list',
+        '--resource-group', $args{resource_group},
+        '--query "[].{name:name}" -o tsv');
+    return script_output($az_cmd);
+}
+
+=head2 az_vm_as_show
+
+    az_vm_as_show(resource_group => 'openqa-rg');
+
+Show all the details of an availability set. For the moment it only show and does not return anything.
+
+=over
+
+=item B<resource_group> - existing resource group where to create the availability set
+
+=item B<name> - name of the availability set
+
+=back
+=cut
+
+sub az_vm_as_show {
+    my (%args) = @_;
+    foreach (qw(resource_group name)) {
+        croak("Argument < $_ > missing") unless $args{$_}; }
+    my $az_cmd = join(' ', 'az vm availability-set show',
+        '--resource-group', $args{resource_group},
+        '--name', $args{name},
+        '-o table');
+    assert_script_run($az_cmd);
+    $az_cmd = join(' ', 'az vm availability-set list-sizes',
+        '--resource-group', $args{resource_group},
+        '--name', $args{name});
     assert_script_run($az_cmd);
 }
 
@@ -1389,12 +1443,13 @@ sub az_network_peering_delete {
     my (%args) = @_;
     foreach (qw(name resource_group vnet)) {
         croak("Argument < $_ > missing") unless $args{$_}; }
+    $args{timeout} //= bmwqemu::scale_timeout(300);
 
     my $az_cmd = join(' ', 'az network vnet peering delete',
         '--name', $args{name},
         '--resource-group', $args{resource_group},
         '--vnet-name', $args{vnet});
-    assert_script_run($az_cmd);
+    return script_run($az_cmd, timeout => $args{timeout});
 }
 
 =head2 az_disk_create
@@ -1869,3 +1924,4 @@ sub az_group_exists {
     croak "Missing mandatory argument: 'resource_group'" unless $args{resource_group};
     return script_output("az group exists --resource-group $args{resource_group}", quiet => $args{quiet});
 }
+1;

--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -315,6 +315,12 @@ sub ipaddr2_infra_deploy {
         name => $as,
         region => $args{region},
         fault_count => 2);
+    # Next two lines are for debug purpose only:
+    # in time to time next vm create fails for missing AS
+    az_vm_as_list(resource_group => $rg);
+    az_vm_as_show(
+        resource_group => $rg,
+        name => $as);
 
     my $storage_name;
     if ($args{diagnostic}) {

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -283,6 +283,25 @@ subtest '[az_vm_as_create]' => sub {
     ok((any { /az vm availability-set create/ } @calls), 'Correct composition of the main command');
 };
 
+subtest '[az_vm_as_list]' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(script_output => sub { push @calls, $_[0]; return; });
+    az_vm_as_list(resource_group => 'Arlecchino');
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /az vm availability-set list/ } @calls), 'Correct composition of the main command');
+};
+
+subtest '[az_vm_as_show]' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+    az_vm_as_show(resource_group => 'Arlecchino',
+        name => 'Truffaldino');
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /az vm availability-set show/ } @calls), 'Correct composition of the main command');
+};
+
 subtest '[az_vm_create]' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
@@ -717,6 +736,7 @@ subtest '[az_network_peering_delete]' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
     $azcli->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
 
     my $res = az_network_peering_delete(
         name => 'Pantalone',


### PR DESCRIPTION
- Add `az_vm_as_list` and `az_vm_as_show` to azure_cli library to interact with Azure Availability Sets.
- Add corresponding tests.
- Use the new functions in `ipaddr2.pm` for debugging purposes.
- Add a timeout to `az_network_peering_delete`.
- Add `1;` to the end of `lib/sles4sap/azure_cli.pm` to ensure the module returns a true value.

# Related ticket:
https://jira.suse.com/browse/TEAM-10496

# Verification run:

 - sle-15-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5-ipaddr2_azure_test@64bit -> http://openqaworker15.qa.suse.cz/tests/337830 :green_circle:  [create](http://openqaworker15.qa.suse.cz/tests/337830/logfile?filename=serial_terminal.txt#line-499), [list](http://openqaworker15.qa.suse.cz/tests/337830/logfile?filename=serial_terminal.txt#line-531) and [show](http://openqaworker15.qa.suse.cz/tests/337830/logfile?filename=serial_terminal.txt#line-538).