### PR TITLE
Make docker_compose reuse patch_sources from bats library

### DIFF
--- a/tests/containers/bats/aardvark.pm
+++ b/tests/containers/bats/aardvark.pm
@@ -43,7 +43,7 @@ sub run {
 
     # Download aardvark sources
     my $aardvark_version = script_output "$aardvark --version | awk '{ print \$2 }'";
-    patch_sources $aardvark_version, "test", bats_patches();
+    patch_sources "aardvark-dns", "v$aardvark_version", "test", bats_patches();
 
     my $errors = run_tests;
     die "ardvark-dns tests failed" if ($errors);

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -87,7 +87,7 @@ sub run {
 
     # Download buildah sources
     my $buildah_version = script_output "buildah --version | awk '{ print \$3 }'";
-    patch_sources $buildah_version, "tests", bats_patches();
+    patch_sources "buildah", "v$buildah_version", "tests", bats_patches();
 
     # Patch mkdir to always use -p
     run_command "sed -i 's/ mkdir /& -p /' tests/*.bats tests/helpers.bash";

--- a/tests/containers/bats/conmon.pm
+++ b/tests/containers/bats/conmon.pm
@@ -49,7 +49,7 @@ sub run {
     record_info("conmon package version", script_output("rpm -q conmon"));
 
     # Download conmon sources
-    patch_sources $conmon_version, "test", bats_patches();
+    patch_sources "conmon", "v$conmon_version", "test", bats_patches();
 
     my $errors = 0;
 

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -40,7 +40,7 @@ sub run {
 
     # Download netavark sources
     my $netavark_version = script_output "$netavark --version | awk '{ print \$2 }'";
-    patch_sources $netavark_version, "test", bats_patches();
+    patch_sources "netavark", "v$netavark_version", "test", bats_patches();
 
     my $firewalld_backend = script_output "awk -F= '\$1 == \"FirewallBackend\" { print \$2 }' < /etc/firewalld/firewalld.conf";
     record_info("Firewalld backend", $firewalld_backend);

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -75,7 +75,7 @@ sub run {
 
     # Download podman sources
     my $podman_version = script_output "podman --version | awk '{ print \$3 }'";
-    patch_sources $podman_version, "test/system", bats_patches();
+    patch_sources "podman", "v$podman_version", "test/system", bats_patches();
 
     $oci_runtime = get_var("OCI_RUNTIME", script_output("podman info --format '{{ .Host.OCIRuntime.Name }}'"));
 

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -47,7 +47,7 @@ sub run {
 
     # Download runc sources
     my $runc_version = script_output "runc --version  | awk '{ print \$3 }'";
-    patch_sources $runc_version, "tests/integration", bats_patches();
+    patch_sources "runc", "v$runc_version", "tests/integration", bats_patches();
 
     # Compile helpers used by the tests
     my $helpers = script_output "find contrib/cmd tests/cmd -mindepth 1 -maxdepth 1 -type d ! -name _bin -printf '%f ' || true";

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -48,7 +48,7 @@ sub run {
 
     # Download skopeo sources
     my $skopeo_version = script_output "skopeo --version  | awk '{ print \$3 }'";
-    patch_sources $skopeo_version, "systemtest", bats_patches();
+    patch_sources "skopeo", "v$skopeo_version", "systemtest", bats_patches();
 
     # Upstream script gets GOARCH by calling `go env GOARCH`.  Drop go dependency for this only use of go
     my $goarch = script_output "podman version -f '{{.OsArch}}' | cut -d/ -f2";

--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -33,34 +33,10 @@ sub setup {
 
     my $version = script_output "$docker_compose version | awk '{ print \$4 }'";
     record_info("version", $version);
-    my $branch = "v$version";
-    my $github_org = "docker";
 
-    # Support these cases for GIT_REPO: [<GITHUB_ORG>]#BRANCH
-    # 1. As GITHUB_ORG#TAG: github_user#test-patch
-    # 2. As TAG only: main, v1.2.3, etc
-    # 3. Empty. Use defaults specified above for $github_org & $branch
-    my $repo = get_var("GIT_REPO", "");
-    if ($repo =~ /#/) {
-        ($github_org, $branch) = split("#", $repo, 2);
-    } elsif ($repo) {
-        $branch = $repo;
-    }
-
-    run_command "cd ~";
-    run_command "git clone --branch $branch https://github.com/$github_org/compose", timeout => 300;
-    run_command "cd ~/compose";
-
-    unless ($repo) {
-        # https://github.com/docker/compose/pull/13214 - test: Set stop_signal to SIGTERM
-        my @patches = qw(13214);
-        foreach my $patch (@patches) {
-            my $url = "https://github.com/docker/compose/pull/$patch";
-            record_info("patch", $url);
-            assert_script_run "curl -O " . data_url("containers/patches/compose/$patch.patch");
-            run_command "git apply -3 --ours $patch.patch";
-        }
-    }
+    # https://github.com/docker/compose/pull/13214 - test: Set stop_signal to SIGTERM
+    my @patches = qw(13214);
+    patch_sources "compose", "v$version", "pkg/e2e", \@patches;
 }
 
 
@@ -93,27 +69,21 @@ sub run {
     $self->wait_boot();
     select_serial_terminal;
 
-    assert_script_run "cd ~/compose";
-    run_command 'PATH=$PATH:$HOME/compose/bin/build';
+    assert_script_run "cd /var/tmp/compose";
+    run_command 'PATH=$PATH:/var/tmp/compose/bin/build';
 
     my @targets = split('\s+', get_var("DOCKER_COMPOSE_TARGETS", "e2e-compose e2e-compose-standalone"));
     test $_ foreach (@targets);
 }
 
-sub cleanup() {
-    script_run "cd / ; rm -rf /root/compose";
-}
-
 sub post_fail_hook {
     my ($self) = @_;
-    cleanup;
     bats_post_hook;
     $self->SUPER::post_fail_hook;
 }
 
 sub post_run_hook {
     my ($self) = @_;
-    cleanup;
     bats_post_hook;
     $self->SUPER::post_run_hook;
 }


### PR DESCRIPTION
Make docker_compose reuse patch_sources from bats library.  No functional change.

Verification runs: 
- https://openqa.opensuse.org/tests/5292326#step/aardvark/178
- https://openqa.opensuse.org/tests/5292325