### PR TITLE
Prevent WSL test from launching powershell twice

### DIFF
--- a/tests/wsl/smoke_test.pm
+++ b/tests/wsl/smoke_test.pm
@@ -26,7 +26,6 @@ sub run {
     elsif (match_has_tag('welcome_to_wsl')) {
         click_lastmatch;
         send_key 'alt-f4';
-        $self->open_powershell_as_admin;
     }
     $self->run_in_powershell(cmd => 'wsl --list --verbose', timeout => 60);
     $self->run_in_powershell(cmd => "wsl mount | Select-String -Pattern $expected{mount}", timeout => 60);


### PR DESCRIPTION
WSL smoke test is failing because powershell is opening in o3 tests twice.

When welcome_to_wsl popup triggers after WSL installation, it should not launch Powershell again.

- Related ticket: https://progress.opensuse.org/issues/187470

- Verification run: 

o3 with welcome_to_wsl: https://openqa.opensuse.org/tests/5257227#
osd without welcome_to_wsl: https://openqa.suse.de/tests/18876765
