### PR TITLE
Use bootloader_start for agama tests in Leap 16

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -344,7 +344,7 @@ sub select_bootmenu_option {
 
     # Special handling for Agama
     if (get_var('AGAMA')) {
-        send_key_until_needlematch 'boot-agama-installation', 'up', 11, 5;
+        send_key_until_needlematch 'boot-agama-installation', 'down', 11, 5;
         return 0;
     }
     if (get_var('LIVECD')) {

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -627,12 +627,14 @@ sub bootmenu_default_params {
         push @params, "Y2DEBUG=1";
     }
     elsif (get_var('AGAMA')) {
-        wait_screen_change { send_key "e" };
-        send_key "down";
-        send_key "down";
-        send_key "down";
-        send_key "down";
-        wait_screen_change { send_key "end" };
+        if (!$args{in_grub_edit}) {
+            wait_screen_change { send_key "e" };
+            send_key "down";
+            send_key "down";
+            send_key "down";
+            send_key "down";
+            wait_screen_change { send_key "end" };
+        }
         # REPO_0 should be set everywhere where we rsync repo (aside from iso)
         if (get_var('REPO_0')) {
             my $host = get_var('OPENQA_HOST', 'https://openqa.opensuse.org');

--- a/schedule/install/agama_install.yaml
+++ b/schedule/install/agama_install.yaml
@@ -2,7 +2,7 @@ name:           leap16_agama_install
 description:    >
     This is prepare install opensuse-16.0 agama installer
 schedule:
-  - installation/bootloader
+  - installation/bootloader_start
   - installation/agama
   - installation/agama_reboot
   - installation/grub_test

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -176,7 +176,7 @@ sub run {
         return;
     }
 
-    bootmenu_default_params;
+    bootmenu_default_params(in_grub_edit => 1);
     save_screenshot();
     unless (is_selfinstall) {
         bootmenu_remote_target;

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -151,8 +151,9 @@ sub run {
     elsif (get_var('VERSION') !~ /agama/) {
         if (get_var("PROMO") || get_var('LIVETEST') || get_var('LIVECD')) {
             send_key_until_needlematch("boot-live-" . get_var("DESKTOP"), 'down', 11, 3);
-        }
-        elsif (!(is_jeos || ((is_sle_micro || is_leap_micro) && !is_selfinstall)) && !is_microos('VMX')) {
+        } elsif (get_var("AGAMA")) {
+            select_bootmenu_option;
+        } elsif (!(is_jeos || ((is_sle_micro || is_leap_micro) && !is_selfinstall)) && !is_microos('VMX')) {
             send_key_until_needlematch('inst-oninstallation', 'down', 11, 0.5);
         }
     }


### PR DESCRIPTION
Switch to bootloader_start as it is a wrapper for different bootloaders which in turn, are able to handle cmdline parameters for booting the installer pointing to the right repositories

- x86: https://openqa.opensuse.org/tests/5274022
- x86 (latest build) https://openqa.opensuse.org/tests/5274301
- s390: https://openqa.opensuse.org/tests/5272383
  - failure is: https://bugzilla.opensuse.org/show_bug.cgi?id=1248800
- aarch64: https://openqa.opensuse.org/tests/5274044
- ppc64: https://openqa.opensuse.org/tests/5274054
  - failure is https://progress.opensuse.org/issues/180929

This is the alternative to #23123

