### PR TITLE
console/sshd: Fix subroutine signature

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -68,7 +68,7 @@ sub run {
     services::sshd::do_ssh_cleanup();
 }
 
-sub test_cryptographic_policies() {
+sub test_cryptographic_policies {
     my %args = @_;
     my $remote_user = $args{remote_user};
 


### PR DESCRIPTION
Passing arguments to a subroutine declared with () is not allowed.

For some reason this only breaks when using `SCHEDULE=...`.

- Failure: https://openqa.opensuse.org/tests/5295093
- Verification run: https://openqa.opensuse.org/tests/5295216