### PR TITLE
Enable BCI tests in sle-micro hosts

### DIFF
--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -106,7 +106,7 @@ sub install_docker_multiplatform {
     }
 
     my $pkg_name = check_var("CONTAINERS_DOCKER_FLAVOUR", "stable") ? "docker-stable" : "docker";
-    if (is_transactional) {
+    if (is_transactional || $host_os =~ /micro/i) {
         select_serial_terminal;
         trup_call("pkg install $pkg_name");
         check_reboot_changes;

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -44,7 +44,8 @@ sub load_config_tests {
     loadtest 'transactional/enable_selinux' if (get_var('ENABLE_SELINUX') && is_image);
     loadtest 'console/suseconnect_scc' if (get_var('SCC_REGISTER') && !is_dvd);
     loadtest 'transactional/install_updates' if (is_sle_micro && is_released);
-    loadtest 'transactional/install_k3s' if (is_sle_micro('6.0+') && (is_x86_64 || is_aarch64));
+    loadtest 'transactional/install_k3s' if (get_var('CONTAINER_UPDATE_HOST') && is_sle_micro('6.0+') && (is_x86_64 || is_aarch64));
+    loadtest 'containers/bci_prepare' if (get_var('CONTAINER_UPDATE_HOST') && get_var('BCI_PREPARE'));
 }
 
 sub load_boot_from_disk_tests {

--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -21,7 +21,7 @@ use serial_terminal 'select_serial_terminal';
 use containers::utils qw(reset_container_network_if_needed);
 use File::Basename;
 use utils qw(systemctl);
-use version_utils qw(get_os_release check_version);
+use version_utils qw(get_os_release check_version is_sle);
 
 my $error_count;
 
@@ -33,7 +33,7 @@ sub skip_testrun {
     return 1 unless get_var('BCI_TESTS');
 
     # Skip Spack on SLES12-SP5 (https://bugzilla.suse.com/show_bug.cgi?id=1224345)
-    return 1 if (check_var('BCI_IMAGE_NAME', 'spack') && check_version('<15', get_required_var('HOST_VERSION')));
+    return 1 if (check_var('BCI_IMAGE_NAME', 'spack') && is_sle && check_version('<15', get_required_var('HOST_VERSION')));
 
     # Skip Kiwi on RES, CentOS, Ubuntu
     my $bci_image_name = get_var('BCI_IMAGE_NAME');


### PR DESCRIPTION
A second attempt.
sle-micro 6.2 is basically sles 16, but with more specific variant. Variable `BCI_PREPARE` should be unset for older sle-micros
- https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2424

This reverts commit 8e17df9cc4b311a3ee9cc8edc543e4fa4d0c0e0b.

#### Verification runs

- [slem6.2 setup](http://kepler.suse.cz/tests/25235#)
- [5.5 BCI_PREPARE=0](http://kepler.suse.cz/tests/25237#)
- [6.0](http://kepler.suse.cz/tests/25236#)
- [15-sp7](http://kepler.suse.cz/tests/25238#step/bci_prepare/84)
