### PR TITLE
Fix LTP installation from Git and tcpdump capture on SLE-16

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -122,7 +122,6 @@ sub install_debugging_tools {
 sub install_runtime_dependencies_network {
     my @deps;
     @deps = qw(
-      dhcp-client
       diffutils
       dnsmasq
       ethtool
@@ -138,6 +137,7 @@ sub install_runtime_dependencies_network {
     zypper_call('-t in ' . join(' ', @deps));
 
     my @maybe_deps = qw(
+      dhcp-client
       dhcp-server
       telnet-server
       wireguard-tools

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -323,7 +323,7 @@ sub upload_tcpdump {
         $old_console = current_console();
         select_console('root-console');
 
-        unless (defined(script_run("timeout 20 sh -c \"kill -s INT $pid && while [ -d /proc/$pid ]; do usleep 100000; done\""))) {
+        unless (defined(script_run("timeout 20 sh -c \"kill -s INT $pid && while [ -d /proc/$pid ]; do sleep 1; done\""))) {
             select_console($old_console, await_console => 0);
             return;
         }
@@ -332,9 +332,10 @@ sub upload_tcpdump {
         assert_script_run("kill -s INT $pid && wait $pid");
     }
 
-    assert_script_run("gzip -f9 /tmp/tcpdump.pcap");
-    upload_logs("/tmp/tcpdump.pcap.gz");
-    upload_logs("/tmp/tcpdump.log");
+    assert_script_run("gzip -f9 /var/tmp/tcpdump.pcap", timeout => 1800);
+    upload_logs("/var/tmp/tcpdump.pcap.gz");
+    upload_logs("/var/tmp/tcpdump.log");
+    script_run('rm /var/tmp/tcpdump.pcap* /var/tmp/tcpdump.log');
     select_console($old_console) if defined($old_console);
 }
 
@@ -349,7 +350,7 @@ sub upload_oprofile {
         $old_console = current_console();
         select_console('root-console');
 
-        unless (defined(script_run("timeout 20 sh -c \"kill -s INT $pid && while [ -d /proc/$pid ]; do usleep 100000; done\""))) {
+        unless (defined(script_run("timeout 20 sh -c \"kill -s INT $pid && while [ -d /proc/$pid ]; do sleep 1; done\""))) {
             select_console($old_console, await_console => 0);
             return;
         }
@@ -407,9 +408,9 @@ sub run {
     my $start_time = thetime();
 
     if (check_var_array('LTP_DEBUG', 'tcpdump')) {
-        $self->{tcpdump_pid} = background_script_run("tcpdump -i any -w /tmp/tcpdump.pcap &>/tmp/tcpdump.log");
+        $self->{tcpdump_pid} = background_script_run("tcpdump -i any -w /var/tmp/tcpdump.pcap &>/var/tmp/tcpdump.log");
         # Wait for tcpdump to initialize before running the test
-        script_run('while [ ! -e /tmp/tcpdump.pcap ]; do usleep 100000; done');
+        script_run('while [ ! -e /var/tmp/tcpdump.pcap ]; do sleep 1; done');
     }
 
     if (check_var_array('LTP_DEBUG', 'oprofile')) {


### PR DESCRIPTION
The `dhcp-client` was removed from SLE-16, move it to optional dependency list. Save tcpdump files to `/var/tmp` because they may be too large for tmpfs on `/tmp`.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - SLE-12SP5: https://openqa.suse.de/tests/19016384
  - SLE-16: https://openqa.suse.de/tests/19016388
