### PR TITLE
containers: Remove flaky search test

### DIFF
--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -56,9 +56,6 @@ sub basic_container_tests {
     die "Undefined container runtime" unless $runtime;
     my $image = get_var("CONTAINER_IMAGE_TO_TEST", "registry.opensuse.org/opensuse/tumbleweed:latest");
 
-    ## Test search feature
-    validate_script_output("$runtime search --no-trunc --format 'table {{.Name}} {{.Description}}' tumbleweed", sub { m/Official openSUSE Tumbleweed images/ }, timeout => 300);
-
     # Test pulling and display of images
     script_retry("$runtime image pull $image", timeout => 600, retry => 3, delay => 120);
     validate_script_output("$runtime image ls", qr/tumbleweed/);


### PR DESCRIPTION
Remove flaky search test.  This test depends that a lot of devel images don't appear at the beginning.   And it's redundant anyway given that we have `test_search_registry`

Failing test: https://openqa.suse.de/tests/18983894#step/podman/152
