### PR TITLE
Test if registrationURL in profile is prefered over kernel parameter

### DIFF
--- a/tests/yam/validate/validate_suseconnect_url.pm
+++ b/tests/yam/validate/validate_suseconnect_url.pm
@@ -13,7 +13,7 @@ use utils;
 
 sub run {
     select_console 'root-console';
-    my $scc_url = get_required_var('SCC_URL');
+    my $scc_url = (get_var('AGAMA_PROFILE_OPTIONS') =~ /registration_url="(?<registration_url>.+)"/) ? $+{registration_url} : get_var('SCC_URL');
     validate_script_output("cat /etc/SUSEConnect", sub { m/\b$scc_url\b/ });
 }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/184750
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/553
- [Verification runs in my dev group](https://openqa.suse.de/tests/overview?arch=&flavor=&machine=&test=sles_rmt_unattended_rk&modules=&module_re=&group_glob=&not_group_glob=&comment=&distri=sle&version=16.0&build=129.5&groupid=585#)
  - on s390x we're still suffering from [bsc#1247933]( https://bugzilla.suse.com/show_bug.cgi?id=1247933)