### PR TITLE
Minor BATS enhancements

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -316,9 +316,9 @@ sub collect_coredumps {
         my $core = "core.$exe.$pid.core";
 
         # Dumping and compressing coredumps may take some time
-        script_run("coredumpctl -o $core dump $pid", 300);
+        my $out = script_output("coredumpctl -o $core dump $pid", timeout => 300, proceed_on_failure => 1);
+        record_info("COREDUMP", $out);
         script_run("xz -9v $core", 300);
-        record_info("COREDUMP", $exe);
     }
 }
 

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -94,6 +94,7 @@ sub run {
 
     # Compile helpers used by the tests
     my $helpers = script_output 'echo $(grep ^all: Makefile | grep -o "bin/[a-z]*" | grep -v bin/buildah)';
+    record_info("helpers", $helpers);
     run_command "make $helpers", timeout => 600;
 
     my $errors = run_tests(rootless => 1, skip_tests => 'BATS_IGNORE_USER');

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -51,6 +51,7 @@ sub run {
 
     # Compile helpers & patch tests
     run_command "make examples", timeout => 600;
+
     unless (get_var("BATS_TESTS")) {
         run_command "rm -f test/100-bridge-iptables.bats" if ($firewalld_backend ne "iptables");
     }

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -50,8 +50,10 @@ sub run {
     bats_sources $runc_version;
 
     # Compile helpers used by the tests
-    my $cmds = script_output "find contrib/cmd tests/cmd -mindepth 1 -maxdepth 1 -type d -printf '%f ' || true";
-    run_command "make $cmds || true";
+    my $helpers = script_output "find contrib/cmd tests/cmd -mindepth 1 -maxdepth 1 -type d ! -name _bin -printf '%f ' || true";
+    record_info("helpers", $helpers);
+    run_command "make $helpers || true";
+
     unless (get_var("BATS_TESTS")) {
         # Skip this test due to https://github.com/opencontainers/runc/issues/4841
         run_command "rm -f tests/integration/cgroups.bats" if is_ppc64le;


### PR DESCRIPTION
- buildah: Output list of helpers
- runc: Output list of helpers and skip `_bin`
- Print trace on `record_info` when dumping core so it's catched by susebats.