### PR TITLE
Deploy sles16 guest system with br0 for virtual network runs

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
@@ -42,7 +42,7 @@
     <guest_storage_backing_format/>
     <guest_storage_others>driver.name=qemu,target.dev=vda,target.bus=virtio,bus=virtio,cache=none</guest_storage_others>
     <guest_network_type>bridge</guest_network_type>
-    <guest_network_mode>bridge</guest_network_mode>
+    <guest_network_mode>host</guest_network_mode>
     <guest_network_device/>
     <guest_network_others/>
     <guest_netaddr/>

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -659,8 +659,12 @@ sub cleanup_host_and_guest_logs {
     $extra_logs_to_cleanup //= '';
 
     #Clean dhcpd and named services up explicity
-    if (get_var('VIRT_AUTOTEST') and !is_alp) {
-        script_run("brctl addbr br123;brctl setfd br123 0;ip addr add 192.168.123.1/24 dev br123;ip link set br123 up");
+    my ($os_running_version) = get_os_release;
+    if (get_var('VIRT_AUTOTEST') and $os_running_version < 16) {
+        my $bridge_name = "br123";
+        if (script_run("ip link show $bridge_name") != 0) {
+            script_run("brctl addbr $bridge_name;brctl setfd $bridge_name 0;ip addr add 192.168.123.1/24 dev $bridge_name;ip link set $bridge_name up");
+        }
         if (!get_var('VIRT_UNIFIED_GUEST_INSTALL')) {
             my @control_operation = ('restart');
             virt_autotest::utils::manage_system_service('dhcpd', \@control_operation);


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/188127
- Verification run: 
VIRTUAL NETWORK:
kermit[uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/19040842#step/libvirt_isolated_virtual_network/90) pass
scooter[uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/19040840#step/libvirt_isolated_virtual_network/90) pass
bare-metal1[uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/19040839#step/libvirt_isolated_virtual_network/90) pass
bare-metal2[uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/19040838#step/libvirt_isolated_virtual_network/90) pass
bare-metal6[uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/19040843#step/libvirt_isolated_virtual_network/90) pass
SRIOV NETWORK + VIRTUAL NETWORK
bare-metal1[uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/19047732#) pass
bare-metal2[uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/19047734#) pass
bare-metal3[uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/19047731#) pass
coco-intel-01[uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/19047733#) pass
kermit[uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/19047736#) pass
scooter[uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/19047738#) pass 
SLES12SP5 [gi-guest_developing-on-host_sles12sp5-kvm](https://openqa.suse.de/tests/19056754#details) pass
SLES15SP7 [gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/19056755#details) pass
