### PR TITLE
Fix Elemental3 systexts download

### DIFF
--- a/tests/elemental3/generate_image.pm
+++ b/tests/elemental3/generate_image.pm
@@ -39,6 +39,9 @@ sub run {
     my $rke2_sysext_found;
     my @sysexts;
 
+    # Clean image filename (useful for cloned jobs)
+    $img_filename =~ tr/\/#:/_/;
+
     # Define timeouts based on the architecture
     my $timeout = (is_aarch64) ? 480 : 240;
 
@@ -73,7 +76,7 @@ sub run {
 
     # Get the system extensions list
     # NOTE: '/' is mandatory at the end of $sysext_path!
-    my @list = split(/[\r\n]+/, script_output("curl -s ${sysext_path}/ | sed -n 's/.*>\\(.*-.*-.*${sysext_arch}.raw\\)<.*/\\1/p'"));
+    my @list = split(/[\r\n]+/, script_output("curl -s ${sysext_path}/ | sed -n 's/.*href=\"\\(.*_${sysext_arch}.raw\\)\">.*/\\1/p'"));
 
     # Clean the list
     foreach (sort @list) {


### PR DESCRIPTION
Due to recent changes in the file naming, the download of the sysext images are not working anymore without this fix.

- Failing run: https://openqa.suse.de/tests/19029343
- Verification run: TO BE DONE
