### PR TITLE
Do not re-open powershell for o3 MSstore installation in WSL

### DIFF
--- a/tests/wsl/smoke_test.pm
+++ b/tests/wsl/smoke_test.pm
@@ -26,8 +26,9 @@ sub run {
     elsif (match_has_tag('welcome_to_wsl')) {
         click_lastmatch;
         send_key 'alt-f4';
-        # We need to re-open powershell for o3 yast-firstrun scenario
-        if (check_var('WSL_FIRSTBOOT', 'yast')) {
+        # We need to re-open powershell for o3 install from build scenario.
+        # osd deals with welcome_to_wsl during installation in distro_install.pm
+        if (check_var('WSL_INSTALL_FROM', 'build')) {
             $self->open_powershell_as_admin;
         }
     }


### PR DESCRIPTION
Powershell is still opening twice for installation from MSStore legacy scenario.
We need to only re-open powershell for installation from build in o3.

Related ticket: https://progress.opensuse.org/issues/187737 and https://progress.opensuse.org/issues/187470

Verification run:

Leap:
wsl_main win 11: https://openqa.opensuse.org/tests/5278591
wsl2_main win 11: https://openqa.opensuse.org/tests/5278592
modern jeos-firstrun win11: https://openqa.opensuse.org/tests/5278583
legacy yast-firstrun win 11: https://openqa.opensuse.org/tests/5278577

TW:
wsl2_main win 11: https://openqa.opensuse.org/tests/5278590
modern jeos-firstrun win11: https://openqa.opensuse.org/tests/5278584
legacy yast-firstrun win 11: https://openqa.opensuse.org/tests/5278578

SLE:
modern jeos-firstrun win11 sp6: https://openqa.suse.de/tests/18992742#
modern jeos-firstrun win 11 sp7: https://openqa.suse.de/tests/18992743#
wsl2_main + register win 11 sp7: https://openqa.suse.de/tests/18992744#
legacy yast-firstrun win 11 sp6: https://openqa.suse.de/tests/18992745#


