### PR TITLE
Kselftests: utils: Add validate_kconfig helper

### DIFF
--- a/tests/kernel/run_kselftests.pm
+++ b/tests/kernel/run_kselftests.pm
@@ -68,6 +68,7 @@ sub run {
         $timeout = "--override-timeout $timeout";    # Individual timeout for each test in the collection
     }
 
+    validate_kconfig($collection);
     assert_script_run("./run_kselftest.sh --per-test-log $timeout $tests | tee summary.tap", 7200);
 
     my $ret = post_process($collection, @tests);


### PR DESCRIPTION
Some tests require specific configuration flags that might be different from the SUT. Make sure to detect and log them accordingly.

Related ticket: https://progress.opensuse.org/issues/157186

Verification run:
- https://rmarliere-openqa.qe.prg2.suse.org/tests/1568
