### PR TITLE
Add namespace as client init argument

### DIFF
--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -20,8 +20,9 @@ has credentials_file_content => undef;
 has container_registry => sub { get_var('PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY', 'suseqectesting') };
 
 sub init {
-    my ($self) = @_;
-    my $data = get_credentials(url_suffix => 'azure.json');
+    my ($self, %args) = @_;
+    $args{namespace} //= get_required_var('PUBLIC_CLOUD_NAMESPACE');
+    my $data = get_credentials(url_suffix => 'azure.json', namespace => $args{namespace});
     $self->subscription($data->{subscription_id});
     define_secret_variable("ARM_SUBSCRIPTION_ID", $self->subscription);
     define_secret_variable("ARM_CLIENT_ID", $data->{client_id});

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -122,7 +122,7 @@ sub run {
     # Needed to create the SAS URI token
     if (!is_azure()) {
         my $azure_client = publiccloud::azure_client->new();
-        $azure_client->init();
+        $azure_client->init(namespace => 'sapha');
     }
 
     # variable to be conditionally used to hold ptf file names,

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -25,7 +25,7 @@ sub run {
     # Needed to create the SAS URI token
     if ($provider_setting ne 'AZURE') {
         my $azure_client = publiccloud::azure_client->new();
-        $azure_client->init();
+        $azure_client->init(namespace => 'sapha');
     }
 
     my %variables;


### PR DESCRIPTION
Add namespace as optional argument for the Azure PC client object. If missing fall back to PUBLIC_CLOUD_NAMESPACE.

- Related ticket: TEAM-10432

# Verification run:
sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-ipaddr2_azure_test test in Azure  not needing the double credentials. This one has been executed using sapha namespace
 - http://openqaworker15.qa.suse.cz/tests/339350 :green_circle: 
 
sle-15-SP7-Qesap-Gcp-Byos-x86_64-Buildmpagot_VR-qesap_gcp_sapconf_test executed in GCE not using the sapha credentials namespace
- http://openqaworker15.qa.suse.cz/tests/339351 :green_circle: failure is the confirmation about the fact that it is working :-) 