### PR TITLE
Use sub-policy for samba in FIPS mode

### DIFF
--- a/data/supportserver/samba/krb5.conf
+++ b/data/supportserver/samba/krb5.conf
@@ -35,3 +35,4 @@
                 minimum_uid = 1
         }
 
+includedir /etc/krb5.conf.d


### PR DESCRIPTION
using the FIPS:AD-SUPPORT policy variant, kerberos init and domain join works; for the still failing winbind authentication we opened a separate bug:

 https://bugzilla.suse.com/show_bug.cgi?id=1249042 and softfailed this test. 

- Related ticket: https://progress.opensuse.org/issues/176940
- Needles: no
- Verification run: https://openqa.suse.de/tests/19040340#step/samba_adcli/208
