### PR TITLE
Update the grub of migration menu match for sle16 migration

### DIFF
--- a/tests/yam/migration/migration_unattended.pm
+++ b/tests/yam/migration/migration_unattended.pm
@@ -30,8 +30,7 @@ sub run {
 
     power_action('reboot', keepconsole => 1, first_reboot => 1);
 
-    assert_screen('grub-menu-migration');
-    assert_screen('migration-running');
+    assert_screen([qw(grub-menu-migration migration-running)]);
     assert_screen('grub2', 400);
 }
 


### PR DESCRIPTION
The time in grub for migration menu is too short, and openqa testing run so fast that non-x86_64 jobs can not catch the migration menu. So update the needle match for it.

- Related failures:
  https://openqa.suse.de/tests/18971256#step/migration_unattended/1 (aarch64)
  https://openqa.suse.de/tests/18971255#step/migration_unattended/1 (ppc64le)
 - Verification run:[ verification runs](https://openqa.suse.de/tests/overview?arch=&flavor=&machine=&test=sles_migration_15sp7_textmode_test&modules=&module_re=&group_glob=&not_group_glob=&comment=&build=chcao_review_132.4&version=16.0&distri=sle#)