### PR TITLE
Modify the bootloader timeout setting in test data

### DIFF
--- a/test_data/yam/agama_sle_extended.yaml
+++ b/test_data/yam/agama_sle_extended.yaml
@@ -11,4 +11,4 @@ repos:
     uri: https://download.opensuse.org/repositories/science/16.0/
     enabled: 'Yes'
     filter: name
-bootloader_timeout: '8'
+bootloader_timeout: '15'


### PR DESCRIPTION
The bootloader timeout is set as '15' in the profile, need to adjust it in the test data.

- To fix this failure: https://openqa.suse.de/tests/19056792#step/validate_bootloader_timeout/7
- Verification run: https://openqa.suse.de/tests/19073436
