### PR TITLE
Reduce test unstabilities when rollback

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -211,14 +211,6 @@
         },
         "type": "bug"
     },
-    "boo#1197904": {
-        "description": "check_config_dict\\(\\) takes 2 positional arguments but 3 were given",
-        "products": {
-            "opensuse": ["15.3", "15.4"],
-            "sle": ["15-SP3", "15-SP4"]
-        },
-        "type": "bug"
-    },
     "bsc#1197679": {
         "description": "route ipv4 0.0.0.0/0 via.*dev eth0#2 type unicast table main scope universe protocol dhcp covered by a ipv4:dhcp lease",
         "products": {

--- a/tests/console/snapper_jeos_cli.pm
+++ b/tests/console/snapper_jeos_cli.pm
@@ -14,6 +14,7 @@ use utils;
 use power_action_utils qw(power_action);
 use Utils::Systemd qw(systemctl);
 use version_utils qw(is_sle);
+use serial_terminal qw(select_serial_terminal);
 
 sub check_package
 {
@@ -35,6 +36,7 @@ sub check_package
 sub rollback_and_reboot {
     my ($self, $rollback_id) = @_;
     assert_script_run("snapper rollback $rollback_id");
+
     assert_script_run("snapper list");
     power_action('reboot');
     if (is_aarch64) {
@@ -43,7 +45,8 @@ sub rollback_and_reboot {
     else {
         $self->wait_boot;
     }
-    select_console('root-console');
+
+    select_serial_terminal();
     assert_script_run("snapper list");
     # check whether SUSEConnect --rollback is running executed by rollback-reset-registration
     # this might cause a system management lock by zypper
@@ -66,7 +69,7 @@ sub run {
         tcpdump => '/usr/sbin/tcpdump'
     );
 
-    select_console('root-console');
+    select_serial_terminal();
     my $file = '/etc/openQA_snapper_test';
     my $pkgname = is_sle('16.0+') ? 'tcpdump' : 'zsh';
     my $check_path = $checks{$pkgname};


### PR DESCRIPTION
- ticket: https://progress.opensuse.org/issues/186678

Tackle typing issues by using `serial_console` instead of tty and vnc.
Try to wait until the load settles after snapper actions.

Remove bugref boo#1197904 - This has been fixed in QU4 images that we should use in sle15sp4

PoC: https://openqa.suse.de/tests/18886279#step/snapper_jeos_cli/1

#### Verification run

* https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=poo186678_investigation2