### PR TITLE
Adjust trup_smoke to new transactional-update behavior

### DIFF
--- a/tests/transactional/trup_smoke.pm
+++ b/tests/transactional/trup_smoke.pm
@@ -25,8 +25,8 @@ sub action {
         script_run("fdectl tpm-authorize");
     }
     if ($reboot && $target =~ /bootloader|grub\.cfg|initrd/ && (is_bootloader_sdboot || is_bootloader_grub2_bls)) {
-        # With sdbootutil, the snapshot is not changed. Verify that and test rebooting.
-        check_reboot_changes(0);
+        # Since transactional-update 5.1 a new snapshot is created, tough it won't have any actual difference
+        check_reboot_changes(1);
         process_reboot(trigger => 1);
     }
     else {

--- a/tests/transactional/trup_smoke.pm
+++ b/tests/transactional/trup_smoke.pm
@@ -24,14 +24,8 @@ sub action {
         record_soft_failure("Workaround for bsc#1228126");
         script_run("fdectl tpm-authorize");
     }
-    if ($reboot && $target =~ /bootloader|grub\.cfg|initrd/ && (is_bootloader_sdboot || is_bootloader_grub2_bls)) {
-        # Since transactional-update 5.1 a new snapshot is created, tough it won't have any actual difference
-        check_reboot_changes(1);
-        process_reboot(trigger => 1);
-    }
-    else {
-        check_reboot_changes($reboot);
-    }
+
+    check_reboot_changes($reboot);
 }
 
 sub run {


### PR DESCRIPTION
Since transactional-update 5.1 a new snapshot is expected to be created even if there won't be any diff between snapshots for `bootloader`, `grub.cfg` and `initrd` sub commands

Ticket: https://progress.opensuse.org/issues/187584

VR: 
- https://openqa.opensuse.org/tests/5257597
- https://openqa.opensuse.org/tests/5257596
