### PR TITLE
Avoid set inst.register_url for scc.suse.com on AGAMA test

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -773,7 +773,7 @@ sub registration_bootloader_cmdline {
     # SCC_URL=https://smt.example.com
     # prevent rogue RMT servers to show up in unexpected selection dialogs
     # https://progress.opensuse.org/issues/94696
-    set_var('SCC_URL', 'https://scc.suse.com') unless get_var('SCC_URL');
+    set_var('SCC_URL', 'https://scc.suse.com') unless (get_var('SCC_URL') || is_agama);
     my $cmdline = '';
     if (my $url = get_var('SMT_URL') || get_var('SCC_URL')) {
         $cmdline .= is_agama ? " inst.register_url=$url" : " regurl=$url";


### PR DESCRIPTION
Set inst.register_url=scc.suse.com will make it a custom url which is not expected.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/18885941#details
