### PR TITLE
containers/podman-py: python3-podman is not available on SLES

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -183,8 +183,9 @@ sub load_host_tests_podman {
     load_compose_tests($run_args);
     loadtest('containers/seccomp', run_args => $run_args, name => $run_args->{runtime} . "_seccomp") unless is_sle('<15');
     loadtest('containers/isolation', run_args => $run_args, name => $run_args->{runtime} . "_isolation") unless (is_public_cloud || is_transactional);
+    # python3-podman is not available on SLES - https://bugzilla.suse.com/show_bug.cgi?id=1248415
     unless (is_jeos || is_staging || is_transactional || get_var("OCI_RUNTIME")) {
-        loadtest('containers/python_runtime', run_args => $run_args, name => "python_podman") if ((is_tumbleweed || is_sle(">=16")) && (is_aarch64 || is_x86_64));
+        loadtest('containers/python_runtime', run_args => $run_args, name => "python_podman") if (is_tumbleweed && (is_aarch64 || is_x86_64));
     }
     loadtest('containers/podmansh') if (is_tumbleweed && !is_staging && !is_transactional);
 }


### PR DESCRIPTION
python3-podman is not available on SLES due to https://bugzilla.suse.com/show_bug.cgi?id=1248415