### PR TITLE
containers: Introduce CONTAINER_TESTS variable

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -337,6 +337,11 @@ sub load_container_tests {
         loadtest 'boot/boot_to_desktop' unless is_public_cloud;
     }
 
+    if (my $container_tests = get_var('CONTAINER_TESTS', '')) {
+        loadtest "containers/$_" foreach (split('\s+', $container_tests));
+        return;
+    }
+
     if (my $bats_package = get_var('BATS_PACKAGE', '')) {
         $bats_package = ($bats_package eq "aardvark-dns") ? "aardvark" : $bats_package;
         loadtest "containers/bats/$bats_package";


### PR DESCRIPTION
This will be used to schedule odd tests.  Undocumented for now.

Also useful for debugging to go straight to a test as the INCLUDE_MODULES is a bit cumbersome.  I need it to schedule some new tests like the podman e2e tests.

Verification run: https://openqa.opensuse.org/tests/5282176 (cloned with `CONTAINER_TESTS=python_runtime`)

NOTES
- The above VR was cancelled, just to verify proper scheduling.