### PR TITLE
Skip sapconf in MinimalVM

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2726,7 +2726,7 @@ sub load_sles4sap_tests {
     loadtest "console/check_os_release";
     loadtest "sles4sap/desktop_icons" if (is_desktop_installed());
     loadtest "sles4sap/patterns";
-    loadtest "sles4sap/sapconf";
+    loadtest "sles4sap/sapconf" if is_sle('<16.0');
     loadtest "sles4sap/saptune";
     loadtest "sles4sap/saptune/mr_test" if (get_var('MR_TEST'));
     if (get_var('NW')) {


### PR DESCRIPTION
SAP MinimalVM images are built only against sle16.0 product, therefore `sapconf` should not be applicable

- sle-16.0-Minimal-VM-Cloud-sap-x86_64-Build33.1-minimalvm-cloud-init@uefi-virtio-vga -> https://openqa.suse.de/tests/19030742
