### PR TITLE
Setup a host bridge on sles16 with the enhancement

### DIFF
--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -77,7 +77,11 @@ sub create_host_bridge_nm {
         script_output($download_script, $wait_script, type_command => 0, proceed_on_failure => 0);
         my $execute_script = "chmod +x ~/$script_name && python3 ~/$script_name";
         script_output($execute_script, $wait_script, type_command => 0, proceed_on_failure => 0);
-        record_info("Create a Host Bridge Network Interface - $host_bridge for sles16", script_output("ip a"));
+        save_screenshot;
+        # Re-establish the SSH connection, poo#187197
+        reset_consoles;
+        select_console('root-ssh');
+        record_info("Create a Host Bridge Network Interface - $host_bridge for sles16", script_output("ip a", proceed_on_failure => 1, timeout => 60));
     }
 }
 


### PR DESCRIPTION
Set up a host bridge on SLES16 with the enhancement

- Related ticket: https://progress.opensuse.org/issues/187197
- Verification run:
kermit [uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/18941941#step/prepare_non_transactional_server/55) pass
bare-metal6[uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/18934181#step/prepare_non_transactional_server/51) pass
