### PR TITLE
bats: Export patch_sources to reuse by other modules

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -5,29 +5,29 @@ aardvark-dns:
   # https://github.com/containers/aardvark-dns/pull/619 is needed for dnsmasq issue
   # https://github.com/containers/aardvark-dns/pull/623 is needed to drop ncat
   opensuse-Tumbleweed:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 623
     BATS_IGNORE:
   sle-16.0:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 581
     - 619
     - 623
     BATS_IGNORE:
   sle-15-SP7:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 519
     - 581
     - 623
     BATS_IGNORE: 100-basic-name-resolution
   sle-15-SP6:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 519
     - 581
     - 623
     BATS_IGNORE: 100-basic-name-resolution
   sle-15-SP5:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 519
     - 581
     - 623
@@ -37,39 +37,39 @@ buildah:
   # https://github.com/containers/buildah/pull/5495 is needed to skip nixery.dev registry
   # https://github.com/containers/buildah/pull/6226 is needed for bud & run
   opensuse-Tumbleweed:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     BATS_IGNORE:
     BATS_IGNORE_ROOT:
     BATS_IGNORE_USER:
   sle-16.0:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 6226
     BATS_IGNORE:
     BATS_IGNORE_ROOT: bud
     BATS_IGNORE_USER:
   sle-15-SP7:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 5495
     - 6226
     BATS_IGNORE:
     BATS_IGNORE_ROOT: bud run
     BATS_IGNORE_USER:
   sle-15-SP6:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 5495
     - 6226
     BATS_IGNORE:
     BATS_IGNORE_ROOT: bud run
     BATS_IGNORE_USER:
   sle-15-SP5:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 5495
     - 6226
     BATS_IGNORE: bud
     BATS_IGNORE_ROOT: run
     BATS_IGNORE_USER:
   sle-15-SP4:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 5495
     - 6226
     BATS_IGNORE: bud
@@ -79,13 +79,13 @@ conmon:
   # Note on patches:
   # https://github.com/containers/conmon/pull/579 is needed to enable tests
   opensuse-Tumbleweed:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 579
     BATS_IGNORE:
     BATS_IGNORE_ROOT:
     BATS_IGNORE_USER:
   sle-16.0:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 579
     BATS_IGNORE:
     BATS_IGNORE_ROOT:
@@ -96,19 +96,19 @@ netavark:
   opensuse-Tumbleweed:
     BATS_IGNORE:
   sle-16.0:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 1191
     BATS_IGNORE:
   sle-15-SP7:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 1191
     BATS_IGNORE: 200-bridge-firewalld 250-bridge-nftables
   sle-15-SP6:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 1191
     BATS_IGNORE: 200-bridge-firewalld 250-bridge-nftables
   sle-15-SP5:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 1191
     BATS_IGNORE: 200-bridge-firewalld 250-bridge-nftables
 podman:
@@ -123,7 +123,7 @@ podman:
   # https://github.com/containers/podman/pull/26798 is needed for 505-networking-pasta
   # https://github.com/containers/podman/pull/26920 is needed to drop ncat
   opensuse-Tumbleweed:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 26017
     - 26798
     - 26920
@@ -134,7 +134,7 @@ podman:
     BATS_IGNORE_USER_LOCAL: 252-quadlet
     BATS_IGNORE_USER_REMOTE: 130-kill
   sle-16.0:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 25792
     - 25858
     - 25918
@@ -149,7 +149,7 @@ podman:
     BATS_IGNORE_USER_LOCAL:
     BATS_IGNORE_USER_REMOTE: 130-kill
   sle-15-SP7:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 21875
     - 24068
     - 25792
@@ -161,7 +161,7 @@ podman:
     BATS_IGNORE_USER_LOCAL:
     BATS_IGNORE_USER_REMOTE:
   sle-15-SP6:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 21875
     - 24068
     - 25792
@@ -176,37 +176,37 @@ runc:
   # Note on patches:
   # https://github.com/opencontainers/runc/pull/4825 is needed for cgroups
   opensuse-Tumbleweed:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 4825
     BATS_IGNORE:
     BATS_IGNORE_ROOT:
     BATS_IGNORE_USER:
   sle-16.0:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 4825
     BATS_IGNORE:
     BATS_IGNORE_ROOT:
     BATS_IGNORE_USER:
   sle-15-SP7:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 4825
     BATS_IGNORE:
     BATS_IGNORE_ROOT:
     BATS_IGNORE_USER: run userns
   sle-15-SP6:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 4825
     BATS_IGNORE:
     BATS_IGNORE_ROOT:
     BATS_IGNORE_USER: run userns
   sle-15-SP5:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 4825
     BATS_IGNORE:
     BATS_IGNORE_ROOT:
     BATS_IGNORE_USER: run userns
   sle-15-SP4:
-    BATS_PATCHES:
+    GITHUB_PATCHES:
     - 4825
     BATS_IGNORE:
     BATS_IGNORE_ROOT:

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -18,21 +18,21 @@ The tests rely on some variables:
 | variable | description |
 | --- | --- |
 | `BATS_PACKAGE` | `aardvark-dns` `buildah` `conmon` `netavark` `podman` `runc` `skopeo` |
-| `BATS_PATCHES` | List of github PR id's containing upstream test patches |
-| `BATS_REPO` | Repo & branch in the form `[<GITHUB_ORG>]#<BRANCH>` |
 | `BATS_TEST_PACKAGES` | List of optional package URL's |
 | `BATS_TEST_REPOS` | List of optional test repositories |
 | `BATS_TESTS` | Run only the specified tests |
 | `BATS_VERSION` | Version of [bats](https://github.com/bats-core/bats-core) to use |
 | `BUILDAH_STORAGE_DRIVER` | Storage driver used for buildah: `vfs` or `overlay` |
 | `ENABLE_SELINUX` | Set to `0` to put SELinux in permissive mode |
+| `GITHUB_PATCHES` | List of github PR id's containing upstream test patches |
+| `GITHUB_REPO` | Repo & branch in the form `[<GITHUB_ORG>]#<BRANCH>` |
 | `OCI_RUNTIME` | OCI runtime to use: `runc` or `crun` |
 
 NOTES
-- `BATS_REPO` can be `SUSE#branch` or a tag `v1.2.3`
-- `BATS_PATCHES` can contain full URL's like `https://github.com/containers/podman/pull/25918.patch`
 - `BATS_TEST_PACKAGES` may be used to test candidate kernels (KOTD, PTF, etc) and other packages.
 - `BATS_TEST_REPOS` may be used to test candidate packages outside the usual maintenance workflow.
+- `GITHUB_REPO` can be `SUSE#branch` or a tag `v1.2.3`
+- `GITHUB_PATCHES` can contain full URL's like `https://github.com/containers/podman/pull/25918.patch`
 
 ### Summary of the `BATS_IGNORE` variables
 
@@ -60,14 +60,14 @@ NOTES
 - The BATS output is collected in the log files with the `.tap.txt` extension
 - The commands are collected in a log file ending with `-commands.txt`
 
-## Adding patches to `BATS_PATCHES`
+## Adding patches to `GITHUB_PATCHES`
 
 Note: We add the [patches](../../../data/containers/patches) to our tree to avoid hitting secondary rate-limits at Github.
 
 1. Identify the commit that fixes the issue.
 1. Identify the PR ID associated with the commit with `gh pr list --search $COMMIT_SHA --state merged`
 1. Download with `wget https://github.com/containers/$PACKAGE/pull/$ID.patch` (`runc` is under `opencontainers`)
-1. Add the ID to `BATS_PATCHES` sorted numerically as we assume lower numbered are merged earlier.
+1. Add the ID to `GITHUB_PATCHES` sorted numerically as we assume lower numbered are merged earlier.
 1. Add verification runs with the above setting to the PR.
 1. Adjust YAML schedule.
 

--- a/tests/containers/bats/aardvark.pm
+++ b/tests/containers/bats/aardvark.pm
@@ -43,7 +43,7 @@ sub run {
 
     # Download aardvark sources
     my $aardvark_version = script_output "$aardvark --version | awk '{ print \$2 }'";
-    bats_sources $aardvark_version;
+    patch_sources $aardvark_version, "test", bats_patches();
 
     my $errors = run_tests;
     die "ardvark-dns tests failed" if ($errors);

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -87,7 +87,7 @@ sub run {
 
     # Download buildah sources
     my $buildah_version = script_output "buildah --version | awk '{ print \$3 }'";
-    bats_sources $buildah_version;
+    patch_sources $buildah_version, "tests", bats_patches();
 
     # Patch mkdir to always use -p
     run_command "sed -i 's/ mkdir /& -p /' tests/*.bats tests/helpers.bash";

--- a/tests/containers/bats/conmon.pm
+++ b/tests/containers/bats/conmon.pm
@@ -49,7 +49,7 @@ sub run {
     record_info("conmon package version", script_output("rpm -q conmon"));
 
     # Download conmon sources
-    bats_sources $conmon_version;
+    patch_sources $conmon_version, "test", bats_patches();
 
     my $errors = 0;
 

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -40,7 +40,7 @@ sub run {
 
     # Download netavark sources
     my $netavark_version = script_output "$netavark --version | awk '{ print \$2 }'";
-    bats_sources $netavark_version;
+    patch_sources $netavark_version, "test", bats_patches();
 
     my $firewalld_backend = script_output "awk -F= '\$1 == \"FirewallBackend\" { print \$2 }' < /etc/firewalld/firewalld.conf";
     record_info("Firewalld backend", $firewalld_backend);

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -75,7 +75,7 @@ sub run {
 
     # Download podman sources
     my $podman_version = script_output "podman --version | awk '{ print \$3 }'";
-    bats_sources $podman_version;
+    patch_sources $podman_version, "test/system", bats_patches();
 
     $oci_runtime = get_var("OCI_RUNTIME", script_output("podman info --format '{{ .Host.OCIRuntime.Name }}'"));
 

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -47,7 +47,7 @@ sub run {
 
     # Download runc sources
     my $runc_version = script_output "runc --version  | awk '{ print \$3 }'";
-    bats_sources $runc_version;
+    patch_sources $runc_version, "tests/integration", bats_patches();
 
     # Compile helpers used by the tests
     my $helpers = script_output "find contrib/cmd tests/cmd -mindepth 1 -maxdepth 1 -type d ! -name _bin -printf '%f ' || true";

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -48,7 +48,7 @@ sub run {
 
     # Download skopeo sources
     my $skopeo_version = script_output "skopeo --version  | awk '{ print \$3 }'";
-    bats_sources $skopeo_version;
+    patch_sources $skopeo_version, "systemtest", bats_patches();
 
     # Upstream script gets GOARCH by calling `go env GOARCH`.  Drop go dependency for this only use of go
     my $goarch = script_output "podman version -f '{{.OsArch}}' | cut -d/ -f2";


### PR DESCRIPTION
Export patch_sources to reuse by other modules like `docker_compose`, `python_runtime` and the upcoming `podman_e2e`.  Also rename the relevant `BATS_` variables.

- Verification run: https://openqa.opensuse.org/tests/5292129#step/aardvark/178
