### PR TITLE
Find command now times out if run too long

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -53,12 +53,10 @@ sub run {
             'find', '-P', '-O3',
             '/tmp/results/',
             '-type', 'f',
-            '-iname', "*.xml",
-            '-print', '2>/dev/null',
-            ';',
-            '[', '$?', '-eq', '124', ']',
-            '&&', 'echo', '"Command find timed out"'
-        );
+            '-iname', '*.xml',
+            '-print', '2>/dev/null;',
+            '[', '$?', '-ne', '124', ']',
+            '||', 'echo', '"Command find timed out"');
         my $ansible_output = script_output("cat $ret[1]");
         my $reference;
         my $desc_known_issue;


### PR DESCRIPTION
Command **find** now run inside of the **timeout**, so is stopped if run too long.

- Related ticket: https://jira.suse.com/browse/TEAM-10544
- Verification run: https://openqa.suse.de/tests/18878305#step/deploy_qesap_ansible/91