### PR TITLE
Revert "Enable BCI tests in sle-micro hosts"

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -106,7 +106,7 @@ sub install_docker_multiplatform {
     }
 
     my $pkg_name = check_var("CONTAINERS_DOCKER_FLAVOUR", "stable") ? "docker-stable" : "docker";
-    if (is_transactional || $host_os =~ /micro/i) {
+    if (is_transactional) {
         select_serial_terminal;
         trup_call("pkg install $pkg_name");
         check_reboot_changes;

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -44,8 +44,7 @@ sub load_config_tests {
     loadtest 'transactional/enable_selinux' if (get_var('ENABLE_SELINUX') && is_image);
     loadtest 'console/suseconnect_scc' if (get_var('SCC_REGISTER') && !is_dvd);
     loadtest 'transactional/install_updates' if (is_sle_micro && is_released);
-    loadtest 'transactional/install_k3s' if (get_var('CONTAINER_UPDATE_HOST') && is_sle_micro('6.0+') && (is_x86_64 || is_aarch64));
-    loadtest 'containers/bci_prepare' if (get_var('CONTAINER_UPDATE_HOST') && get_var('BCI_PREPARE'));
+    loadtest 'transactional/install_k3s' if (is_sle_micro('6.0+') && (is_x86_64 || is_aarch64));
 }
 
 sub load_boot_from_disk_tests {

--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -21,7 +21,7 @@ use serial_terminal 'select_serial_terminal';
 use containers::utils qw(reset_container_network_if_needed);
 use File::Basename;
 use utils qw(systemctl);
-use version_utils qw(get_os_release check_version is_sle);
+use version_utils qw(get_os_release check_version);
 
 my $error_count;
 
@@ -33,7 +33,7 @@ sub skip_testrun {
     return 1 unless get_var('BCI_TESTS');
 
     # Skip Spack on SLES12-SP5 (https://bugzilla.suse.com/show_bug.cgi?id=1224345)
-    return 1 if (check_var('BCI_IMAGE_NAME', 'spack') && is_sle && check_version('<15', get_required_var('HOST_VERSION')));
+    return 1 if (check_var('BCI_IMAGE_NAME', 'spack') && check_version('<15', get_required_var('HOST_VERSION')));
 
     # Skip Kiwi on RES, CentOS, Ubuntu
     my $bci_image_name = get_var('BCI_IMAGE_NAME');


### PR DESCRIPTION
Revert https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/23021

There are multiple issues:
- The concept of modules is not enabled on SLE 16.0: https://openqa.suse.de/tests/18918231#step/bci_prepare/26
- skopeo is not available in SLEM < 5.5: https://openqa.suse.de/tests/18918216#step/bci_prepare/20
- git (should be git-core) is also not available in SLEM < 5.5 

I tried to address them with https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/23091 without luck.