### PR TITLE
Improve security-audit tests

### DIFF
--- a/tests/security/audit/aureport.pm
+++ b/tests/security/audit/aureport.pm
@@ -21,7 +21,11 @@ sub run {
     # Generate audit records for testing
     assert_script_run("echo '' > $audit_log");
 
-    if (is_sle('<16')) {
+    # Check if the SUT has apparmor and restart it
+    my $is_apparmor = script_run('systemctl status apparmor | grep "Active: active"');
+
+    # Confusing, but the previous cmd should return 0 if apparmor is there
+    if ($is_apparmor == 0) {
         assert_script_run('systemctl restart apparmor');
     } else {
         # SLE >=16 uses SELinux; let's generate logs with runcon


### PR DESCRIPTION
Improve security-audit tests

Determine whether the system runs apparmor or selinux in a better way.
Adjust pid extraction from audit events when running on Tumbleweed.

### Related ticket

https://progress.opensuse.org/issues/187635

### Verification runs

Tumbleweed
https://openqa.suse.de/tests/18878977

SLE-16
https://openqa.suse.de/tests/18878979

SLE-15 SP7
https://openqa.suse.de/tests/18878980

SLE-15 SP6
https://openqa.suse.de/tests/18879900