### PR TITLE
Validate bootloader timeout value

### DIFF
--- a/schedule/yam/agama_extended.yaml
+++ b/schedule/yam/agama_extended.yaml
@@ -13,3 +13,4 @@ schedule:
   - installation/first_boot
   - yam/validate/validate_hostname
   - yam/validate/validate_connectivity
+  - yam/validate/validate_bootloader_timeout

--- a/schedule/yam/agama_extended_unattended.yaml
+++ b/schedule/yam/agama_extended_unattended.yaml
@@ -12,4 +12,5 @@ schedule:
   - yam/validate/validate_post_partitioning
   - yam/validate/validate_deployed_files
   - yam/validate/validate_systemd_timers
+  - yam/validate/validate_bootloader_timeout
   - console/validate_repos

--- a/test_data/yam/agama_sle_extended_unattended.yaml
+++ b/test_data/yam/agama_sle_extended_unattended.yaml
@@ -11,4 +11,4 @@ repos:
     uri: https://download.opensuse.org/repositories/science/16.0/
     enabled: 'Yes'
     filter: name
-bootloader_timeout: '8'
+bootloader_timeout: '15'

--- a/tests/yam/validate/validate_bootloader_timeout.pm
+++ b/tests/yam/validate/validate_bootloader_timeout.pm
@@ -1,0 +1,21 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Validate bootloader timeout value.
+# Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
+
+use base "consoletest";
+use testapi;
+use scheduler 'get_test_suite_data';
+
+sub run {
+    select_console 'root-console';
+
+    my $grub_timeout = get_test_suite_data()->{bootloader_timeout};
+    assert_script_run("cat /etc/default/grub");
+    assert_script_run("grep GRUB_TIMEOUT=$grub_timeout /etc/default/grub");
+}
+
+1;


### PR DESCRIPTION
Like a safety and for completeness, we could have a test module to check the value in /etc/default/grub and add that module to both interactive and unattended with different values per each.

- Related ticket: https://progress.opensuse.org/issues/184073#change-991524
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/565
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?version=16.0&build=lemon-suse%2Fos-autoinst-distri-opensuse%23enhance-bootloader-timeout&distri=sle
