### PR TITLE
Adapt schedule for software selection unattended on s390x

### DIFF
--- a/schedule/yam/agama_software_selection_unattended_s390x.yaml
+++ b/schedule/yam/agama_software_selection_unattended_s390x.yaml
@@ -6,6 +6,6 @@ schedule:
   - yam/agama/boot_agama
   - yam/agama/patch_agama_tests
   - yam/agama/agama
-  - installation/grub_test
   - boot/reconnect_mgmt_console
+  - installation/first_boot
   - yam/validate/validate_installed_patterns


### PR DESCRIPTION
##
### Adapt schedule for software selection unattended on s390x
- Related ticket: https://progress.opensuse.org/issues/187686
- Needles: N/A
- Verification run: 
   - [sles_software_selection_unattended_s390x_dev](https://openqa.suse.de/tests/overview?version=16.0&distri=sle&build=hjluo%2Fos-autoinst-distri-opensuse%23fix_patterns_s390x)

##
