### PR TITLE
Disable grub timeout in SLES for SAP 16.0 tests on pvm_hmc

### DIFF
--- a/data/sles4sap/agama/sles_sap_default_ppc64le.jsonnet
+++ b/data/sles4sap/agama/sles_sap_default_ppc64le.jsonnet
@@ -3,6 +3,9 @@
     id: '{{AGAMA_PRODUCT_ID}}',
     registrationCode: '{{SCC_REGCODE_SLES4SAP}}',
   },
+  bootloader: {
+    stopOnBootMenu: true
+  },
   root: {
     password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
     hashedPassword: true,

--- a/schedule/sles4sap/agama_saptune_on_pvm.yaml
+++ b/schedule/sles4sap/agama_saptune_on_pvm.yaml
@@ -12,6 +12,7 @@ vars:
 schedule:
   - installation/bootloader
   - installation/agama_reboot
+  - installation/grub_test
   - installation/first_boot
   - console/system_prepare
   - sles4sap/saptune/mr_test

--- a/schedule/sles4sap/hana/pvm_hana_cluster_node_sle16.yaml
+++ b/schedule/sles4sap/hana/pvm_hana_cluster_node_sle16.yaml
@@ -40,6 +40,7 @@ schedule:
   - '{{barrier_init}}'
   - installation/bootloader
   - installation/agama_reboot
+  - installation/grub_test
   - installation/first_boot
   - ha/wait_barriers
   - console/system_prepare
@@ -78,9 +79,11 @@ conditional_schedule:
     HA_CLUSTER_INIT:
       yes:
         - boot/reconnect_mgmt_console
+        - installation/grub_test
         - installation/first_boot
   boot_to_desktop_non_init:
     HA_CLUSTER_INIT:
       no:
         - boot/reconnect_mgmt_console
+        - installation/grub_test
         - installation/first_boot

--- a/schedule/sles4sap/sles4sap_agama_auto_install_pvm_test.yaml
+++ b/schedule/sles4sap/sles4sap_agama_auto_install_pvm_test.yaml
@@ -7,6 +7,7 @@ schedule:
   - '{{barrier_init}}'
   - yam/agama/boot_agama
   - installation/agama_reboot
+  - installation/grub_test
   - installation/first_boot
   - console/system_prepare
   - console/consoletest_setup


### PR DESCRIPTION
The default 8s timeout can cause some tests on pvm_hmc backend to fail as `lib/sles4sap::reboot()` would call 2 times `lib/opensusebasetests::wait_grub()`, and 8s could be not enough time to assert the grub screen twice.

This commit disables the grub timeout on SLES for SAP 16.0 installations by adding `stopOnBootMenu` in
`data/sles4sap/agama/sles_sap_default_ppc64le.jsonnet` and also adds on the related schedules the module `installation/grub_test` to handle the grub screen before first boot.

- Related Ticket: https://jira.suse.com/browse/TEAM-10611
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?build=VR4PR23193&distri=sle&version=16.0
