### PR TITLE
Enable BCI tests in sle-micro hosts

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -106,7 +106,7 @@ sub install_docker_multiplatform {
     }
 
     my $pkg_name = check_var("CONTAINERS_DOCKER_FLAVOUR", "stable") ? "docker-stable" : "docker";
-    if (is_transactional) {
+    if (is_transactional || $host_os =~ /micro/i) {
         select_serial_terminal;
         trup_call("pkg install $pkg_name");
         check_reboot_changes;

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -44,7 +44,8 @@ sub load_config_tests {
     loadtest 'transactional/enable_selinux' if (get_var('ENABLE_SELINUX') && is_image);
     loadtest 'console/suseconnect_scc' if (get_var('SCC_REGISTER') && !is_dvd);
     loadtest 'transactional/install_updates' if (is_sle_micro && is_released);
-    loadtest 'transactional/install_k3s' if (is_sle_micro('6.0+') && (is_x86_64 || is_aarch64));
+    loadtest 'transactional/install_k3s' if (get_var('CONTAINER_UPDATE_HOST') && is_sle_micro('6.0+') && (is_x86_64 || is_aarch64));
+    loadtest 'containers/bci_prepare' if (get_var('CONTAINER_UPDATE_HOST') && get_var('BCI_PREPARE'));
 }
 
 sub load_boot_from_disk_tests {

--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -27,6 +27,7 @@ use db_utils qw(push_image_data_to_db);
 use containers::common;
 use testapi;
 use serial_terminal 'select_serial_terminal';
+use transactional qw(trup_call reboot_on_changes);
 
 sub prepare_virtual_env {
     my ($version, $sp, $host_distri) = @_;
@@ -65,6 +66,9 @@ sub prepare_virtual_env {
             push @packages, qw(git-core python311);
         }
         zypper_call("--quiet in " . join(' ', @packages), timeout => $install_timeout);
+    } elsif ($host_distri =~ /micro/) {
+        trup_call('pkg in skopeo tar git jq');
+        reboot_on_changes;
     } else {
         die("Host is not supported for running BCI tests.");
     }
@@ -72,8 +76,8 @@ sub prepare_virtual_env {
     assert_script_run("$python --version");
     assert_script_run("$python -m venv bci");
     assert_script_run("source $virtualenv");
-    assert_script_run('pip --quiet install --upgrade pip', timeout => $install_timeout);
-    assert_script_run('pip --quiet install tox', timeout => $install_timeout);
+    assert_script_run("$python -m pip --quiet install --upgrade pip", timeout => $install_timeout);
+    assert_script_run("$python -m pip --quiet install tox", timeout => $install_timeout);
     assert_script_run('deactivate');
 }
 
@@ -110,7 +114,7 @@ sub run {
     # CONTAINER_RUNTIMES can be "docker", "podman" or both "podman,docker"
     my $engines = get_required_var('CONTAINER_RUNTIMES');
     # For BCI tests using podman, buildah package is also needed
-    install_buildah_when_needed($host_distri) if ($engines =~ /podman/);
+    install_buildah_when_needed($host_distri) if ($engines =~ /podman/ && $host_distri !~ /micro/i);
 }
 
 sub test_flags {

--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -21,7 +21,7 @@ use serial_terminal 'select_serial_terminal';
 use containers::utils qw(reset_container_network_if_needed);
 use File::Basename;
 use utils qw(systemctl);
-use version_utils qw(get_os_release check_version);
+use version_utils qw(get_os_release check_version is_sle);
 
 my $error_count;
 
@@ -33,7 +33,7 @@ sub skip_testrun {
     return 1 unless get_var('BCI_TESTS');
 
     # Skip Spack on SLES12-SP5 (https://bugzilla.suse.com/show_bug.cgi?id=1224345)
-    return 1 if (check_var('BCI_IMAGE_NAME', 'spack') && check_version('<15', get_required_var('HOST_VERSION')));
+    return 1 if (check_var('BCI_IMAGE_NAME', 'spack') && is_sle && check_version('<15', get_required_var('HOST_VERSION')));
 
     # Skip Kiwi on RES, CentOS, Ubuntu
     my $bci_image_name = get_var('BCI_IMAGE_NAME');


### PR DESCRIPTION
There are several constrains that come with sle-micro. Not all python3 modules are packaged, therefore we need to rely in builtin modules and features of the pre-installed interpreter.
`buildah` package is not available either, this might cause problems when the test will be building custom container image.

- ticket: [[BCI] Add SLEM test runs](https://progress.opensuse.org/issues/178993)

##### Verification runs

* [busybox@docker](http://kepler.suse.cz/tests/25230)
* [busybox@podman](http://kepler.suse.cz/tests/25229)