### PR TITLE
Simplify scc_login_to_registry

### DIFF
--- a/tests/containers/scc_login_to_registry.pm
+++ b/tests/containers/scc_login_to_registry.pm
@@ -22,25 +22,15 @@ sub run {
 
     select_serial_terminal;
 
-    install_kubectl();
     install_helm();
 
-    my $runtime = get_required_var('CONTAINER_RUNTIMES');
-
-    # Container runtime login
     assert_script_run(
-        qq(echo "$password" | $runtime login -u "$username" --password-stdin $registry)
-    ) if script_run("command -v $runtime") == 0;
+        qq(echo "$password" | helm registry login -u "$username" --password-stdin $registry)
+    );
+}
 
-    # If HELM_CHART is set, also log in Helm's OCI registry (covers oci:// charts)
-    if (get_var('HELM_CHART')) {
-        assert_script_run(
-            qq(echo "$password" | helm registry login -u "$username" --password-stdin $registry)
-        ) if script_run("command -v helm") == 0;
-        assert_script_run(
-            qq(kubectl create secret docker-registry suse-registry --docker-server=$registry --docker-username=$username --docker-password=$password)
-        ) if script_run("command -v kubectl") == 0;
-    }
+sub test_flags {
+    return {milestone => 1, fatal => 1};
 }
 
 1;


### PR DESCRIPTION
Since the purpose is only to add credentials for helm, remove all other parts which are not needed.

- Related failure: https://openqa.suse.de/tests/18963662#step/scc_login_to_registry/57
- Verification run: https://duck-norris.qe.suse.de/tests/14931#step/privateregistry/54 (unrelated issue)