### PR TITLE
Add missed including for is_ppc64le

### DIFF
--- a/lib/Distribution/Opensuse/Leap/16Latest.pm
+++ b/lib/Distribution/Opensuse/Leap/16Latest.pm
@@ -17,6 +17,7 @@ use Yam::Agama::Pom::GrubMenuLeapPage;
 use Yam::Agama::Pom::GrubMenuAgamaPage;
 use Yam::Agama::Pom::GrubMenuAgamaDeprecatedEntryOrderPage;
 use testapi qw(record_soft_failure);
+use Utils::Architectures qw(is_ppc64le);
 
 sub get_grub_menu_installed_system {
     my $self = shift;

--- a/lib/Distribution/Sle/16Latest.pm
+++ b/lib/Distribution/Sle/16Latest.pm
@@ -17,6 +17,7 @@ use Yam::Agama::Pom::GrubMenuSlesPage;
 use Yam::Agama::Pom::GrubMenuAgamaPage;
 use Yam::Agama::Pom::GrubMenuAgamaDeprecatedEntryOrderPage;
 use testapi qw(record_soft_failure);
+use Utils::Architectures qw(is_ppc64le);
 
 sub get_grub_menu_installed_system {
     my $self = shift;


### PR DESCRIPTION

- Related ticket: N/A
- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/23047
- Needles:  N/A
- Verification run: 
 Sle development power 10 kvm: https://openqa.suse.de/tests/18913903#step/agama/11
 Leap ppc64le: https://openqa.opensuse.org/tests/5262095#live
