### PR TITLE
Allow reexecution install_kubectl and install_helm

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -156,10 +156,7 @@ Installs kubectl from the respositories
 =cut
 
 sub install_kubectl {
-    if (script_run("which kubectl") == 0) {
-        record_info('kubectl preinstalled', script_output('kubectl version --client'));
-        return;
-    }
+    return if (script_run("which kubectl") == 0);
 
     # kubectl is in the container module
     add_suseconnect_product(get_addon_fullname('contm')) if (is_sle("<16"));
@@ -174,6 +171,8 @@ Installs helm from our upstream or repositories
 =cut
 
 sub install_helm {
+    return if (script_run("which helm") == 0);
+
     if (get_var('HELM_INSTALL_UPSTREAM')) {
         assert_script_run("curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3");
         assert_script_run("chmod 700 get_helm.sh");

--- a/tests/containers/scc_login_to_registry.pm
+++ b/tests/containers/scc_login_to_registry.pm
@@ -13,6 +13,7 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use utils;
 use serial_terminal qw(select_serial_terminal);
+use containers::k8s qw(install_kubectl install_helm);
 
 sub run {
     my $registry = get_required_var('SCC_REGISTRY');
@@ -20,6 +21,9 @@ sub run {
     my $password = get_required_var('SCC_PROXY_PASSWORD');
 
     select_serial_terminal;
+
+    install_kubectl();
+    install_helm();
 
     my $runtime = get_required_var('CONTAINER_RUNTIMES');
 


### PR DESCRIPTION
Allow install_kubectl and install_helm to be called multiple times. On subsequent calls the routines will not re-install the packages.

- Related failure: https://openqa.suse.de/tests/18963129#step/privateregistry/60
- Verification run: https://duck-norris.qe.suse.de/tests/14930
