### PR TITLE
agama_install: use bootloader_s390 on s390x

### DIFF
--- a/schedule/install/agama_install.yaml
+++ b/schedule/install/agama_install.yaml
@@ -1,8 +1,19 @@
 name:           leap16_agama_install
 description:    >
     This is prepare install opensuse-16.0 agama installer
+conditional_schedule:
+  bootloader:
+    ARCH:
+      aarch64:
+        - installation/bootloader
+      ppc64le: 
+        - installation/bootloader
+      s390x:
+        - installation/bootloader_s390
+      x86_64:
+        - installation/bootloader
 schedule:
-  - installation/bootloader
+  - '{{bootloader}}'
   - installation/agama
   - installation/agama_reboot
   - installation/grub_test


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/187206
- Needles: N/A
- Verification run: Much more wrong - but a step: https://openqa.opensuse.org/tests/5271282#step/bootloader_s390/61 - next seems to be product bug (missing suse.ins in repo root)
