### PR TITLE
Adapt for 'boot from disk' on ppc64le development

### DIFF
--- a/lib/Distribution/Opensuse/AgamaDevel.pm
+++ b/lib/Distribution/Opensuse/AgamaDevel.pm
@@ -14,7 +14,6 @@ use parent 'susedistribution';
 
 use Yam::Agama::Pom::GrubMenuBasePage;
 use Yam::Agama::Pom::GrubMenuAgamaPage;
-use Yam::Agama::Pom::GrubMenuAgamaDeprecatedEntryOrderPage;
 use Yam::Agama::Pom::GrubMenuTumbleweedPage;
 use Yam::Agama::Pom::GrubEntryEditionPage;
 use Yam::Agama::Pom::AgamaUpAndRunningPage;
@@ -25,18 +24,10 @@ use Yam::Agama::Pom::EnterPassphraseForSwapPage;
 use Yam::Agama::Pom::EnterPassphraseForHomePage;
 
 use Utils::Architectures;
-use testapi qw(record_soft_failure);
 
 sub get_grub_menu_agama {
-    if (is_ppc64le()) {
-        record_soft_failure 'bsc#1248161 Boot from hard disk has not been implemented on ppc64le';
-        return Yam::Agama::Pom::GrubMenuAgamaDeprecatedEntryOrderPage->new({
-                grub_menu_agama => Yam::Agama::Pom::GrubMenuAgamaPage->new({
-                        grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()})});
-    } else {
-        return Yam::Agama::Pom::GrubMenuAgamaPage->new({
-                grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()});
-    }
+    return Yam::Agama::Pom::GrubMenuAgamaPage->new({
+            grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()});
 }
 
 sub get_grub_menu_base {

--- a/lib/Distribution/Opensuse/Leap/16Latest.pm
+++ b/lib/Distribution/Opensuse/Leap/16Latest.pm
@@ -14,10 +14,25 @@ use strict;
 use warnings FATAL => 'all';
 
 use Yam::Agama::Pom::GrubMenuLeapPage;
+use Yam::Agama::Pom::GrubMenuAgamaPage;
+use Yam::Agama::Pom::GrubMenuAgamaDeprecatedEntryOrderPage;
+use testapi qw(record_soft_failure);
 
 sub get_grub_menu_installed_system {
     my $self = shift;
     return Yam::Agama::Pom::GrubMenuLeapPage->new({grub_menu_base => $self->get_grub_menu_base()});
+}
+
+sub get_grub_menu_agama {
+    if (is_ppc64le()) {
+        record_soft_failure 'bsc#1248161 Boot from hard disk has not been implemented on ppc64le';
+        return Yam::Agama::Pom::GrubMenuAgamaDeprecatedEntryOrderPage->new({
+                grub_menu_agama => Yam::Agama::Pom::GrubMenuAgamaPage->new({
+                        grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()})});
+    } else {
+        return Yam::Agama::Pom::GrubMenuAgamaPage->new({
+                grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()});
+    }
 }
 
 1;

--- a/lib/Distribution/Sle/16Latest.pm
+++ b/lib/Distribution/Sle/16Latest.pm
@@ -14,10 +14,25 @@ use strict;
 use warnings FATAL => 'all';
 
 use Yam::Agama::Pom::GrubMenuSlesPage;
+use Yam::Agama::Pom::GrubMenuAgamaPage;
+use Yam::Agama::Pom::GrubMenuAgamaDeprecatedEntryOrderPage;
+use testapi qw(record_soft_failure);
 
 sub get_grub_menu_installed_system {
     my $self = shift;
     return Yam::Agama::Pom::GrubMenuSlesPage->new({grub_menu_base => $self->get_grub_menu_base()});
+}
+
+sub get_grub_menu_agama {
+    if (is_ppc64le()) {
+        record_soft_failure 'bsc#1248161 Boot from hard disk has not been implemented on ppc64le';
+        return Yam::Agama::Pom::GrubMenuAgamaDeprecatedEntryOrderPage->new({
+                grub_menu_agama => Yam::Agama::Pom::GrubMenuAgamaPage->new({
+                        grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()})});
+    } else {
+        return Yam::Agama::Pom::GrubMenuAgamaPage->new({
+                grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()});
+    }
 }
 
 1;

--- a/lib/Distribution/Sle/AgamaDevel.pm
+++ b/lib/Distribution/Sle/AgamaDevel.pm
@@ -20,4 +20,9 @@ sub get_grub_menu_installed_system {
             grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()});
 }
 
+sub get_grub_menu_agama {
+    return Yam::Agama::Pom::GrubMenuAgamaPage->new({
+            grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()});
+}
+
 1;


### PR DESCRIPTION
We need workaround distributions that 'boot from disk' hasn't reached yet for sle production and Leap production on ppc64le.

- Related ticket: N/A
- Needles:  grub-menu-first-entry-highlighted grub-menu-install-product
- Verification run: https://openqa.suse.de/tests/18876670#details
