### PR TITLE
Don't schedule download_repos when not needed

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -22,7 +22,7 @@ our @EXPORT = qw(load_publiccloud_tests load_publiccloud_download_repos);
 sub load_maintenance_publiccloud_tests {
     my $args = OpenQA::Test::RunArgs->new();
 
-    loadtest "publiccloud/download_repos";
+    loadtest "publiccloud/download_repos" unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
     loadtest "publiccloud/prepare_instance", run_args => $args;
     if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
         loadtest("publiccloud/check_registercloudguest", run_args => $args);

--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -29,71 +29,65 @@ sub run {
     select_host_console();    # select console on the host, not the PC instance
 
 
-    if (get_var('PUBLIC_CLOUD_SKIP_MU')) {
-        # Skip maintenance updates. This is useful for debug runs
-        record_info('Skip download', 'Skipping maintenance update download (triggered by setting)');
+    # Remove the ~/repos so they can be redownloaded
+    if (get_var('PUBLIC_CLOUD_REDOWNLOAD_MU')) {
+        script_run("rm -rf ~/repos");
+    }
+    # Skip if we already downloaded the repos
+    if (get_repo_status() == 1) {
+        record_info("Downloaded", "Skipping download because the repositories have been already downloaded");
         return;
-    } else {
-        # Remove the ~/repos so they can be redownloaded
-        if (get_var('PUBLIC_CLOUD_REDOWNLOAD_MU')) {
-            script_run("rm -rf ~/repos");
+    }
+
+    assert_script_run("mkdir ~/repos");
+    assert_script_run("cd ~/repos");
+    # Note: Clear previous qem_download_status.txt file here
+    assert_script_run("echo 'Starting download' > ~/repos/qem_download_status.txt");
+
+    # In Incidents there is INCIDENT_REPO instead of MAINT_TEST_REPO
+    # Those two variables contain list of repositories separated by comma
+    set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO')) unless get_var('MAINT_TEST_REPO');
+    my @repos = split(/,/, get_var('MAINT_TEST_REPO'));
+    assert_script_run('touch /tmp/repos.list.txt');
+
+    # Failsafe: Fail if there are no test repositories, otherwise we have the wrong template link
+    my $count = scalar @repos;
+    my $check_empty_repos = get_var('PUBLIC_CLOUD_IGNORE_EMPTY_REPO', 0) == 0;
+    die "No test repositories" if ($check_empty_repos && $count == 0);
+    my $ret = 0;
+    my $reject = "'robots.txt,*.ico,*.png,*.gif,*.css,*.js,*.htm*,*.mirrorlist'";
+    my $regex = "'s390x\\/|ppc64le\\/|kernel*debuginfo*.rpm|src\\/'";
+
+    set_var("PUBLIC_CLOUD_EMBARGOED_UPDATES_DETECTED", 0);
+
+    for my $maintrepo (@repos) {
+        unless (validate_repo($maintrepo)) {
+            set_var("PUBLIC_CLOUD_EMBARGOED_UPDATES_DETECTED", 1);
+            next;
         }
-        # Skip if we already downloaded the repos
-        if (get_repo_status() == 1) {
-            record_info("Downloaded", "Skipping download because the repositories have been already downloaded");
-            return;
-        }
 
-        assert_script_run("mkdir ~/repos");
-        assert_script_run("cd ~/repos");
-        # Note: Clear previous qem_download_status.txt file here
-        assert_script_run("echo 'Starting download' > ~/repos/qem_download_status.txt");
+        script_run("echo 'Downloading $maintrepo ...' >> ~/repos/qem_download_status.txt");
+        my ($parent) = $maintrepo =~ 'https?://(.*)$';
+        my ($domain) = $parent =~ '^([a-zA-Z.]*)';
+        my ($realpath) = $parent =~ m|ibs/(.*)|;
 
-        # In Incidents there is INCIDENT_REPO instead of MAINT_TEST_REPO
-        # Those two variables contain list of repositories separated by comma
-        set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO')) unless get_var('MAINT_TEST_REPO');
-        my @repos = split(/,/, get_var('MAINT_TEST_REPO'));
-        assert_script_run('touch /tmp/repos.list.txt');
-
-        # Failsafe: Fail if there are no test repositories, otherwise we have the wrong template link
-        my $count = scalar @repos;
-        my $check_empty_repos = get_var('PUBLIC_CLOUD_IGNORE_EMPTY_REPO', 0) == 0;
-        die "No test repositories" if ($check_empty_repos && $count == 0);
-        my $ret = 0;
-        my $reject = "'robots.txt,*.ico,*.png,*.gif,*.css,*.js,*.htm*,*.mirrorlist'";
-        my $regex = "'s390x\\/|ppc64le\\/|kernel*debuginfo*.rpm|src\\/'";
-
-        set_var("PUBLIC_CLOUD_EMBARGOED_UPDATES_DETECTED", 0);
-
-        for my $maintrepo (@repos) {
-            unless (validate_repo($maintrepo)) {
-                set_var("PUBLIC_CLOUD_EMBARGOED_UPDATES_DETECTED", 1);
-                next;
-            }
-
-            script_run("echo 'Downloading $maintrepo ...' >> ~/repos/qem_download_status.txt");
-            my ($parent) = $maintrepo =~ 'https?://(.*)$';
-            my ($domain) = $parent =~ '^([a-zA-Z.]*)';
-            my ($realpath) = $parent =~ m|ibs/(.*)|;
-
-            $ret = script_run("wget -nH --cut-dirs=1 --no-clobber -r --reject $reject --reject-regex=$regex --domains $domain --no-parent $maintrepo/", timeout => 600);
-            if ($ret !~ /0|8/) {
-                # softfailure, if repo doesn't exist (anymore). This is required for cloning jobs, because the original test repos could be empty already
-                record_info('Softfail', "Download /failed (rc=$ret):\n$maintrepo", result => 'softfail');
-                script_run("echo 'Download failed for $maintrepo ...' >> ~/repos/qem_download_status.txt");
+        $ret = script_run("wget -nH --cut-dirs=1 --no-clobber -r --reject $reject --reject-regex=$regex --domains $domain --no-parent $maintrepo/", timeout => 600);
+        if ($ret !~ /0|8/) {
+            # softfailure, if repo doesn't exist (anymore). This is required for cloning jobs, because the original test repos could be empty already
+            record_info('Softfail', "Download /failed (rc=$ret):\n$maintrepo", result => 'softfail');
+            script_run("echo 'Download failed for $maintrepo ...' >> ~/repos/qem_download_status.txt");
+        } else {
+            assert_script_run("echo -en '\\n" . ('#' x 80) . "\\n# $maintrepo:\\n' >> /tmp/repos.list.txt");
+            assert_script_run("echo 'Downloaded $maintrepo:' \$(du -hs $realpath | cut -f1) >> ~/repos/qem_download_status.txt");
+            if (script_run("ls $realpath/*.repo") == 0) {
+                assert_script_run(sprintf(q(sed -i '1 s/]/_%s]/' %s/*.repo), random_string(4), $realpath));
+                assert_script_run("find $realpath >> /tmp/repos.list.txt");
+            } elsif (is_sle_micro(">=6.0")) {
+                assert_script_run("find $realpath >> /tmp/repos.list.txt");
             } else {
-                assert_script_run("echo -en '\\n" . ('#' x 80) . "\\n# $maintrepo:\\n' >> /tmp/repos.list.txt");
-                assert_script_run("echo 'Downloaded $maintrepo:' \$(du -hs $realpath | cut -f1) >> ~/repos/qem_download_status.txt");
-                if (script_run("ls $realpath/*.repo") == 0) {
-                    assert_script_run(sprintf(q(sed -i '1 s/]/_%s]/' %s/*.repo), random_string(4), $realpath));
-                    assert_script_run("find $realpath >> /tmp/repos.list.txt");
-                } elsif (is_sle_micro(">=6.0")) {
-                    assert_script_run("find $realpath >> /tmp/repos.list.txt");
-                } else {
-                    record_info('Softfail', "No .repo file found in $realpath. This directory will be removed.", result => 'softfail');
-                    assert_script_run("echo 'No .repo found for $maintrepo' >> ~/repos/qem_download_status.txt");
-                    assert_script_run("rm -rf $realpath");
-                }
+                record_info('Softfail', "No .repo file found in $realpath. This directory will be removed.", result => 'softfail');
+                assert_script_run("echo 'No .repo found for $maintrepo' >> ~/repos/qem_download_status.txt");
+                assert_script_run("rm -rf $realpath");
             }
         }
 

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -22,75 +22,70 @@ sub run {
 
     my $instance = $args->{my_instance};
     my $remote = $instance->username . '@' . $args->{my_instance}->public_ip;
-    my $skip_mu = get_var('PUBLIC_CLOUD_SKIP_MU', 0);
     my $repodir = "/opt/repos/";
-    # Trigger to skip the download to speed up verification runs
-    if ($skip_mu) {
-        record_info('Skip download', 'Skipping maintenance update download (triggered by setting)');
-    } else {
-        assert_script_run('du -sh ~/repos');
-        my $timeout = 2400;
-        $instance->retry_ssh_command(cmd => "which rsync || sudo zypper -n in rsync", timeout => 420, retry => 6, delay => 60);
 
-        # In Incidents there is INCIDENT_REPO instead of MAINT_TEST_REPO
-        # Those two variables contain list of repositories separated by comma
-        set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO')) unless get_var('MAINT_TEST_REPO');
+    assert_script_run('du -sh ~/repos');
+    my $timeout = 2400;
+    $instance->retry_ssh_command(cmd => "which rsync || sudo zypper -n in rsync", timeout => 420, retry => 6, delay => 60);
 
-        # We need to exclude embargoed incidents
-        my @all_repos = split(/,/, get_var('MAINT_TEST_REPO'));
-        for my $exclude (split(/,/, get_var('EXCLUDED_TEST_REPO', ''))) {
-            for my $index (reverse 0 .. $#all_repos) {
-                splice(@all_repos, $index, 1, ()) if ($all_repos[$index] =~ /$exclude/);
-            }
+    # In Incidents there is INCIDENT_REPO instead of MAINT_TEST_REPO
+    # Those two variables contain list of repositories separated by comma
+    set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO')) unless get_var('MAINT_TEST_REPO');
+
+    # We need to exclude embargoed incidents
+    my @all_repos = split(/,/, get_var('MAINT_TEST_REPO'));
+    for my $exclude (split(/,/, get_var('EXCLUDED_TEST_REPO', ''))) {
+        for my $index (reverse 0 .. $#all_repos) {
+            splice(@all_repos, $index, 1, ()) if ($all_repos[$index] =~ /$exclude/);
         }
-
-        my @repos;
-        my ($incident, $type);
-        for my $maintrepo (@all_repos) {
-            if (is_sle_micro(">=6.0")) {
-                push(@repos, $maintrepo);
-            } else {
-                ($incident, $type) = ($2, $1) if ($maintrepo =~ /\/(PTF|Maintenance):\/(\d+)/g);
-                push(@repos, $maintrepo) unless (is_embargo_update($incident, $type)); }
-        }
-
-        s/https?:\/\/.*\/ibs\/// for @repos;
-
-        # Create list of directories for rsync
-        for my $repo (@repos) {
-            assert_script_run("echo $repo | tee -a /tmp/transfer_repos.txt");
-        }
-        # VM repos.dir support preparation
-        $instance->ssh_assert_script_run("sudo mkdir $repodir;sudo chmod 777 $repodir");
-        # Mitigate occasional CSP network problems (especially one CSP is prone to those issues!)
-        # Delay of 2 minutes between the tries to give their network some time to recover after a failure
-        # For rsync the ~/repos/./ means that the --relative will take efect after.
-        # * The --relative (-R) option is implied when --files-from is specified.
-        # * The --dirs (-d) option is implied whn --files-from is specified.
-        # * The --archive (-a) option's behavior does not imply --recursive (-r) when --files-from is specified.
-        # --recursive (-r), --update (-u), --archive (-a), --human-readable (-h), --rsh (-e)
-        script_retry("rsync --timeout=$timeout -ruahd -e ssh --files-from /tmp/transfer_repos.txt ~/repos/./ '$remote:$repodir'", timeout => $timeout + 10, retry => 3, delay => 120);
-
-        my $total_size = $instance->ssh_script_output(cmd => "du -hs $repodir");
-        record_info("Repo size", "Total repositories size: $total_size");
-        $instance->ssh_assert_script_run("find $repodir -name '*.rpm' -exec du -h '{}' + | sort -h > /tmp/rpm_list.txt", timeout => 60);
-        $instance->upload_log('/tmp/rpm_list.txt');
-
-        if (is_sle_micro(">=6.0")) {
-            my $counter = 0;
-            for my $repo (@repos) {
-                $instance->ssh_assert_script_run("sudo zypper ar -p10 " . $repodir . $repo . " ToTest_$counter");
-                $counter += 1;
-            }
-        }
-        else {
-            $instance->ssh_assert_script_run("sudo find $repodir -name *.repo -exec sed -i 's,http://download.suse.de/ibs/,$repodir,g' '{}' \\;");
-            $instance->ssh_assert_script_run("sudo find $repodir -name *.repo -exec zypper ar -p10 '{}' \\;");
-            $instance->ssh_assert_script_run("sudo find $repodir -name *.repo -exec echo '{}' \\;");
-        }
-
-        $instance->ssh_assert_script_run("zypper lr -P");
     }
+
+    my @repos;
+    my ($incident, $type);
+    for my $maintrepo (@all_repos) {
+        if (is_sle_micro(">=6.0")) {
+            push(@repos, $maintrepo);
+        } else {
+            ($incident, $type) = ($2, $1) if ($maintrepo =~ /\/(PTF|Maintenance):\/(\d+)/g);
+            push(@repos, $maintrepo) unless (is_embargo_update($incident, $type)); }
+    }
+
+    s/https?:\/\/.*\/ibs\/// for @repos;
+
+    # Create list of directories for rsync
+    for my $repo (@repos) {
+        assert_script_run("echo $repo | tee -a /tmp/transfer_repos.txt");
+    }
+    # VM repos.dir support preparation
+    $instance->ssh_assert_script_run("sudo mkdir $repodir;sudo chmod 777 $repodir");
+    # Mitigate occasional CSP network problems (especially one CSP is prone to those issues!)
+    # Delay of 2 minutes between the tries to give their network some time to recover after a failure
+    # For rsync the ~/repos/./ means that the --relative will take efect after.
+    # * The --relative (-R) option is implied when --files-from is specified.
+    # * The --dirs (-d) option is implied whn --files-from is specified.
+    # * The --archive (-a) option's behavior does not imply --recursive (-r) when --files-from is specified.
+    # --recursive (-r), --update (-u), --archive (-a), --human-readable (-h), --rsh (-e)
+    script_retry("rsync --timeout=$timeout -ruahd -e ssh --files-from /tmp/transfer_repos.txt ~/repos/./ '$remote:$repodir'", timeout => $timeout + 10, retry => 3, delay => 120);
+
+    my $total_size = $instance->ssh_script_output(cmd => "du -hs $repodir");
+    record_info("Repo size", "Total repositories size: $total_size");
+    $instance->ssh_assert_script_run("find $repodir -name '*.rpm' -exec du -h '{}' + | sort -h > /tmp/rpm_list.txt", timeout => 60);
+    $instance->upload_log('/tmp/rpm_list.txt');
+
+    if (is_sle_micro(">=6.0")) {
+        my $counter = 0;
+        for my $repo (@repos) {
+            $instance->ssh_assert_script_run("sudo zypper ar -p10 " . $repodir . $repo . " ToTest_$counter");
+            $counter += 1;
+        }
+    }
+    else {
+        $instance->ssh_assert_script_run("sudo find $repodir -name *.repo -exec sed -i 's,http://download.suse.de/ibs/,$repodir,g' '{}' \\;");
+        $instance->ssh_assert_script_run("sudo find $repodir -name *.repo -exec zypper ar -p10 '{}' \\;");
+        $instance->ssh_assert_script_run("sudo find $repodir -name *.repo -exec echo '{}' \\;");
+    }
+
+    $instance->ssh_assert_script_run("zypper lr -P");
 }
 
 sub test_flags {

--- a/variables.md
+++ b/variables.md
@@ -395,7 +395,7 @@ PUBLIC_CLOUD_RESOURCE_GROUP | string | "qesaposd" | Allows to specify resource g
 PUBLIC_CLOUD_RESOURCE_NAME | string | "openqa-vm" | The name we use when creating our VM.
 PUBLIC_CLOUD_ROOT_DISK_SIZE | int |  | Set size of system disk in GiB for public cloud instance. Default size is 30 for Azure and 20 for GCE and EC2 
 PUBLIC_CLOUD_SCC_ENDPOINT | string | "registercloudguest" | Name of binary which will be used to register image . Except default value only possible value is "SUSEConnect" anything else will lead to test failure!
-PUBLIC_CLOUD_SKIP_MU | boolean | false | Debug variable used to run test without maintenance updates repository being applied.
+PUBLIC_CLOUD_SKIP_MU | boolean | false | Run tests without downloading/applying maintenance updates.
 PUBLIC_CLOUD_SLES4SAP | boolean | false | If set, sles4sap test module is added to the job.
 PUBLIC_CLOUD_STORAGE_ACCOUNT | string | "" | Storage account used e.g. for custom disk and container images
 PUBLIC_CLOUD_TERRAFORM_DIR | string | "/root/terraform" | Override default root path to terraform directory


### PR DESCRIPTION
If `PUBLIC_CLOUD_SKIP_MU` is applied, the download_repos test should not be scheduled.

Also removes unnecessary checks for `PUBLIC_CLOUD_SKIP_MU` in modules which are not scheduled anymore if `PUBLIC_CLOUD_SKIP_MU=1` is set.

Follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/23126#issuecomment-3228660768

## Verification runs

* https://duck-norris.qe.suse.de/tests/14926 
* https://duck-norris.qe.suse.de/tests/14927 (with `PUBLIC_CLOUD_SKIP_MU=1`)
