### PR TITLE
Move Azure network peering to IBSm lib

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -265,7 +265,11 @@ sub az_network_vnet_subnet_update {
 
     my $res = az_network_vnet_get(resource_group => 'openqa-rg')
 
-Return the output of az network vnet list
+Return the output of az network vnet list as an object.
+Take care that this command is always calling the az cli with --json
+and returns the decoded object. But the format of the object can change
+accordingly to the provided value of --query. It is also possible that
+some query result in the function to die on decode_json.
 
 =over
 
@@ -692,7 +696,7 @@ sub az_vm_as_list {
 
 =head2 az_vm_as_show
 
-    az_vm_as_show(resource_group => 'openqa-rg');
+    az_vm_as_show(resource_group => 'openqa-rg', name => 'openqa-as');
 
 Show all the details of an availability set. For the moment it only show and does not return anything.
 
@@ -709,11 +713,13 @@ sub az_vm_as_show {
     my (%args) = @_;
     foreach (qw(resource_group name)) {
         croak("Argument < $_ > missing") unless $args{$_}; }
+
     my $az_cmd = join(' ', 'az vm availability-set show',
         '--resource-group', $args{resource_group},
         '--name', $args{name},
         '-o table');
     assert_script_run($az_cmd);
+
     $az_cmd = join(' ', 'az vm availability-set list-sizes',
         '--resource-group', $args{resource_group},
         '--name', $args{name});
@@ -1436,6 +1442,8 @@ Delete a specific network peering
 
 =item B<vnet> - existing vnet in resource_group, used as source of the peering
 
+=item B<timeout> - (Optional) Timeout for the assert_script_run command
+
 =back
 =cut
 
@@ -1924,4 +1932,5 @@ sub az_group_exists {
     croak "Missing mandatory argument: 'resource_group'" unless $args{resource_group};
     return script_output("az group exists --resource-group $args{resource_group}", quiet => $args{quiet});
 }
+
 1;

--- a/lib/sles4sap/ibsm.pm
+++ b/lib/sles4sap/ibsm.pm
@@ -32,9 +32,12 @@ use warnings;
 use Carp qw(croak);
 use Exporter 'import';
 use testapi;
+use sles4sap::azure_cli;
 
 our @EXPORT = qw(
   ibsm_calculate_address_range
+  ibsm_network_peering_azure_create
+  ibsm_network_peering_azure_delete
 );
 
 =head1 DESCRIPTION
@@ -53,7 +56,7 @@ ip2 and ip3 are calculated using the slot number as seed.
 
 =over
 
-=item B<SLOT> - integer to be used as seed in calculating addresses
+=item B<slot> - integer to be used as seed in calculating addresses
 
 =back
 
@@ -75,6 +78,123 @@ sub ibsm_calculate_address_range {
         main_address_range => sprintf("10.%d.%d.0/21", $ip2, $ip3),
         subnet_address_range => sprintf("10.%d.%d.0/24", $ip2, $ip3),
     );
+}
+
+=head2 ibsm_network_peering_azure_create
+
+    ibsm_network_peering_azure_create(ibsm_rg => 'IBSmMyRg');
+
+Create bidirectional network peering in Azure
+
+=over
+
+=item B<ibsm_rg> - Azure resource group of the IBSm
+
+=item B<sut_rg> - Azure resource group of the SUT
+
+=item B<name_prefix> - prefix to be applied at the beginning of each peering name
+
+=back
+=cut
+
+sub ibsm_network_peering_azure_create {
+    my (%args) = @_;
+    foreach (qw(ibsm_rg sut_rg)) { croak("Argument < $_ > missing") unless $args{$_}; }
+
+    my %vnet_names;
+    foreach ('ibsm', 'sut') {
+        my $res = az_network_vnet_get(resource_group => $args{$_ . '_rg'}, query => '[].name');
+        $vnet_names{$_} = $res->[0];
+    }
+
+    my @peering_name;
+    push @peering_name, $args{name_prefix} if ($args{name_prefix});
+    push @peering_name, $vnet_names{sut};
+    push @peering_name, $vnet_names{ibsm};
+    az_network_peering_create(name => join('-', @peering_name),
+        source_rg => $args{sut_rg}, source_vnet => $vnet_names{sut},
+        target_rg => $args{ibsm_rg}, target_vnet => $vnet_names{ibsm});
+    record_info('PEERING SUCCESS ' . join('-', @peering_name),
+        "Peering from $args{sut_rg}.$vnet_names{sut} server was successful");
+
+    @peering_name = ();
+    push @peering_name, $args{name_prefix} if ($args{name_prefix});
+    push @peering_name, $vnet_names{ibsm};
+    push @peering_name, $vnet_names{sut};
+    az_network_peering_create(name => join('-', @peering_name),
+        source_rg => $args{ibsm_rg}, source_vnet => $vnet_names{ibsm},
+        target_rg => $args{sut_rg}, target_vnet => $vnet_names{sut});
+    record_info('PEERING SUCCESS ' . join('-', @peering_name),
+        "Peering from $args{ibsm_rg}.$vnet_names{ibsm} server was successful");
+}
+
+=head3 ibsm_network_peering_azure_delete
+
+    Delete all the network peering between the two provided deployments.
+
+=over
+
+=item B<ibsm_rg> - Azure resource group of the IBSm
+
+=item B<sut_rg> - Azure resource group of the SUT
+
+=item B<sut_vnet> - substring in the SUT vnet. Optional and only needed if only one specific VNET has to be considered. Most of the time it is get_current_job_id()
+
+=item B<timeout> - default is 5 mins
+
+=back
+=cut
+
+sub ibsm_network_peering_azure_delete {
+    my (%args) = @_;
+    foreach (qw(sut_rg ibsm_rg)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
+    $args{timeout} //= bmwqemu::scale_timeout(300);
+
+    my $res = az_network_vnet_get(resource_group => $args{sut_rg},
+        query => $args{sut_vnet} ? "[?contains(name,'" . $args{sut_vnet} . "')].name" : '[0].name');
+    my $sut_vnet = $res->[0];
+
+    $res = az_network_vnet_get(resource_group => $args{ibsm_rg},
+        query => '[0].name');
+    my $ibsm_vnet = $res->[0];
+
+    $res = az_network_peering_list(resource_group => $args{sut_rg}, vnet => $sut_vnet);
+    my $peering_name = $res->[0];
+    if (!$peering_name) {
+        record_info('NO PEERING',
+            "No peering between $args{sut_rg} and resources belonging to the current job to be destroyed!");
+        return;
+    }
+
+    my $source_ret = 0;
+    record_info("Destroying SUT->IBSM peering '$peering_name'");
+    if ($args{sut_rg}) {
+        $source_ret = az_network_peering_delete(
+            name => $peering_name,
+            resource_group => $args{sut_rg},
+            vnet => $sut_vnet,
+            timeout => $args{timeout});
+    }
+    else {
+        record_info('NO PEERING',
+            "No peering between SUT and IBSM - maybe it wasn't created, or the resources have been destroyed.");
+    }
+
+    $res = az_network_peering_list(resource_group => $args{ibsm_rg}, vnet => $ibsm_vnet);
+    $peering_name = $res->[0];
+    record_info("Destroying IBSM->SUT peering '$peering_name'");
+    my $target_ret = az_network_peering_delete(
+        name => $peering_name,
+        resource_group => $args{ibsm_rg},
+        vnet => $ibsm_vnet,
+        timeout => $args{timeout});
+
+    record_info("source_ret:'$source_ret' target_ret:'$target_ret'");
+    if ($source_ret == 0 && $target_ret == 0) {
+        record_info('Peering deletion SUCCESS', 'The peering was successfully destroyed');
+        return;
+    }
+    die("Peering destruction FAIL: There may be leftover peering connections, please check - jsc#7487");
 }
 
 1;

--- a/lib/sles4sap/qesap/azure.pm
+++ b/lib/sles4sap/qesap/azure.pm
@@ -46,9 +46,6 @@ our @EXPORT = qw(
   qesap_az_create_sas_token
   qesap_az_list_container_files
   qesap_az_diagnostic_log
-  qesap_az_vnet_peering
-  qesap_az_vnet_peering_delete
-  qesap_az_get_active_peerings
 );
 
 =head1 DESCRIPTION
@@ -72,224 +69,12 @@ by the qe-sap-deployment
 
 sub qesap_az_get_resource_group {
     my (%args) = @_;
-    my $substring = $args{substring} ? " | grep $args{substring}" : "";
     my $job_id = get_var('QESAP_DEPLOYMENT_IMPORT', get_current_job_id());    # in case existing deployment is used
-    my $result = script_output("az group list --query \"[].name\" -o tsv | grep $job_id $substring", proceed_on_failure => 1);
-    record_info('QESAP RG', "result:$result");
-    return $result;
-}
-
-=head3 qesap_az_vnet_peering
-
-    Create a pair of network peering between
-    the two provided deployments.
-
-=over
-
-=item B<SOURCE_GROUP> - resource group of source
-
-=item B<TARGET_GROUP> - resource group of target
-
-=item B<TIMEOUT> - default is 5 mins
-
-=back
-=cut
-
-sub qesap_az_vnet_peering {
-    my (%args) = @_;
-    foreach (qw(source_group target_group)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
-    my $source_vnet = az_network_vnet_get(resource_group => $args{source_group}, query => '[0].name');
-    my $target_vnet = az_network_vnet_get(resource_group => $args{target_group}, query => '[0].name');
-    $args{timeout} //= bmwqemu::scale_timeout(300);
-
-    my $vnet_show_cmd = 'az network vnet show --query id --output tsv';
-
-    my $source_vnet_id = script_output(join(' ',
-            $vnet_show_cmd,
-            '--resource-group', $args{source_group},
-            '--name', $source_vnet));
-    record_info("source vnet ID: $source_vnet_id");
-
-    my $target_vnet_id = script_output(join(' ',
-            $vnet_show_cmd,
-            '--resource-group', $args{target_group},
-            '--name', $target_vnet));
-    record_info("[M] target vnet ID: $target_vnet_id");
-
-    my $peering_name = "$source_vnet-$target_vnet";
-    my $peering_cmd = join(' ',
-        'az network vnet peering create',
-        '--name', $peering_name,
-        '--allow-vnet-access',
-        '--output table');
-
-    assert_script_run(join(' ',
-            $peering_cmd,
-            '--resource-group', $args{source_group},
-            '--vnet-name', $source_vnet,
-            '--remote-vnet', $target_vnet_id), timeout => $args{timeout});
-    record_info('PEERING SUCCESS (source)',
-        "Peering from $args{source_group}.$source_vnet server was successful");
-
-    assert_script_run(join(' ',
-            $peering_cmd,
-            '--resource-group', $args{target_group},
-            '--vnet-name', $target_vnet,
-            '--remote-vnet', $source_vnet_id), timeout => $args{timeout});
-    record_info('PEERING SUCCESS (target)',
-        "Peering from $args{target_group}.$target_vnet server was successful");
-
-    record_info('Checking peering status');
-    assert_script_run(join(' ',
-            'az network vnet peering show',
-            '--name', $peering_name,
-            '--resource-group', $args{target_group},
-            '--vnet-name', $target_vnet,
-            '--output table'));
-    record_info('AZURE PEERING SUCCESS');
-}
-
-=head3 qesap_az_simple_peering_delete
-
-    Delete a single peering one way
-
-=over
-
-=item B<RG> - Name of the resource group
-
-=item B<VNET_NAME> - Name of the vnet
-
-=item B<PEERING_NAME> - Name of the peering
-
-=item B<TIMEOUT> - (Optional) Timeout for the script_run command
-
-=back
-=cut
-
-sub qesap_az_simple_peering_delete {
-    my (%args) = @_;
-    foreach (qw(rg vnet_name peering_name)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
-    $args{timeout} //= bmwqemu::scale_timeout(300);
-    my $peering_cmd = join(' ',
-        'az network vnet peering delete',
-        '-n', $args{peering_name},
-        '--resource-group', $args{rg},
-        '--vnet-name', $args{vnet_name});
-    return script_run($peering_cmd, timeout => $args{timeout});
-}
-
-=head3 qesap_az_vnet_peering_delete
-
-    Delete all the network peering between the two provided deployments.
-
-=over
-
-=item B<SOURCE_GROUP> - resource group of source.
-                        This parameter is optional, if not provided
-                        the related peering will be ignored.
-
-=item B<TARGET_GROUP> - resource group of target.
-                        This parameter is mandatory and
-                        the associated resource group is supposed to still exist.
-
-=item B<TIMEOUT> - default is 5 mins
-
-=back
-=cut
-
-sub qesap_az_vnet_peering_delete {
-    my (%args) = @_;
-    croak 'Missing mandatory target_group argument' unless $args{target_group};
-    $args{timeout} //= bmwqemu::scale_timeout(300);
-
-    my $target_vnet = az_network_vnet_get(resource_group => $args{target_group}, query => '[0].name');
-
-    my $peering_name = qesap_az_get_peering_name(resource_group => $args{target_group});
-    if (!$peering_name) {
-        record_info('NO PEERING',
-            "No peering between $args{target_group} and resources belonging to the current job to be destroyed!");
-        return;
-    }
-
-    record_info('Attempting peering destruction');
-    my $source_ret = 0;
-    record_info('Destroying job_resources->IBSM peering');
-    if ($args{source_group}) {
-        my $source_vnet = az_network_vnet_get(resource_group => $args{source_group}, query => '[0].name');
-        $source_ret = qesap_az_simple_peering_delete(
-            rg => $args{source_group},
-            vnet_name => $source_vnet,
-            peering_name => $peering_name,
-            timeout => $args{timeout});
-    }
-    else {
-        record_info('NO PEERING',
-            'No peering between job VMs and IBSM - maybe it was not created, or the resources have been destroyed.');
-    }
-    record_info('Destroying IBSM -> job_resources peering');
-    my $target_ret = qesap_az_simple_peering_delete(
-        rg => $args{target_group},
-        vnet_name => $target_vnet,
-        peering_name => $peering_name,
-        timeout => $args{timeout});
-
-    if ($source_ret == 0 && $target_ret == 0) {
-        record_info('Peering deletion SUCCESS', 'The peering was successfully destroyed');
-        return;
-    }
-    record_soft_failure('Peering destruction FAIL: There may be leftover peering connections, please check - jsc#7487');
-}
-
-=head3 qesap_az_peering_list_cmd
-
-    Compose the azure peering list command, using the provided:
-    - resource group, and
-    - vnet
-    Returns the command string to be run.
-
-=over
-
-=item B<RESOURCE_GROUP> - resource group connected to the peering
-
-=item B<VNET> - vnet connected to the peering
-
-=back
-=cut
-
-sub qesap_az_peering_list_cmd {
-    my (%args) = @_;
-    foreach (qw(resource_group vnet)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
-
-    return join(' ', 'az network vnet peering list',
-        '-g', $args{resource_group},
-        '--vnet-name', $args{vnet},
-        '--query "[].name"',
-        '-o tsv');
-}
-
-=head3 qesap_az_get_peering_name
-
-    Search for all network peering related to both:
-     - resource group related to the current job
-     - the provided resource group.
-    Returns the peering name or
-    empty string if a peering doesn't exist
-
-=over
-
-=item B<RESOURCE_GROUP> - resource group connected to the peering
-
-=back
-=cut
-
-sub qesap_az_get_peering_name {
-    my (%args) = @_;
-    croak 'Missing mandatory target_group argument' unless $args{resource_group};
-
-    my $job_id = get_current_job_id();
-    my $cmd = qesap_az_peering_list_cmd(resource_group => $args{resource_group}, vnet => az_network_vnet_get(resource_group => $args{resource_group}, query => '[0].name'));
-    $cmd .= ' | grep ' . $job_id;
-    return script_output($cmd, proceed_on_failure => 1);
+    my $all_rg = az_group_name_get();
+    my @selected_rg = grep(/$job_id/, @$all_rg);
+    @selected_rg = grep(/$args{substring}/, @selected_rg) if ($args{substring});
+    record_info('QESAP RG', $selected_rg[0] ? "result:$selected_rg[0]" : 'result:EMPTY');
+    return $selected_rg[0];
 }
 
 =head3 qesap_az_get_active_peerings
@@ -308,11 +93,9 @@ sub qesap_az_get_peering_name {
 sub qesap_az_get_active_peerings {
     my (%args) = @_;
     foreach (qw(rg vnet)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
-    my $cmd = qesap_az_peering_list_cmd(resource_group => $args{rg}, vnet => $args{vnet});
-    my $output_str = script_output($cmd);
-    my @output = split(/\n/, $output_str);
+    my $peerings = az_network_peering_list(resource_group => $args{rg}, vnet => $args{vnet});
     my %result;
-    foreach my $line (@output) {
+    for my $line (@{$peerings}) {
         # find integers in the vnet name that are 6 digits or longer - this would be the job id
         my @matches = $line =~ /(\d{6,})/g;
         $result{$line} = $matches[-1] if @matches;
@@ -341,7 +124,10 @@ sub qesap_az_clean_old_peerings {
     while (my ($key, $value) = each %peerings) {
         if (qesap_is_job_finished(job_id => $value)) {
             record_info('Leftover Peering', "$key is leftover from a finished job. Attempting to delete...");
-            qesap_az_simple_peering_delete(rg => $args{rg}, vnet_name => $args{vnet}, peering_name => $key);
+            az_network_peering_delete(
+                name => $key,
+                resource_group => $args{rg},
+                vnet => $args{vnet});
         }
     }
 }

--- a/t/35_ibsm.t
+++ b/t/35_ibsm.t
@@ -3,8 +3,8 @@ use warnings;
 use Test::More;
 use Test::Exception;
 use Test::Warnings;
-
-
+use Test::MockModule;
+use List::Util qw(any);
 use sles4sap::ibsm;
 
 subtest '[ibsm_calculate_address_range]' => sub {
@@ -26,6 +26,135 @@ subtest '[ibsm_calculate_address_range]' => sub {
     is($result_8192{subnet_address_range}, "10.255.248.0/24", 'result_8192 subnet_address_range is correct');
     dies_ok { ibsm_calculate_address_range(slot => 0); } "Expected die for slot < 1";
     dies_ok { ibsm_calculate_address_range(slot => 8193); } "Expected die for slot > 8192";
+};
+
+subtest '[ibsm_network_peering_azure_create]' => sub {
+    my $ibsm = Test::MockModule->new('sles4sap::ibsm', no_auto => 1);
+
+    $ibsm->redefine(az_network_vnet_get => sub {
+            my (%args) = @_;
+            note(" --> az_network_vnet_get(resource_group => '$args{resource_group}', query => '$args{query}')");
+            return ['VNET' . $args{resource_group}]; });
+    my @peering_names;
+    $ibsm->redefine(az_network_peering_create => sub {
+            my (%args) = @_;
+            push @peering_names, $args{name};
+            note(" --> az_network_peering_create(name => '$args{name}, source_rg => '$args{source_rg}, source_vnet => '$args{source_vnet}', target_rg => '$args{target_rg},  target_vnet => '$args{target_vnet}')");
+            return; });
+    $ibsm->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    ibsm_network_peering_azure_create(ibsm_rg => 'COLIBRI', sut_rg => 'PASSEROTTO');
+
+    note("\n  PN-->  " . join("\n  PN-->  ", @peering_names));
+    ok((any { /VNETPASSEROTTO-VNETCOLIBRI/ } @peering_names), 'Peering named VNETPASSEROTTO-VNETCOLIBRI');
+    ok((any { /VNETCOLIBRI-VNETPASSEROTTO/ } @peering_names), 'Peering named VNETCOLIBRI-VNETPASSEROTTO');
+};
+
+subtest '[ibsm_network_peering_azure_create] with name' => sub {
+    my $ibsm = Test::MockModule->new('sles4sap::ibsm', no_auto => 1);
+
+    $ibsm->redefine(az_network_vnet_get => sub {
+            my (%args) = @_;
+            note(" --> az_network_vnet_get(resource_group => '$args{resource_group}', query => '$args{query}')");
+            return ['VNET' . $args{resource_group}]; });
+    my @peering_names;
+    $ibsm->redefine(az_network_peering_create => sub {
+            my (%args) = @_;
+            push @peering_names, $args{name};
+            note(" --> az_network_peering_create(name => '$args{name}, source_rg => '$args{source_rg}, source_vnet => '$args{source_vnet}', target_rg => '$args{target_rg},  target_vnet => '$args{target_vnet}')");
+            return; });
+    $ibsm->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    ibsm_network_peering_azure_create(
+        ibsm_rg => 'COLIBRI',
+        sut_rg => 'PASSEROTTO',
+        name_prefix => 'PETTIROSSO');
+
+    note("\n  PN-->  " . join("\n  PN-->  ", @peering_names));
+    ok((any { /PETTIROSSO-VNETPASSEROTTO-VNETCOLIBRI/ } @peering_names), 'Peering named VNETPASSEROTTO-VNETCOLIBRI');
+    ok((any { /PETTIROSSO-VNETCOLIBRI-VNETPASSEROTTO/ } @peering_names), 'Peering named VNETCOLIBRI-VNETPASSEROTTO');
+};
+
+subtest '[ibsm_network_peering_azure_create] az integration' => sub {
+    my $ibsm = Test::MockModule->new('sles4sap::ibsm', no_auto => 1);
+    my $az_cli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+
+    my @calls;
+    $az_cli->redefine(script_run => sub {
+            push @calls, 'SR: ' . $_[0];
+            return; });
+
+    $az_cli->redefine(assert_script_run => sub {
+            push @calls, 'ASR: ' . $_[0];
+            return; });
+
+    $az_cli->redefine(script_output => sub {
+            push @calls, 'SO: ' . $_[0];
+            if ($_[0] =~ /az network vnet list -g (.*) --query.*/) { return '["VNET-' . $1 . '"]'; }
+            if ($_[0] =~ /az network vnet show --query id.*--name (.*)/) { return $1 . '-ID'; }
+            return 'NOT VALID'; });
+
+    $ibsm->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    ibsm_network_peering_azure_create(ibsm_rg => 'COLIBRI', sut_rg => 'PASSEROTTO');
+
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    ok((any { /.*ASR: az network vnet peering create.*/ } @calls), 'There is at least 1 "az network vnet peering create" (there should be exactly 2).');
+    ok((any { /.*ASR: az network vnet peering create.*name VNET-PASSEROTTO-VNET-COLIBRI.*/ } @calls), 'Peering named VNET-PASSEROTTO-VNET-COLIBRI');
+    ok((any { /.*ASR: az network vnet peering create.*resource-group PASSEROTTO.*/ } @calls), 'Peering resource group PASSEROTTO');
+    ok((any { /.*ASR: az network vnet peering create.*vnet-name VNET-PASSEROTTO.*/ } @calls), 'Peering source vnet VNET-PASSEROTTO');
+    ok((any { /.*ASR: az network vnet peering create.*remote-vnet VNET-COLIBRI-ID/ } @calls), 'Peering remote vnet id VNET-COLIBRI-ID');
+    ok((any { /.*ASR: az network vnet peering create.*name VNET-COLIBRI-VNET-PASSEROTTO.*/ } @calls), 'Peering named VNET-COLIBRI-VNET-PASSEROTTO');
+    ok((any { /.*ASR: az network vnet peering create.*resource-group COLIBRI.*/ } @calls), 'Peering resource group COLIBRI');
+    ok((any { /.*ASR: az network vnet peering create.*vnet-name VNET-COLIBRI.*/ } @calls), 'Peering source vnet VNET-COLIBRI');
+    ok((any { /.*ASR: az network vnet peering create.*remote-vnet VNET-PASSEROTTO-ID/ } @calls), 'Peering remote vnet id VNET-PASSEROTTO-ID');
+};
+
+subtest '[ibsm_network_peering_azure_delete]' => sub {
+    my $ibsm = Test::MockModule->new('sles4sap::ibsm', no_auto => 1);
+
+    $ibsm->redefine(az_network_vnet_get => sub {
+            my (%args) = @_;
+            note(" --> az_network_vnet_get(resource_group => '$args{resource_group}', query => '$args{query}')");
+            return ['VNET' . $args{resource_group}]; });
+    $ibsm->redefine(az_network_peering_list => sub {
+            my (%args) = @_;
+            note(" --> az_network_peering_list(resource_group => '$args{resource_group}', vnet => '$args{vnet}')");
+            return ['PEERING' . $args{resource_group}]; });
+    my $peering_delete = 0;
+    $ibsm->redefine(az_network_peering_delete => sub { $peering_delete = 1; return 0; });
+    $ibsm->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    ibsm_network_peering_azure_delete(sut_rg => 'PICCIONE', ibsm_rg => 'COLOMBA');
+    ok($peering_delete eq 1), 'az_network_peering_delete called';
+};
+
+subtest '[ibsm_network_peering_azure_delete] az integrate' => sub {
+    my $ibsm = Test::MockModule->new('sles4sap::ibsm', no_auto => 1);
+    $ibsm->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    my $az_cli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $az_cli->redefine(script_run => sub {
+            push @calls, 'SR: ' . $_[0];
+            return 0; });
+
+    $az_cli->redefine(assert_script_run => sub {
+            push @calls, 'ASR: ' . $_[0];
+            return; });
+
+    $az_cli->redefine(script_output => sub {
+            push @calls, 'SO: ' . $_[0];
+            if ($_[0] =~ /az network vnet list -g (.*) --query.*/) { return '["VNET-' . $1 . '"]'; }
+            if ($_[0] =~ /az network vnet show --query id.*--name (.*)/) { return $1 . '-ID'; }
+            if ($_[0] =~ /az network vnet peering list/) { return '["GABBIANO"]'; }
+            if ($_[0] =~ /az network vnet peering delete/) { return 0; }
+            return 'NOT VALID'; });
+
+    ibsm_network_peering_azure_delete(sut_rg => 'PICCIONE', ibsm_rg => 'COLOMBA');
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    ok((any { /.*SR: az network vnet peering delete.*/ } @calls), 'There is at least 1 "az network vnet peering delete" (there should be exactly 2).');
+    ok((any { /.*SR: az network vnet peering delete.*name GABBIANO / } @calls), 'There is at least 1 call with peering name GABBIANO.');
 };
 
 done_testing;

--- a/tests/sles4sap/ipaddr2/cluster_create.pm
+++ b/tests/sles4sap/ipaddr2/cluster_create.pm
@@ -57,17 +57,12 @@ QE-SAP <qe-sap@suse.de>
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
-use sles4sap::qesap::azure qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
   ipaddr2_configure_web_server
   ipaddr2_bastion_pubip
   ipaddr2_cluster_create
   ipaddr2_cluster_check_version
-  ipaddr2_deployment_logs
-  ipaddr2_infra_destroy
-  ipaddr2_cloudinit_logs
-  ipaddr2_azure_resource_group
-);
+  ipaddr2_cleanup);
 
 sub run {
     my ($self) = @_;
@@ -106,12 +101,10 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
-    if (my $ibsm_rg = get_var('IBSM_RG')) {
-        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
-    }
-    ipaddr2_infra_destroy();
+    ipaddr2_cleanup(
+        diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
+        cloudinit => get_var('IPADDR2_CLOUDINIT', 1),
+        ibsm_rg => get_var('IBSM_RG'));
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -54,16 +54,12 @@ QE-SAP <qe-sap@suse.de>
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
-use sles4sap::qesap::azure qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
   ipaddr2_bastion_key_accept
   ipaddr2_bastion_pubip
-  ipaddr2_deployment_logs
-  ipaddr2_infra_destroy
   ipaddr2_internal_key_accept
   ipaddr2_internal_key_gen
-  ipaddr2_cloudinit_logs
-);
+  ipaddr2_cleanup);
 
 sub run {
     my ($self) = @_;
@@ -93,9 +89,9 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
-    ipaddr2_infra_destroy();
+    ipaddr2_cleanup(
+        diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
+        cloudinit => get_var('IPADDR2_CLOUDINIT', 1));
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -53,7 +53,7 @@ of a custom image in Azure Blob Storage uploaded via B<publiccloud_upload_img>.
 If not set, a catalog image specified via B<PUBLIC_CLOUD_IMAGE_ID>
 is used.
 
-=item B<SCC_REGCODE_SLES4SAP> 
+=item B<SCC_REGCODE_SLES4SAP>
 
 SUSE Customer Center registration code for SLES for SAP.
 Required if the OS image is BYOS.
@@ -77,11 +77,8 @@ use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
   ipaddr2_cloudinit_create
   ipaddr2_infra_deploy
-  ipaddr2_deployment_logs
   ipaddr2_deployment_sanity
-  ipaddr2_infra_destroy
-  ipaddr2_cloudinit_logs
-);
+  ipaddr2_cleanup);
 
 sub run {
     my ($self) = @_;
@@ -144,9 +141,8 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
-    ipaddr2_infra_destroy();
+    ipaddr2_cleanup(diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
+        cloudinit => get_var('IPADDR2_CLOUDINIT', 1));
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/ipaddr2/destroy.pm
+++ b/tests/sles4sap/ipaddr2/destroy.pm
@@ -57,13 +57,10 @@ QE-SAP <qe-sap@suse.de>
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
-use sles4sap::qesap::azure qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
-  ipaddr2_deployment_logs
   ipaddr2_infra_destroy
-  ipaddr2_cloudinit_logs
   ipaddr2_azure_resource_group
-);
+  ipaddr2_cleanup);
 
 sub run {
     my ($self) = @_;
@@ -74,8 +71,12 @@ sub run {
     select_serial_terminal;
 
     if (my $ibsm_rg = get_var('IBSM_RG')) {
-        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
+        ibsm_network_peering_azure_delete(
+            sut_rg => ipaddr2_azure_resource_group(),
+            sut_vnet => get_current_job_id(),
+            ibsm_rg => $ibsm_rg);
     }
+    ipaddr2_cloudinit_logs() unless (check_var('IPADDR2_CLOUDINIT', 0));
     ipaddr2_infra_destroy();
 }
 
@@ -85,12 +86,10 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
-    if (my $ibsm_rg = get_var('IBSM_RG')) {
-        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
-    }
-    ipaddr2_infra_destroy();
+    ipaddr2_cleanup(
+        diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
+        cloudinit => get_var('IPADDR2_CLOUDINIT', 1),
+        ibsm_rg => get_var('IBSM_RG'));
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/ipaddr2/network_peering.pm
+++ b/tests/sles4sap/ipaddr2/network_peering.pm
@@ -56,15 +56,10 @@ QE-SAP <qe-sap@suse.de>
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
-use sles4sap::qesap::azure qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
-  ipaddr2_deployment_logs
-  ipaddr2_cloudinit_logs
-  ipaddr2_infra_destroy
   ipaddr2_network_peering_create
   ipaddr2_repos_add_server_to_hosts
-  ipaddr2_azure_resource_group
-);
+  ipaddr2_cleanup);
 
 sub run {
     my ($self) = @_;
@@ -86,12 +81,10 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
-    if (my $ibsm_rg = get_var('IBSM_RG')) {
-        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
-    }
-    ipaddr2_infra_destroy();
+    ipaddr2_cleanup(
+        diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
+        cloudinit => get_var('IPADDR2_CLOUDINIT', 1),
+        ibsm_rg => get_var('IBSM_RG'));
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/ipaddr2/patch_system.pm
+++ b/tests/sles4sap/ipaddr2/patch_system.pm
@@ -54,20 +54,13 @@ QE-SAP <qe-sap@suse.de>
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
-use sles4sap::qesap::azure qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
-  ipaddr2_deployment_logs
-  ipaddr2_cloudinit_logs
-  ipaddr2_azure_resource_group
-  ipaddr2_infra_destroy
   ipaddr2_patch_system
-);
+  ipaddr2_cleanup);
 
 sub run {
     my ($self) = @_;
-
     select_serial_terminal;
-
     ipaddr2_patch_system();
 }
 
@@ -77,12 +70,10 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
-    if (my $ibsm_rg = get_var('IBSM_RG')) {
-        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
-    }
-    ipaddr2_infra_destroy();
+    ipaddr2_cleanup(
+        diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
+        cloudinit => get_var('IPADDR2_CLOUDINIT', 1),
+        ibsm_rg => get_var('IBSM_RG'));
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/ipaddr2/registration.pm
+++ b/tests/sles4sap/ipaddr2/registration.pm
@@ -58,16 +58,13 @@ use testapi;
 use serial_terminal qw( select_serial_terminal );
 use publiccloud::utils;
 use sles4sap::ipaddr2 qw(
-  ipaddr2_deployment_logs
-  ipaddr2_cloudinit_logs
-  ipaddr2_infra_destroy
   ipaddr2_scc_addons
   ipaddr2_scc_check
   ipaddr2_scc_register
   ipaddr2_repo_refresh
   ipaddr2_repo_list
   ipaddr2_bastion_pubip
-);
+  ipaddr2_cleanup);
 
 sub run {
     my ($self) = @_;
@@ -117,9 +114,10 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
-    ipaddr2_infra_destroy();
+    ipaddr2_cleanup(
+        diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
+        cloudinit => get_var('IPADDR2_CLOUDINIT', 1),
+        ibsm_rg => get_var('IBSM_RG'));
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/ipaddr2/sanity_cluster.pm
+++ b/tests/sles4sap/ipaddr2/sanity_cluster.pm
@@ -14,9 +14,12 @@ This module runs sanity checks specifically on the Pacemaker cluster created
 for the ipaddr2 test. It verifies the cluster's health, ensuring that it is
 properly configured and all resources are in the expected state.
 
-It primarily calls the C<ipaddr2_cluster_sanity> function from the shared
-library to perform the checks.
+It performs the following checks:
 
+- Verifies the overall cluster health using C<crm status>.
+- Ensures the cluster reports no issues via C<crm_mon>.
+- Confirms that exactly three primitive resources are configured.
+- Checks for the presence of the nginx resource agent and its corresponding package.
 
 =head1 SETTINGS
 
@@ -53,15 +56,10 @@ QE-SAP <qe-sap@suse.de>
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
-use sles4sap::qesap::azure qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
   ipaddr2_bastion_pubip
   ipaddr2_cluster_sanity
-  ipaddr2_deployment_logs
-  ipaddr2_infra_destroy
-  ipaddr2_cloudinit_logs
-  ipaddr2_azure_resource_group
-);
+  ipaddr2_cleanup);
 
 sub run {
     my ($self) = @_;
@@ -81,12 +79,10 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
-    if (my $ibsm_rg = get_var('IBSM_RG')) {
-        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
-    }
-    ipaddr2_infra_destroy();
+    ipaddr2_cleanup(
+        diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
+        cloudinit => get_var('IPADDR2_CLOUDINIT', 1),
+        ibsm_rg => get_var('IBSM_RG'));
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/sles4sap/ipaddr2/test_move_resource.pm
+++ b/tests/sles4sap/ipaddr2/test_move_resource.pm
@@ -49,20 +49,15 @@ QE-SAP <qe-sap@suse.de>
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
-use sles4sap::qesap::azure qw (qesap_az_vnet_peering_delete);
 use sles4sap::ipaddr2 qw(
   ipaddr2_bastion_pubip
   ipaddr2_crm_clear
   ipaddr2_crm_move
-  ipaddr2_deployment_logs
-  ipaddr2_infra_destroy
-  ipaddr2_cloudinit_logs
   ipaddr2_os_connectivity_sanity
   ipaddr2_test_master_vm
   ipaddr2_test_other_vm
   ipaddr2_wait_for_takeover
-  ipaddr2_azure_resource_group
-);
+  ipaddr2_cleanup);
 
 sub run {
     my ($self) = @_;
@@ -130,12 +125,10 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    ipaddr2_deployment_logs() if check_var('IPADDR2_DIAGNOSTIC', 1);
-    ipaddr2_cloudinit_logs() unless check_var('IPADDR2_CLOUDINIT', 0);
-    if (my $ibsm_rg = get_var('IBSM_RG')) {
-        qesap_az_vnet_peering_delete(source_group => ipaddr2_azure_resource_group(), target_group => $ibsm_rg);
-    }
-    ipaddr2_infra_destroy();
+    ipaddr2_cleanup(
+        diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
+        cloudinit => get_var('IPADDR2_CLOUDINIT', 1),
+        ibsm_rg => get_var('IBSM_RG'));
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
Move code about peering the the IBSm in Azure to the IBSm library as code does not have any dependency to qe-sap-deployment. Implement some qesap::azure functions using the azure_cli lib. Remove ipaddr2 test module dependency to qesap.

Ticket: https://jira.suse.com/browse/TEAM-10496

# Verification run:
sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-ipaddr2_azure_test
 - http://openqaworker15.qa.suse.cz/tests/338169
 - http://openqaworker15.qa.suse.cz/tests/338183

sle-15-SP6-Azure-SAP-PAYG-Incidents-x86_64-Build:39929:zypper-ipaddr2
 - http://openqaworker15.qa.suse.cz/tests/338172
 - http://openqaworker15.qa.suse.cz/tests/338184


https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=15-SP5&build=%3A39928%3Azypper&groupid=46

https://openqaworker15.qa.suse.cz/tests/overview?build=%3A39926%3Azypper&distri=sle&version=15-SP4&groupid=21

https://openqaworker15.qa.suse.cz/tests/overview?distri=sle&version=12-SP5&build=%3A39869%3Asaptune&groupid=28