### PR TITLE
kernel_kexec: Remove old workaround

### DIFF
--- a/tests/kernel/kernel_kexec.pm
+++ b/tests/kernel/kernel_kexec.pm
@@ -13,8 +13,6 @@ use utils;
 sub run {
     my $self = shift;
     select_serial_terminal;
-    # clear console to prevent linux-login to match before reboot
-    clear_console;
     # Copy kernel image and rename it
     my $find_output = script_output('find /boot -maxdepth 1 -name "*$(uname -r)"', 600);
     record_info('Find output', $find_output);


### PR DESCRIPTION
On some overloaded aarch64 workers, clear_console might hang and trigger a timeout.

Related ticket: https://progress.opensuse.org/issues/184097

Verification runs:

- Many retries failed to reproduce the error when clear_console is absent: https://openqa.suse.de/tests/18965821#next_previous
- Error was reproduced on the third time when clear_console is present: https://openqa.suse.de/tests/18964435#next_previous