### PR TITLE
bats/netavark: ncat is no longer needed on netavark v1.16.0

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -75,21 +75,7 @@ sub install_git {
 }
 
 sub install_ncat {
-    # Upstream tests use Nmap's ncat but this is a problematic tool for multiple reasons:
-    # - Behaviour breaks between versions. See https://nmap.org/changelog.html#7.96
-    # - Nmap changed license and both Fedora & openSUSE won't ship new versions
-    # Tumbleweed has ncat 7.95 and SLES 16.0 has 7.92. These versions are unlikely to change
-    if (is_tumbleweed) {
-        if (is_aarch64) {
-            run_command "zypper addrepo http://download.opensuse.org/ports/aarch64/tumbleweed/repo/non-oss/ non-oss";
-        } elsif (is_ppc64le) {
-            run_command "zypper addrepo https://download.opensuse.org/repositories/openSUSE:/Factory:/PowerPC:/NonFree/standard/openSUSE:Factory:PowerPC:NonFree.repo";
-        } elsif (is_s390x) {
-            run_command "zypper addrepo http://download.opensuse.org/ports/zsystems/tumbleweed/repo/non-oss/ non-oss";
-        } else {
-            run_command "zypper addrepo http://download.opensuse.org/tumbleweed/repo/non-oss/ non-oss";
-        }
-    } elsif (is_sle('<16')) {
+    if (is_sle('<16')) {
         # This repo has ncat 7.94
         run_command "zypper addrepo https://download.opensuse.org/repositories/network:/utilities/15.6/network:utilities.repo";
     }

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -29,7 +29,8 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    my @pkgs = qw(aardvark-dns cargo firewalld iproute2 make ncat protobuf-devel netavark);
+    my @pkgs = qw(aardvark-dns cargo firewalld iproute2 make protobuf-devel netavark);
+    push @pkgs, "ncat" if is_sle;
     push @pkgs, is_sle("<16") ? qw(dbus-1) : qw(dbus-1-daemon);
 
     $self->setup_pkgs(@pkgs);

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -48,6 +48,11 @@ sub run {
 
     # Compile helpers & patch tests
     run_command "make examples", timeout => 600;
+    unless (is_sle) {
+        # This helper replaces ncat
+        run_command "cargo build --bin netavark-connection-tester", timeout => 600;
+        run_command "cp target/debug/netavark-connection-tester bin/";
+    }
 
     unless (get_var("BATS_TESTS")) {
         run_command "rm -f test/100-bridge-iptables.bats" if ($firewalld_backend ne "iptables");


### PR DESCRIPTION
Drop ncat dependency on Tumbleweed as it's no longer needed on netavark v1.16.0.

Verification run: https://openqa.opensuse.org/tests/5290240

NOTES:
- The above VR was cloned with `BATS_TEST_REPOS=https://download.opensuse.org/repositories/home:/danishprakash:/branches:/devel:/microos/openSUSE_Tumbleweed/home:danishprakash:branches:devel:microos.repo`