### PR TITLE
Skip transfer_repos when MU should be skipped

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -316,7 +316,7 @@ sub load_slem_on_pc_tests {
         loadtest("publiccloud/registration", run_args => $args);
         # 2 next modules of pubcloud needed for sle-micro incidents/repos verification
         if (get_var('PUBLIC_CLOUD_QAM', 0)) {
-            loadtest("publiccloud/transfer_repos", run_args => $args);
+            loadtest("publiccloud/transfer_repos", run_args => $args) unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
             loadtest("publiccloud/patch_and_reboot", run_args => $args);
         }
         if (get_var('PUBLIC_CLOUD_LTP', 0)) {

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -29,7 +29,7 @@ sub load_maintenance_publiccloud_tests {
     } else {
         loadtest("publiccloud/registration", run_args => $args);
     }
-    loadtest "publiccloud/transfer_repos", run_args => $args;
+    loadtest "publiccloud/transfer_repos", run_args => $args unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
     loadtest "publiccloud/patch_and_reboot", run_args => $args;
     if (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
         loadtest "publiccloud/check_services", run_args => $args;


### PR DESCRIPTION
There is no reason to even schedule the transfer_repos test run, if the variable for skipping maintenance updates is set (`PUBLIC_CLOUD_SKIP_MU`).

## Verification runs

* [SLES 15-SP7 GCE](https://duck-norris.qe.suse.de/tests/14923)
* [SLES 15-SP7 GCE with PUBLIC_CLOUD_SKIP_MU=1](https://duck-norris.qe.suse.de/tests/14924)
