### PR TITLE
bats: Ignore coredumps generated on SIGQUIT

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -312,7 +312,7 @@ sub collect_coredumps {
     script_run('coredumpctl list > coredumpctl.txt');
 
     # Get PID and executable for all dumps
-    my @lines = split /\n/, script_output(q{coredumpctl -q --no-pager --no-legend | awk '$9 == "present" { print $5, $10 }'}, proceed_on_failure => 1);
+    my @lines = split /\n/, script_output(q{coredumpctl -q --no-pager --no-legend | awk '$8 != "SIGQUIT" && $9 == "present" { print $5, $10 }'}, proceed_on_failure => 1);
 
     foreach my $line (@lines) {
         my ($pid, $exe) = split /\s+/, $line;


### PR DESCRIPTION
Ignore coredumps generated on SIGQUIT like those seen [here](https://openqa.opensuse.org/tests/5288928#step/docker_compose/161).  This is a bad practice seen on some base images like the official nginx.

Opened an issue upstream: https://github.com/nginx/docker-nginx/issues/1000