### PR TITLE
Limit timeout for supportconfig

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -884,8 +884,8 @@ sub do_systemd_analyze_time {
 
 sub upload_supportconfig_log {
     my ($self, %args) = @_;
-    $self->ssh_script_run(cmd => 'sudo supportconfig -R /var/tmp -B supportconfig -x AUDIT', timeout => 7200);
-    $self->ssh_script_run(cmd => 'sudo chmod 755 /var/tmp/scc_supportconfig.txz', timeout => 3600);
+    $self->ssh_script_run(cmd => 'sudo supportconfig -R /var/tmp -B supportconfig -x AUDIT', timeout => 600);
+    $self->ssh_script_run(cmd => 'sudo chmod 0644 /var/tmp/scc_supportconfig.txz');
     $self->upload_log('/var/tmp/scc_supportconfig.txz', failok => 1, timeout => 600);
 }
 


### PR DESCRIPTION
If supportconfig fails, it internally restarts. This means that if it fails over and over, it will just run until it hits a timeout (2h). Since there is effectively no progress, this timeout is way too high.

If after 10 minutes the supportconfig is not yet done, it's safe to assume it's stuck and should be cancelled.

- Related ticket: https://progress.opensuse.org/issues/187863
- Verification run: https://duck-norris.qe.suse.de/tests/14925#live
