### PR TITLE
Increase TIMEOUT_SCALE for clusters on pvm_hmc

### DIFF
--- a/schedule/ha/bv/pvm_cluster.yaml
+++ b/schedule/ha/bv/pvm_cluster.yaml
@@ -31,7 +31,7 @@ vars:
   DESKTOP: 'textmode'
   HA_CLUSTER: '1'
   HDD_SCC_REGISTERED: '1'
-  TIMEOUT_SCALE: '2'
+  TIMEOUT_SCALE: '4'
 schedule:
   - '{{barrier_init}}'
   - installation/bootloader


### PR DESCRIPTION
... in the schedule.

Some times using `TIMEOUT_SCALE: 2` leads to jobs reporting a failure during `shutdown/shutdown`, but it seems it just needs more time.

This increases it to `TIMEOUT_SCALE: 4`.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?build=PR23176&distri=sle&version=16.0
