### PR TITLE
Ignore watchdog message when reboot

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -264,7 +264,7 @@
         "type": "ignore"
     },
     "bsc#1245376": {
-        "description": "kernel: watchdog: watchdog0: watchdog did not stop!",
+        "description": "kernel: watchdog: watchdog0: watchdog did not stop!|Failed to send WATCHDOG=1 notification message: Connection refused",
         "products": {
             "sle-micro": ["6.2"],
             "opensuse": ["Tumbleweed"],


### PR DESCRIPTION
The detected message appears during shutdown/reboot phase. It is not the same as https://bugzilla.suse.com/show_bug.cgi?id=1245376, but seems like watchdog messages during reboot can be ignored

