### PR TITLE
boot_agama: Revert console order change

### DIFF
--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -26,7 +26,7 @@ sub prepare_boot_params {
     my @params = ();
 
     # add mandatory boot params
-    push @params, 'console=tty', 'console=' . (is_x86_64 ? 'ttyS0' : (is_ppc64le ? 'hvc0' : 'ttyAMA0'));
+    push @params, 'console=' . (is_x86_64 ? 'ttyS0' : (is_ppc64le ? 'hvc0' : 'ttyAMA0')), 'console=tty';
     push @params, 'kernel.softlockup_panic=1';
     push @params, "live.password=$testapi::password";
 


### PR DESCRIPTION
16876c9a1a

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1248829 https://progress.opensuse.org/issues/187902
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=jpupava_agama
