### PR TITLE
bats/aardvark-dns: Backport PR#623 to drop ncat dependency

### DIFF
--- a/data/containers/bats/patches/aardvark-dns/581.patch
+++ b/data/containers/bats/patches/aardvark-dns/581.patch
@@ -1,0 +1,62 @@
+From a70c535b8586adf50580f05a3d7c55f4c0ba8f3d Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Thu, 13 Mar 2025 14:24:40 +0100
+Subject: [PATCH] test: use ncat not nc
+
+nc can be provided by either ncat (nmap) or netcat (OpenBSD), we only
+work with the nmap version so make sure we always use that one and not
+the short alias which can be resolved to either one.
+
+It is not clear to me what changed on rawhide but it seems on the tmt
+env nc is preferred even though we have nmap-ncat installed.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/100-basic-name-resolution.bats | 4 ++--
+ test/600-errors.bats                | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/test/100-basic-name-resolution.bats b/test/100-basic-name-resolution.bats
+index e1c0ae79..93900ff8 100644
+--- a/test/100-basic-name-resolution.bats
++++ b/test/100-basic-name-resolution.bats
+@@ -75,7 +75,7 @@ function teardown() {
+ 	setup_dnsmasq
+ 
+ 	# using sh-exec to keep the udp query hanging for at least 3 seconds
+-	nsenter -m -n -t $HOST_NS_PID nc -l -u 127.5.5.5 53 --sh-exec "sleep 3" 3>/dev/null &
++	nsenter -m -n -t $HOST_NS_PID ncat -l -u 127.5.5.5 53 --sh-exec "sleep 3" 3>/dev/null &
+ 	HELPER_PID=$!
+ 
+ 	subnet_a=$(random_subnet 5)
+@@ -91,7 +91,7 @@ function teardown() {
+ 	assert "$output" =~ "Query time: [23][0-9]{3} msec" "timeout should be 2.5s so request should then work shortly after (udp)"
+ 
+ 	# Now the same with tcp.
+-	nsenter -m -n -t $HOST_NS_PID nc -l 127.5.5.5 53 --sh-exec "sleep 3" 3>/dev/null &
++	nsenter -m -n -t $HOST_NS_PID ncat -l 127.5.5.5 53 --sh-exec "sleep 3" 3>/dev/null &
+ 	HELPER_PID=$!
+ 	run_in_container_netns "$a1_pid" "dig" +tcp "$TEST_DOMAIN" "@$gw"
+ 	assert "$output" =~ "Query time: [23][0-9]{3} msec" "timeout should be 2.5s so request should then work shortly after (tcp)"
+diff --git a/test/600-errors.bats b/test/600-errors.bats
+index 96b1dbf7..0b1b6844 100644
+--- a/test/600-errors.bats
++++ b/test/600-errors.bats
+@@ -17,7 +17,7 @@ function teardown() {
+ @test "aardvark-dns should fail when udp port is already bound" {
+ 	# bind the port to force a failure for aardvark-dns
+ 	# we cannot use run_is_host_netns to run in the background
+-	nsenter -m -n -t $HOST_NS_PID nc -u -l 0.0.0.0 53 </dev/null 3> /dev/null &
++	nsenter -m -n -t $HOST_NS_PID ncat -u -l 0.0.0.0 53 </dev/null 3> /dev/null &
+ 	NCPID=$!
+ 
+ 	# ensure nc has time to bind the port
+@@ -33,7 +33,7 @@ function teardown() {
+ @test "aardvark-dns should fail when tcp port is already bound" {
+ 	# bind the port to force a failure for aardvark-dns
+ 	# we cannot use run_is_host_netns to run in the background
+-	nsenter -m -n -t $HOST_NS_PID nc -l 0.0.0.0 53 </dev/null 3> /dev/null &
++	nsenter -m -n -t $HOST_NS_PID ncat -l 0.0.0.0 53 </dev/null 3> /dev/null &
+ 	NCPID=$!
+ 
+ 	# ensure nc has time to bind the port

--- a/data/containers/bats/patches/aardvark-dns/623.patch
+++ b/data/containers/bats/patches/aardvark-dns/623.patch
@@ -1,0 +1,151 @@
+From 50d736664f5140bae008644a6fc0fee42e54c13a Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Thu, 14 Aug 2025 14:07:37 +0200
+Subject: [PATCH 1/3] test: replace ncat with socat
+
+ncat keeps causing issues with different versions having different
+behaviors. And many distro ship different incompatible versions so it is
+hard to make the test work everywhere consistently.
+
+To address replace ncat with socat. Socat seems to much more stable and
+we have been using it in podman for pasta tests for a while without
+problems.
+
+Fixes: #622
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/100-basic-name-resolution.bats |  7 ++++---
+ test/600-errors.bats                | 16 ++++++++--------
+ 2 files changed, 12 insertions(+), 11 deletions(-)
+
+diff --git a/test/100-basic-name-resolution.bats b/test/100-basic-name-resolution.bats
+index 40fbd1e5..e81639c0 100644
+--- a/test/100-basic-name-resolution.bats
++++ b/test/100-basic-name-resolution.bats
+@@ -74,8 +74,8 @@ function teardown() {
+ @test "basic container - dns itself (bad and good should fall back)" {
+ 	setup_dnsmasq
+ 
+-	# using sh-exec to keep the udp query hanging for at least 3 seconds
+-	nsenter -m -n -t $HOST_NS_PID ncat -l -u 127.5.5.5 53 --sh-exec "sleep 3" 3>/dev/null &
++	# using exec to keep the udp query hanging for at least 3 seconds
++	nsenter -m -n -t $HOST_NS_PID socat UDP4-LISTEN:53,bind=127.5.5.5 EXEC:"sleep 3" 3>/dev/null &
+ 	HELPER_PID=$!
+ 
+ 	subnet_a=$(random_subnet 5)
+@@ -90,8 +90,9 @@ function teardown() {
+ 	run_in_container_netns "$a1_pid" "dig" "$TEST_DOMAIN" "@$gw"
+ 	assert "$output" =~ "Query time: [23][0-9]{3} msec" "timeout should be 2.5s so request should then work shortly after (udp)"
+ 
++	kill -9 "$HELPER_PID" || true
+ 	# Now the same with tcp.
+-	nsenter -m -n -t $HOST_NS_PID ncat -l 127.5.5.5 53 --sh-exec "sleep 3" 3>/dev/null &
++	nsenter -m -n -t $HOST_NS_PID socat TCP4-LISTEN:53,bind=127.5.5.5 EXEC:"sleep 3" 3>/dev/null &
+ 	HELPER_PID=$!
+ 	run_in_container_netns "$a1_pid" "dig" +tcp "$TEST_DOMAIN" "@$gw"
+ 	assert "$output" =~ "Query time: [23][0-9]{3} msec" "timeout should be 2.5s so request should then work shortly after (tcp)"
+diff --git a/test/600-errors.bats b/test/600-errors.bats
+index 0b1b6844..273a13ff 100644
+--- a/test/600-errors.bats
++++ b/test/600-errors.bats
+@@ -6,10 +6,10 @@
+ load helpers
+ 
+ 
+-NCPID=
++SOCAT_PID=
+ 
+ function teardown() {
+-    kill -9 $NCPID
++    kill -9 $SOCAT_PID
+     basic_teardown
+ }
+ 
+@@ -17,10 +17,10 @@ function teardown() {
+ @test "aardvark-dns should fail when udp port is already bound" {
+ 	# bind the port to force a failure for aardvark-dns
+ 	# we cannot use run_is_host_netns to run in the background
+-	nsenter -m -n -t $HOST_NS_PID ncat -u -l 0.0.0.0 53 </dev/null 3> /dev/null &
+-	NCPID=$!
++	nsenter -m -n -t $HOST_NS_PID socat UDP4-LISTEN:53 - 3> /dev/null &
++	SOCAT_PID=$!
+ 
+-	# ensure nc has time to bind the port
++	# ensure socat has time to bind the port
+ 	sleep 1
+ 
+ 	subnet_a=$(random_subnet 5)
+@@ -33,10 +33,10 @@ function teardown() {
+ @test "aardvark-dns should fail when tcp port is already bound" {
+ 	# bind the port to force a failure for aardvark-dns
+ 	# we cannot use run_is_host_netns to run in the background
+-	nsenter -m -n -t $HOST_NS_PID ncat -l 0.0.0.0 53 </dev/null 3> /dev/null &
+-	NCPID=$!
++	nsenter -m -n -t $HOST_NS_PID socat TCP4-LISTEN:53 - 3> /dev/null &
++	SOCAT_PID=$!
+ 
+-	# ensure nc has time to bind the port
++	# ensure socat has time to bind the port
+ 	sleep 1
+ 
+ 	subnet_a=$(random_subnet 5)
+
+From 071143f5ea92ecd50d198e45c3919b8f6eb982d4 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Thu, 14 Aug 2025 14:12:21 +0200
+Subject: [PATCH 2/3] rpm: tests require socat instead of ncat now
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ rpm/aardvark-dns.spec | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/rpm/aardvark-dns.spec b/rpm/aardvark-dns.spec
+index 13c34633..6a1866e0 100644
+--- a/rpm/aardvark-dns.spec
++++ b/rpm/aardvark-dns.spec
+@@ -61,7 +61,7 @@ Requires: bats
+ Requires: bind-utils
+ Requires: jq
+ Requires: netavark
+-Requires: nmap-ncat
++Requires: socat
+ Requires: dnsmasq
+ 
+ %description tests
+@@ -97,7 +97,7 @@ tar fx %{SOURCE1}
+ 
+ %{__install} -d -p %{buildroot}%{_datadir}/%{name}/test
+ %{__cp} -rp test/* %{buildroot}%{_datadir}/%{name}/test/
+-%{__rm} -rf %{buildroot}%{_datadir}/%{name}/test/tmt/    
++%{__rm} -rf %{buildroot}%{_datadir}/%{name}/test/tmt/
+ 
+ # Add empty check section to silence rpmlint warning.
+ # No tests meant to be run here.
+
+From 32deed993c33b2481a39c423f67842e60f181a3c Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Wed, 20 Aug 2025 17:07:11 +0200
+Subject: [PATCH 3/3] update CI images
+
+Build in https://github.com/containers/automation_images/pull/415.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ .cirrus.yml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/.cirrus.yml b/.cirrus.yml
+index 0b31ac75..efd8fb4e 100644
+--- a/.cirrus.yml
++++ b/.cirrus.yml
+@@ -19,7 +19,7 @@ env:
+     NETAVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/netavark/success/binary.zip?branch=${NETAVARK_BRANCH}"
+     # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
+     SCRIPT_BASE: "./contrib/cirrus"
+-    IMAGE_SUFFIX: "c20250422t130822z-f42f41d13"
++    IMAGE_SUFFIX: "c20250820t132717z-f42f41d13"
+     FEDORA_NETAVARK_IMAGE: "fedora-netavark-${IMAGE_SUFFIX}"
+     FEDORA_NETAVARK_AMI: "fedora-netavark-aws-arm64-${IMAGE_SUFFIX}"
+     EC2_INST_TYPE: "t4g.xlarge"

--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -2,9 +2,11 @@ aardvark-dns:
   # Note on patches:
   # https://github.com/containers/aardvark-dns/pull/519 is needed for 100-basic-name-resolution
   # https://github.com/containers/aardvark-dns/pull/619 is needed for dnsmasq issue
+  # https://github.com/containers/aardvark-dns/pull/623 is needed to drop ncat
   opensuse-Tumbleweed:
     BATS_PATCHES:
     - 619
+    - 623
     BATS_IGNORE:
   sle-16.0:
     BATS_PATCHES:

--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -1,6 +1,7 @@
 aardvark-dns:
   # Note on patches:
   # https://github.com/containers/aardvark-dns/pull/519 is needed for 100-basic-name-resolution
+  # https://github.com/containers/aardvark-dns/pull/581 is needed for PR#623
   # https://github.com/containers/aardvark-dns/pull/619 is needed for dnsmasq issue
   # https://github.com/containers/aardvark-dns/pull/623 is needed to drop ncat
   opensuse-Tumbleweed:
@@ -10,19 +11,27 @@ aardvark-dns:
     BATS_IGNORE:
   sle-16.0:
     BATS_PATCHES:
+    - 581
     - 619
+    - 623
     BATS_IGNORE:
   sle-15-SP7:
     BATS_PATCHES:
     - 519
+    - 581
+    - 623
     BATS_IGNORE: 100-basic-name-resolution
   sle-15-SP6:
     BATS_PATCHES:
     - 519
+    - 581
+    - 623
     BATS_IGNORE: 100-basic-name-resolution
   sle-15-SP5:
     BATS_PATCHES:
     - 519
+    - 581
+    - 623
     BATS_IGNORE: 100-basic-name-resolution
 buildah:
   # Note on patches:

--- a/tests/containers/bats/aardvark.pm
+++ b/tests/containers/bats/aardvark.pm
@@ -34,7 +34,7 @@ sub run {
 
     # Install tests dependencies
     my @pkgs = qw(aardvark-dns firewalld iproute2 jq netavark podman);
-    push @pkgs, is_sle('<16') ? 'netcat-openbsd' : 'ncat';
+    push @pkgs, is_sle('<16') ? 'netcat-openbsd' : (is_sle ? 'ncat' : 'socat');
     push @pkgs, (is_tumbleweed || is_sle('>=16.0')) ? 'dbus-1-daemon' : 'dbus-1';
     $self->bats_setup(@pkgs);
 

--- a/tests/containers/bats/aardvark.pm
+++ b/tests/containers/bats/aardvark.pm
@@ -33,8 +33,7 @@ sub run {
     select_serial_terminal;
 
     # Install tests dependencies
-    my @pkgs = qw(aardvark-dns firewalld iproute2 jq netavark podman);
-    push @pkgs, is_sle('<16') ? 'netcat-openbsd' : (is_sle ? 'ncat' : 'socat');
+    my @pkgs = qw(aardvark-dns firewalld iproute2 jq netavark podman socat);
     push @pkgs, (is_tumbleweed || is_sle('>=16.0')) ? 'dbus-1-daemon' : 'dbus-1';
     $self->bats_setup(@pkgs);
 


### PR DESCRIPTION
Nmap's ncat is a problematic dependency and we can drop it completely for the aardvark-dns upstream tests by backporting these fixes:
- https://github.com/containers/aardvark-dns/pull/581
- https://github.com/containers/aardvark-dns/pull/623

Verification runs:
- Tumbleweed:
  - aarch64: https://openqa.opensuse.org/tests/5269822
  - ppc64le: https://openqa.opensuse.org/tests/5269823
  - x86_64: https://openqa.opensuse.org/tests/5269863
- SLES 16.0:
  - aarch64: https://openqa.suse.de/tests/18936477
  - ppc64le: https://openqa.suse.de/tests/18936478
  - s390x: https://openqa.suse.de/tests/18937818
  - x86_64: https://openqa.suse.de/tests/18938094
- SLES 15-SP6:
  - aarch64: https://openqa.suse.de/tests/18938648
  - x86_64: https://openqa.suse.de/tests/18939104
- SLES 15-SP7:
  - aarch64: https://openqa.suse.de/tests/18939398
  - x86_64: https://openqa.suse.de/tests/18939669

aardvark-dns versions:

```
$ susepkg -p any aardvark-dns | grep -e SLES -e Tumbleweed
SLES/15.3 aardvark-dns 1.12.2-150300.7.11.1
SLES/15.4 aardvark-dns 1.12.2-150400.9.11.1
SLES/15.5 aardvark-dns 1.12.2-150500.3.9.1
SLES/15.6 aardvark-dns 1.12.2-150500.3.9.1
SLES/15.7 aardvark-dns 1.12.2-150500.3.9.1
SLES/16.0 aardvark-dns 1.14.0-160000.2.3
openSUSE_Tumbleweed aardvark-dns 1.15.0-1.1
```

