### PR TITLE
Add known issues for sle16.0

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -958,5 +958,33 @@
             "microos":  ["Tumbleweed"]
         },
         "type": "bug"
+    },
+    "bsc#1236723": {
+        "description": "hv_storvsc.*: tag#\\d+ cmd 0x5a status: scsi 0x2 srb 0x86 host 0xc0000001",
+        "products": {
+            "sle": ["16.0"]
+        },
+        "type": "bug"
+    },
+    "bsc#1246862": {
+        "description": "hcnscan:error code 5, Failed to load bonding module|hcn-init-NetworkManager.service: Failed with result 'exit-code'|Failed to start hybrid virtual network scan and config for NetworkManager",
+        "products": {
+            "sle": ["16.0"]
+        },
+        "type": "bug"
+    },
+    "bsc#1238885": {
+        "description": "kernel: Could not retrieve perf counters \\(-19\\)",
+        "products": {
+            "sle": ["16.0"]
+        },
+        "type": "ignore"
+    },
+    "replenish-aarch74": {
+        "description": "kernel: sched: DL replenish lagged too much",
+        "products": {
+            "sle": ["16.0"]
+        },
+        "type": "ignore"
     }
 }


### PR DESCRIPTION
`kernel: Could not retrieve perf counters (-19)` ->
https://bugzilla.suse.com/show_bug.cgi?id=1238885#c4, VM setup related issue, is not a problem with MinimalVM testing scope

`hv_storvsc 79eee825-a6ca-42ba-92e6-dbc0db1b5ef6: tag#75 cmd 0x5a status: scsi 0x2 srb 0x86 host 0xc0000001` -> reported as part of https://bugzilla.suse.com/show_bug.cgi?id=1236723

`kernel: sched: DL replenish lagged too much` -> happens only in aarch64, more of a load problem of the workers


 - [sle-16.0-Minimal-VM-for-MS-HyperV-x86_64-Build32.10-minimalvm-kdump@svirt-hyperv2022](https://openqa.suse.de/tests/18852518#step/journal_check/5)
 - [sle-16.0-Minimal-VM-for-kvm-and-xen-aarch64-Build32.10-minimalvm-ltp-commands@aarch64](https://openqa.suse.de/tests/18852519#step/journal_check/1)
 - [ppc64le](https://openqa.suse.de/tests/18852543#step/journal_check/9)