### PR TITLE
Add auto-refresh for migration repos

### DIFF
--- a/tests/yam/migration/migration_unattended.pm
+++ b/tests/yam/migration/migration_unattended.pm
@@ -22,8 +22,8 @@ sub run {
 
     my $repo_home = "http://download.suse.de/ibs/home:/fcrozat:/SLES16/SLE_\$releasever";
     my $repo_images = 'http://download.suse.de/ibs/home:/fcrozat:/SLES16/images/';
-    zypper_call("ar -p 90 '$repo_home' home_sles16");
-    zypper_call("ar -p 90 $repo_images home_images");
+    zypper_call("ar --refresh -p 90 '$repo_home' home_sles16");
+    zypper_call("ar --refresh -p 90 $repo_images home_images");
 
     # install the migration image and active it
     zypper_call("--gpg-auto-import-keys -n in suse-migration-sle16-activation");


### PR DESCRIPTION
Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1248998#c14

- Related ticket: N/A
- Needles: N/A
- Verification run:  https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=lemon-suse%2Fos-autoinst-distri-opensuse%23add-auto-refresh-for-migration-repo  4/10 reproduced, it seems add auto refresh can't fix the issue
