### PR TITLE
Ensure console selection after boot process in power kvm

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -854,7 +854,7 @@ sub activate_console {
         else {
             # on s390x we need to login here by providing a password
             handle_password_prompt if is_s390x;
-            assert_screen("inst-console", 300);
+            assert_screen 'inst-console';
         }
     }
 

--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -26,7 +26,7 @@ sub prepare_boot_params {
     my @params = ();
 
     # add mandatory boot params
-    push @params, 'console=' . (is_x86_64 ? 'ttyS0' : (is_ppc64le ? 'hvc0' : 'ttyAMA0')), 'console=tty';
+    push @params, 'console=tty', 'console=' . (is_x86_64 ? 'ttyS0' : (is_ppc64le ? 'hvc0' : 'ttyAMA0'));
     push @params, 'kernel.softlockup_panic=1';
     push @params, "live.password=$testapi::password";
 


### PR DESCRIPTION
We have tested different approaches and we concluded this is the cleanest and safer of all. To swap console order.

- Related ticket: https://progress.opensuse.org/issues/187464
- Needles: N/A
- Verification run:
  1. https://openqa.suse.de/tests/18879635
  2. https://openqa.suse.de/tests/18879636
  3. https://openqa.suse.de/tests/18879637
  4. https://openqa.suse.de/tests/18879638
  5. https://openqa.suse.de/tests/18879639
  6. https://openqa.suse.de/tests/18879640
  7. https://openqa.suse.de/tests/18879641
  8. https://openqa.suse.de/tests/18879642
  9. https://openqa.suse.de/tests/18879644
  10. https://openqa.suse.de/tests/18879645
  11. https://openqa.suse.de/tests/18879646
  12. https://openqa.suse.de/tests/18879647
  13. https://openqa.suse.de/tests/18879648
  14. https://openqa.suse.de/tests/18879649
  15. https://openqa.suse.de/tests/18879650
  16. https://openqa.suse.de/tests/18879651
  17. https://openqa.suse.de/tests/18879652
  18. https://openqa.suse.de/tests/18879653
  19. https://openqa.suse.de/tests/18879654
  20. https://openqa.suse.de/tests/18879655
 
