### PR TITLE
Adjust matching a 12h clock after bsc#1247286

### DIFF
--- a/tests/console/timezone.pm
+++ b/tests/console/timezone.pm
@@ -46,7 +46,7 @@ sub run {
     assert_script_run("rpm -q timezone");
 
     validate_script_output("zdump Europe/London", sub { m/Europe\/London\s+\w{3} \w{3}\s+\d+ (\d{2}|:){5} \d{4} (GMT|BST)/ });
-    validate_script_output("date", sub { m/\w{3} \w{3}\s+\d+ (\d{2}|:){5} (AM|PM) \w+ \d{4}/ });
+    validate_script_output("LC_TIME=\$(localectl status | head -n1 | cut -d= -f2) date", sub { m/\w{3} \w{3}\s+\d+ (\d{2}|:){5} (AM|PM) \w+ \d{4}/ });
 
     my $zdump_cmd = "zdump -v Europe/Rome | grep -E 'Sun Mar 25 [0-9]{2}:[0:9]{2}:[0-9]{2} 2018'";
 


### PR DESCRIPTION
This is to address bsc#1248147 which happens as a result of bsc#1247286

Basically the SUT is now properly matching the type of clock that is dictated by the `LANG` and `LC_*` (en_US) which has a 12h clock (for Tumbleweed), by using localectl's output to set LC_TIME, we can always guarantee that the clock will match an expected hour/clock format.

VR: 
- [Tumbleweed](https://openqa.opensuse.org/tests/5251673#step/timezone/5)
- [Leap](https://openqa.opensuse.org/tests/5251674#step/timezone/5)
