### PR TITLE
Introduce context object in ipaddr2

### DIFF
--- a/lib/sles4sap/cloud_zypper_patch.pm
+++ b/lib/sles4sap/cloud_zypper_patch.pm
@@ -13,8 +13,9 @@ use Carp qw(croak);
 use Exporter qw(import);
 use Mojo::JSON qw( decode_json );
 use mmapi qw(get_current_job_id);
-use sles4sap::azure_cli;
 use publiccloud::utils qw(get_ssh_private_key_path);
+use sles4sap::azure_cli;
+use sles4sap::ibsm;
 
 
 =head1 SYNOPSIS
@@ -180,26 +181,10 @@ sub zp_azure_netpeering {
     my (%args) = @_;
     croak('Argument < target_rg > missing') unless $args{target_rg};
 
-    my $rg = zp_azure_resource_group();
-
-    my $target_vnet = az_network_vnet_get(resource_group => $args{target_rg});
-    my $target_vnet_name = @$target_vnet[0];
-
-    az_network_peering_create(
-        name => join('-', $rg, $vnet, $target_vnet_name),
-        source_rg => $rg,
-        source_vnet => $vnet,
-        target_rg => $args{target_rg},
-        target_vnet => $target_vnet_name);
-    az_network_peering_create(
-        name => zp_ibsm2sut_peering_name(target_rg => $args{target_rg}, target_vnet_name => $target_vnet_name),
-        source_rg => $args{target_rg},
-        source_vnet => $target_vnet_name,
-        target_rg => $rg,
-        target_vnet => $vnet);
-
-    az_network_peering_list(resource_group => $rg, vnet => $vnet);
-    az_network_peering_list(resource_group => $args{target_rg}, vnet => $target_vnet_name);
+    ibsm_network_peering_azure_create(
+        ibsm_rg => $args{target_rg},
+        sut_rg => zp_azure_resource_group(),
+        name_prefix => DEPLOY_PREFIX);
 }
 
 =head2 zp_ssh_connect

--- a/lib/sles4sap/qesap/aws.pm
+++ b/lib/sles4sap/qesap/aws.pm
@@ -463,7 +463,7 @@ sub qesap_aws_vnet_peering {
         return 0;
     }
 
-    # For qe-sap-deployment this one match or contain the Terraform deloyment_name
+    # For qe-sap-deployment this one match or contain the Terraform deployment_name
     my $vpc_tag_name = qesap_aws_get_vpc_workspace(vpc_id => $args{vpc_id});
     unless ($vpc_tag_name) {
         record_info('AWS PEERING', 'Empty vpc_tag_name');

--- a/tests/sles4sap/cloud_netconfig/deploy.pm
+++ b/tests/sles4sap/cloud_netconfig/deploy.pm
@@ -17,7 +17,7 @@ single network interface.
 
 The created resources include:
 
-=over 4
+=over
 
 =item * A virtual machine (VM) to host the test.
 
@@ -27,7 +27,7 @@ The created resources include:
 
 =item * Three IP configurations associated with the single NIC:
 
-=over 2
+=over
 
 =item - The primary IP configuration with a public IP address.
 
@@ -43,7 +43,7 @@ The created resources include:
 
 =head1 VARIABLES
 
-=over 4
+=over
 
 =item B<PUBLIC_CLOUD_PROVIDER>
 

--- a/tests/sles4sap/ipaddr2/cluster_create.pm
+++ b/tests/sles4sap/ipaddr2/cluster_create.pm
@@ -59,7 +59,6 @@ use testapi;
 use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
   ipaddr2_configure_web_server
-  ipaddr2_bastion_pubip
   ipaddr2_cluster_create
   ipaddr2_cluster_check_version
   ipaddr2_cleanup);
@@ -72,15 +71,12 @@ sub run {
 
     select_serial_terminal;
 
-    my $bastion_ip = ipaddr2_bastion_pubip();
-
     # Check if cloudinit is active or not. In case it is,
     # registration was eventually there and no need to per performed here.
     if (check_var('IPADDR2_CLOUDINIT', 0)) {
         record_info("TEST STAGE", "Install the web server");
         my %web_install_args;
         $web_install_args{external_repo} = get_var('IPADDR2_NGINX_EXTREPO') if get_var('IPADDR2_NGINX_EXTREPO');
-        $web_install_args{bastion_ip} = $bastion_ip;
         foreach (1 .. 2) {
             $web_install_args{id} = $_;
             ipaddr2_configure_web_server(%web_install_args);
@@ -90,9 +86,7 @@ sub run {
     record_info("TEST STAGE", "Init and configure the Pacemaker cluster");
 
     ipaddr2_cluster_check_version();
-    ipaddr2_cluster_create(
-        bastion_ip => $bastion_ip,
-        rootless => get_var('IPADDR2_ROOTLESS', '0'));
+    ipaddr2_cluster_create(rootless => get_var('IPADDR2_ROOTLESS', '0'));
 }
 
 sub test_flags {

--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -75,6 +75,7 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
+  ipaddr2_context_create
   ipaddr2_cloudinit_create
   ipaddr2_infra_deploy
   ipaddr2_deployment_sanity
@@ -107,6 +108,9 @@ sub run {
     } else {
         $os = $provider->get_image_id();
     }
+
+    # This call will create the context
+    ipaddr2_context_create(slot => get_var('WORKER_ID'));
 
     my %cloudinit_args;
     # This line of code is not really specific to cloud-init,

--- a/tests/sles4sap/ipaddr2/sanity_cluster.pm
+++ b/tests/sles4sap/ipaddr2/sanity_cluster.pm
@@ -57,7 +57,6 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
-  ipaddr2_bastion_pubip
   ipaddr2_cluster_sanity
   ipaddr2_cleanup);
 
@@ -69,8 +68,7 @@ sub run {
 
     select_serial_terminal;
 
-    my $bastion_ip = ipaddr2_bastion_pubip();
-    ipaddr2_cluster_sanity(bastion_ip => $bastion_ip);
+    ipaddr2_cluster_sanity();
 }
 
 sub test_flags {

--- a/tests/sles4sap/ipaddr2/sanity_os.pm
+++ b/tests/sles4sap/ipaddr2/sanity_os.pm
@@ -63,7 +63,6 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
-  ipaddr2_bastion_pubip
   ipaddr2_os_sanity
   ipaddr2_cleanup);
 
@@ -75,11 +74,9 @@ sub run {
 
     select_serial_terminal;
 
-    my $bastion_ip = ipaddr2_bastion_pubip();
-
     # Default for ipaddr2_os_sanity is cloudadmin.
     # It has to know about it to decide which ssh are expected in internal VMs
-    my %sanity_args = (bastion_ip => $bastion_ip);
+    my %sanity_args;
     $sanity_args{user} = 'root' unless check_var('IPADDR2_ROOTLESS', '1');
     ipaddr2_os_sanity(%sanity_args);
 }

--- a/tests/sles4sap/ipaddr2/test_move_resource.pm
+++ b/tests/sles4sap/ipaddr2/test_move_resource.pm
@@ -50,7 +50,6 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
-  ipaddr2_bastion_pubip
   ipaddr2_crm_clear
   ipaddr2_crm_move
   ipaddr2_os_connectivity_sanity
@@ -67,8 +66,6 @@ sub run {
 
     select_serial_terminal;
 
-    my $bastion_ip = ipaddr2_bastion_pubip();
-
     # 1. get the webpage using the LB floating IP. It should be from VM1 at the test beginning
     # 2. move the cluster resource on the VM2
     # 3. get the webpage using the LB floating IP. It should be from VM2
@@ -78,45 +75,45 @@ sub run {
     # the load balancer entity in Azure is notified about the move
     # and should change the routing from the frontend IP to the
     # backend IP of the VM-02
-    ipaddr2_crm_move(bastion_ip => $bastion_ip, destination => 2);
+    ipaddr2_crm_move(destination => 2);
     sleep 30;
 
     # probe the webserver using the frontend IP
     # until the reply come from the VM-02
-    die "Takeover does not happens in time" unless ipaddr2_wait_for_takeover(bastion_ip => $bastion_ip, destination => 2);
+    die "Takeover does not happens in time" unless ipaddr2_wait_for_takeover(destination => 2);
 
     ipaddr2_os_connectivity_sanity();
 
     # Check the status on the VM that is supposed to be
     # the master for the webservice
-    ipaddr2_test_master_vm(bastion_ip => $bastion_ip, id => 2);
-    ipaddr2_test_other_vm(bastion_ip => $bastion_ip, id => 1);
+    ipaddr2_test_master_vm(id => 2);
+    ipaddr2_test_other_vm(id => 1);
 
     # Slow down, take a break, then check again, nothing should be changed.
     sleep 60;
     ipaddr2_os_connectivity_sanity();
-    ipaddr2_test_master_vm(bastion_ip => $bastion_ip, id => 2);
-    ipaddr2_test_other_vm(bastion_ip => $bastion_ip, id => 1);
+    ipaddr2_test_master_vm(id => 2);
+    ipaddr2_test_other_vm(id => 1);
 
     # Repeat the same but this time from VM-02 to VM-01
     #test_step "Move back the IpAddr2 resource to VM1"
-    ipaddr2_crm_move(bastion_ip => $bastion_ip, destination => 1);
+    ipaddr2_crm_move(destination => 1);
     sleep 30;
 
-    die "Takeover does not happens in time" unless ipaddr2_wait_for_takeover(bastion_ip => $bastion_ip, destination => 1);
+    die "Takeover does not happens in time" unless ipaddr2_wait_for_takeover(destination => 1);
 
     ipaddr2_os_connectivity_sanity();
-    ipaddr2_test_master_vm(bastion_ip => $bastion_ip, id => 1);
-    ipaddr2_test_other_vm(bastion_ip => $bastion_ip, id => 2);
+    ipaddr2_test_master_vm(id => 1);
+    ipaddr2_test_other_vm(id => 2);
 
     # Slow down, take a break, then check again, nothing should be changed.
     sleep 60;
     ipaddr2_os_connectivity_sanity();
-    ipaddr2_test_master_vm(bastion_ip => $bastion_ip, id => 1);
-    ipaddr2_test_other_vm(bastion_ip => $bastion_ip, id => 2);
+    ipaddr2_test_master_vm(id => 1);
+    ipaddr2_test_other_vm(id => 2);
 
     # Clear all location constrain used during the test
-    ipaddr2_crm_clear(bastion_ip => $bastion_ip);
+    ipaddr2_crm_clear();
 }
 
 sub test_flags {


### PR DESCRIPTION
The ipaddr2 library has been refactored to use a context object for managing deployment-specific information. This change addresses the issues like repeatedly passing the bastion_ip as an argument to numerous functions. The context structure contains the following keys:
- main_address_range: address range for the vnet
- subnet_address_range: address range for the subnet
- priv_ip_range: private IP range
- frontend_ip: internal IP used as frontend IP to expose the web server through the LB
- bastion_ip: public IP of the bastion host Refactoring of existing functions to utilize
the context object, removing the need for the bastion_ip argument. Removal of the get_private_ip_range function, with its logic integrated into ipaddr2_context_create.

- Related ticket: 

# Verification run:

sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-ipaddr2_azure_test
 - http://openqaworker15.qa.suse.cz/tests/339202
 - http://openqaworker15.qa.suse.cz/tests/339203