### PR TITLE
Enable docker-py tests on SLES 15-SP4+

### DIFF
--- a/data/containers/patches/docker-py/3199.patch
+++ b/data/containers/patches/docker-py/3199.patch
@@ -1,0 +1,54 @@
+From 2a5f354b502fe0624239f8b2607cc624857027cb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pawe=C5=82=20Gronowski?= <pawel.gronowski@docker.com>
+Date: Fri, 15 Dec 2023 10:40:27 +0100
+Subject: [PATCH] Bump default API version to 1.43 (Moby 24.0)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>
+---
+ Makefile                  | 4 ++--
+ docker/constants.py       | 2 +-
+ tests/Dockerfile-ssh-dind | 4 ++--
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 79486e3ec2..00ebca05ce 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,5 @@
+-TEST_API_VERSION ?= 1.41
+-TEST_ENGINE_VERSION ?= 20.10
++TEST_API_VERSION ?= 1.43
++TEST_ENGINE_VERSION ?= 24.0
+ 
+ ifeq ($(OS),Windows_NT)
+     PLATFORM := Windows
+diff --git a/docker/constants.py b/docker/constants.py
+index ed341a9020..71e543e530 100644
+--- a/docker/constants.py
++++ b/docker/constants.py
+@@ -1,7 +1,7 @@
+ import sys
+ from .version import __version__
+ 
+-DEFAULT_DOCKER_API_VERSION = '1.41'
++DEFAULT_DOCKER_API_VERSION = '1.43'
+ MINIMUM_DOCKER_API_VERSION = '1.21'
+ DEFAULT_TIMEOUT_SECONDS = 60
+ STREAM_HEADER_SIZE_BYTES = 8
+diff --git a/tests/Dockerfile-ssh-dind b/tests/Dockerfile-ssh-dind
+index 0da15aa40f..2b7332b8b6 100644
+--- a/tests/Dockerfile-ssh-dind
++++ b/tests/Dockerfile-ssh-dind
+@@ -1,7 +1,7 @@
+ # syntax=docker/dockerfile:1
+ 
+-ARG API_VERSION=1.41
+-ARG ENGINE_VERSION=20.10
++ARG API_VERSION=1.43
++ARG ENGINE_VERSION=24.0
+ 
+ FROM docker:${ENGINE_VERSION}-dind
+ 

--- a/data/containers/patches/docker-py/3203.patch
+++ b/data/containers/patches/docker-py/3203.patch
@@ -1,0 +1,44 @@
+From 0fad869cc62829b6e51898dc8e2ca0832aec6d43 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pawe=C5=82=20Gronowski?= <pawel.gronowski@docker.com>
+Date: Tue, 19 Dec 2023 10:25:34 +0100
+Subject: [PATCH] integration/commit: Don't check for deprecated fields
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Container related Image fields (`Container` and `ContainerConfig`) will
+be deprecated in API v1.44 and will be removed in v1.45.
+
+Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>
+---
+ tests/integration/api_image_test.py | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/tests/integration/api_image_test.py b/tests/integration/api_image_test.py
+index 7081b53b8f..5c37219581 100644
+--- a/tests/integration/api_image_test.py
++++ b/tests/integration/api_image_test.py
+@@ -85,13 +85,8 @@ def test_commit(self):
+         img_id = res['Id']
+         self.tmp_imgs.append(img_id)
+         img = self.client.inspect_image(img_id)
+-        assert 'Container' in img
+-        assert img['Container'].startswith(id)
+-        assert 'ContainerConfig' in img
+-        assert 'Image' in img['ContainerConfig']
+-        assert TEST_IMG == img['ContainerConfig']['Image']
+-        busybox_id = self.client.inspect_image(TEST_IMG)['Id']
+         assert 'Parent' in img
++        busybox_id = self.client.inspect_image(TEST_IMG)['Id']
+         assert img['Parent'] == busybox_id
+ 
+     def test_commit_with_changes(self):
+@@ -103,8 +98,6 @@ def test_commit_with_changes(self):
+         )
+         self.tmp_imgs.append(img_id)
+         img = self.client.inspect_image(img_id)
+-        assert 'Container' in img
+-        assert img['Container'].startswith(cid['Id'])
+         assert '8000/tcp' in img['Config']['ExposedPorts']
+         assert img['Config']['Cmd'] == ['bash']
+ 

--- a/data/containers/patches/docker-py/3206.patch
+++ b/data/containers/patches/docker-py/3206.patch
@@ -1,0 +1,170 @@
+From af365676477c00c6d1133c6de1e11ecd1d8f602a Mon Sep 17 00:00:00 2001
+From: Aarni Koskela <akx@iki.fi>
+Date: Thu, 21 Dec 2023 10:27:32 +0200
+Subject: [PATCH 1/2] Update Ruff, simplify condition flagged by it
+
+Signed-off-by: Aarni Koskela <akx@iki.fi>
+---
+ .github/workflows/ci.yml    | 2 +-
+ docker/models/containers.py | 6 +++---
+ test-requirements.txt       | 2 +-
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 127d5b6822..628c53504a 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -14,7 +14,7 @@ jobs:
+             - uses: actions/setup-python@v4
+               with:
+                   python-version: '3.x'
+-            - run: pip install -U ruff==0.0.284
++            - run: pip install -U ruff==0.1.8
+             - name: Run ruff
+               run: ruff docker tests
+ 
+diff --git a/docker/models/containers.py b/docker/models/containers.py
+index 4725d6f6fb..32676bb852 100644
+--- a/docker/models/containers.py
++++ b/docker/models/containers.py
+@@ -903,9 +903,9 @@ def run(self, image, command=None, stdout=True, stderr=False,
+                 container, exit_status, command, image, out
+             )
+ 
+-        return out if stream or out is None else b''.join(
+-            [line for line in out]
+-        )
++        if stream or out is None:
++            return out
++        return b''.join(out)
+ 
+     def create(self, image, command=None, **kwargs):
+         """
+diff --git a/test-requirements.txt b/test-requirements.txt
+index 031d0acf0a..2c0e3622c6 100644
+--- a/test-requirements.txt
++++ b/test-requirements.txt
+@@ -1,6 +1,6 @@
+ setuptools==65.5.1
+ coverage==7.2.7
+-ruff==0.0.284
++ruff==0.1.8
+ pytest==7.4.2
+ pytest-cov==4.1.0
+ pytest-timeout==2.1.0
+
+From aa9c066b8d67f0536f43920cbbd44c7208d40113 Mon Sep 17 00:00:00 2001
+From: Aarni Koskela <akx@iki.fi>
+Date: Thu, 21 Dec 2023 10:28:46 +0200
+Subject: [PATCH 2/2] Correct Ruff target version, enable UP, autofix
+
+Signed-off-by: Aarni Koskela <akx@iki.fi>
+---
+ docker/utils/socket.py              | 4 ++--
+ docker/utils/utils.py               | 2 +-
+ pyproject.toml                      | 4 +++-
+ tests/integration/api_build_test.py | 4 +---
+ tests/ssh/api_build_test.py         | 4 +---
+ tests/unit/api_test.py              | 2 +-
+ 6 files changed, 9 insertions(+), 11 deletions(-)
+
+diff --git a/docker/utils/socket.py b/docker/utils/socket.py
+index 2306ed0736..c7cb584d4f 100644
+--- a/docker/utils/socket.py
++++ b/docker/utils/socket.py
+@@ -64,7 +64,7 @@ def read_exactly(socket, n):
+     Reads exactly n bytes from socket
+     Raises SocketError if there isn't enough data
+     """
+-    data = bytes()
++    data = b""
+     while len(data) < n:
+         next_data = read(socket, n - len(data))
+         if not next_data:
+@@ -152,7 +152,7 @@ def consume_socket_output(frames, demux=False):
+     if demux is False:
+         # If the streams are multiplexed, the generator returns strings, that
+         # we just need to concatenate.
+-        return bytes().join(frames)
++        return b"".join(frames)
+ 
+     # If the streams are demultiplexed, the generator yields tuples
+     # (stdout, stderr)
+diff --git a/docker/utils/utils.py b/docker/utils/utils.py
+index 759ddd2f1a..4b3fb7cff3 100644
+--- a/docker/utils/utils.py
++++ b/docker/utils/utils.py
+@@ -152,7 +152,7 @@ def convert_volume_binds(binds):
+             ]
+             if 'propagation' in v and v['propagation'] in propagation_modes:
+                 if mode:
+-                    mode = ','.join([mode, v['propagation']])
++                    mode = f"{mode},{v['propagation']}"
+                 else:
+                     mode = v['propagation']
+ 
+diff --git a/pyproject.toml b/pyproject.toml
+index 0a67279661..a64e120eee 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -5,14 +5,16 @@ requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+ write_to = 'docker/_version.py'
+ 
+ [tool.ruff]
+-target-version = "py37"
++target-version = "py38"
+ extend-select = [
+     "B",
+     "C",
+     "F",
++    "UP",
+     "W",
+ ]
+ ignore = [
++    "UP012",  # unnecessary `UTF-8` argument (we want to be explicit)
+     "C901",  # too complex (there's a whole bunch of these)
+ ]
+ 
+diff --git a/tests/integration/api_build_test.py b/tests/integration/api_build_test.py
+index 2add2d87af..540ef2b0fb 100644
+--- a/tests/integration/api_build_test.py
++++ b/tests/integration/api_build_test.py
+@@ -389,9 +389,7 @@ def test_build_stderr_data(self):
+         lines = []
+         for chunk in stream:
+             lines.append(chunk.get('stream'))
+-        expected = '{0}{2}\n{1}'.format(
+-            control_chars[0], control_chars[1], snippet
+-        )
++        expected = f'{control_chars[0]}{snippet}\n{control_chars[1]}'
+         assert any(line == expected for line in lines)
+ 
+     def test_build_gzip_encoding(self):
+diff --git a/tests/ssh/api_build_test.py b/tests/ssh/api_build_test.py
+index d060f465f2..3b542994fc 100644
+--- a/tests/ssh/api_build_test.py
++++ b/tests/ssh/api_build_test.py
+@@ -380,9 +380,7 @@ def test_build_stderr_data(self):
+         lines = []
+         for chunk in stream:
+             lines.append(chunk.get('stream'))
+-        expected = '{0}{2}\n{1}'.format(
+-            control_chars[0], control_chars[1], snippet
+-        )
++        expected = f'{control_chars[0]}{snippet}\n{control_chars[1]}'
+         assert any(line == expected for line in lines)
+ 
+     def test_build_gzip_encoding(self):
+diff --git a/tests/unit/api_test.py b/tests/unit/api_test.py
+index 7bc2ea8cda..0ca9bbb950 100644
+--- a/tests/unit/api_test.py
++++ b/tests/unit/api_test.py
+@@ -82,7 +82,7 @@ def fake_delete(self, url, *args, **kwargs):
+ 
+ 
+ def fake_read_from_socket(self, response, stream, tty=False, demux=False):
+-    return bytes()
++    return b''
+ 
+ 
+ url_base = f'{fake_api.prefix}/'

--- a/data/containers/patches/docker-py/3231.patch
+++ b/data/containers/patches/docker-py/3231.patch
@@ -1,0 +1,141 @@
+From cb21af7f69fc44572c9f9a326c84275ae2be9c63 Mon Sep 17 00:00:00 2001
+From: Rob Murray <rob.murray@docker.com>
+Date: Wed, 13 Mar 2024 14:54:25 +0000
+Subject: [PATCH 1/3] Fix tests that look at 'Aliases'
+
+Inspect output for 'NetworkSettings.Networks.<network>.Aliases'
+includes the container's short-id (although it will be removed
+in API v1.45, in moby 26.0).
+
+Signed-off-by: Rob Murray <rob.murray@docker.com>
+---
+ tests/integration/models_containers_test.py | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/tests/integration/models_containers_test.py b/tests/integration/models_containers_test.py
+index 219b9a4cb1..87ba89b1de 100644
+--- a/tests/integration/models_containers_test.py
++++ b/tests/integration/models_containers_test.py
+@@ -110,12 +110,12 @@ def test_run_with_networking_config(self):
+         client.networks.create(net_name)
+         self.tmp_networks.append(net_name)
+ 
+-        test_aliases = ['hello']
++        test_alias = 'hello'
+         test_driver_opt = {'key1': 'a'}
+ 
+         networking_config = {
+             net_name: client.api.create_endpoint_config(
+-                aliases=test_aliases,
++                aliases=[test_alias],
+                 driver_opt=test_driver_opt
+             )
+         }
+@@ -132,8 +132,10 @@ def test_run_with_networking_config(self):
+         assert 'NetworkSettings' in attrs
+         assert 'Networks' in attrs['NetworkSettings']
+         assert list(attrs['NetworkSettings']['Networks'].keys()) == [net_name]
+-        assert attrs['NetworkSettings']['Networks'][net_name]['Aliases'] == \
+-               test_aliases
++        # Expect Aliases to list 'test_alias' and the container's short-id.
++        # In API version 1.45, the short-id will be removed.
++        assert attrs['NetworkSettings']['Networks'][net_name]['Aliases'] \
++               == [test_alias, attrs['Id'][:12]]
+         assert attrs['NetworkSettings']['Networks'][net_name]['DriverOpts'] \
+                == test_driver_opt
+ 
+@@ -190,7 +192,9 @@ def test_run_with_networking_config_only_undeclared_network(self):
+         assert 'NetworkSettings' in attrs
+         assert 'Networks' in attrs['NetworkSettings']
+         assert list(attrs['NetworkSettings']['Networks'].keys()) == [net_name]
+-        assert attrs['NetworkSettings']['Networks'][net_name]['Aliases'] is None
++        # Aliases should include the container's short-id (but it will be removed
++        # in API v1.45).
++        assert attrs['NetworkSettings']['Networks'][net_name]['Aliases'] == [attrs["Id"][:12]]
+         assert (attrs['NetworkSettings']['Networks'][net_name]['DriverOpts']
+                 is None)
+ 
+
+From e91b280074784026135573ab1726a565c090cd82 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pawe=C5=82=20Gronowski?= <pawel.gronowski@docker.com>
+Date: Thu, 7 Mar 2024 13:12:32 +0100
+Subject: [PATCH 2/3] Bump default API version to 1.44 (Moby 25.0)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>
+---
+ Makefile                  | 4 ++--
+ docker/constants.py       | 2 +-
+ tests/Dockerfile-ssh-dind | 4 ++--
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 00ebca05ce..25a83205b6 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,5 @@
+-TEST_API_VERSION ?= 1.43
+-TEST_ENGINE_VERSION ?= 24.0
++TEST_API_VERSION ?= 1.44
++TEST_ENGINE_VERSION ?= 25.0
+ 
+ ifeq ($(OS),Windows_NT)
+     PLATFORM := Windows
+diff --git a/docker/constants.py b/docker/constants.py
+index 71e543e530..8e7350d3d9 100644
+--- a/docker/constants.py
++++ b/docker/constants.py
+@@ -1,7 +1,7 @@
+ import sys
+ from .version import __version__
+ 
+-DEFAULT_DOCKER_API_VERSION = '1.43'
++DEFAULT_DOCKER_API_VERSION = '1.44'
+ MINIMUM_DOCKER_API_VERSION = '1.21'
+ DEFAULT_TIMEOUT_SECONDS = 60
+ STREAM_HEADER_SIZE_BYTES = 8
+diff --git a/tests/Dockerfile-ssh-dind b/tests/Dockerfile-ssh-dind
+index 2b7332b8b6..250c20f2c8 100644
+--- a/tests/Dockerfile-ssh-dind
++++ b/tests/Dockerfile-ssh-dind
+@@ -1,7 +1,7 @@
+ # syntax=docker/dockerfile:1
+ 
+-ARG API_VERSION=1.43
+-ARG ENGINE_VERSION=24.0
++ARG API_VERSION=1.44
++ARG ENGINE_VERSION=25.0
+ 
+ FROM docker:${ENGINE_VERSION}-dind
+ 
+
+From dd82f9ae8e601d3c82ef8d4f2dbab0c16109152f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pawe=C5=82=20Gronowski?= <pawel.gronowski@docker.com>
+Date: Thu, 7 Mar 2024 13:12:45 +0100
+Subject: [PATCH 3/3] Bump minimum API version to 1.24
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+25.0 raised the minimum supported API verison: https://github.com/moby/moby/pull/46887
+
+Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>
+---
+ docker/constants.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/docker/constants.py b/docker/constants.py
+index 8e7350d3d9..213ff61ed1 100644
+--- a/docker/constants.py
++++ b/docker/constants.py
+@@ -2,7 +2,7 @@
+ from .version import __version__
+ 
+ DEFAULT_DOCKER_API_VERSION = '1.44'
+-MINIMUM_DOCKER_API_VERSION = '1.21'
++MINIMUM_DOCKER_API_VERSION = '1.24'
+ DEFAULT_TIMEOUT_SECONDS = 60
+ STREAM_HEADER_SIZE_BYTES = 8
+ CONTAINER_LIMITS_KEYS = [

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -220,7 +220,7 @@ sub load_host_tests_docker {
         loadtest 'containers/rootless_docker' unless (is_public_cloud);
     }
     unless (is_jeos || is_staging || is_transactional || check_var("CONTAINERS_DOCKER_FLAVOUR", "stable")) {
-        loadtest('containers/python_runtime', run_args => $run_args, name => "python_docker") if ((is_tumbleweed || is_sle(">=16")) && (is_aarch64 || is_x86_64));
+        loadtest('containers/python_runtime', run_args => $run_args, name => "python_docker") if ((is_tumbleweed || is_sle(">=15-SP4")) && (is_aarch64 || is_x86_64));
     }
     # Expected to work anywhere except of real HW backends, PC and Micro
     unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro || (is_sle('=12-SP5') && is_aarch64)) {

--- a/tests/containers/python_runtime.pm
+++ b/tests/containers/python_runtime.pm
@@ -151,6 +151,16 @@ sub test ($target) {
             # Flaky test
             "tests/integration/api_container_test.py::AttachContainerTest::test_attach_no_stream"
         );
+        if (is_sle("<16")) {
+            push @deselect, (
+                # These tests fail due to https://bugzilla.suse.com/show_bug.cgi?id=1248755
+                "tests/unit/client_test.py::ClientTest::test_default_pool_size_unix",
+                "tests/unit/client_test.py::ClientTest::test_pool_size_unix",
+                "tests/unit/client_test.py::FromEnvTest::test_default_pool_size_from_env_unix",
+                "tests/unit/client_test.py::FromEnvTest::test_pool_size_from_env_unix",
+                "tests/unit/api_test.py::UnixSocketStreamTest::test_early_stream_response"
+            );
+        }
     } else {
         push @deselect, (
             # This test depends on an image available only for x86_64
@@ -189,7 +199,8 @@ sub run {
     setup;
 
     test $_ foreach (qw(unit integration));
-    if ($runtime eq "docker") {
+    # This test fails on SLES 15 due to https://bugzilla.suse.com/show_bug.cgi?id=1248755
+    if ($runtime eq "docker" && (is_sle(">=16.0") || is_tumbleweed)) {
         assert_script_run "export DOCKER_HOST=ssh://root@127.0.0.1";
         test "ssh";
     }

--- a/tests/containers/python_runtime.pm
+++ b/tests/containers/python_runtime.pm
@@ -99,7 +99,7 @@ sub setup {
     assert_script_run "cd ~/$runtime-py";
 
     unless ($repo) {
-        my @patches = ($runtime eq "podman") ? qw(572 575) : (is_sle("<16") ? qw(3290 3354) : qw(3261 3290 3354));
+        my @patches = ($runtime eq "podman") ? qw(572 575) : (is_sle("<16") ? qw(3199 3203 3206 3231 3290) : qw(3290 3354));
         foreach my $patch (@patches) {
             assert_script_run "curl -O " . data_url("containers/patches/$runtime-py/$patch.patch");
             assert_script_run "git apply -3 --ours $patch.patch";

--- a/tests/containers/python_runtime.pm
+++ b/tests/containers/python_runtime.pm
@@ -106,6 +106,8 @@ sub setup {
     unless ($repo) {
         my @patches = ($runtime eq "podman") ? qw(572 575) : (is_sle("<16") ? qw(3199 3203 3206 3231 3290) : qw(3290 3354));
         foreach my $patch (@patches) {
+            my $url = "https://github.com/$github_org/$runtime-py/pull/$patch";
+            record_info("patch", $url);
             assert_script_run "curl -O " . data_url("containers/patches/$runtime-py/$patch.patch");
             assert_script_run "git apply -3 --ours $patch.patch";
         }


### PR DESCRIPTION
Enable docker-py tests on SLES 15-SP4+

For this we need to:
- Backport some nice & sweet test fixes.
- Use latest git to take advantage of `git apply -3 --ours` like we do in bats tests.

Also:
- Introduce `DOCKER_API_VERSION` to test different API version when requested.
- Use `/etc/sysconfig/docker` as it's better than patching `/etc/docker/daemon.json`

Opened bug: https://bugzilla.suse.com/show_bug.cgi?id=1248755

Verification runs of the individual module so you get an idea how much little time it takes:
- SLES 15-SP7: https://openqa.suse.de/tests/18942696
- SLES 15-SP4: https://openqa.suse.de/tests/18942697
- SLES 16.0: https://openqa.suse.de/tests/18942552
- Tumbleweed: https://openqa.suse.de/tests/18940292

Full verification runs:
 - sle-15-SP4 aarch64: https://openqa.suse.de/tests/18942709
 - sle-15-SP4 x86_64: https://openqa.suse.de/tests/18942710
 - sle-15-SP5 aarch64: https://openqa.suse.de/tests/18942711
 - sle-15-SP5 x86_64: https://openqa.suse.de/tests/18943048
 - sle-15-SP6 aarch64: https://openqa.suse.de/tests/18943049
 - sle-15-SP6 x86_64: https://openqa.suse.de/tests/18943079
 - sle-15-SP7 aarch64: https://openqa.suse.de/tests/18942715
 - sle-15-SP7 x86_64: https://openqa.suse.de/tests/18943179