### PR TITLE
Handle new LibreOffice welcome popup

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -1013,6 +1013,9 @@ sub libreoffice_start_program {
     my %start_program_args;
     $start_program_args{timeout} = 100 if get_var('LIVECD') && check_var('MACHINE', 'uefi-usb');
     x11_start_program($program, %start_program_args);
+    if (check_screen('welcome-to-libreoffice')) {
+        send_key "alt-f4";
+    }
     if (check_screen([qw(ooffice-tip-of-the-day oomath-tip-of-the-day)], 5)) {
         # Unselect "_S_how tips on startup", select "_O_k"
         send_key "alt-s";


### PR DESCRIPTION
All three modules have their welcome needle counterpart created, however it is not visible in the test runs (popup shows up once at launch and is global).

Failure: https://openqa.opensuse.org/tests/5281998#step/oocalc/4

VR:
- https://openqa.opensuse.org/tests/overview?distri=opensuse&build=foursixnine%2Fos-autoinst-distri-opensuse%2323205&version=Staging%3AE

