### PR TITLE
xfstests: Add dependency openssl in NFS-tls tests

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -359,7 +359,7 @@ sub install_dependencies_nfs {
       nfs-kernel-server
       nfs4-acl-tools
     );
-    push @deps, 'ktls-utils' if ($NFS_VERSION =~ 'TLS');
+    push @deps, 'ktls-utils', 'openssl-3' if ($NFS_VERSION =~ 'TLS');
     push @deps, 'krb5-client', 'krb5-server' if ($NFS_VERSION =~ 'krb5');
     script_run('zypper --gpg-auto-import-keys ref');
     if (is_transactional) {


### PR DESCRIPTION
In s390x and ppc64le, the openssl-3 is not installed by default, which caused an error during xfstests for NSF-tls related tests. Add this dependency to solve it.

- Related ticket: https://progress.opensuse.org/issues/187938
- Verification run: https://openqa.suse.de/tests/18963101