### PR TITLE
Adapt validate_raid for  SLES16 ppc64le

### DIFF
--- a/tests/console/validate_raid.pm
+++ b/tests/console/validate_raid.pm
@@ -72,7 +72,7 @@ my (
 );
 # Prepare test data depending on specific architecture/product
 sub prepare_test_data {
-    if (is_ppc64le || is_ppc64) {
+    if ((is_ppc64le || is_ppc64) && is_sle('<16')) {
         @partitioning = (
             $raid_partitions_3_arrays, $hard_disks, $linux_raid_member_3_arrays,
             $ext4_boot,


### PR DESCRIPTION
##
### Adapt validate_raid for ppc64le for SLES16
For SLES16 we're not use the old raid configuration. so we can't use the old logic to prepare_test_data.

- Related ticket: https://progress.opensuse.org/issues/184177
- Needles: N/A
- Verification run: 
  - SLES15-SP7:
    - https://openqa.suse.de/tests/18876818
  - SLES16:
    - https://openqa.suse.de/tests/18876811
