### PR TITLE
Explicitly install xmllint in the oscap as the test suite depends on it

### DIFF
--- a/tests/security/openscap/oscap_setup.pm
+++ b/tests/security/openscap/oscap_setup.pm
@@ -13,7 +13,7 @@ use version_utils 'is_opensuse';
 
 sub run {
 
-    zypper_call("in openscap-utils libxslt-tools wget");
+    zypper_call("in openscap-utils libxslt-tools wget /usr/bin/xmllint");
 
     oscap_get_test_file("oval.xml");
     oscap_get_test_file("xccdf.xml");


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/184861

The oscap testsuite requires xmllint to work, with the switch to grub2-bls xmllint won't be installed in the system by default, instead of having multiple if/else install the binary by path

VR:
- TW: https://openqa.opensuse.org/tests/5297058#step/oscap_setup/2
- SLE 12-SP5: https://openqa.suse.de/tests/19073846#step/oscap_setup/2

Failures in TW are: https://progress.opensuse.org/issues/177378
