### PR TITLE
Update test code about validate_packages_and_patterns for sle16

### DIFF
--- a/tests/console/validate_packages_and_patterns.pm
+++ b/tests/console/validate_packages_and_patterns.pm
@@ -56,7 +56,7 @@ sub run {
     $software{'salt-minion'} = {
         repo => $repo,
         installed => is_jeos() ? 1 : 0,    # On JeOS Salt is present in the default image
-        condition => sub { is_sle('15+') },
+        condition => sub { is_sle('15+') && is_sle('<15-SP7') },
     };
     $software{'sles-ltss-release'} = {
         repo => $ltss_release_repo ? $ltss_release_repo : 'LTSS',


### PR DESCRIPTION
Update test code about validate_packages_and_patterns for sle16

- Related ticket:  https://progress.opensuse.org/issues/187824
- Verification run: https://openqa.suse.de/tests/18942167#step/validate_packages_and_patterns/8
