### PR TITLE
Add missing import in ipaddr2 destroy

### DIFF
--- a/lib/sles4sap/ibsm.pm
+++ b/lib/sles4sap/ibsm.pm
@@ -150,12 +150,15 @@ sub ibsm_network_peering_azure_delete {
     foreach (qw(sut_rg ibsm_rg)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
     $args{timeout} //= bmwqemu::scale_timeout(300);
 
+    # Take care to keep all the query to always return a json list, even if of a sigle element,
+    # and not a string.
+    my $vnet_get_query = '[].name';
     my $res = az_network_vnet_get(resource_group => $args{sut_rg},
-        query => $args{sut_vnet} ? "[?contains(name,'" . $args{sut_vnet} . "')].name" : '[0].name');
+        query => $args{sut_vnet} ? "[?contains(name,'" . $args{sut_vnet} . "')].name" : $vnet_get_query);
     my $sut_vnet = $res->[0];
 
     $res = az_network_vnet_get(resource_group => $args{ibsm_rg},
-        query => '[0].name');
+        query => $vnet_get_query);
     my $ibsm_vnet = $res->[0];
 
     $res = az_network_peering_list(resource_group => $args{sut_rg}, vnet => $sut_vnet);

--- a/t/35_ibsm.t
+++ b/t/35_ibsm.t
@@ -120,6 +120,8 @@ subtest '[ibsm_network_peering_azure_delete]' => sub {
     $ibsm->redefine(az_network_peering_list => sub {
             my (%args) = @_;
             note(" --> az_network_peering_list(resource_group => '$args{resource_group}', vnet => '$args{vnet}')");
+            # The function is calling the az cli with "[?contains(name,'" . $args{sut_vnet} . "')].name" or '[].name'
+            # that both return a json list, even if usually only of one element.
             return ['PEERING' . $args{resource_group}]; });
     my $peering_delete = 0;
     $ibsm->redefine(az_network_peering_delete => sub { $peering_delete = 1; return 0; });

--- a/tests/sles4sap/ipaddr2/destroy.pm
+++ b/tests/sles4sap/ipaddr2/destroy.pm
@@ -57,6 +57,8 @@ QE-SAP <qe-sap@suse.de>
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
+use mmapi qw( get_current_job_id );
+use sles4sap::ibsm qw( ibsm_network_peering_azure_delete );
 use sles4sap::ipaddr2 qw(
   ipaddr2_infra_destroy
   ipaddr2_azure_resource_group


### PR DESCRIPTION
Add missing import from get_current_job_id in ipaddr2 destroy test module. This commit solves a regression introduced in 8b988324e8bca873f203d3682e214f9acbca765b.

Ticket: https://jira.suse.com/browse/TEAM-10496

# Verification run:
sle-15-SP5-Azure-SAP-PAYG-Incidents-x86_64-Build:39928:zypper-ipaddr2
 - http://openqaworker15.qa.suse.cz/tests/338356 :green_apple: 