### PR TITLE
Update the test data of repos for medium installation testsuites

### DIFF
--- a/test_data/yam/agama_sap_media.yaml
+++ b/test_data/yam/agama_sap_media.yaml
@@ -10,7 +10,7 @@ os_release:
   CPE_NAME: "cpe:/o:suse:sles:16:%VERSION%"
   SUSE_SUPPORT_PRODUCT: "SUSE Linux Enterprise Server for SAP applications"
 repos:
-  - name: SUSE Linux Enterprise Server for SAP applications %VERSION% Beta
+  - name: SUSE Linux Enterprise Server for SAP applications %VERSION%
     alias: SLES_SAP
     uri: dvd:/install
     enabled: 'No'

--- a/test_data/yam/agama_sle_media.yaml
+++ b/test_data/yam/agama_sle_media.yaml
@@ -10,7 +10,7 @@ os_release:
   CPE_NAME: "cpe:/o:suse:sles:16:%VERSION%"
   SUSE_SUPPORT_PRODUCT: "SUSE Linux Enterprise Server"
 repos:
-  - name: SUSE Linux Enterprise Server %VERSION% Beta
+  - name: SUSE Linux Enterprise Server %VERSION%
     alias: SLES
     uri: dvd:/install
     enabled: 'No'


### PR DESCRIPTION
It is quite close to sle16 GMC now, it is reasonable to remove the 'Beta' string from the repos' name. So update the test data of repos for media installation. BTW, there isn't 'Beta' string in the installation cases in Online flavor, so no need to update datas for Online testsuites.

- Related failure: https://openqa.suse.de/tests/18952108#step/validate_repos/7
- Verification run: 
  https://openqa.suse.de/tests/18959946 (sles)
  https://openqa.suse.de/tests/18959956 (sap)
