### PR TITLE
Fix Elemental3 qcow2 filename

### DIFF
--- a/tests/elemental3/generate_image.pm
+++ b/tests/elemental3/generate_image.pm
@@ -40,7 +40,7 @@ sub run {
     my @sysexts;
 
     # Clean image filename (useful for cloned jobs)
-    $img_filename =~ tr/\/#:/_/;
+    $img_filename =~ tr/\/#/_/;
 
     # Define timeouts based on the architecture
     my $timeout = (is_aarch64) ? 480 : 240;


### PR DESCRIPTION
In fact we need to keep the `:` character if we have some, as it is usually part of the BUILD variable which is used in the chained jobs.

- Failing run: https://openqa.suse.de/tests/19030766
- Verification run: 