### PR TITLE
Quick fix for greedy regex in validate_suseconnect_url

### DIFF
--- a/tests/yam/validate/validate_suseconnect_url.pm
+++ b/tests/yam/validate/validate_suseconnect_url.pm
@@ -13,7 +13,7 @@ use utils;
 
 sub run {
     select_console 'root-console';
-    my $scc_url = (get_var('AGAMA_PROFILE_OPTIONS') =~ /registration_url="(?<registration_url>.+)"/) ? $+{registration_url} : get_var('SCC_URL');
+    my $scc_url = (get_var('AGAMA_PROFILE_OPTIONS') =~ /registration_url="(?<registration_url>.+?)"/) ? $+{registration_url} : get_var('SCC_URL');
     validate_script_output("cat /etc/SUSEConnect", sub { m/\b$scc_url\b/ });
 }
 


### PR DESCRIPTION
It turned out that the named regex in the validate_suseconnect_url test was matching more than it should. This is fixed now by using the "non-greedy" quantifier "?".

- Failed test: https://openqa.suse.de/tests/18941892#step/validate_suseconnect_url/2
- VR for fix:  https://openqa.suse.de/tests/18942563
