### PR TITLE
Kselftests: Add $test_name to test_progs BPF parser

### DIFF
--- a/lib/Kselftests/parsers/bpf/test_progs.pm
+++ b/lib/Kselftests/parsers/bpf/test_progs.pm
@@ -17,13 +17,16 @@ our $test_idx = 1;
 
 sub parse_line {
     my ($self, $test_ln) = @_;
-    my ($description, $st, $diag);
+    my ($description, $st, $test_name, $diag);
     if ($test_ln =~ /^#\s#\S+\s+(\S+):(OK|FAIL|SKIP)$/) {
         ($description, $st) = ($1, $2);
-    } elsif ($test_ln =~ /^#\s(\S*?):(PASS|SKIP|FAIL):(.*)$/) {
-        ($description, $st, $diag) = ($1, $2, $3);
+    } elsif ($test_ln =~ /^#\s(\S*?):(PASS|SKIP|FAIL):(\S*?)\s(.*)$/) {
+        ($description, $st, $test_name, $diag) = ($1, $2, $3, $4);
     }
     if ($description) {
+        if ($test_name) {
+            $description .= "/$test_name";
+        }
         my $normalized;
         if ($st eq 'PASS') {
             $normalized = "# ok $test_idx $description";


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/187791

Verification runs:
- Before: https://rmarliere-openqa.qe.prg2.suse.org/tests/1535/logfile?filename=run_kselftests-kselftest.tap.txt#line-82
- After: https://rmarliere-openqa.qe.prg2.suse.org/tests/1539/logfile?filename=run_kselftests-kselftest.tap.txt#line-82