### PR TITLE
SLES4SAP: Add new function 'run_cmd_retry'

### DIFF
--- a/t/12_sles4sap_publiccloud.t
+++ b/t/12_sles4sap_publiccloud.t
@@ -529,7 +529,7 @@ subtest '[get_hana_topology]' => sub {
         }
     );
     $sles4sap_publiccloud->redefine(calculate_hana_topology => sub { return \%test_topology; });
-    $sles4sap_publiccloud->redefine(run_cmd => sub {
+    $sles4sap_publiccloud->redefine(run_cmd_retry => sub {
             my ($self, %args) = @_;
             push @calls, $args{cmd};
             return "Output does no matter as calculate_hana_topology is redefined.";


### PR DESCRIPTION
This function adds retry capability on top of 'run_cmd'. Use this new function in 'get_hana_topology' to reduce chance of sporadic failure.

This function is modeled after `script_output_retry`:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/c56f08cd935d9b1f02d69bd5bc2aa7f9594e8aee/lib/utils.pm#L2074

- Related ticket: https://jira.suse.com/browse/TEAM-10485
- Needles: none
- Verification run:
example that this PR does not break test: https://openqa.suse.de/tests/19004924#step/Stop_site_a-primary/124
example where the retry mechanism work: https://openqa.suse.de/tests/18991224#step/qesap_prevalidate/79