### PR TITLE
Use crm command supported across all versions

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -2064,7 +2064,7 @@ Returns full type name ('external/sbd', 'fence_azure_arm', ...).
 =cut
 
 sub get_fencing_type {
-    my $stonith_type = script_output('crm configure show related:stonith | grep primitive');
+    my $stonith_type = script_output('crm configure show type:primitive | grep stonith');
     $stonith_type =~ m/stonith:(.*)\s/;
     return $1;
 }

--- a/t/11_hacluster.t
+++ b/t/11_hacluster.t
@@ -931,12 +931,9 @@ subtest '[get_fencing_type] ' => sub {
         'external/sbd' => 'primitive some-name stonith:external/sbd \\',
         'fence_azure_arm' => 'primitive rsc_st_azure stonith:fence_azure_arm \\',
     );
-
-    for my $expected_result (keys(%tested_values)) {
-        $hacluster->redefine(script_output => sub { return $tested_values{$expected_result}; });
-        is get_fencing_type, $expected_result, "Return correct fencing type '$expected_result'";
-    }
-
+    my @tested_keys = keys(%tested_values);
+    $hacluster->redefine(script_output => sub { return $tested_values{shift(@tested_keys)}; });
+    is get_fencing_type, $_, "Return correct fencing type '$_'" foreach @tested_keys;
 };
 
 done_testing;


### PR DESCRIPTION
Function `get_fencing_type` uses crm shell command which is supported only on newer crm shell versions. This makes function to fail. This PR replaces `crm configure show related:stonith` with call supported by older crm shell versions.

Ticket: https://jira.suse.com/browse/TEAM-10612
Verification run: 
15SP4 : https://openqaworker15.qa.suse.cz/tests/339963#
15SP5 : https://openqaworker15.qa.suse.cz/tests/339958
