### PR TITLE
kernel: Add support for new SLE16 maintenance flavors

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -59,7 +59,7 @@ sub load_kernel_tests {
             get_var('ASSET_CHANGE_KERNEL_RPM')) {
             loadtest_kernel 'change_kernel';
         }
-        if (get_var('FLAVOR', '') =~ /Incidents-Kernel/) {
+        if (get_var('FLAVOR', '') =~ /Incidents-Kernel|Online-Kernel-Updates-Staging|Online-Increments/) {
             loadtest_kernel 'update_kernel';
         }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/185671
- Needles: none
- Verification run: https://openqa.suse.de/tests/19018639   update_kernel is scheduled, but fails in patch
