### PR TITLE
Run fs_stress directly rather than use qa-run

### DIFF
--- a/schedule/jeos/sle/jeos-fs_stress.yaml
+++ b/schedule/jeos/sle/jeos-fs_stress.yaml
@@ -26,6 +26,4 @@ schedule:
     - jeos/diskusage
     - jeos/build_key
     - console/suseconnect_scc
-    - qa_automation/prepare_qa_repo
-    - qa_automation/install_test_suite
-    - qa_automation/execute_test_run
+    - console/fs_stress


### PR DESCRIPTION
https://progress.opensuse.org/issues/187416

- Verification run: http://openqa.suse.de/tests/19015804