### PR TITLE
Kselftests: Add BPF test_xsk_sh parser

### DIFF
--- a/lib/Kselftests/parser.pm
+++ b/lib/Kselftests/parser.pm
@@ -27,6 +27,7 @@ use Kselftests::parsers::bpf::test_tc_tunnel_sh;
 use Kselftests::parsers::bpf::test_tcpnotify_user;
 use Kselftests::parsers::bpf::test_verifier;
 use Kselftests::parsers::bpf::test_xdping_sh;
+use Kselftests::parsers::bpf::test_xsk_sh;
 
 use testapi;
 use strict;

--- a/lib/Kselftests/parsers/bpf/test_xsk_sh.pm
+++ b/lib/Kselftests/parsers/bpf/test_xsk_sh.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Parser for the bpf:test_xsk.sh selftest
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package Kselftests::parsers::bpf::test_xsk_sh;
+
+use base 'Kselftests::parsers::main';
+use testapi;
+use strict;
+use warnings;
+
+sub parse_line {
+    my ($self, $test_ln) = @_;
+    if ($test_ln =~ /^#\s(?<status>ok|not ok)?\s(?<idx>\d+)\s(?:PASS|FAIL):\s(?<mode>\S*)\s(?<subtest>\S*)$/) {
+        my ($status, $idx, $mode, $subtest) = @+{qw(status idx mode subtest)};
+        return "# $status $idx ${mode}_${subtest}";
+    } elsif ($test_ln =~ /SKIP/) {
+        return $test_ln;
+    }
+    return undef;
+}
+
+1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/187791
- Verification run: https://rmarliere-openqa.qe.prg2.suse.org/tests/1546#external