### PR TITLE
bci_prepare: Limit block to openSUSE & SLES

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -114,10 +114,12 @@ sub run {
     # For BCI tests using podman, buildah package is also needed
     install_buildah_when_needed($host_distri) if ($engines =~ /podman/);
 
-    if (get_var('BCI_PREPARE') && is_sle("15-SP7+", get_var('HOST_VERSION', get_required_var('VERSION')))) {
-        install_k3s();
-        systemctl 'disable --now firewalld';
-        install_helm();
+    if ($host_distri =~ /opensuse|sles/) {
+        if (get_var('BCI_PREPARE') && is_sle("15-SP7+", get_var('HOST_VERSION', get_required_var('VERSION')))) {
+            install_k3s();
+            systemctl 'disable --now firewalld';
+            install_helm();
+        }
     }
 }
 


### PR DESCRIPTION
Limit block to openSUSE & SLES.

Fix `bash: zypper: command not found`

Failing test: https://openqa.suse.de/tests/18992102#step/bci_prepare/167