### PR TITLE
gnomecase: fix expected application associations for mimetypes

### DIFF
--- a/tests/x11/gnomecase/gnome_default_applications.pm
+++ b/tests/x11/gnomecase/gnome_default_applications.pm
@@ -18,11 +18,11 @@ sub run {
     x11_start_program('xterm');
 
     my @applications = (
-        ['image/jpg', 'eog.desktop'],
-        ['image/png', 'eog.desktop'],
-        ['application/pdf', 'evince.desktop'],
-        ['application/x-bzip2', 'org.gnome.FileRoller.desktop'],
-        ['application/gzip', 'org.gnome.FileRoller.desktop']);
+        ['image/jpeg', 'org.gnome.Loupe.desktop'],
+        ['image/png', 'org.gnome.Loupe.desktop'],
+        ['application/pdf', 'org.gnome.Papers.desktop'],
+        ['application/x-bzip2', 'org.gnome.Nautilus.desktop'],
+        ['application/gzip', 'org.gnome.Nautilus.desktop']);
     my $defaultApps = check_default_apps(@applications);
     if ($defaultApps) {
         prepare_application_environment();


### PR DESCRIPTION
* image/jpg is not a valid mimetype; it's image/jpeg - assign to Loupe
* image/png assigned to Loupe
* application/pdf assigned to Papers (replaced evince)
* application/{x-bzip2,gzip} to be opened by Nautilus internal compressor, not FileRoller

- Related ticket: https://progress.opensuse.org/issues/121276
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/5271258

openqa: clone https://openqa.opensuse.org/tests/5269391
