### PR TITLE
Support to run bridge virtual network tests in virt MU

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2577,6 +2577,9 @@ sub load_hypervisor_tests {
         ENABLE_VIR_NET => {
             modules => ['virt_autotest/libvirt_host_bridge_virtual_network', 'virt_autotest/libvirt_nated_virtual_network', 'virt_autotest/libvirt_isolated_virtual_network'],
         },
+        ENABLE_NATED_VIR_NET => {
+            modules => ['virt_autotest/libvirt_nated_virtual_network'],
+        },
         ENABLE_VIRTMANAGER => {
             modules => ['virtualization/universal/virtmanager_init', 'virtualization/universal/virtmanager_offon', 'virtualization/universal/virtmanager_add_devices', 'virtualization/universal/virtmanager_rm_devices'],
         },

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -225,18 +225,8 @@ sub test_network_interface {
         $nic = script_output "ssh root\@$guest \"grep '$mac' /sys/class/net/*/address | cut -d'/' -f5 | head -n1\"";
     }
     die "$mac not found in guest $guest" unless $nic;
-    if ((get_var('TEST', '') =~ m/qam-(kvm|xen)-install-and-features-test/ || $is_sriov_test eq "true") and !is_sle('16+')) {
+    unless (is_sle('16+')) {
         assert_script_run("ssh root\@$guest \"echo BOOTPROTO=\\'dhcp\\' > /etc/sysconfig/network/ifcfg-$nic\"");
-
-        # Restart the network - the SSH connection may drop here, so no return code is checked.
-        if ($is_sriov_test ne "true") {
-            script_run("ssh root\@$guest systemctl restart network", 300);
-        }
-        # Exit the SSH master socket if open
-        script_run("ssh -O exit root\@$guest");
-        # Wait until guest's primary interface is back up
-        script_retry("ping -c3 $guest", delay => 6, retry => 30);
-        # Activate guest's secondary (tested) interface
         script_retry("ssh root\@$guest ifup $nic", delay => 10, retry => 20, timeout => 120);
     }
 

--- a/tests/virt_autotest/libvirt_nated_virtual_network.pm
+++ b/tests/virt_autotest/libvirt_nated_virtual_network.pm
@@ -20,8 +20,6 @@ use version_utils qw(is_sle);
 sub run_test {
     my ($self) = @_;
 
-    #Refer to bsc#1214223 more details
-    record_soft_failure('bsc#1214223 - Failed to attach NAT virtual network interface to guest system') if (is_xen_host && !is_monolithic_libvirtd);
     #Download libvirt host bridge virtual network configuration file
     my $vnet_nated_cfg_name = "vnet_nated.xml";
     virt_autotest::virtual_network_utils::download_network_cfg($vnet_nated_cfg_name);

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -72,15 +72,6 @@ sub run_test {
 
         # SLES16 guest uses networkmanager to control network, no /etc/sysconfig/network/ifcfg*
         next if ($guest =~ /sles-16/i);
-        #Prepare the new guest network interface files for libvirt virtual network
-        #for some guests, interfaces are named eth0, eth1, eth2, ...
-        #for TW kvm guest, they are enp1s0, enp2s0, enp3s0, ...
-        my $primary_nic = script_output("ssh root\@$guest \"ip a|awk -F': ' '/state UP/ {print \\\$2}'|head -n1\"");
-        $primary_nic =~ /([a-zA-Z]*)(\d)(\w*)/;
-        for (my $i = 1; $i <= 6; $i++) {
-            my $nic = $1 . (int($2) + $i) . $3;
-            assert_script_run("ssh root\@$guest 'cp /etc/sysconfig/network/ifcfg-$primary_nic /etc/sysconfig/network/ifcfg-$nic'");
-        }
         #enable guest wickedd debugging
         assert_script_run "ssh root\@$guest \"sed -i 's/^WICKED_DEBUG=.*/WICKED_DEBUG=\"all\"/g' /etc/sysconfig/network/config\"";
         assert_script_run "ssh root\@$guest 'grep 'WICKED_DEBUG' /etc/sysconfig/network/config'";


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/175186

- Add `ENABLE_NATED_VIR_NET` to switch on the libvirt_nated_virtual_network tests.
- Remove the soft failure warning as [bsc#1214223](https://bugzilla.suse.com/show_bug.cgi?id=1214223) has been fixed.
- Create `ifcfg-$nic` files in guests for all network tests on sle15 or lower.
- Need not copy `ifcfg-*` files from the host to guests as they are created during network tests, besides the interface name is unknown at the moment yet


Verification run: 
//virtual-network-test
[MU sle15sp7 qam-kvm-install-and-virtual-network-test](https://openqa.suse.de/tests/19144235)
[MU sle12sp5 qam-kvm-install-and-virtual-network-test](https://openqa.suse.de/tests/19144495)
[MU sle15sp6 qam-kvm-install-and-virtual-network-test](https://openqa.suse.de/tests/19144499)
[MU sle15sp7 qam-xen-install-and-virtual-network-test](https://openqa.suse.de/tests/19144507)
[MU sle15sp6 qam-xen-install-and-virtual-network-test](https://openqa.suse.de/tests/19144506)
[MU sle12sp5 qam-xen-install-and-virtual-network-test](https://openqa.suse.de/tests/19144508)

//feature tests
[MU sle15sp7 qam-kvm-install-and-features-test](https://openqa.suse.de/tests/19144243)
[MU sle15sp6 qam-kvm-install-and-features-test](https://openqa.suse.de/tests/19145175)
[MU sle15sp7 qam-xen-install-and-features-test](https://openqa.suse.de/tests/19144490)
[MU sle12sp5 qam-xen-install-and-features-test](https://openqa.suse.de/tests/19156013)

//sriov tests
[MU sle15sp6 qam-kvm-install-and-sriov-test](https://openqa.suse.de/tests/19144049)


//sle16 tests
[sle16 GMC](https://openqa.suse.de/tests/19131869)
