### PR TITLE
lib: Fix script_retry dies on timeout

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -2032,11 +2032,11 @@ sub script_retry {
         $cmd =~ s/^\s+//;    # left trim spaces after the exclamation mark
         $negate = '!';
     }
-    my $exec = join ' ', grep { defined && length } ($negate, 'timeout', $option, $timeout, $cmd);
+    my $exec = join ' ', grep { defined && length } ($negate, 'timeout -k 5', $option, $timeout, $cmd);
     my $ret;
     for (1 .. $retry) {
         # timeout for script_run must be larger than for the 'timeout ...' command
-        $ret = script_run($exec, ($timeout + 3));
+        $ret = script_run($exec, ($timeout + 10));
         last if defined($ret) && $ret == $ecode;
 
         die($fail_msg) if $retry == $_ && $die == 1;

--- a/t/05_utils_auxiliary.t
+++ b/t/05_utils_auxiliary.t
@@ -34,7 +34,7 @@ subtest 'script_retry' => sub {
     my $cmd;
     $testapi->redefine('script_run', sub { $cmd = shift; 0 });
     is script_retry('true', delay => 0, retry => 2, timeout => 1), 0, 'script_retry(true) is ok mocked to collect call';
-    is $cmd, 'timeout 1 true', 'expected concatenated command (no double spaces)';
+    is $cmd, 'timeout -k 5 1 true', 'expected concatenated command (no double spaces)';
 };
 
 


### PR DESCRIPTION
Adds a safeguard for the timeout command to kill the underlying command if stuck.

Adding the "kill after 5 seconds" option to timeout should be relatively safe, because without this the test would fail with a timeout, and this gives the system under test another retry to do run a command. If the system is borked, it will very likely fail on those subsequent tries.

- Related ticket: https://progress.opensuse.org/issues/187566
- Verification run: https://openqa.suse.de/tests/18879000
