### PR TITLE
containers: Skip docker-py tests on public cloud

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -184,7 +184,7 @@ sub load_host_tests_podman {
     loadtest('containers/seccomp', run_args => $run_args, name => $run_args->{runtime} . "_seccomp") unless is_sle('<15');
     loadtest('containers/isolation', run_args => $run_args, name => $run_args->{runtime} . "_isolation") unless (is_public_cloud || is_transactional);
     # python3-podman is not available on SLES - https://bugzilla.suse.com/show_bug.cgi?id=1248415
-    unless (is_jeos || is_staging || is_transactional || get_var("OCI_RUNTIME")) {
+    unless (is_jeos || is_public_cloud || is_staging || is_transactional || get_var("OCI_RUNTIME")) {
         loadtest('containers/python_runtime', run_args => $run_args, name => "python_podman") if (is_tumbleweed && (is_aarch64 || is_x86_64));
     }
     loadtest('containers/podmansh') if (is_tumbleweed && !is_staging && !is_transactional);
@@ -219,7 +219,7 @@ sub load_host_tests_docker {
         # select_user_serial_terminal is broken on public cloud
         loadtest 'containers/rootless_docker' unless (is_public_cloud);
     }
-    unless (is_jeos || is_staging || is_transactional || check_var("CONTAINERS_DOCKER_FLAVOUR", "stable")) {
+    unless (is_jeos || is_public_cloud || is_staging || is_transactional || check_var("CONTAINERS_DOCKER_FLAVOUR", "stable")) {
         loadtest('containers/python_runtime', run_args => $run_args, name => "python_docker") if ((is_tumbleweed || is_sle(">=15-SP4")) && (is_aarch64 || is_x86_64));
     }
     # Expected to work anywhere except of real HW backends, PC and Micro

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -220,7 +220,7 @@ sub load_host_tests_docker {
         loadtest 'containers/rootless_docker' unless (is_public_cloud);
     }
     unless (is_jeos || is_public_cloud || is_staging || is_transactional || check_var("CONTAINERS_DOCKER_FLAVOUR", "stable")) {
-        loadtest('containers/python_runtime', run_args => $run_args, name => "python_docker") if ((is_tumbleweed || is_sle(">=15-SP4")) && (is_aarch64 || is_x86_64));
+        loadtest('containers/python_runtime', run_args => $run_args, name => "python_docker") if ((is_tumbleweed || is_sle(">=16")) && (is_aarch64 || is_x86_64));
     }
     # Expected to work anywhere except of real HW backends, PC and Micro
     unless (is_generalhw || is_ipmi || is_public_cloud || is_openstack || is_sle_micro || is_microos || is_leap_micro || (is_sle('=12-SP5') && is_aarch64)) {


### PR DESCRIPTION
Skip docker-py tests on public cloud