### PR TITLE
Use PC provider to get image ID

### DIFF
--- a/tests/sles4sap/cloud_zypper_patch/add_repo.pm
+++ b/tests/sles4sap/cloud_zypper_patch/add_repo.pm
@@ -2,12 +2,65 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Add all additional zypper repositories defined in INCIDENT_REPO
-# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+=head1 NAME
+
+cloud_zypper_patch/add_repo.pm - Add additional repositories and register the SUT
+
+=head1 DESCRIPTION
+
+This module performs two main tasks:
+- It registers the SUT (System Under Test) with the SUSE Customer Center (SCC)
+  if a registration code is provided.
+- It adds additional Zypper repositories to the SUT, which are retrieved from
+  the IBSM (Infrastructure Build and Support mirror) environment.
+
+=head1 SETTINGS
+
+=over
+
+=item B<PUBLIC_CLOUD_PROVIDER>
+
+Specifies the public cloud provider. This module currently only supports 'AZURE'.
+
+=item B<SCC_REGCODE_SLES4SAP>
+
+The SUSE Customer Center registration code for SLES for SAP. If provided, the
+module will register the SUT.
+
+=item B<REPO_MIRROR_HOST>
+
+The hostname of the repository mirror. Defaults to 'download.suse.de'.
+
+=item B<IBSM_IP>
+
+The IP address of the IBSM server. This is required to add the repositories.
+
+=item B<IBSM_RG>
+
+The name of the Azure Resource Group for the IBSM environment. This is used in
+the C<post_fail_hook> to clean up the network peering on failure.
+
+=item B<INCIDENT_REPO>
+
+A comma-separated list of incident-specific repository URLs. This variable is
+used by the C<get_test_repos> function to retrieve the list of repositories to
+add. Other variables ending with C<_TEST_REPOS> are also considered.
+
+=back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=cut
 
 use Mojo::Base 'publiccloud::basetest';
-use sles4sap::cloud_zypper_patch;
 use testapi;
 use serial_terminal 'select_serial_terminal';
+use qam 'get_test_repos';
+use sles4sap::cloud_zypper_patch;
 
 sub run {
     my ($self) = @_;
@@ -18,10 +71,22 @@ sub run {
     select_serial_terminal;
 
     zp_ssh_connect();
+
+    if (get_var('SCC_REGCODE_SLES4SAP')) {
+        # Check if somehow the image is already registered or not
+        my $is_registered = zp_scc_check();
+        record_info('is_registered', $is_registered);
+        # Conditionally register the SLES for SAP instance.
+        # Registration is attempted only if the instance is not currently registered and a
+        # registration code ('SCC_REGCODE_SLES4SAP') is available.
+        zp_scc_register(scc_code => get_required_var('SCC_REGCODE_SLES4SAP')) if ($is_registered ne 1);
+    }
+
     my $repo_host = get_var('REPO_MIRROR_HOST', 'download.suse.de');
-    zp_add_repos(ip => get_required_var('IBSM_IP'),
+    my @repos = get_test_repos();
+    zp_repos_add(ip => get_required_var('IBSM_IP'),
         name => $repo_host,
-        repos => get_var('INCIDENT_REPO'));
+        repos => \@repos);
 }
 
 sub test_flags {
@@ -30,7 +95,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    zp_azure_destroy(target_rg => get_required_var('ZP_IBSM_RG'));
+    zp_azure_destroy(ibsm_rg => get_required_var('IBSM_RG'));
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/cloud_zypper_patch/deploy.pm
+++ b/tests/sles4sap/cloud_zypper_patch/deploy.pm
@@ -2,13 +2,46 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: create a deployment with a single VM on Microsoft Azure cloud.
-# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+=head1 NAME
+
+cloud_zypper_patch/deploy.pm - Deploy a single VM on Microsoft Azure
+
+=head1 DESCRIPTION
+
+This module deploys a single virtual machine (VM) on Microsoft Azure to be used
+as a System Under Test (SUT) for patching tests.
+
+=head1 SETTINGS
+
+=over
+
+=item B<PUBLIC_CLOUD_PROVIDER>
+
+Specifies the public cloud provider. This module currently only supports 'AZURE'.
+
+=item B<PUBLIC_CLOUD_IMAGE_ID>
+
+The ID of the Azure image to be used for the VM deployment.
+
+=item B<PUBLIC_CLOUD_IMAGE_LOCATION>
+
+The location of the Azure image to be used for the VM deployment. This is used
+if B<PUBLIC_CLOUD_IMAGE_ID> is not set.
+
+=back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=cut
 
 use Mojo::Base 'publiccloud::basetest';
-use sles4sap::cloud_zypper_patch;
 use testapi;
 use serial_terminal 'select_serial_terminal';
-
+use sles4sap::cloud_zypper_patch;
 
 sub run {
     my ($self) = @_;
@@ -23,7 +56,7 @@ sub run {
 
     zp_azure_deploy(
         region => $provider->provider_client->region,
-        os => get_required_var('CLUSTER_OS_VER'));
+        os => $provider->get_image_id());
 }
 
 sub test_flags {

--- a/tests/sles4sap/cloud_zypper_patch/destroy.pm
+++ b/tests/sles4sap/cloud_zypper_patch/destroy.pm
@@ -2,7 +2,46 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: destroy the cloud deployment
-# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+=head1 NAME
+
+cloud_zypper_patch/destroy.pm - Destroy the cloud deployment
+
+=head1 DESCRIPTION
+
+This module is responsible for cleaning up and destroying all the Azure
+resources created for the cloud_zypper_patch test.
+
+Its main tasks are:
+
+- If a network peering was established with an IBSm (Infrastructure Build and
+  Support mirror) environment, it deletes the peering connection.
+- It destroys the entire Azure Resource Group, which contains the VM and other
+  resources created by the C<deploy.pm> module.
+
+This module is typically the last one to run in the test suite.
+
+=head1 SETTINGS
+
+=over
+
+=item B<PUBLIC_CLOUD_PROVIDER>
+
+Specifies the public cloud provider. This module currently only supports 'AZURE'.
+
+=item B<IBSM_RG>
+
+The name of the Azure Resource Group for the IBSm (Infrastructure Build and
+Support mirror) environment. This is required to clean up the network peering.
+
+=back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=cut
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
@@ -17,7 +56,7 @@ sub run {
 
     select_serial_terminal;
 
-    zp_azure_destroy(target_rg => get_required_var('ZP_IBSM_RG'));
+    zp_azure_destroy(ibsm_rg => get_required_var('IBSM_RG'));
 }
 
 sub test_flags {
@@ -26,7 +65,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    zp_azure_destroy(target_rg => get_required_var('ZP_IBSM_RG'));
+    zp_azure_destroy(ibsm_rg => get_required_var('IBSM_RG'));
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/cloud_zypper_patch/network_peering.pm
+++ b/tests/sles4sap/cloud_zypper_patch/network_peering.pm
@@ -2,13 +2,43 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Create a network peering to the IBSm
-# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+=head1 NAME
+
+cloud_zypper_patch/network_peering.pm - Create a network peering to the IBSm
+
+=head1 DESCRIPTION
+
+This module establishes a network peering between the test environment and an
+IBSm (Infrastructure Build and Support mirror) server. This is necessary to
+allow the SUT (System Under Test) to access the repositories hosted on the IBSm.
+
+=head1 SETTINGS
+
+=over
+
+=item B<PUBLIC_CLOUD_PROVIDER>
+
+Specifies the public cloud provider. This module currently only supports 'AZURE'.
+
+=item B<IBSM_RG>
+
+The name of the Azure Resource Group for the IBSm environment. This is
+required to create the VNet peering.
+
+=back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=cut
 
 use Mojo::Base 'publiccloud::basetest';
-use sles4sap::cloud_zypper_patch;
 use testapi;
 use serial_terminal 'select_serial_terminal';
-
+use sles4sap::cloud_zypper_patch;
 
 sub run {
     my ($self) = @_;
@@ -18,7 +48,7 @@ sub run {
 
     select_serial_terminal;
 
-    zp_azure_netpeering(target_rg => get_required_var('ZP_IBSM_RG'));
+    zp_azure_netpeering(target_rg => get_required_var('IBSM_RG'));
 }
 
 sub test_flags {
@@ -27,7 +57,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    zp_azure_destroy(target_rg => get_required_var('ZP_IBSM_RG'));
+    zp_azure_destroy(ibsm_rg => get_required_var('IBSM_RG'));
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/cloud_zypper_patch/zypper_patch.pm
+++ b/tests/sles4sap/cloud_zypper_patch/zypper_patch.pm
@@ -2,13 +2,44 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: perform a zypper patch on the SUT
-# Maintainer: QE-SAP <qe-sap@suse.de>, Michele Pagot <michele.pagot@suse.com>
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+=head1 NAME
+
+cloud_zypper_patch/zypper_patch.pm - Perform a zypper patch on the SUT
+
+=head1 DESCRIPTION
+
+This module applies all available patches to the SUT (System Under Test) using
+the `zypper patch` command. This ensures that the system is up-to-date before
+any further tests are performed.
+
+=head1 SETTINGS
+
+=over
+
+=item B<PUBLIC_CLOUD_PROVIDER>
+
+Specifies the public cloud provider. This module currently only supports 'AZURE'.
+
+=item B<IBSM_RG>
+
+The name of the Azure Resource Group for the IBSm (Infrastructure Build and
+Support mirror) environment. This is used in the C<post_fail_hook> to clean up
+the network peering on failure.
+
+=back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=cut
 
 use Mojo::Base 'publiccloud::basetest';
-use sles4sap::cloud_zypper_patch;
 use testapi;
 use serial_terminal 'select_serial_terminal';
-
+use sles4sap::cloud_zypper_patch;
 
 sub run {
     my ($self) = @_;
@@ -27,7 +58,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    zp_azure_destroy(target_rg => get_required_var('ZP_IBSM_RG'));
+    zp_azure_destroy(ibsm_rg => get_required_var('IBSM_RG'));
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
Use get_image_id() instead of CLUSTER_OS_VER to get the cloud image name for the test.

# Verification run:

sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-cloud_zypper_patch_azure_test
 - http://openqaworker15.qa.suse.cz/tests/337990