### PR TITLE
Open powershell after removing welcome_to_wsl popup

### DIFF
--- a/tests/wsl/smoke_test.pm
+++ b/tests/wsl/smoke_test.pm
@@ -26,9 +26,10 @@ sub run {
     elsif (match_has_tag('welcome_to_wsl')) {
         click_lastmatch;
         send_key 'alt-f4';
-        if (check_var('WSL_FIRSTBOOT', 'yast')) {   
+        # We need to re-open powershell for o3 yast-firstrun scenario
+        if (check_var('WSL_FIRSTBOOT', 'yast')) {
             $self->open_powershell_as_admin;
-        }    
+        }
     }
     $self->run_in_powershell(cmd => 'wsl --list --verbose', timeout => 60);
     $self->run_in_powershell(cmd => "wsl mount | Select-String -Pattern $expected{mount}", timeout => 60);


### PR DESCRIPTION
We need to find the cases where powershell has to be opened again after closing welcome_to_wsl popup and the cases where this should not happen.



- Related ticket: https://progress.opensuse.org/issues/187737 and https://progress.opensuse.org/issues/187470

- Verification run: 

Leap:
wsl_main win 11: https://openqa.opensuse.org/tests/5267129
wsl2_main win 11: https://openqa.opensuse.org/tests/5267131
modern jeos-firstrun win11: https://openqa.opensuse.org/tests/5267134

TW:
wsl2_main win 11: https://openqa.opensuse.org/tests/5267132
modern jeos-firstrun win11: https://openqa.opensuse.org/tests/5267136

SLE:
modern jeos-firstrun win11 sp6: https://openqa.suse.de/tests/18932695 
modern jeos-firstrun win 11 sp7: https://openqa.suse.de/tests/18932696
wsl2_main + register win 11 sp7: https://openqa.suse.de/tests/18932834
