### PR TITLE
Make systemd_resolved test more reliable

### DIFF
--- a/tests/console/systemd_resolved.pm
+++ b/tests/console/systemd_resolved.pm
@@ -19,6 +19,7 @@ sub clean_up {
     assert_script_run("rm /etc/systemd/resolved.conf.d/dnssec.conf");
     assert_script_run("rm /etc/systemd/resolved.conf.d/dns_over_tls.conf");
     assert_script_run("mv /etc/resolv.conf{.bak,}");
+    assert_script_run("rm /etc/nsswitch.conf");
     systemctl 'disable --now systemd-resolved', timeout => 30;
     zypper_call 'rm systemd-resolved';
     systemctl 'restart NetworkManager', timeout => 30;

--- a/tests/console/systemd_resolved.pm
+++ b/tests/console/systemd_resolved.pm
@@ -34,7 +34,7 @@ sub run {
     systemctl 'enable --now systemd-resolved', timeout => 30;
     assert_script_run 'ln -s /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf';
     assert_script_run "cp /usr/etc/nsswitch.conf /etc/nsswitch.conf";
-    assert_script_run "sed -i 's/^hosts:\(.*\)\(files\)/hosts:\1\2 resolved [!UNAVAIL=return]/' /etc/nsswitch.conf";
+    assert_script_run "sed -i 's/^hosts:.*files/hosts: files resolved [!UNAVAIL=return]/' /etc/nsswitch.conf";
     script_run 'cat /etc/nsswitch.conf';
     systemctl 'start NetworkManager', timeout => 30;
     validate_script_output("resolvectl status", sub { m/Global/ });

--- a/tests/console/systemd_resolved.pm
+++ b/tests/console/systemd_resolved.pm
@@ -37,7 +37,7 @@ sub run {
     systemctl 'enable --now systemd-resolved', timeout => 30;
     assert_script_run 'ln -s /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf';
     assert_script_run "cp /usr/etc/nsswitch.conf /etc/nsswitch.conf";
-    assert_script_run "sed -i 's/^hosts:.*files/hosts: files resolved [!UNAVAIL=return]/' /etc/nsswitch.conf";
+    assert_script_run "sed -i 's/^hosts:.*files/hosts: files resolve [!UNAVAIL=return]/' /etc/nsswitch.conf";
     script_run 'cat /etc/nsswitch.conf';
     systemctl 'start NetworkManager', timeout => 30;
     validate_script_output("resolvectl status", sub { m/Global/ });

--- a/tests/console/systemd_resolved.pm
+++ b/tests/console/systemd_resolved.pm
@@ -31,6 +31,8 @@ sub run {
     zypper_call 'in systemd-resolved';
     systemctl 'stop NetworkManager', timeout => 30;
     assert_script_run("mv /etc/resolv.conf{,.bak}");
+    # Add workaround for bsc#1248501
+    assert_script_run("touch /usr/share/dbus-1/system.d/org.freedesktop.resolve1.conf");
     systemctl 'enable --now systemd-resolved', timeout => 30;
     assert_script_run 'ln -s /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf';
     assert_script_run "cp /usr/etc/nsswitch.conf /etc/nsswitch.conf";


### PR DESCRIPTION
Test could fail sometimes when starting NetworkManager or resolved would not be able to resolve queries; moreover due to a possible race condition, sometimes the test would be able to pass

- failed to resolve: https://openqa.opensuse.org/tests/5257140#step/systemd_resolved/61
- NetworkManager failing to start: https://openqa.opensuse.org/tests/5257044#step/systemd_resolved/85

Ticket: https://progress.opensuse.org/issues/187653

VR: 
- https://openqa.opensuse.org/tests/overview?version=Tumbleweed&build=foursixnine%2Fos-autoinst-distri-opensuse%2323067&distri=opensuse

Failures in wpa_supplicant are unrelated

~Failures in systemd-resolved are:~ See also: https://bugzilla.opensuse.org/show_bug.cgi?id=1248501