### PR TITLE
Support both Online and Full flavors in FIPS ker mode install

### DIFF
--- a/schedule/security/fips/sle16/agama_install_fips_ker_mode.yaml
+++ b/schedule/security/fips/sle16/agama_install_fips_ker_mode.yaml
@@ -8,9 +8,7 @@ vars:
   BOOTPARAMS: 'fips=1'
 schedule:
   - yam/agama/boot_agama
-  - yam/agama/agama_arrange
-  - yam/agama/patch_agama_tests
-  - yam/agama/agama
+  - '{{agama_flavor}}'
   - installation/grub_test
   - installation/first_boot
   - yam/validate/validate_base_product
@@ -21,3 +19,12 @@ schedule:
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown
+conditional_schedule:
+  agama_flavor:
+    FLAVOR:
+      Online:
+        - yam/agama/agama_auto
+      Full:
+        - yam/agama/agama_arrange
+        - yam/agama/patch_agama_tests
+        - yam/agama/agama


### PR DESCRIPTION
This change lets us use the schedule for both flavors, Online and Full.

- Related ticket: https://progress.opensuse.org/issues/186125
- Verification runs:
  - Online: WIP
  - Full: https://openqa.suse.de/tests/18851869
