### PR TITLE
New installation method for .tar.xz images

### DIFF
--- a/tests/wsl/distro_install.pm
+++ b/tests/wsl/distro_install.pm
@@ -10,6 +10,7 @@ use Mojo::Base "windowsbasetest";
 use testapi;
 use version_utils;
 use Utils::Architectures 'is_aarch64';
+use utils qw(enter_cmd_slow);
 
 sub install_certificates {
     my ($self) = @_;
@@ -54,23 +55,35 @@ sub run {
     if ($install_from eq 'build') {
         # We can use WSL_CUSTOM_IMAGE var to provide a custom URL to download a
         # different image from the ASSET_1 provided via IBS
-        my $wsl_appx_uri = get_var('WSL_CUSTOM_IMAGE', data_url('ASSET_1'));
-        my $wsl_appx_filename = (split /\//, $wsl_appx_uri)[-1];
+        my $wsl_image_uri = get_var('WSL_CUSTOM_IMAGE', data_url('ASSET_1'));
+        my $wsl_image_filename = (split /\//, $wsl_image_uri)[-1];
+        my $wsl_image_ext = (split /\./, $wsl_image_filename)[-1];
+        die("The image provided is not in .appx neither .tar.xz format.\nImage extension: $wsl_image_ext")
+          unless ($wsl_image_ext =~ /^(appx|xz)$/);
         # Enable the 'developer mode' in Windows
         $self->run_in_powershell(
             cmd => 'New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" -Name AllowDevelopmentWithoutDevLicense -PropertyType DWORD -Value 1'
-        );
-        $self->run_in_powershell(
-            cmd => "Start-BitsTransfer -Source $wsl_appx_uri -Destination C:\\\\$wsl_appx_filename",
-            timeout => 60
         );
 
         $self->install_certificates;
 
         $self->run_in_powershell(
-            cmd => "Add-AppxPackage -Path C:\\$wsl_appx_filename",
+            cmd => "Start-BitsTransfer -Source $wsl_image_uri -Destination C:\\\\$wsl_image_filename",
             timeout => 60
         );
+        # Select the installation method based on the file extension
+        if ($wsl_image_ext eq 'appx') {
+            $self->run_in_powershell(
+                cmd => "Add-AppxPackage -Path C:\\$wsl_image_filename",
+                timeout => 60
+            );
+        } elsif ($wsl_image_ext eq 'xz') {
+            $self->run_in_powershell(cmd => "mkdir C:\\$WSL_version");
+            $self->run_in_powershell(
+                cmd => "wsl --import $WSL_version C:\\$WSL_version C:\\$wsl_image_filename",
+                timeout => 60
+            );
+        }
         $self->close_powershell;
         $self->use_search_feature($WSL_version =~ s/\-/\ /gr);
         assert_and_click 'wsl-suse-startup-search';


### PR DESCRIPTION
As stated by developers, Microsoft is deprecating the .appx format in favor of .tar.xz. These new images are already being uploaded to the Microsoft Store and are what we've been referring to as "modern" images.

The aim of this ticket is to formalize a new, tested procedure for extracting and installing future .tar.xz images when needed. This method has been verified locally and is a straightforward, three-step process.

- Related ticket: https://progress.opensuse.org/issues/187728
- Verification runs:
  - [SLE .tar.xz](https://openqa.suse.de/tests/18944338#step/distro_install/23)
  - [SLE .appx](https://openqa.suse.de/tests/18961861#step/distro_install/21)
  - [SLE wrong extension](https://openqa.suse.de/tests/18943869#step/distro_install/14)
  - [TW x86_64 .tar.xz](https://openqa.opensuse.org/tests/5271775#step/distro_install/23)
  - [TW aarch64 .tar.xz](https://openqa.opensuse.org/tests/5271845#step/distro_install/22)
