### PR TITLE
Fix Elemental3 RKE2 start

### DIFF
--- a/tests/elemental3/test_image.pm
+++ b/tests/elemental3/test_image.pm
@@ -9,6 +9,7 @@ use base qw(opensusebasetest);
 use testapi;
 use power_action_utils qw(power_action);
 use serial_terminal qw(select_serial_terminal);
+use utils qw(systemctl);
 use Utils::Architectures qw(is_aarch64);
 
 =head2 wait_kubectl_cmd
@@ -80,6 +81,9 @@ sub run {
     my $rootpwd = get_required_var('TEST_PASSWORD');
     $testapi::password = $rootpwd;    # Set default root password
 
+    # Define timeouts based on the architecture
+    my $timeout = (is_aarch64) ? 480 : 240;
+
     # For HDD image boot
     if (check_var('IMAGE_TYPE', 'disk')) {
         # Wait for GRUB and select default entry
@@ -94,6 +98,10 @@ sub run {
 
     # Record boot
     record_info('OS boot', 'Successfully booted!');
+
+    # Start rke2-server
+    # TODO: use the ReleaseManifest functionality later!
+    systemctl('enable --now rke2-server', timeout => $timeout);
 
     # Wait for kubectl command to be available
     wait_kubectl_cmd();


### PR DESCRIPTION
Due to the changes added in PR https://github.com/SUSE/elemental/pull/168 we should start the RKE2 service during the test.

- Failing run: https://openqa.suse.de/tests/19031687
- Verification run: https://openqa.suse.de/tests/19031866
