### PR TITLE
Explicitly install mokutil in kernel_lockdown test

### DIFF
--- a/tests/security/secureboot/kernel_lockdown.pm
+++ b/tests/security/secureboot/kernel_lockdown.pm
@@ -8,11 +8,12 @@
 
 use base 'opensusebasetest';
 use testapi;
+use utils;
 use serial_terminal 'select_serial_terminal';
 
 sub run {
     select_serial_terminal;
-
+    zypper_call('in mokutil');
     # Make sure system is secureboot enabled
     validate_script_output('mokutil --sb-state', sub { m/SecureBoot enabled/ });
 


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/184861

The test doesn't fail per se on normal Tumbleweed, but with the grub2-bls changes it would: https://openqa.opensuse.org/tests/5294088

VR: https://openqa.opensuse.org/tests/5297311

