### PR TITLE
Rename needle tag to avoid breaking other tests

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -1013,7 +1013,7 @@ sub libreoffice_start_program {
     my %start_program_args;
     $start_program_args{timeout} = 100 if get_var('LIVECD') && check_var('MACHINE', 'uefi-usb');
     x11_start_program($program, %start_program_args);
-    if (check_screen('welcome-to-libreoffice')) {
+    if (check_screen('popup-welcome-to-libreoffice')) {
         send_key "alt-f4";
     }
     if (check_screen([qw(ooffice-tip-of-the-day oomath-tip-of-the-day)], 5)) {


### PR DESCRIPTION
Previously chosen tag is also used in libreoffice_open_specified_file
test which breaks SLE and TW in turn (https://bugzilla.suse.com/show_bug.cgi?id=1246876)

Needle changes: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/846

VR: 
- https://openqa.suse.de/tests/19030718
- https://openqa.opensuse.org/tests/5286515

Follows  #23205
