### PR TITLE
Use ibus-libpinyin for SLE16 and above

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2220,10 +2220,12 @@ sub load_common_x11 {
     elsif (check_var("REGRESSION", "ibus")) {
         loadtest "boot/boot_to_desktop";
         loadtest "x11/ibus/ibus_installation";
-        loadtest "x11/ibus/ibus_test_cn";
-        loadtest "x11/ibus/ibus_test_jp";
-        loadtest "x11/ibus/ibus_test_kr";
-        loadtest "x11/ibus/ibus_clean";
+        if ((is_sle("<16")) || is_tumbleweed) {
+            loadtest "x11/ibus/ibus_test_cn";
+            loadtest "x11/ibus/ibus_test_jp";
+            loadtest "x11/ibus/ibus_test_kr";
+            loadtest "x11/ibus/ibus_clean";
+        }
     }
 }
 

--- a/tests/x11/ibus/ibus_installation.pm
+++ b/tests/x11/ibus/ibus_installation.pm
@@ -12,11 +12,11 @@
 use base "x11test";
 use testapi;
 use utils;
-use version_utils 'is_tumbleweed';
+use version_utils qw(is_sle is_tumbleweed);
 use x11utils qw(default_gui_terminal handle_relogin);
 
 sub install_ibus {
-    my $ibus_pinyin = is_tumbleweed() ? "ibus-libpinyin" : "ibus-pinyin";
+    my $ibus_pinyin = (is_sle('16+') || is_tumbleweed) ? "ibus-libpinyin" : "ibus-pinyin";
     ensure_installed("ibus $ibus_pinyin ibus-kkc ibus-hangul");
 }
 
@@ -29,6 +29,7 @@ sub override_i18n {
 }
 
 sub ibus_daemon_started {
+    send_key 'esc';
     x11_start_program(default_gui_terminal());
     wait_still_screen;
 


### PR DESCRIPTION
Use ibus-libpinyin instead of ibus-pinyin for SLE16+ 
Only enable ibus_installation for SLE16+ due to bsc#1248831

- Related ticket: https://progress.opensuse.org/issues/188457
- Needles: N/A
- Verification run: 
> SLE16 : https://openqa.suse.de/tests/19055771
> SLE15 SP7 : https://openqa.suse.de/tests/19055791  
