### PR TITLE
Fix missing imports

### DIFF
--- a/tests/sles4sap/redirection_tests/check_ensa2_cluster.pm
+++ b/tests/sles4sap/redirection_tests/check_ensa2_cluster.pm
@@ -13,9 +13,8 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use sles4sap::console_redirection;
 use sles4sap::console_redirection::redirection_data_tools;
-use hacluster qw(wait_for_idle_cluster check_cluster_state);
+use hacluster;
 use sles4sap::sap_host_agent qw(saphostctrl_list_instances);
-use hacluster qw($crm_mon_cmd list_configured_sbd sbd_device_report);
 use sles4sap::sapcontrol qw(sapcontrol);
 
 =head1 NAME

--- a/tests/sles4sap/redirection_tests/check_hana_database.pm
+++ b/tests/sles4sap/redirection_tests/check_hana_database.pm
@@ -13,10 +13,9 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use sles4sap::console_redirection;
 use sles4sap::console_redirection::redirection_data_tools;
-use hacluster qw(wait_for_idle_cluster check_cluster_state get_fencing_type);
+use hacluster;
 use sles4sap::database_hana qw(hdb_info);
 use sles4sap::sap_host_agent qw(saphostctrl_list_instances);
-use hacluster qw($crm_mon_cmd list_configured_sbd sbd_device_report);
 
 =head1 NAME
 

--- a/tests/sles4sap/sap_deployment_automation_framework/deploy_workload_zone.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/deploy_workload_zone.pm
@@ -43,7 +43,7 @@ sub run {
     # additional 30m buffer.
     # Tests will therefore attempt to assign only networks which are older than max terraform runtime.
     my $terraform_retries = 3;
-    my $terraform_timeout = 1800;
+    my $terraform_timeout = 2600;
     my $networks_older_than = $terraform_retries * $terraform_timeout + 1800;
 
     # reserve network address space either by reusing already existing one or create a new file


### PR DESCRIPTION
There are missing imports in 'check_hana_database' and 'check_ensa2_cluster' modules. This PR fixes the bug.

Ticket: no ticket

Failing test: https://openqaworker15.qa.suse.cz/tests/339244#step/check_ensa2_cluster/83
VR:
ENSA2: https://openqaworker15.qa.suse.cz/tests/339380#
HanaSR: https://openqaworker15.qa.suse.cz/tests/339383#
