### PR TITLE
Add identifier in crmsh version command output

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -770,7 +770,9 @@ sub check_cluster_state {
 
     # If running with versions of crmsh older than 4.4.2, do not use check_online_nodes (see POD below)
     # Fall back to the older method of checking Online vs. Configured nodes
-    my $cmp_result = package_version_cmp(script_output(q|rpm -q --qf '%{VERSION}\n' crmsh|), '4.4.2');
+    my $out = script_output(q|rpm -q --qf 'crmshver=%{VERSION}\n' crmsh|);
+    my ($ver) = $out =~ /^crmshver=(\S+)/m or die "Couldn't parse crmsh version from: $out";
+    my $cmp_result = package_version_cmp($ver, '4.4.2');
     if ($cmp_result < 0) {
         $cmd_sub->(q/crm_mon -s | grep "$(crm node list | grep -E -c ': member|: normal') nodes online"/);
     }
@@ -1821,7 +1823,9 @@ B<Return values:>
 sub crm_list_options {
     my (%args) = @_;
 
-    my $cmp_result = package_version_cmp(script_output(q|rpm -q --qf '%{VERSION}\n' crmsh|), '5.0.0');
+    my $outver = script_output(q|rpm -q --qf 'crmshver=%{VERSION}\n' crmsh|);
+    my ($ver) = $outver =~ /^crmshver=(\S+)/m or die "Couldn't parse crmsh version from: $outver";
+    my $cmp_result = package_version_cmp($ver, '5.0.0');
     return 0 if ($cmp_result < 0);
     my $out;
 

--- a/t/11_hacluster.t
+++ b/t/11_hacluster.t
@@ -464,7 +464,7 @@ subtest '[check_cluster_state]' => sub {
     $hacluster->redefine(script_run => sub { push @calls, $_[0]; });
     $hacluster->redefine(assert_script_run => sub { push @calls, $_[0]; });
     $hacluster->redefine(check_online_nodes => sub { push @calls, 'check_online_nodes'; });
-    $hacluster->redefine(script_output => sub { return '4.4.2'; });
+    $hacluster->redefine(script_output => sub { return 'crmshver=4.4.2'; });
 
     check_cluster_state();
     note("\n  -->  " . join("\n  -->  ", @calls));
@@ -480,7 +480,7 @@ subtest '[check_cluster_state] assert calls normally' => sub {
     $hacluster->redefine(script_run => sub { push @calls, 'script_run'; });
     $hacluster->redefine(assert_script_run => sub { push @calls, 'assert_script_run'; });
     $hacluster->redefine(check_online_nodes => sub { return; });
-    $hacluster->redefine(script_output => sub { return '4.4.2'; });
+    $hacluster->redefine(script_output => sub { return 'crmshver=4.4.2'; });
 
     check_cluster_state();
     note("\n  -->  " . join("\n  -->  ", @calls));
@@ -494,7 +494,7 @@ subtest '[check_cluster_state] proceed_on_failure' => sub {
     $hacluster->redefine(script_run => sub { push @calls, 'script_run'; });
     $hacluster->redefine(assert_script_run => sub { push @calls, 'assert_script_run'; });
     $hacluster->redefine(check_online_nodes => sub { return; });
-    $hacluster->redefine(script_output => sub { return '4.4.2'; });
+    $hacluster->redefine(script_output => sub { return 'crmshver=4.4.2'; });
 
     check_cluster_state(proceed_on_failure => 1);
     note("\n  -->  " . join("\n  -->  ", @calls));
@@ -508,7 +508,7 @@ subtest '[check_cluster_state] migration scenario' => sub {
     $hacluster->redefine(script_run => sub { push @calls, 'script_run'; });
     $hacluster->redefine(assert_script_run => sub { push @calls, 'assert_script_run'; });
     $hacluster->redefine(check_online_nodes => sub { return; });
-    $hacluster->redefine(script_output => sub { return '4.4.2'; });
+    $hacluster->redefine(script_output => sub { return 'crmshver=4.4.2'; });
     set_var('HDDVERSION', 'some version');
 
     check_cluster_state();
@@ -525,7 +525,7 @@ subtest '[check_cluster_state] old crmsh' => sub {
     $hacluster->redefine(script_run => sub { push @calls, $_[0]; });
     $hacluster->redefine(assert_script_run => sub { push @calls, $_[0]; });
     $hacluster->redefine(check_online_nodes => sub { push @calls, 'check_online_nodes'; });
-    $hacluster->redefine(script_output => sub { return '3.6.0'; });
+    $hacluster->redefine(script_output => sub { return 'crmshver=3.6.0'; });
 
     check_cluster_state();
     note("\n  -->  " . join("\n  -->  ", @calls));
@@ -729,7 +729,7 @@ subtest '[crm_list_options] no op for crm verions older than 5.0.0' => sub {
     $hacluster->redefine(script_output => sub { push @calls, $_[0]; return $this_test_ver; });
     $hacluster->redefine(record_info => sub { note(join(' ', "RECORD_INFO ( $this_test_ver )-->", @_)); });
 
-    foreach ('0.1.1', '4.3.2', '4.4.1', '4.4.2', '4.5.2') {
+    foreach ('crmshver=0.1.1', 'crmshver=4.3.2', 'crmshver=4.4.1', 'crmshver=4.4.2', 'crmshver=4.5.2') {
         @calls = ();
         $this_test_ver = $_;
         my $res = crm_list_options();
@@ -758,7 +758,7 @@ END
     $hacluster->redefine(record_info => sub { note(join(' ', "RECORD_INFO ( $this_test_ver )-->", @_)); });
 
     foreach ('5.0.0', '5.0.4', '6.0.0') {
-        $this_test_ver = $_;
+        $this_test_ver = "crmshver=$_";
         @calls = ();
         my $res = crm_list_options();
         note("\n  -->  " . join("\n  -->  ", @calls));
@@ -775,7 +775,7 @@ subtest '[crm_list_options] invalid xml' => sub {
 
     my $this_test_ver;
     $hacluster->redefine(script_output => sub {
-            return $this_test_ver if ($_[0] =~ /rpm/);
+            return "crmshver=$this_test_ver" if ($_[0] =~ /rpm/);
             # Intentionally do not collect rpm calls
             push @calls, $_[0];
             # Intentionally invalid XML


### PR DESCRIPTION
This pr adds an identifier (`crmshver=`) before the output of the `crmsh` version rpm command, so that the version can be caught even if extra noise makes it to the output. 

- Related ticket: https://jira.suse.com/browse/TEAM-10587
- Verification run: https://openqa.suse.de/tests/18886257 (and dependencies)
