### PR TITLE
Kselftests: Add BPF parsers

### DIFF
--- a/lib/Kselftests/parser.pm
+++ b/lib/Kselftests/parser.pm
@@ -9,8 +9,24 @@
 package Kselftests::parser;
 
 use Kselftests::parsers::main;
+
 use Kselftests::parsers::net::l2tp_sh;
+
 use Kselftests::parsers::livepatch;
+
+use Kselftests::parsers::bpf::test_bpftool_sh;
+use Kselftests::parsers::bpf::test_lru_map;
+use Kselftests::parsers::bpf::test_maps;
+use Kselftests::parsers::bpf::test_progs;
+use Kselftests::parsers::bpf::test_progs_cpuv4;
+use Kselftests::parsers::bpf::test_progs_no_alu32;
+use Kselftests::parsers::bpf::test_sockmap;
+use Kselftests::parsers::bpf::test_tag;
+use Kselftests::parsers::bpf::test_tc_edt_sh;
+use Kselftests::parsers::bpf::test_tc_tunnel_sh;
+use Kselftests::parsers::bpf::test_tcpnotify_user;
+use Kselftests::parsers::bpf::test_verifier;
+use Kselftests::parsers::bpf::test_xdping_sh;
 
 use testapi;
 use strict;

--- a/lib/Kselftests/parsers/bpf/test_bpftool_sh.pm
+++ b/lib/Kselftests/parsers/bpf/test_bpftool_sh.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Parser for the bpf:test_bpftool.sh selftest
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package Kselftests::parsers::bpf::test_bpftool_sh;
+
+use base 'Kselftests::parsers::main';
+use testapi;
+use strict;
+use warnings;
+
+our $test_idx = 1;
+
+sub parse_line {
+    my ($self, $test_ln) = @_;
+    if ($test_ln =~ /^#\s(\S+)\s\((.*)\)\s...\s(ok|FAIL)$/) {
+        my ($description, $diagnostic, $st) = ($1, $2, $3);
+        my $normalized;
+        if ($st eq 'ok') {
+            $normalized = "# ok $test_idx $description # $diagnostic";
+        } else {
+            $normalized = "# not ok $test_idx $description # $diagnostic";
+        }
+        $test_idx++;
+        return $normalized;
+    }
+    return undef;
+}
+
+1;

--- a/lib/Kselftests/parsers/bpf/test_lru_map.pm
+++ b/lib/Kselftests/parsers/bpf/test_lru_map.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Parser for the bpf:test_lru_map selftest
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package Kselftests::parsers::bpf::test_lru_map;
+
+use base 'Kselftests::parsers::main';
+use testapi;
+use strict;
+use warnings;
+
+our $test_idx = 1;
+
+sub parse_line {
+    my ($self, $test_ln) = @_;
+    if ($test_ln =~ /^#\s(\S+)\s(.*):\sPass$/) {
+        my ($description, $diagnostic) = ($1, $2);
+        $test_idx++;
+        return "# ok $test_idx $description # $diagnostic";
+    }
+    return undef;
+}
+
+1;

--- a/lib/Kselftests/parsers/bpf/test_maps.pm
+++ b/lib/Kselftests/parsers/bpf/test_maps.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Parser for the bpf:test_maps selftest
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package Kselftests::parsers::bpf::test_maps;
+
+use base 'Kselftests::parsers::main';
+use testapi;
+use strict;
+use warnings;
+
+our $test_idx = 1;
+
+sub parse_line {
+    my ($self, $test_ln) = @_;
+    if ($test_ln =~ /^#\s(\S+)+:(PASS|FAIL)$/) {
+        my ($description, $st) = ($1, $2);
+        my $normalized;
+        if ($st eq 'PASS') {
+            $normalized = "# ok $test_idx $description";
+        } else {
+            $normalized = "# not ok $test_idx $description";
+        }
+        $test_idx++;
+        return $normalized;
+    }
+    return undef;
+}
+
+1;

--- a/lib/Kselftests/parsers/bpf/test_progs.pm
+++ b/lib/Kselftests/parsers/bpf/test_progs.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Parser for the bpf:test_progs selftest
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package Kselftests::parsers::bpf::test_progs;
+
+use base 'Kselftests::parsers::main';
+use testapi;
+use strict;
+use warnings;
+
+our $test_idx = 1;
+
+sub parse_line {
+    my ($self, $test_ln) = @_;
+    my ($description, $st, $diag);
+    if ($test_ln =~ /^#\s#\S+\s+(\S+):(OK|FAIL|SKIP)$/) {
+        ($description, $st) = ($1, $2);
+    } elsif ($test_ln =~ /^#\s(\S*?):(PASS|SKIP|FAIL):(.*)$/) {
+        ($description, $st, $diag) = ($1, $2, $3);
+    }
+    if ($description) {
+        my $normalized;
+        if ($st eq 'PASS') {
+            $normalized = "# ok $test_idx $description";
+        } elsif ($st eq 'FAIL') {
+            $normalized = "# not ok $test_idx $description";
+        } else {
+            $normalized = "# ok $test_idx $description # SKIP";
+        }
+        if ($diag) {
+            $normalized .= " # $diag";
+        }
+        $test_idx++;
+        return $normalized;
+    }
+    return undef;
+}
+
+1;

--- a/lib/Kselftests/parsers/bpf/test_progs_cpuv4.pm
+++ b/lib/Kselftests/parsers/bpf/test_progs_cpuv4.pm
@@ -1,0 +1,15 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Parser for the bpf:test_progs-cpuv4 selftest
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package Kselftests::parsers::bpf::test_progs_cpuv4;
+
+use base 'Kselftests::parsers::bpf::test_progs';
+use strict;
+use warnings;
+
+1;

--- a/lib/Kselftests/parsers/bpf/test_progs_no_alu32.pm
+++ b/lib/Kselftests/parsers/bpf/test_progs_no_alu32.pm
@@ -1,0 +1,15 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Parser for the bpf:test_progs-no_alu32 selftest
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package Kselftests::parsers::bpf::test_progs_no_alu32;
+
+use base 'Kselftests::parsers::bpf::test_progs';
+use strict;
+use warnings;
+
+1;

--- a/lib/Kselftests/parsers/bpf/test_sockmap.pm
+++ b/lib/Kselftests/parsers/bpf/test_sockmap.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Parser for the bpf:test_sockmap selftest
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package Kselftests::parsers::bpf::test_sockmap;
+
+use base 'Kselftests::parsers::main';
+use testapi;
+use strict;
+use warnings;
+
+our $test_idx = 1;
+
+sub parse_line {
+    my ($self, $test_ln) = @_;
+    if ($test_ln =~ /^#\s#\d+\/[\d|\s]\d+?\s(.*):(OK|FAIL)/) {
+        my ($description, $st) = ($1, $2);
+        my $normalized;
+        if ($st eq 'OK') {
+            $normalized = "# ok $test_idx $description";
+        } else {
+            $normalized = "# not ok $test_idx $description";
+        }
+        $test_idx++;
+        return $normalized;
+    }
+    return undef;
+}
+
+1;

--- a/lib/Kselftests/parsers/bpf/test_tag.pm
+++ b/lib/Kselftests/parsers/bpf/test_tag.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Parser for the bpf:test_tag selftest
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package Kselftests::parsers::bpf::test_tag;
+
+use base 'Kselftests::parsers::main';
+use testapi;
+use strict;
+use warnings;
+
+sub parse_line {
+    my ($self, $test_ln) = @_;
+    if ($test_ln =~ /^#\s\S+:\sOK\s(.*)$/) {
+        my $n = $1;
+        return "# ok 1 test_tag # $n";
+    }
+    return undef;
+}
+
+1;

--- a/lib/Kselftests/parsers/bpf/test_tc_edt_sh.pm
+++ b/lib/Kselftests/parsers/bpf/test_tc_edt_sh.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Parser for the bpf:test_tc_edt.sh selftest
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package Kselftests::parsers::bpf::test_tc_edt_sh;
+
+use base 'Kselftests::parsers::main';
+use testapi;
+use strict;
+use warnings;
+
+sub parse_line {
+    my ($self, $test_ln) = @_;
+    if ($test_ln =~ /# PASS/) {
+        return "# ok 1 test_tc_edt";
+    } elsif ($test_ln =~ /# FAIL/) {
+        return "# not ok 1 test_tc_edt";
+    }
+    return undef;
+}
+
+1;

--- a/lib/Kselftests/parsers/bpf/test_tc_tunnel_sh.pm
+++ b/lib/Kselftests/parsers/bpf/test_tc_tunnel_sh.pm
@@ -1,0 +1,46 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Parser for the bpf:test_tc_tunnel.sh selftest
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package Kselftests::parsers::bpf::test_tc_tunnel_sh;
+
+use base 'Kselftests::parsers::main';
+use testapi;
+use strict;
+use warnings;
+
+our $test_idx = 1;
+our %cur;
+
+sub parse_line {
+    my ($self, $test_ln) = @_;
+    if ($test_ln =~ /^#\stest\s(.*?)(?:\s*\((expect failure)\))?$/) {
+        $cur{description} = $1;
+        $cur{expect_failure} = $2;
+    } elsif ($test_ln =~ /^#\s([0-1])$/) {
+        my $st = $1;
+        my $normalized;
+        if ($cur{expect_failure}) {
+            if ($st) {
+                $normalized = "# ok $test_idx $cur{description}";
+            } else {
+                $normalized = "# not ok $test_idx $cur{description}";
+            }
+        } else {
+            if ($st) {
+                $normalized = "# not ok $test_idx $cur{description}";
+            } else {
+                $normalized = "# ok $test_idx $cur{description}";
+            }
+        }
+        $test_idx++;
+        return $normalized;
+    }
+    return undef;
+}
+
+1;

--- a/lib/Kselftests/parsers/bpf/test_tcpnotify_user.pm
+++ b/lib/Kselftests/parsers/bpf/test_tcpnotify_user.pm
@@ -1,0 +1,24 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Parser for the bpf:test_tcpnotify_user selftest
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package Kselftests::parsers::bpf::test_tcpnotify_user;
+
+use base 'Kselftests::parsers::main';
+use testapi;
+use strict;
+use warnings;
+
+sub parse_line {
+    my ($self, $test_ln) = @_;
+    if ($test_ln =~ /# PASSED!/) {
+        return "# ok 1 test_tcpnotify_user";
+    }
+    return undef;
+}
+
+1;

--- a/lib/Kselftests/parsers/bpf/test_verifier.pm
+++ b/lib/Kselftests/parsers/bpf/test_verifier.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Parser for the bpf:test_verifier selftest
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package Kselftests::parsers::bpf::test_verifier;
+
+use base 'Kselftests::parsers::main';
+use testapi;
+use strict;
+use warnings;
+
+our $test_idx = 1;
+
+sub parse_line {
+    my ($self, $test_ln) = @_;
+    if ($test_ln =~ /^#\s#\S*\s(.*)\s(SKIP|FAIL|OK)$/) {
+        my ($description, $st) = ($1, $2);
+        my $normalized;
+        if ($st eq 'OK') {
+            $normalized = "# ok $test_idx $description";
+        } elsif ($st eq 'FAIL') {
+            $normalized = "# not ok $test_idx $description";
+        } else {
+            $normalized = "# ok $test_idx $description # SKIP";
+        }
+        $test_idx++;
+        return $normalized;
+    }
+    return undef;
+}
+
+1;

--- a/lib/Kselftests/parsers/bpf/test_xdping_sh.pm
+++ b/lib/Kselftests/parsers/bpf/test_xdping_sh.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Parser for the bpf:test_xdping.sh selftest
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package Kselftests::parsers::bpf::test_xdping_sh;
+
+use base 'Kselftests::parsers::main';
+use testapi;
+use strict;
+use warnings;
+
+our $test_idx = 1;
+
+sub parse_line {
+    my ($self, $test_ln) = @_;
+    if ($test_ln =~ /^#\sTest\s(.*):\s(PASS)$/) {
+        my $diagnostic = $1;
+        my $normalized = "# ok $test_idx # $diagnostic";
+        $test_idx++;
+        return $normalized;
+    }
+    return undef;
+}
+
+1;

--- a/lib/Kselftests/parsers/net/l2tp_sh.pm
+++ b/lib/Kselftests/parsers/net/l2tp_sh.pm
@@ -3,7 +3,7 @@
 # Copyright 2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: Parser for the net:l2tp.sh subtest
+# Summary: Parser for the net:l2tp.sh selftest
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
 package Kselftests::parsers::net::l2tp_sh;

--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -75,7 +75,7 @@ sub post_process {
     for my $test (@tests) {
         $test_index++;
         my $test_name = $test =~ s/^\w+://r;    # Remove the $collection from it, sub . with _
-        my $sanitized_test_name = $test_name =~ s/\./_/gr;    # Dots should be underscore for better handling in Perl and YAML files
+        my $sanitized_test_name = $test_name =~ s/\.|-/_/gr;    # Dots and hyphens should be underscore for better handling in Perl and YAML files
 
         # Check test result in the summary
         my $summary_ln;

--- a/tests/kernel/run_kselftests.pm
+++ b/tests/kernel/run_kselftests.pm
@@ -38,6 +38,7 @@ sub run {
 
     # At this point, CWD has the file 'kselftest-list.txt' listing all the available tests
     my @all_tests = split(/\n/, script_output("./run_kselftest.sh --list | grep '^$collection'"));
+    record_info("Available Tests", join("\n", @all_tests));
 
     # Filter which tests will run using KSELFTEST_TESTS
     my @tests = @{get_var_array('KSELFTEST_TESTS')};
@@ -46,6 +47,7 @@ sub run {
     # Filter which tests will *NOT* run using KSELFTEST_SKIP
     my @skip = map { s/^\s+|\s+$//gr } @{get_var_array('KSELFTEST_SKIP')};
     if (@skip) {
+        record_info("Skipping Tests", join("\n", @skip));
         my %skip = map { $_ => 1 } @skip;
         # Remove tests that are in @skip
         @tests = grep { !$skip{$_} } @tests;
@@ -54,8 +56,10 @@ sub run {
     # Run specific tests if the arrays have different lengths
     my $tests = '';
     if (@tests == @all_tests) {
+        record_info("Running Collection", $collection);
         $tests = "--collection $collection";
     } else {
+        record_info("Running Tests", join("\n", @tests));
         $tests .= "--test $_ " for @tests;
     }
 


### PR DESCRIPTION
Add the post-processing parsers for BPF.

- Related ticket: https://progress.opensuse.org/issues/157186
- Verification run: https://rmarliere-openqa.qe.prg2.suse.org/tests/1528
