### PR TITLE
bci: Install python3 module only on SLES 15-SP{4..7}

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -60,7 +60,7 @@ sub prepare_virtual_env {
             @packages = ('jq');
             # PackageHub is needed for jq
             script_retry("SUSEConnect -p PackageHub/12.5/$arch", delay => 60, retry => 3, timeout => $scc_timeout);
-        } elsif ($version !~ /15\.[1-3]/) {
+        } elsif ($version =~ /15\.[4-7]/) {
             $python = 'python3.11';
             script_retry("SUSEConnect -p sle-module-python3/$version/$arch", delay => 60, retry => 3, timeout => $scc_timeout) unless ($host_distri =~ /opensuse/);
             push @packages, qw(git-core python311);

--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -48,6 +48,9 @@ sub prepare_virtual_env {
         script_retry("apt-get -y install python3-venv", timeout => $install_timeout);
     } elsif ($host_distri =~ /centos|rhel/) {
         script_retry("dnf install -y --allowerasing git-core python3 jq", timeout => $install_timeout);
+    } elsif ($host_distri =~ /micro/) {
+        trup_call('pkg in skopeo tar git jq');
+        reboot_on_changes;
     } elsif ($host_distri =~ /opensuse|sles/) {
         my @packages = ('jq', 'skopeo');
         # Avoid PackageKit to conflict about lock with zypper
@@ -66,9 +69,6 @@ sub prepare_virtual_env {
             push @packages, qw(git-core python311);
         }
         zypper_call("--quiet in " . join(' ', @packages), timeout => $install_timeout);
-    } elsif ($host_distri =~ /micro/) {
-        trup_call('pkg in skopeo tar git jq');
-        reboot_on_changes;
     } else {
         die("Host is not supported for running BCI tests.");
     }


### PR DESCRIPTION
Install python3 module only on SLES 15-SP{4..7}.  SLE 16 dropped the concept of modules.

Failing job: https://openqa.suse.de/tests/18918231#step/bci_prepare/26
Verification run:
- SLES 15-SP7: https://openqa.suse.de/tests/18919566
- SLES 16.0: https://openqa.suse.de/tests/18918793

NOTE: VR failing at:
https://openqa.suse.de/tests/18918793#step/bci_prepare/34
`# Test died: 'zypper -n --quiet in jq skopeo' failed with code 5`
