### PR TITLE
Kselftests: BPF: Remove sub-sub-test parsing from test_progs

### DIFF
--- a/lib/Kselftests/parsers/bpf/test_progs.pm
+++ b/lib/Kselftests/parsers/bpf/test_progs.pm
@@ -17,16 +17,8 @@ our $test_idx = 1;
 
 sub parse_line {
     my ($self, $test_ln) = @_;
-    my ($description, $st, $test_name, $diag);
     if ($test_ln =~ /^#\s#\S+\s+(\S+):(OK|FAIL|SKIP)$/) {
-        ($description, $st) = ($1, $2);
-    } elsif ($test_ln =~ /^#\s(\S*?):(PASS|SKIP|FAIL):(\S*?)\s(.*)$/) {
-        ($description, $st, $test_name, $diag) = ($1, $2, $3, $4);
-    }
-    if ($description) {
-        if ($test_name) {
-            $description .= "/$test_name";
-        }
+        my ($description, $st) = ($1, $2);
         my $normalized;
         if ($st eq 'PASS') {
             $normalized = "# ok $test_idx $description";
@@ -34,9 +26,6 @@ sub parse_line {
             $normalized = "# not ok $test_idx $description";
         } else {
             $normalized = "# ok $test_idx $description # SKIP";
-        }
-        if ($diag) {
-            $normalized .= " # $diag";
         }
         $test_idx++;
         return $normalized;


### PR DESCRIPTION
This will enable a smaller known issues file while preserving enough test granularity and also provide better output in the openQA job.

Related ticket: https://progress.opensuse.org/issues/187791

Verification runs:
- Before: https://openqa.opensuse.org/tests/5284180
- After: https://openqa.opensuse.org/tests/5284251
