### PR TITLE
[WIP]xfstests: Fix NFS with krb5 tests fails in s390x

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -422,7 +422,7 @@ END
 }
 
 sub setup_krb5 {
-    script_run('hostname localhost');
+    script_run('hostnamectl set-hostname susetest@SUSETEST.COM');
     my $content = <<END;
 includedir  /etc/krb5.conf.d
 
@@ -452,17 +452,17 @@ END
     script_run('kdb5_util create -s -P susetest -r SUSETEST.COM');
     script_run('systemctl start krb5kdc kadmind; systemctl enable krb5kdc kadmind');
     script_run('echo -e "susetest\nsusetest" | kadmin.local -q "addprinc root/admin@SUSETEST.COM"');
-    script_run('kadmin.local -q "addprinc -randkey nfs/$(hostname -f)@SUSETEST.COM"');
-    script_run('kadmin.local -q "ktadd -k /etc/krb5.keytab nfs/$(hostname -f)@SUSETEST.COM"');
+    script_run('kadmin.local -q "addprinc -randkey nfs/susetest@SUSETEST.COM"');
+    script_run('kadmin.local -q "ktadd -k /etc/krb5.keytab nfs/susetest@SUSETEST.COM"');
 
     #verify the key
     script_run('klist -kte /etc/krb5.keytab');
-    script_run('kadmin.local -q "getprinc nfs/$(hostname -f)@SUSETEST.COM"');
+    script_run('kadmin.local -q "getprinc nfs/susetest@SUSETEST.COM"');
 
     #get kerberos ticket and check
-    script_run('kinit -k host/$(hostname -f)@SUSETEST.COM');
+    script_run('kinit -k host/susetest@SUSETEST.COM');
     script_run('klist');
-    script_run('kinit -k nfs/$(hostname -f)@SUSETEST.COM');
+    script_run('kinit -k nfs/susetest@SUSETEST.COM');
     script_run('klist');
 }
 


### PR DESCRIPTION
In s390x hostname will cause unexpacted fail, change to use localhost in this part directly

- Ticket: https://progress.opensuse.org/issues/188094
- Verification run: https://openqa.suse.de/tests/19007032

