### PR TITLE
Fix SDAF cleanup fails on removing network peering

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
@@ -94,7 +94,13 @@ sub full_cleanup {
     # Resource retention time can be controlled by OpenQA parameter: SDAF_DEPLOYER_VM_RETENTION_SEC
     record_info('Remove orphans', 'Cleaning up orphaned resources');
     destroy_orphaned_resources();
-    destroy_orphaned_peerings();
+    if (my $ret = destroy_orphaned_peerings()) {
+        record_info('Retry', 'Delete orphaned peerings failed and retry');
+        $ret = destroy_orphaned_peerings();
+        if ($ret) {
+            die('Delete orphaned peerings failed, please check log and delete manually');
+        }
+    }
 }
 
 sub post_fail_hook {

--- a/t/26_deployment_connector.t
+++ b/t/26_deployment_connector.t
@@ -289,15 +289,19 @@ subtest '[destroy_orphaned_peerings]' => sub {
     $mock_function->redefine(az_network_vnet_get => sub { return ['Zabi-VNET']; });
     $mock_function->redefine(az_group_exists => sub { return 'true' if grep /^existing$/, @_; return 'false' });
     $mock_function->redefine(az_network_peering_list => sub { return [
-                {"workload_resource_group" => "not_existing", "peering_name" => "Iron_blooded_orphans"},
+                {"workload_resource_group" => "existing", "peering_name" => "Iron_blooded_orphans"},
                 {"workload_resource_group" => "existing", "peering_name" => "EarthFederation"}];
     });
 
     set_var('SDAF_DEPLOYER_RESOURCE_GROUP', 'Karaba');
     set_var('SDAF_DEPLOYER_VNET_CODE', 'Zabi');
 
-    ok(grep(/Iron_blooded_orphans/, @{destroy_orphaned_peerings()}), 'Delete orphaned peering');
-    ok(!grep(/EarthFederation/, @{destroy_orphaned_peerings()}), 'Do not delete orphaned peering');
+    ok(!destroy_orphaned_peerings(), 'Do not delete orphaned peering');
+    $mock_function->redefine(az_network_peering_list => sub { return [
+                {"workload_resource_group" => "not_existing", "peering_name" => "Iron_blooded_orphans"},
+                {"workload_resource_group" => "not_existing", "peering_name" => "EarthFederation"}];
+    });
+    ok(!destroy_orphaned_peerings(), 'Delete orphaned peering');
 
     undef_variables;
 };


### PR DESCRIPTION
Fix SDAF cleanup fails on removing network peerings
Introduce `retry mechanism` when deleting  orphaned peerings failed

- Related ticket: [TEAM-10533](https://jira.suse.com/browse/TEAM-10533) - [SDAF][BUG] Cleanup fails on removing network peerings
- Verification run:
It is not easy to reproduce the issue mentioned in ticket but at least this PR did not introduce regressions, see the VRs:
https://openqaworker15.qa.suse.cz/tests/340562#step/cleanup/310 (**found** orphaned peerings and deleting, passed)
http://openqaworker15.qa.suse.cz/tests/340568#step/cleanup/254 (**found no** orphaned peerings needs to be deleted, passed)
