### PR TITLE
Quickfix for boot_agama on Leap 16

### DIFF
--- a/lib/Distribution/Opensuse/Leap/16Latest.pm
+++ b/lib/Distribution/Opensuse/Leap/16Latest.pm
@@ -14,18 +14,10 @@ use strict;
 use warnings FATAL => 'all';
 
 use Yam::Agama::Pom::GrubMenuLeapPage;
-use Yam::Agama::Pom::GrubMenuAgamaPage;
-use Yam::Agama::Pom::GrubMenuAgamaDeprecatedEntryOrderPage;
 
 sub get_grub_menu_installed_system {
     my $self = shift;
     return Yam::Agama::Pom::GrubMenuLeapPage->new({grub_menu_base => $self->get_grub_menu_base()});
-}
-
-sub get_grub_menu_agama {
-    return Yam::Agama::Pom::GrubMenuAgamaDeprecatedEntryOrderPage->new({
-            grub_menu_agama => Yam::Agama::Pom::GrubMenuAgamaPage->new({
-                    grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()})});
 }
 
 1;


### PR DESCRIPTION
- Meanwhile Leap 16 Grub menu also has "boot from harddisk" as first entry in the menu, so no need to handle Leap differently anymore.

- Verification run: https://openqa.opensuse.org/tests/5275008