### PR TITLE
Revert prepare_test_data for ppc64le

### DIFF
--- a/tests/console/validate_raid.pm
+++ b/tests/console/validate_raid.pm
@@ -72,7 +72,7 @@ my (
 );
 # Prepare test data depending on specific architecture/product
 sub prepare_test_data {
-    if (is_pvm) {
+    if (is_ppc64le || is_ppc64) {
         @partitioning = (
             $raid_partitions_3_arrays, $hard_disks, $linux_raid_member_3_arrays,
             $ext4_boot,


### PR DESCRIPTION
##
## Revert prepare_test_data for ppc64le
- Related ticket: Quick PR
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/18876753

##
