### PR TITLE
agama_install: use bootloader_s390 on s390x

### DIFF
--- a/schedule/install/agama_install.yaml
+++ b/schedule/install/agama_install.yaml
@@ -11,7 +11,7 @@ conditional_schedule:
       s390x:
         - installation/bootloader_s390
       x86_64:
-        - installation/bootloader
+        - installation/bootloader_uefi
 schedule:
   - '{{bootloader}}'
   - installation/agama


### PR DESCRIPTION

*    Related ticket: https://progress.opensuse.org/issues/187206
*    Needles: N/A
*    Verification run: Much more wrong - but a step: https://openqa.opensuse.org/tests/5271282#step/bootloader_s390/61 - next seems to be product bug (missing suse.ins in repo root)

CC @skriesch 