### PR TITLE
Pc check ip change

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -359,17 +359,15 @@ When the IP differs from `$self->public_ip` we update `$self->public_ip`.
 =cut
 
 sub update_instance_ip {
-    my ($self, %args) = @_;
-    $args{timeout} //= 600;
-    my $delay = $args{timeout} > 180 ? 5 : 1;
+    my $self = shift;
+    my $timeout = 300;
+    my $delay = 5;
+    my $changed = 0;
+    my $public_ip_from_provider = $self->provider->get_public_ip();
 
-    # skip SLES4SAP as incompatible with get_public_ip
-    if (!get_var('PUBLIC_CLOUD_SLES4SAP')) {
-        my $public_ip_from_provider = $self->provider->get_public_ip();
-        
-        my $duration;
-        my $start_time = time();
-        until ($public_ip_from_provider !~ /null/ || ($duration = time() - $start_time) >= $args{timeout}) {
+    return if (get_var('PUBLIC_CLOUD_SLES4SAP');) {
+    until ($public_ip_from_provider !~ /null/ || (time() - $start_time) >= 300 {
+    ...
             sleep($delay);
             $public_ip_from_provider = $self->provider->get_public_ip();
         }

--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -116,6 +116,7 @@ sub run_cmd {
     delete($args{timeout});
     delete($args{runas});
 
+    $self->{my_instance}->update_instance_ip();
     $self->{my_instance}->wait_for_ssh(timeout => $timeout);
     my $out = $self->{my_instance}->run_ssh_command(cmd => "sudo $cmd", timeout => $timeout, %args);
     record_info("$title output - $self->{my_instance}->{instance_id}", $out) unless ($timeout == 0 or $args{quiet} or $args{rc_only});
@@ -392,6 +393,7 @@ sub stop_hana {
         # Crash needs to be executed as root and wait for host reboot
 
         # Ensure the remote node is in a normal state before to trigger the crash
+        $self->{my_instance}->update_instance_ip();
         $self->{my_instance}->wait_for_ssh(timeout => $timeout, scan_ssh_host_key => 1);
 
         $self->{my_instance}->run_ssh_command(cmd => 'sudo su -c sync', timeout => $timeout);
@@ -439,6 +441,7 @@ sub stop_hana {
     else {
         my $sapadmin = lc(get_required_var('INSTANCE_SID')) . 'adm';
         $self->run_cmd(cmd => $cmd, runas => $sapadmin, timeout => $timeout);
+        $self->{my_instance}->update_instance_ip();
         $self->{my_instance}->wait_for_ssh(username => 'cloudadmin', scan_ssh_host_key => 1);
     }
 }

--- a/tests/publiccloud/bsc_1205002.pm
+++ b/tests/publiccloud/bsc_1205002.pm
@@ -34,6 +34,7 @@ sub run {
     $provider->start_instance($instance);
 
     # The instance changes its public IP address so the key must be rescanned
+    $instance->update_instance_ip();
     $instance->wait_for_ssh(scan_ssh_host_key => 1);
     $instance->ssh_assert_script_run("echo we can login");
 }

--- a/tests/sles4sap/publiccloud/azure_fence_agents_test.pm
+++ b/tests/sles4sap/publiccloud/azure_fence_agents_test.pm
@@ -118,6 +118,7 @@ sub run {
         $self->{my_instance} = $instance;
         # do not probe VMs that are not part of the cluster
         next unless grep(/^$instance->{instance_id}$/, @cluster_nodes);
+        $instance->update_instance_ip();
         $instance->wait_for_ssh();
         my $scp_cmd = join('', 'scp /tmp/bashrc ',
             $instance->{username},

--- a/tests/sles4sap/publiccloud/qesap_prevalidate.pm
+++ b/tests/sles4sap/publiccloud/qesap_prevalidate.pm
@@ -31,6 +31,7 @@ sub run {
         $self->{my_instance} = $instance;
         my $instance_id = $instance->{'instance_id'};
         # Check ssh connection for all hosts
+        $instance->update_instance_ip();
         $instance->wait_for_ssh();
 
         # Skip instances without HANA db or setup without cluster

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -270,6 +270,7 @@ sub run {
         $self->set_cli_ssh_opts;
         my $expected_hostname = $instance->{instance_id};
         # We need to scan for the SSH host key as the Ansible later
+        $instance->update_instance_ip();
         $instance->wait_for_ssh();
 
         my $real_hostname = $instance->ssh_script_output(cmd => 'hostname', username => 'cloudadmin');

--- a/tests/sles4sap/sap_deployment_automation_framework/setup_publiccloud_instances.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/setup_publiccloud_instances.pm
@@ -58,6 +58,7 @@ sub run {
     for my $instance (@$instances) {
         $self->{my_instance} = $instance;
         record_info('Wait SSH', 'Running "wait_for_ssh()" on: ' . $instance->{instance_id});
+        $instance->update_instance_ip();
         $instance->wait_for_ssh();
 
         # Check hostname and verify `ssh_script_output` function working


### PR DESCRIPTION
The `publiccloud::instance::wait_for_ssh()` is too big and does too much.
As @m-dati suggested to separate the public IP change check here it is.

- Verification run:
[Buildwait_for_ssh](https://pdostal-server.suse.cz/tests/overview?build=wait_for_ssh&distri=sle&version=15-SP7) of sle-15-SP7-Azure-SAP-BYOS-Incidents.x86_64	[wait_for_ssh@az_Standard_E4s_v3](https://pdostal-server.suse.cz/tests/9981)
[Buildwait_for_ssh](https://pdostal-server.suse.cz/tests/overview?build=wait_for_ssh&distri=sle&version=15-SP7) of sle-15-SP7-EC2-SAP-BYOS-Incidents.x86_64	[wait_for_ssh@ec2_r4.8xlarge](https://pdostal-server.suse.cz/tests/9982)
[Buildwait_for_ssh](https://pdostal-server.suse.cz/tests/overview?build=wait_for_ssh&distri=sle&version=15-SP7) of sle-15-SP7-GCE-SAP-BYOS-Incidents-saptune.x86_64	[wait_for_ssh@gce_n1_highmem_32](https://pdostal-server.suse.cz/tests/9983)
[Buildwait_for_ssh](https://pdostal-server.suse.cz/tests/overview?build=wait_for_ssh&distri=sle&version=15-SP6) of sle-15-SP6-Qesap-Aws-Byos.x86_64	[wait_for_ssh@64bit](https://pdostal-server.suse.cz/tests/9984)
[Buildwait_for_ssh](https://pdostal-server.suse.cz/tests/overview?build=wait_for_ssh&distri=sle&version=15-SP7) of sle-15-SP7-EC2-BYOS-Updates.x86_64	[wait_for_ssh@64bit](https://pdostal-server.suse.cz/tests/9985)
[Buildwait_for_ssh](https://pdostal-server.suse.cz/tests/overview?build=wait_for_ssh&distri=sle&version=15-SP5) of sle-15-SP5-GCE-Updates.aarch64	[wait_for_ssh@64bit](https://pdostal-server.suse.cz/tests/9986)
[Buildwait_for_ssh](https://pdostal-server.suse.cz/tests/overview?build=wait_for_ssh&distri=sle&version=15-SP7) of sle-15-SP7-Azure-BYOS-Updates.aarch64	[wait_for_ssh@64bit](https://pdostal-server.suse.cz/tests/9980)
[Buildwait_for_ssh](https://pdostal-server.suse.cz/tests/overview?build=wait_for_ssh&distri=sle&version=15-SP7) of sle-15-SP7-Azure-BYOS-Updates.aarch64	[wait_for_ssh@64bit](https://pdostal-server.suse.cz/tests/9987)