### PR TITLE
Introduce K3S and Helm pre-installation

### DIFF
--- a/schedule/containers/create_hdd_autoyast.yaml
+++ b/schedule/containers/create_hdd_autoyast.yaml
@@ -16,6 +16,10 @@ conditional_schedule:
         FIPS:
             '1':
                 - fips/fips_setup
+    k3s_helm_install:
+        INSTALL_K3S:
+            '1':
+                - containers/k3s_helm_install
 
 schedule:
     - autoyast/prepare_profile
@@ -30,6 +34,7 @@ schedule:
     - console/system_prepare
     - '{{fips}}'
     - containers/bci_prepare
+    - '{{k3s_helm_install}}'
     - shutdown/cleanup_before_shutdown
     - shutdown/shutdown
     - '{{svirt_upload_assets}}'

--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -113,14 +113,6 @@ sub run {
     my $engines = get_required_var('CONTAINER_RUNTIMES');
     # For BCI tests using podman, buildah package is also needed
     install_buildah_when_needed($host_distri) if ($engines =~ /podman/);
-
-    if ($host_distri =~ /opensuse|sles/) {
-        if (get_var('BCI_PREPARE') && is_sle("15-SP7+", get_var('HOST_VERSION', get_required_var('VERSION')))) {
-            install_k3s();
-            systemctl 'disable --now firewalld';
-            install_helm();
-        }
-    }
 }
 
 sub test_flags {

--- a/tests/containers/k3s_helm_install.pm
+++ b/tests/containers/k3s_helm_install.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: k3s helm
+# Summary: Ensure that k3s and helm is installed in the system
+# - check if k3s is installed; if not, install k3s
+# - check if helm is installed; if not, install helm
+# Maintainer: qe-c <qe-c@suse.de>
+
+use Mojo::Base 'containers::basetest';
+use testapi;
+use utils;
+use serial_terminal qw(select_serial_terminal);
+use containers::k8s qw(install_helm install_k3s);
+
+# Expected to work only on x86_64 and aarch64 due to k3s restrictions and only on Suse hosts due to the usage of zypper
+sub run {
+    select_serial_terminal;
+
+    install_k3s();
+    systemctl 'disable --now firewalld';
+    install_helm() if get_var("INSTALL_HELM");
+}
+
+1;

--- a/variables.md
+++ b/variables.md
@@ -99,6 +99,8 @@ HPC_WAREWULF_CONTAINER | string | | Set the container meant for warewulf test su
 HPC_WAREWULF_CONTAINER_NAME | string | The OS name which is expected to run from HPC_WAREWULF_CONTAINER.
 HPC_WAREWULF_CONTAINER_USERNAME | string | Defining username enables authentication for containers, needs valid HPC subscription on SCC for containers from registry.suse.com. If you want use default HPC subscription, just set same value as in SCC_EMAIL
 _SECRET_HPC_WAREWULF_CONTAINER_PASSWORD | string | Password for container, needs valid HPC subscription on SCC for containers from registry.suse.com. If not specified it will use code from SCC_REGCODE_HPC
+INSTALL_HELM | boolean | | If set, install HELM
+INSTALL_K3S | boolean | | If set, install K3S
 INSTALL_KEYBOARD_LAYOUT | string | | Specify one of the supported keyboard layout to switch to during installation or to be used in autoyast scenarios e.g.: cz, fr
 INSTALL_SOURCE | string | | Specify network protocol to be used as installation source e.g. MIRROR_HTTP
 INSTALLATION_VALIDATION | string | | Comma separated list of modules to be used for installed system validation, should be used in combination with INSTALLONLY, to schedule only relevant test modules.


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/186465
- Verification run: 
[s390x should fail in k3s installation because `Downloading hash https://github.com/k3s-io/k3s/releases/download/v1.33.4+k3s1/sha256sum-s390x.txt`](https://openqa.suse.de/tests/19007643)
[x86_64 should pass](https://openqa.suse.de/tests/19007644)
[aarch64 should pass](https://openqa.suse.de/tests/19007645)
[ppc64le should fail in k3s installation because otherwise `[ERROR]  Unsupported architecture ppc64le`](https://openqa.suse.de/tests/19007647)