### PR TITLE
Avoid excluding Tumbleweed in validate_raid for ppc64le

### DIFF
--- a/tests/console/validate_raid.pm
+++ b/tests/console/validate_raid.pm
@@ -72,7 +72,7 @@ my (
 );
 # Prepare test data depending on specific architecture/product
 sub prepare_test_data {
-    if ((is_ppc64le || is_ppc64) && is_sle('<16')) {
+    if ((is_ppc64le || is_ppc64) && !is_sle('16+')) {
         @partitioning = (
             $raid_partitions_3_arrays, $hard_disks, $linux_raid_member_3_arrays,
             $ext4_boot,


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/187839

VR: 
- Tumbleweed https://openqa.opensuse.org/tests/5278586
- SLE 15-SP7: https://openqa.suse.de/tests/18992486
- SLE 16: https://openqa.suse.de/tests/18992577#details
