### PR TITLE
Do not delete k3s after usage

### DIFF
--- a/tests/containers/run_container_in_k3s.pm
+++ b/tests/containers/run_container_in_k3s.pm
@@ -54,12 +54,6 @@ sub run {
         assert_script_run('kubectl wait --timeout=600s --for=condition=Ready pod/testing-pod', timeout => 610);
         validate_script_output('kubectl exec testing-pod -- cat /etc/os-release', sub { m/SUSE Linux Enterprise Server/ }, timeout => 300);
     }
-
-}
-
-sub cleanup {
-    my ($self) = @_;
-    uninstall_k3s();
 }
 
 sub post_fail_hook {
@@ -71,12 +65,10 @@ sub post_fail_hook {
     record_info('K3s pods', script_output('kubectl get pods --all-namespaces'));
     script_run('kubectl describe pods --all-namespaces');
     script_run('kubectl describe jobs --all-namespaces');
-    $self->cleanup();
 }
 
 sub post_run_hook {
     my ($self) = @_;
-    $self->cleanup();
 }
 
 


### PR DESCRIPTION
We need the k3s for helm chart testing so do not delete the k3s installation after using it.

- Related failure: https://duck-norris.qe.suse.de/tests/14937#step/run_container_in_k3s/60
- Verification run: TBD
