### PR TITLE
Ensure console selection after boot process in power kvm

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -854,8 +854,7 @@ sub activate_console {
         else {
             # on s390x we need to login here by providing a password
             handle_password_prompt if is_s390x;
-            send_key_until_needlematch('inst-console', 'ret') if is_ppc64le && is_agama;
-            assert_screen "inst-console";
+            assert_screen("inst-console", 300);
         }
     }
 


### PR DESCRIPTION
We have removed the return key send and replaced with a long timeout in screen selection.

- Related ticket: https://progress.opensuse.org/issues/187464
- Needles: N/A
- Verification run: 
  - sles_default: https://openqa.suse.de/tests/18852946
  - sles_sap_default: https://openqa.suse.de/tests/18852945
