### PR TITLE
containers: Decrease loop cycle count for volumes test

### DIFF
--- a/tests/containers/volumes.pm
+++ b/tests/containers/volumes.pm
@@ -3,8 +3,8 @@
 # Copyright 2023,2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Package: podman network
-# Summary: Test podman network
+# Packages: podman & docker
+# Summary: Test podman & docker volumes
 # Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'containers::basetest';
@@ -86,7 +86,7 @@ sub run {
     assert_script_run("$runtime volume rm $test_volume");
     assert_script_run("! $runtime volume inspect $test_volume");
 
-    for (my $i = 1; $i <= 10; $i++) {
+    for (my $i = 1; $i <= 2; $i++) {
         assert_script_run("$runtime volume create $test_volume");
 
         # Test --volume option with volume (read-write)


### PR DESCRIPTION
Retrying the same commands 10 times is no better than 2 times and only increases the chance of running into some weird backend timeouts.

I'd rather remove the whole loop but let's just decrease it.

Related ticket: https://progress.opensuse.org/issues/187557

Failing test: https://openqa.suse.de/tests/18861325#step/volumes_docker/338

TODO in another PR:
- Run this test as rootless as we do with other modules like compose, etc.