### PR TITLE
Re-add kubectl create secret

### DIFF
--- a/tests/containers/scc_login_to_registry.pm
+++ b/tests/containers/scc_login_to_registry.pm
@@ -27,6 +27,9 @@ sub run {
     assert_script_run(
         qq(echo "$password" | helm registry login -u "$username" --password-stdin $registry)
     );
+    assert_script_run(
+        qq(kubectl create secret docker-registry suse-registry --docker-server=$registry --docker-username=$username --docker-password=$password)
+    );
 }
 
 sub test_flags {


### PR DESCRIPTION
Credentials are needed so that k3s can download the released containers.

* Follow-up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/23145

- Verification run: https://duck-norris.qe.suse.de/tests/14932#live
