### PR TITLE
Configurable GCE project name

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp.yaml
@@ -11,7 +11,7 @@ apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
-    project: 'ei-sle-qa-sap-8469'
+    project: '%GOOGLE_PROJECT%'
     region: '%REGION%'
     deployment_name: '%DEPLOYMENTNAME%'
     os_image: '%OS_VER%'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_fencing.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_fencing.yaml
@@ -9,7 +9,7 @@ apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
-    project: 'ei-sle-qa-sap-8469'
+    project: '%GOOGLE_PROJECT%'
     region: '%REGION%'
     deployment_name: '%DEPLOYMENTNAME%'
     os_image: '%OS_VER%'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_peering.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_peering.yaml
@@ -11,7 +11,7 @@ apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
-    project: 'ei-sle-qa-sap-8469'
+    project: '%GOOGLE_PROJECT%'
     region: '%REGION%'
     deployment_name: '%DEPLOYMENTNAME%'
     os_image: '%OS_VER%'

--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_sapconf.yaml
@@ -11,7 +11,7 @@ apiver: 4
 terraform:
   bin: '%TERRAFORM_RUNNER%'
   variables:
-    project: 'ei-sle-qa-sap-8469'
+    project: '%GOOGLE_PROJECT%'
     region: '%REGION%'
     deployment_name: '%DEPLOYMENTNAME%'
     os_image: '%OS_VER%'

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -23,6 +23,7 @@
 # INSTANCE_ID - SAP instance id
 # ANSIBLE_REMOTE_PYTHON - define python version to be used for qe-sap-deployment (default '/usr/bin/python3')
 # PUBLIC_CLOUD_IMAGE_LOCATION - needed by get_blob_uri
+# HANA_NAMESPACE - used to configure the Azure credentials involved in obtaining the HANA media
 
 use base 'sles4sap_publiccloud_basetest';
 use testapi;
@@ -122,7 +123,7 @@ sub run {
     # Needed to create the SAS URI token
     if (!is_azure()) {
         my $azure_client = publiccloud::azure_client->new();
-        $azure_client->init(namespace => 'sapha');
+        $azure_client->init(namespace => get_var('HANA_NAMESPACE', 'sapha'));
     }
 
     # variable to be conditionally used to hold ptf file names,

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -25,7 +25,7 @@ sub run {
     # Needed to create the SAS URI token
     if ($provider_setting ne 'AZURE') {
         my $azure_client = publiccloud::azure_client->new();
-        $azure_client->init(namespace => 'sapha');
+        $azure_client->init(namespace => get_var('QESAPDEPLOY_HANA_NAMESPACE', 'sapha'));
     }
 
     my %variables;
@@ -79,9 +79,9 @@ sub run {
     $variables{SCC_REGCODE_SLES4SAP} = get_var('SCC_REGCODE_SLES4SAP', '');
     $variables{SCC_LTSS_REGCODE} = get_var('SCC_REGCODE_LTSS', '');
     $variables{SCC_LTSS_MODULE} = get_var('QESAPDEPLOY_SCC_LTSS_MODULE', '');
-    if ($provider_setting eq 'EC2') {
-        $variables{HANA_INSTANCE_TYPE} = get_var('QESAPDEPLOY_HANA_INSTANCE_TYPE', 'r6i.xlarge');
-    }
+
+    $variables{GOOGLE_PROJECT} = get_var('QESAPDEPLOY_GOOGLE_PROJECT', 'ei-sle-qa-sap-8469') if ($provider_setting eq 'GCE');
+    $variables{HANA_INSTANCE_TYPE} = get_var('QESAPDEPLOY_HANA_INSTANCE_TYPE', 'r6i.xlarge') if ($provider_setting eq 'EC2');
 
     $variables{HANA_ACCOUNT} = get_required_var('QESAPDEPLOY_HANA_ACCOUNT');
     $variables{HANA_CONTAINER} = get_required_var('QESAPDEPLOY_HANA_CONTAINER');


### PR DESCRIPTION
Make the project name in the qe-sap-deployment config.yaml templates configureble via setting.
Add a second setting for the Azure client namespace used to get the HANA media.

- Related ticket: https://jira.suse.com/browse/TEAM-10432

# Verification run:

## qesap regression
sle-15-SP7-Qesap-Gcp-Byos-x86_64-Buildmpagot_VR-qesap_gcp_sapconf_test

With new GCP namespace and QESAPDEPLOY_GOOGLE_PROJECT for that 
- http://openqaworker15.qa.suse.cz/tests/339407 :green_circle:  right project is in http://openqaworker15.qa.suse.cz/tests/339407/file/configure-qesap_gcp_sapconf.yaml and the overall deployment is ok.

With old namespace and without QESAPDEPLOY_GOOGLE_PROJECT
- http://openqaworker15.qa.suse.cz/tests/339408 :green_circle: 

sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_angi_test
- http://openqaworker15.qa.suse.cz/tests/339409 :green_circle: 

## hanasr
sle-15-SP7-HanaSr-Gcp-Payg-x86_64-Build15-SP7_2025-08-28T02:03:19Z-hanasr_gcp_test_fencing_native_stop_kill gce_n1_highmem_32
 -http://openqaworker15.qa.suse.cz/tests/339410 :green_circle: deployment is ok
