### PR TITLE
containers: Further limit third-party test module

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -60,9 +60,16 @@ sub load_third_party_image_test {
     # - Public Cloud
     # - VMWare due to lack of latest CPU version support
     # - Testing alternative cgroups version
+    # - Testing docker-stable with CONTAINERS_DOCKER_FLAVOUR
     # - Testing latest Tumbleweed image with CONTAINER_IMAGE_TO_TEST
     # - FIPS tests
-    return if (is_staging || is_public_cloud || is_vmware || get_var("CONTAINERS_CGROUP_VERSION") || get_var("CONTAINER_IMAGE_TO_TEST") || get_var("FIPS_ENABLED"));
+    # - Testing a different OCI runtime like crun
+    return if (is_staging || is_public_cloud || is_vmware ||
+        get_var("CONTAINERS_CGROUP_VERSION") ||
+        get_var("CONTAINERS_DOCKER_FLAVOUR") ||
+        get_var("CONTAINER_IMAGE_TO_TEST") ||
+        get_var("FIPS_ENABLED") ||
+        get_var("OCI_RUNTIME"));
     my ($run_args) = @_;
     loadtest('containers/third_party_images', run_args => $run_args, name => $run_args->{runtime} . '_3rd_party_images');
 }


### PR DESCRIPTION
Further limit third-party test module. 
 
It's also redundant for `docker-stable` & different `OCI_RUNTIME=crun`

- Related ticket: https://progress.opensuse.org/issues/179566