### PR TITLE
Adapt boot from hdd for sle16 production group on ppc64le

### DIFF
--- a/lib/Distribution/Sle/16Latest.pm
+++ b/lib/Distribution/Sle/16Latest.pm
@@ -14,26 +14,10 @@ use strict;
 use warnings FATAL => 'all';
 
 use Yam::Agama::Pom::GrubMenuSlesPage;
-use Yam::Agama::Pom::GrubMenuAgamaPage;
-use Yam::Agama::Pom::GrubMenuAgamaDeprecatedEntryOrderPage;
-use testapi qw(record_soft_failure);
-use Utils::Architectures qw(is_ppc64le);
 
 sub get_grub_menu_installed_system {
     my $self = shift;
     return Yam::Agama::Pom::GrubMenuSlesPage->new({grub_menu_base => $self->get_grub_menu_base()});
-}
-
-sub get_grub_menu_agama {
-    if (is_ppc64le()) {
-        record_soft_failure 'bsc#1248161 Boot from hard disk has not been implemented on ppc64le';
-        return Yam::Agama::Pom::GrubMenuAgamaDeprecatedEntryOrderPage->new({
-                grub_menu_agama => Yam::Agama::Pom::GrubMenuAgamaPage->new({
-                        grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()})});
-    } else {
-        return Yam::Agama::Pom::GrubMenuAgamaPage->new({
-                grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()});
-    }
 }
 
 1;


### PR DESCRIPTION
It is implemented to boot from hard disk as default on ppc64le in the production group with sle16 build132.4. Adapt this change for openqa testing.

- Related failure: https://openqa.suse.de/tests/18951215#step/boot_agama/2
- Verification run: https://openqa.suse.de/tests/18960301#details
