### PR TITLE
Ensure PackageKit gets masked properly by scheduling system_prepare

### DIFF
--- a/schedule/security/autoyast_btrfs_luks2_tw.yaml
+++ b/schedule/security/autoyast_btrfs_luks2_tw.yaml
@@ -12,6 +12,7 @@ schedule:
   - installation/boot_encrypt
   - installation/first_boot
   - autoyast/console
+  - console/system_prepare
   - console/zypper_ar
   - console/zypper_ref
   - security/tpm2/tpm2_env_setup


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/187083

Current schedule has a failure rate of [about 50%](https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=opensuse&flavor=DVD&machine=64bit&test=unlock_luks2_volume_with_tpm2&version=Tumbleweed#next_previous) due to a race when calling `zypper` while `PackageKit` is still running in the background

VR: https://openqa.opensuse.org/tests/overview?version=Tumbleweed&build=foursixnine%2Fos-autoinst-distri-opensuse%2323188&distri=opensuse

