### PR TITLE
Add tests for docker-py & podman-py

### DIFF
--- a/data/containers/patches/docker-py/3261.patch
+++ b/data/containers/patches/docker-py/3261.patch
@@ -1,0 +1,85 @@
+From e47e966e944deb637a16f445abd5fc92f6dba38a Mon Sep 17 00:00:00 2001
+From: Sebastiaan van Stijn <github@gone.nl>
+Date: Wed, 22 May 2024 15:12:42 +0200
+Subject: [PATCH] Bump default API version to 1.45 (Moby 26.0/26.1)
+
+- Update API version to the latest maintained release.
+0 Adjust tests for API 1.45
+
+Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
+---
+ Makefile                                    |  4 ++--
+ docker/constants.py                         |  2 +-
+ tests/Dockerfile-ssh-dind                   |  4 ++--
+ tests/integration/models_containers_test.py | 11 +++++------
+ 4 files changed, 10 insertions(+), 11 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 13a00f5e20..d1c07ac739 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,5 @@
+-TEST_API_VERSION ?= 1.44
+-TEST_ENGINE_VERSION ?= 25.0
++TEST_API_VERSION ?= 1.45
++TEST_ENGINE_VERSION ?= 26.1
+ 
+ ifeq ($(OS),Windows_NT)
+     PLATFORM := Windows
+diff --git a/docker/constants.py b/docker/constants.py
+index 3c527b47e3..0e39dc2917 100644
+--- a/docker/constants.py
++++ b/docker/constants.py
+@@ -2,7 +2,7 @@
+ 
+ from .version import __version__
+ 
+-DEFAULT_DOCKER_API_VERSION = '1.44'
++DEFAULT_DOCKER_API_VERSION = '1.45'
+ MINIMUM_DOCKER_API_VERSION = '1.24'
+ DEFAULT_TIMEOUT_SECONDS = 60
+ STREAM_HEADER_SIZE_BYTES = 8
+diff --git a/tests/Dockerfile-ssh-dind b/tests/Dockerfile-ssh-dind
+index 250c20f2c8..49529f84b7 100644
+--- a/tests/Dockerfile-ssh-dind
++++ b/tests/Dockerfile-ssh-dind
+@@ -1,7 +1,7 @@
+ # syntax=docker/dockerfile:1
+ 
+-ARG API_VERSION=1.44
+-ARG ENGINE_VERSION=25.0
++ARG API_VERSION=1.45
++ARG ENGINE_VERSION=26.1
+ 
+ FROM docker:${ENGINE_VERSION}-dind
+ 
+diff --git a/tests/integration/models_containers_test.py b/tests/integration/models_containers_test.py
+index 2cd713ec8a..8727455932 100644
+--- a/tests/integration/models_containers_test.py
++++ b/tests/integration/models_containers_test.py
+@@ -131,10 +131,9 @@ def test_run_with_networking_config(self):
+         assert 'NetworkSettings' in attrs
+         assert 'Networks' in attrs['NetworkSettings']
+         assert list(attrs['NetworkSettings']['Networks'].keys()) == [net_name]
+-        # Expect Aliases to list 'test_alias' and the container's short-id.
+-        # In API version 1.45, the short-id will be removed.
++        # Aliases no longer include the container's short-id in API v1.45.
+         assert attrs['NetworkSettings']['Networks'][net_name]['Aliases'] \
+-               == [test_alias, attrs['Id'][:12]]
++               == [test_alias]
+         assert attrs['NetworkSettings']['Networks'][net_name]['DriverOpts'] \
+                == test_driver_opt
+ 
+@@ -191,9 +190,9 @@ def test_run_with_networking_config_only_undeclared_network(self):
+         assert 'NetworkSettings' in attrs
+         assert 'Networks' in attrs['NetworkSettings']
+         assert list(attrs['NetworkSettings']['Networks'].keys()) == [net_name]
+-        # Aliases should include the container's short-id (but it will be removed
+-        # in API v1.45).
+-        assert attrs['NetworkSettings']['Networks'][net_name]['Aliases'] == [attrs["Id"][:12]]
++        # Aliases no longer include the container's short-id in API v1.45.
++        assert (attrs['NetworkSettings']['Networks'][net_name]['Aliases']
++                is None)
+         assert (attrs['NetworkSettings']['Networks'][net_name]['DriverOpts']
+                 is None)
+ 

--- a/data/containers/patches/docker-py/3290.patch
+++ b/data/containers/patches/docker-py/3290.patch
@@ -1,0 +1,79 @@
+From 96ef4d3bee53ed17bf62670837b51c73911d7455 Mon Sep 17 00:00:00 2001
+From: Laura Brehm <laurabrehm@hey.com>
+Date: Fri, 27 Sep 2024 13:36:48 +0100
+Subject: [PATCH 1/2] tests/exec: expect 127 exit code for missing executable
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Docker Engine has always returned `126` when starting an exec fails due
+to a missing binary, but this was due to a bug in the daemon causing the
+correct exit code to be overwritten in some cases – see: https://github.com/moby/moby/issues/45795
+
+Change tests to expect correct exit code (`127`).
+
+Signed-off-by: Laura Brehm <laurabrehm@hey.com>
+---
+ tests/integration/models_containers_test.py | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/tests/integration/models_containers_test.py b/tests/integration/models_containers_test.py
+index 476263ae23..c65f3d7f88 100644
+--- a/tests/integration/models_containers_test.py
++++ b/tests/integration/models_containers_test.py
+@@ -359,8 +359,11 @@ def test_exec_run_failed(self):
+             "alpine", "sh -c 'sleep 60'", detach=True
+         )
+         self.tmp_containers.append(container.id)
+-        exec_output = container.exec_run("docker ps")
+-        assert exec_output[0] == 126
++        exec_output = container.exec_run("non-existent")
++        # older versions of docker return `126` in the case that an exec cannot
++        # be started due to a missing executable. We're fixing this for the
++        # future, so accept both for now.
++        assert exec_output[0] == 127 or exec_output == 126
+ 
+     def test_kill(self):
+         client = docker.from_env(version=TEST_API_VERSION)
+
+From b1265470e64c29d8b270e43387c5abb442e084c7 Mon Sep 17 00:00:00 2001
+From: Laura Brehm <laurabrehm@hey.com>
+Date: Fri, 27 Sep 2024 15:05:08 +0100
+Subject: [PATCH 2/2] tests/exec: add test for exit code from exec
+
+Execs should return the exit code of the exec'd process, if it started.
+
+Signed-off-by: Laura Brehm <laurabrehm@hey.com>
+---
+ tests/integration/models_containers_test.py | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/tests/integration/models_containers_test.py b/tests/integration/models_containers_test.py
+index c65f3d7f88..2cd713ec8a 100644
+--- a/tests/integration/models_containers_test.py
++++ b/tests/integration/models_containers_test.py
+@@ -353,6 +353,15 @@ def test_exec_run_success(self):
+         assert exec_output[0] == 0
+         assert exec_output[1] == b"hello\n"
+ 
++    def test_exec_run_error_code_from_exec(self):
++        client = docker.from_env(version=TEST_API_VERSION)
++        container = client.containers.run(
++            "alpine", "sh -c 'sleep 20'", detach=True
++        )
++        self.tmp_containers.append(container.id)
++        exec_output = container.exec_run("sh -c 'exit 42'")
++        assert exec_output[0] == 42
++
+     def test_exec_run_failed(self):
+         client = docker.from_env(version=TEST_API_VERSION)
+         container = client.containers.run(
+@@ -363,7 +372,7 @@ def test_exec_run_failed(self):
+         # older versions of docker return `126` in the case that an exec cannot
+         # be started due to a missing executable. We're fixing this for the
+         # future, so accept both for now.
+-        assert exec_output[0] == 127 or exec_output == 126
++        assert exec_output[0] == 127 or exec_output[0] == 126
+ 
+     def test_kill(self):
+         client = docker.from_env(version=TEST_API_VERSION)

--- a/data/containers/patches/docker-py/3354.patch
+++ b/data/containers/patches/docker-py/3354.patch
@@ -1,0 +1,42 @@
+From 6efb722c941af7daef1f4a7e4c9c670f61e90c9b Mon Sep 17 00:00:00 2001
+From: Ricardo Branco <rbranco@suse.de>
+Date: Wed, 20 Aug 2025 21:02:52 +0200
+Subject: [PATCH] tests: Fix deprecation warning for utcfromtimestamp()
+
+Fix DeprecationWarning for datetime.datetime.utcfromtimestamp()
+
+It suggests to use timezone-aware objects to represent datetimes in UTC
+with datetime.UTC but datetime.timezone.utc is backwards compatible.
+
+Signed-off-by: Ricardo Branco <rbranco@suse.de>
+---
+ tests/unit/api_container_test.py | 2 +-
+ tests/unit/api_test.py           | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tests/unit/api_container_test.py b/tests/unit/api_container_test.py
+index b2e5237a2a..1c4dda756a 100644
+--- a/tests/unit/api_container_test.py
++++ b/tests/unit/api_container_test.py
+@@ -1302,7 +1302,7 @@ def test_log_since_with_float(self):
+ 
+     def test_log_since_with_datetime(self):
+         ts = 809222400
+-        time = datetime.datetime.utcfromtimestamp(ts)
++        time = datetime.datetime.fromtimestamp(ts, datetime.timezone.utc)
+         with mock.patch('docker.api.client.APIClient.inspect_container',
+                         fake_inspect_container):
+             self.client.logs(fake_api.FAKE_CONTAINER_ID, stream=False,
+diff --git a/tests/unit/api_test.py b/tests/unit/api_test.py
+index 3ce127b346..7e3e95178a 100644
+--- a/tests/unit/api_test.py
++++ b/tests/unit/api_test.py
+@@ -231,7 +231,7 @@ def test_events(self):
+ 
+     def test_events_with_since_until(self):
+         ts = 1356048000
+-        now = datetime.datetime.utcfromtimestamp(ts)
++        now = datetime.datetime.fromtimestamp(ts, datetime.timezone.utc)
+         since = now - datetime.timedelta(seconds=10)
+         until = now + datetime.timedelta(seconds=10)
+ 

--- a/data/containers/patches/podman-py/572.patch
+++ b/data/containers/patches/podman-py/572.patch
@@ -1,0 +1,25 @@
+From 74d880c4771ded8cda6dd69bb827688d56792e0b Mon Sep 17 00:00:00 2001
+From: Ricardo Branco <rbranco@suse.de>
+Date: Thu, 21 Aug 2025 21:28:09 +0200
+Subject: [PATCH] tests: Fix tests to reflect removal of rw as default option
+
+Behaviour changed upstream with https://github.com/containers/podman/pull/25942
+
+Signed-off-by: Ricardo Branco <rbranco@suse.de>
+---
+ podman/tests/integration/test_container_create.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/podman/tests/integration/test_container_create.py b/podman/tests/integration/test_container_create.py
+index f098efbc..4e751163 100644
+--- a/podman/tests/integration/test_container_create.py
++++ b/podman/tests/integration/test_container_create.py
+@@ -316,7 +316,7 @@ def test_container_mounts(self):
+             self.containers.append(container)
+             self.assertEqual(
+                 container.attrs.get('HostConfig', {}).get('Tmpfs', {}).get(mount['target']),
+-                f"size={mount['size']},rw,rprivate,nosuid,nodev,tmpcopyup",
++                f"size={mount['size']},rprivate,nosuid,nodev,tmpcopyup",
+             )
+ 
+             container.start()

--- a/data/containers/patches/podman-py/575.patch
+++ b/data/containers/patches/podman-py/575.patch
@@ -1,0 +1,39 @@
+From a27a9d06a47cec4f684d7c16d14096f277d4fe30 Mon Sep 17 00:00:00 2001
+From: Ricardo Branco <rbranco@suse.de>
+Date: Sun, 24 Aug 2025 13:10:17 +0200
+Subject: [PATCH] tests: Fix deprecation warning for utcfromtimestamp()
+
+Fix DeprecationWarning for datetime.datetime.utcfromtimestamp()
+
+It suggests to use timezone-aware objects to represent datetimes in UTC
+with datetime.UTC but datetime.timezone.utc is backwards compatible.
+
+Signed-off-by: Ricardo Branco <rbranco@suse.de>
+---
+ podman/api/parse_utils.py | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/podman/api/parse_utils.py b/podman/api/parse_utils.py
+index 39e30da7..0294712d 100644
+--- a/podman/api/parse_utils.py
++++ b/podman/api/parse_utils.py
+@@ -4,7 +4,7 @@
+ import ipaddress
+ import json
+ import struct
+-from datetime import datetime
++from datetime import datetime, timezone
+ from typing import Any, Optional, Union
+ from collections.abc import Iterator
+ 
+@@ -48,7 +48,9 @@ def prepare_timestamp(value: Union[datetime, int, None]) -> Optional[int]:
+         return value
+ 
+     if isinstance(value, datetime):
+-        delta = value - datetime.utcfromtimestamp(0)
++        if value.tzinfo is None:
++            value = value.replace(tzinfo=timezone.utc)
++        delta = value - datetime.fromtimestamp(0, timezone.utc)
+         return delta.seconds + delta.days * 24 * 3600
+ 
+     raise ValueError(f"Type '{type(value)}' is not supported by prepare_timestamp()")

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -183,6 +183,9 @@ sub load_host_tests_podman {
     load_compose_tests($run_args);
     loadtest('containers/seccomp', run_args => $run_args, name => $run_args->{runtime} . "_seccomp") unless is_sle('<15');
     loadtest('containers/isolation', run_args => $run_args, name => $run_args->{runtime} . "_isolation") unless (is_public_cloud || is_transactional);
+    unless (is_jeos || is_staging || is_transactional || !is_tumbleweed || get_var("OCI_RUNTIME")) {
+        loadtest('containers/python_runtime', run_args => $run_args, name => "python_podman");
+    }
     loadtest('containers/podmansh') if (is_tumbleweed && !is_staging && !is_transactional);
 }
 
@@ -214,6 +217,9 @@ sub load_host_tests_docker {
     if (is_tumbleweed || is_leap || is_sle && (is_sle('>=16') || is_sle('>=15-SP4') && !check_var("CONTAINERS_DOCKER_FLAVOUR", "stable"))) {
         # select_user_serial_terminal is broken on public cloud
         loadtest 'containers/rootless_docker' unless (is_public_cloud);
+    }
+    unless (is_jeos || is_staging || is_transactional || !is_tumbleweed || check_var("CONTAINERS_DOCKER_FLAVOUR", "stable")) {
+        loadtest('containers/python_runtime', run_args => $run_args, name => "python_docker");
     }
     # Expected to work anywhere except of real HW backends, PC and Micro
     unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro || (is_sle('=12-SP5') && is_aarch64)) {

--- a/tests/containers/python_runtime.pm
+++ b/tests/containers/python_runtime.pm
@@ -132,7 +132,9 @@ sub test {
             # These 3 tests fail because our patches force log-opts max-file & max-size:
             "tests/integration/api_container_test.py::CreateContainerTest::test_valid_log_driver_and_log_opt",
             "tests/integration/api_container_test.py::CreateContainerTest::test_valid_no_config_specified",
-            "tests/integration/api_container_test.py::CreateContainerTest::test_valid_no_log_driver_specified"
+            "tests/integration/api_container_test.py::CreateContainerTest::test_valid_no_log_driver_specified",
+            # Flaky test
+            "tests/integration/api_container_test.py::AttachContainerTest::test_attach_no_stream"
         );
     }
     my $deselect = join " ", map { "--deselect=$_" } @deselect;

--- a/tests/containers/python_runtime.pm
+++ b/tests/containers/python_runtime.pm
@@ -89,7 +89,7 @@ sub setup {
     assert_script_run "cd ~/$runtime-py";
 
     unless ($repo) {
-        my @patches = ($runtime eq "podman") ? qw(572) : qw(3261 3290);
+        my @patches = ($runtime eq "podman") ? qw(572) : ();
         foreach my $patch (@patches) {
             assert_script_run "curl -O " . data_url("containers/patches/$runtime-py/$patch.patch");
             # We need git 2.47.0+ to use `--ours` with `git apply -3`

--- a/tests/containers/python_runtime.pm
+++ b/tests/containers/python_runtime.pm
@@ -1,0 +1,185 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Packages: python3-docker & python3-podman
+# Summary: Test podman & docker python packages
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'containers::basetest';
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use version_utils;
+use utils;
+use containers::common qw(install_packages);
+
+my $runtime;
+
+# Translate RPM arch to Go arch
+sub deb_arch {
+    my $arch = shift;
+    if ($arch eq "x86_64") {
+        return "amd64";
+    } elsif ($arch eq "aarch64") {
+        return "arm64";
+    } else {
+        return $arch;
+    }
+}
+
+sub setup {
+    my $python3 = "python3";
+    my @pkgs = ($runtime, "$python3-$runtime");
+    push @pkgs, qq(git-core jq make $python3-pytest);
+    if ($runtime eq "podman") {
+        push @pkgs, qq($python3-fixtures $python3-requests-mock);
+    } else {
+        push @pkgs, qq(password-store $python3-paramiko $python3-pytest-timeout);
+    }
+    install_packages(@pkgs);
+
+    # Add IP to /etc/hosts
+    my $iface = script_output "ip -4 --json route list match default | jq -Mr '.[0].dev'";
+    my $ip_addr = script_output "ip -4 --json addr show $iface | jq -Mr '.[0].addr_info[0].local'";
+    assert_script_run "echo $ip_addr \$(hostname) >> /etc/hosts";
+
+    # Enable SSH
+    my $algo = "ed25519";
+    systemctl 'enable --now sshd';
+    assert_script_run "ssh-keygen -t $algo -N '' -f ~/.ssh/id_$algo";
+    assert_script_run "cat ~/.ssh/id_$algo.pub >> ~/.ssh/authorized_keys";
+    assert_script_run "ssh-keyscan localhost 127.0.0.1 ::1 | tee -a ~/.ssh/known_hosts";
+
+    if ($runtime eq "podman") {
+        systemctl "enable --now podman.socket";
+    } else {
+        assert_script_run "cp -f /etc/docker/daemon.json /etc/docker/daemon.json.bak";
+        assert_script_run qq(echo '"hosts": ["tcp://127.0.0.1:2375", "unix:///var/run/docker.sock"]' > /etc/docker/daemon.json);
+        record_info("docker daemon.json", script_output("cat /etc/docker/daemon.json"));
+        systemctl "daemon-reload";
+        systemctl "enable --now docker";
+        record_info("docker info", script_output("docker info"));
+        # Setup docker credentials helpers
+        my $credstore_version = "v0.9.3";
+        my $arch = deb_arch(get_var("ARCH"));
+        my $url = "https://github.com/docker/docker-credential-helpers/releases/download/$credstore_version/docker-credential-pass-$credstore_version.linux-$arch";
+        assert_script_run "curl -sSLo /usr/local/bin/docker-credential-pass $url";
+        assert_script_run "chmod +x /usr/local/bin/docker-credential-pass";
+    }
+
+    my $version = script_output "$python3 -c 'import $runtime; print($runtime.__version__)'";
+    record_info("Version", $version);
+    my $branch = ($runtime eq "podman") ? "v$version" : $version;
+    my $github_org = ($runtime eq "podman") ? "containers" : "docker";
+
+    # Support these cases for GIT_REPO: [<GITHUB_ORG>]#BRANCH
+    # 1. As GITHUB_ORG#TAG: github_user#test-patch
+    # 2. As TAG only: main, v1.2.3, etc
+    # 3. Empty. Use defaults specified above for $github_org & $branch
+    my $repo = get_var("GIT_REPO", "");
+    if ($repo =~ /#/) {
+        ($github_org, $branch) = split("#", $repo, 2);
+    } elsif ($repo) {
+        $branch = $repo;
+    }
+
+    assert_script_run "cd ~";
+    assert_script_run "git clone --branch $branch https://github.com/$github_org/$runtime-py", timeout => 300;
+    assert_script_run "cd ~/$runtime-py";
+
+    unless ($repo) {
+        my @patches = ($runtime eq "podman") ? qw(572) : qw(3261 3290);
+        foreach my $patch (@patches) {
+            assert_script_run "curl -O " . data_url("containers/patches/$runtime-py/$patch.patch");
+            # We need git 2.47.0+ to use `--ours` with `git apply -3`
+            assert_script_run "git apply -3 --ours $patch.patch";
+        }
+    }
+
+    if ($runtime eq "docker") {
+        # Fill credentials store. Taken from https://github.com/docker/docker-py/blob/main/tests/Dockerfile
+        assert_script_run "gpg2 --import ./tests/gpg-keys/secret";
+        assert_script_run "gpg2 --import-ownertrust ./tests/gpg-keys/ownertrust";
+        assert_script_run "yes | pass init \$(gpg2 --no-auto-check-trustdb --list-secret-key | awk '/^sec/{getline; \$1=\$1; print}')";
+        assert_script_run "gpg2 --check-trustdb";
+    }
+}
+
+sub test {
+    my $target = shift;
+
+    my @deselect = ();
+    if ($runtime eq "docker") {
+        push @deselect, (
+            # This test with websockets is broken
+            "tests/integration/api_container_test.py::AttachContainerTest::test_run_container_reading_socket_ws",
+            # These 3 tests fail because our patches force log-opts max-file & max-size:
+            "tests/integration/api_container_test.py::CreateContainerTest::test_valid_log_driver_and_log_opt",
+            "tests/integration/api_container_test.py::CreateContainerTest::test_valid_no_config_specified",
+            "tests/integration/api_container_test.py::CreateContainerTest::test_valid_no_log_driver_specified",
+            # This test fails because we have a weird IPv6 setup with multiple "valid" addresses
+            "tests/integration/models_swarm_test.py::SwarmTest::test_join_on_already_joined_swarm"
+        );
+    }
+    my $deselect = join " ", map { "--deselect=$_" } @deselect;
+
+    # Tests directory
+    my $tests = ($runtime eq "podman") ? "podman/tests" : "tests";
+
+    my %env = ();
+    if ($runtime eq "docker") {
+        my $api_version = script_output 'make --eval=\'version: ; @echo $(TEST_API_VERSION)\' version';
+        $env{DOCKER_TEST_API_VERSION} = $api_version;
+        # Fix docker-py test issues with datetimes on different timezones by using UTC
+        $env{TZ} = "UTC";
+    }
+    my $env = join " ", map { "$_=$env{$_}" } sort keys %env;
+    my $pytest_args = "-vv --capture=tee-sys -o junit_logging=all --junit-xml $target.xml $deselect";
+
+    script_run "$env pytest $pytest_args $tests/$target |& tee $target.txt", timeout => 3600;
+
+    # Patch the test name in the first line of the JUnit XML file so each target is parsed independently
+    my $name = ($runtime eq "podman") ? "pytest" : "docker-py";
+    assert_script_run qq{sed -ri '0,/name=/s/name="$name"/name="pytest-$target"/' $target.xml};
+    parse_extra_log(XUnit => "$target.xml");
+    upload_logs("$target.txt");
+}
+
+sub run {
+    my ($self, $args) = @_;
+    $runtime = $args->{runtime};
+
+    select_serial_terminal;
+
+    setup;
+
+    my @targets = (qw(unit integration));
+    foreach my $target (@targets) {
+        test $target;
+    }
+    if ($runtime eq "docker") {
+        assert_script_run "export DOCKER_HOST=ssh://root@127.0.0.1";
+        test "ssh";
+    }
+}
+
+sub cleanup() {
+    script_run "unset DOCKER_HOST";
+    script_run "cp -f /etc/docker/daemon.json.bak /etc/docker/daemon.json";
+    script_run "cd / ; rm -rf /root/$runtime-py";
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    cleanup;
+    $self->SUPER::post_fail_hook;
+}
+
+sub post_run_hook {
+    my ($self) = @_;
+    cleanup;
+    $self->SUPER::post_run_hook;
+}
+
+1;

--- a/tests/containers/python_runtime.pm
+++ b/tests/containers/python_runtime.pm
@@ -13,6 +13,7 @@ use serial_terminal qw(select_serial_terminal);
 use version_utils;
 use utils;
 use containers::common qw(install_packages);
+use Utils::Architectures qw(is_x86_64);
 
 my $runtime;
 
@@ -117,6 +118,8 @@ sub test {
             "tests/integration/api_swarm_test.py",
             "tests/integration/models_swarm_test.py"
         );
+        # This test uses the vieux/sshfs plugin which doesn't seem to be available for other arches
+        push @ignore, "tests/integration/api_plugin_test.py" unless is_x86_64;
     }
     my $ignore = join " ", map { "--ignore=$_" } @ignore;
 

--- a/tests/containers/python_runtime.pm
+++ b/tests/containers/python_runtime.pm
@@ -136,6 +136,11 @@ sub test {
             # Flaky test
             "tests/integration/api_container_test.py::AttachContainerTest::test_attach_no_stream"
         );
+    } else {
+        push @deselect, (
+            # This test depends on an image available only for x86_64
+            "podman/tests/integration/test_manifests.py::ManifestsIntegrationTest::test_manifest_crud"
+        ) unless is_x86_64;
     }
     my $deselect = join " ", map { "--deselect=$_" } @deselect;
 

--- a/tests/containers/python_runtime.pm
+++ b/tests/containers/python_runtime.pm
@@ -89,7 +89,7 @@ sub setup {
     assert_script_run "cd ~/$runtime-py";
 
     unless ($repo) {
-        my @patches = ($runtime eq "podman") ? qw(572) : qw(3261 3290);
+        my @patches = ($runtime eq "podman") ? qw(572) : qw(3261 3290 3354);
         foreach my $patch (@patches) {
             assert_script_run "curl -O " . data_url("containers/patches/$runtime-py/$patch.patch");
             # We need git 2.47.0+ to use `--ours` with `git apply -3`

--- a/tests/containers/python_runtime.pm
+++ b/tests/containers/python_runtime.pm
@@ -89,7 +89,7 @@ sub setup {
     assert_script_run "cd ~/$runtime-py";
 
     unless ($repo) {
-        my @patches = ($runtime eq "podman") ? qw(572) : qw(3261 3290 3354);
+        my @patches = ($runtime eq "podman") ? qw(572 575) : qw(3261 3290 3354);
         foreach my $patch (@patches) {
             assert_script_run "curl -O " . data_url("containers/patches/$runtime-py/$patch.patch");
             # We need git 2.47.0+ to use `--ours` with `git apply -3`

--- a/tests/containers/python_runtime.pm
+++ b/tests/containers/python_runtime.pm
@@ -89,7 +89,7 @@ sub setup {
     assert_script_run "cd ~/$runtime-py";
 
     unless ($repo) {
-        my @patches = ($runtime eq "podman") ? qw(572) : ();
+        my @patches = ($runtime eq "podman") ? qw(572) : qw(3261 3290);
         foreach my $patch (@patches) {
             assert_script_run "curl -O " . data_url("containers/patches/$runtime-py/$patch.patch");
             # We need git 2.47.0+ to use `--ours` with `git apply -3`


### PR DESCRIPTION
Add tests for python3-docker & python3-podman.

This brings lots of benefits:
- The python3-docker's runs hundreds of tests that we don't run in openQA because we lack other upstream tests for Docker, 
- Helping catch [bsc#1248415 - python3-podman package is not available](https://bugzilla.suse.com/show_bug.cgi?id=1248415)
- It already helped catch some test issues:
  - https://github.com/docker/docker-py/pull/3354
  - https://github.com/containers/podman-py/pull/572
  - https://github.com/containers/podman-py/pull/575

These tests take only ~7 minutes.

TODO (in another PR):
- Eventually, these tests should be extended to catch bugs like https://bugzilla.suse.com/show_bug.cgi?id=1248373
- Extend to SLES 16.0?  This needs git 2.47+ for `git apply -3 --ours` so a special repo is needed like we do with BATS tests.

Verification runs:
 - docker_apparmor x86_64: https://openqa.opensuse.org/tests/5261956
 - docker_selinux x86_64: https://openqa.opensuse.org/tests/5261957
 - podman_apparmor x86_64: https://openqa.opensuse.org/tests/5261958
 - podman_selinux x86_64: https://openqa.opensuse.org/tests/5261960
 - podman_apparmor aarch64: https://openqa.opensuse.org/tests/5261961
 - podman_selinux aarch64: https://openqa.opensuse.org/tests/5261983
 - docker_apparmor aarch64: https://openqa.opensuse.org/tests/5261964
 - docker_selinux aarch64: https://openqa.opensuse.org/tests/5261965

Using GIT_REPO: https://openqa.opensuse.org/tests/5258587