### PR TITLE
Kselftests: Don't expect $collection/config* files to exist

### DIFF
--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -148,7 +148,7 @@ sub validate_kconfig
         return;
     }
     my $arch = script_output('uname -m');
-    my @expected = split(/\n/, script_output("cat $collection/{config,config.$arch}"));
+    my @expected = split(/\n/, script_output("cat $collection/{config,config.$arch}", proceed_on_failure => 1));
     if (!@expected) {
         return;
     }


### PR DESCRIPTION
Some collections might not have both files.

Related ticket: https://progress.opensuse.org/issues/157186

Verification runs:

- Before https://openqa.opensuse.org/tests/5290960#step/run_kselftests/64
- After https://openqa.opensuse.org/tests/5293955#step/run_kselftests/62
