### PR TITLE
publiccloud/run_ltp: Remove obsolete --framework ltp

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -321,7 +321,6 @@ sub prepare_ltp_cmd {
 
     my $python_exec = get_python_exec();
     my $cmd = "$python_exec kirk ";
-    $cmd .= "--framework ltp ";
     $cmd .= '--verbose ';
     $cmd .= '--exec-timeout=1200 ';
     $cmd .= '--suite-timeout=5400 ';


### PR DESCRIPTION
kirk --framework option was removed in [1] (released in kirk 2.1), now kirk supports only LTP. It might be deleted in the future therefore safe to remove it.

In fact it was never needed for LTP, because LTP was the default framework, therefore it will work on older kirk (which supported more testsuites via --framework option).

[1] https://github.com/linux-test-project/kirk/commit/515a5053170a04d3b6f9db0be7217f66fb6cfcb8

@asmorodskyi @ricardobranco777 @volodymyrkatkalov enhancement for you :). 
@acerv FYI