### PR TITLE
Don't define reg_url if SCC is used for Agama install

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -192,9 +192,13 @@ sub set_bootscript_agama_cmdline_extra {
         $agama_install_url =~ s/^\s+|\s+$//g;
         $cmdline_extra .= "inst.install_url=$agama_install_url ";
     }
-    # Add register URL
-    if (my $register_url = get_var('SCC_URL')) {
-        $cmdline_extra .= "inst.register_url=$register_url ";
+    # Add register URL, we don't need to register the system in case:
+    #   1. Any install repos are used
+    #   2. Register the system via scc, see https://bugzilla.suse.com/show_bug.cgi?id=1246600
+    unless (get_var('INST_INSTALL_URL')) {
+        if (my $register_url = get_var('SCC_URL')) {
+            $cmdline_extra .= "inst.register_url=$register_url " unless $register_url =~ /https:\/\/scc.suse.com/;
+        }
     }
     if (is_ipmi) {
         my $ipxe_console = get_required_var('IPXE_CONSOLE');


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1246600

- Verification run: 
https://openqa.suse.de/tests/18915252 [Please ignore the failed module, it is known issue]

- Regression [ with proxy scc]
https://openqa.suse.de/tests/18915415

-----------------------------------------------------------------------------
See the kernel command line during the installation:

`
linux root=live:http://openqa.suse.de/assets/iso/SLES-16.0-Online-x86_64-Build129.5.install.iso live.password=nots3cr3t inst.auto=http://worker36.oqa.prg2.suse.org:20603/KygwbobHyN8_yYG7/files/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet inst.finish=stop console=ttyS1,115200 linuxrc.log=/dev/ttyS1 linuxrc.core=/dev/ttyS1 linuxrc.debug=4,trace
`

Regression:

`kernel http://openqa.suse.de/assets/repo/SLES-16.0-Online-x86_64-Build129.5.install/boot/x86_64/loader/linux root=live:http://openqa.suse.de/assets/iso/SLES-16.0-Online-x86_64-Build129.5.install.iso live.password=nots3cr3t  inst.auto=http://worker36.oqa.prg2.suse.org:20633/CF_hX6lTLmklOB8N/files/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet inst.finish=stop inst.register_url=http://all-129.5.proxy.scc.suse.de/ console=ttyS1,115200 linuxrc.log=/dev/ttyS1 linuxrc.core=/dev/ttyS1 linuxrc.debug=4,trace`