### PR TITLE
Drop some unneeded patches since latest Tumbleweed 20250829

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -104,8 +104,6 @@ podman:
   # https://github.com/containers/podman/pull/26920 is needed to drop ncat
   opensuse-Tumbleweed:
     BATS_PATCHES:
-    - 25918
-    - 25942
     - 26017
     - 26798
     - 26920

--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -37,7 +37,6 @@ buildah:
   # https://github.com/containers/buildah/pull/6226 is needed for bud & run
   opensuse-Tumbleweed:
     BATS_PATCHES:
-    - 6226
     BATS_IGNORE:
     BATS_IGNORE_ROOT:
     BATS_IGNORE_USER:

--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -6,7 +6,6 @@ aardvark-dns:
   # https://github.com/containers/aardvark-dns/pull/623 is needed to drop ncat
   opensuse-Tumbleweed:
     BATS_PATCHES:
-    - 619
     - 623
     BATS_IGNORE:
   sle-16.0:


### PR DESCRIPTION
These patches are no longer needed since Tumbleweed 20250829:

- aardvark-dns: PR#619 not needed since v1.16.0
- buildah: PR#6226 not needed since v1.41.3
- podman: PR#25918 & 25942 not needed since v5.6.0

Even though these patches are idempotent, we must clean them up from the list to have a minimal reproducer.  The patches are not removed from the repo because they'll be needed when podman is upgraded on SLES.