### PR TITLE
Refactor fixfiles to consider any file type (also sockets)

### DIFF
--- a/lib/selinuxtest.pm
+++ b/lib/selinuxtest.pm
@@ -93,19 +93,13 @@ sub create_test_file {
 sub fixfiles_restore {
     my ($self, $file_name, $fcontext_pre, $fcontext_post) = @_;
 
-    if (script_run("[ -z \"$file_name\" ]") == 0) {
+    if (!$file_name) {
         record_info("WARNING", "no file need to be restored", result => "softfail");
+        return;
     }
-    elsif (script_run("[ -f \"$file_name\" ]") == 0) {
-        validate_script_output("ls -Z \"$file_name\"", sub { m/$fcontext_pre/ });
-        assert_script_run("fixfiles restore \"$file_name\"");
-        validate_script_output("ls -Z \"$file_name\"", sub { m/$fcontext_post/ });
-    }
-    elsif (script_run("[ -d \"$file_name\" ]") == 0) {
-        validate_script_output("ls -Zd \"$file_name\"", sub { m/$fcontext_pre/ });
-        assert_script_run("fixfiles restore \"$file_name\"");
-        validate_script_output("ls -Zd \"$file_name\"", sub { m/$fcontext_post/ });
-    }
+    validate_script_output qq{stat -c %C "$file_name"}, sub { m/$fcontext_pre/ };
+    assert_script_run qq{fixfiles restore "$file_name"};
+    validate_script_output qq{stat -c %C "$file_name"}, sub { m/$fcontext_post/ };
 }
 
 # check SELinux contexts of a file/dir

--- a/tests/security/selinux/fixfiles.pm
+++ b/tests/security/selinux/fixfiles.pm
@@ -1,9 +1,8 @@
-# Copyright 2020 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Test "fixfiles" can fix file SELinux security contexts
 # Maintainer: QE Security <none@suse.de>
-# Tags: poo#65672, tc#1745370
 
 use base "selinuxtest";
 use power_action_utils "power_action";
@@ -17,30 +16,23 @@ sub run {
 
     select_serial_terminal;
 
-    # test `fixfiles check` can print any incorrect file context labels
+    # `fixfiles check` prints any incorrect file context labels
     assert_script_run("fixfiles check > $file_output 2>&1", timeout => 300);
 
-    # pick up a test file to test. We need to use sed+awk to deal with potential spaces in the file path.
-    my $file_info = script_output("grep -i 'Would relabel' $file_output | tail -1 | sed 's/Would relabel //'");
-    my $file_name = script_output("echo $file_info | awk \'{split(\$0, array, \" from \"); print array[1]}\'");
-    my $fcontext_pre = script_output("echo $file_info | awk \'{split(\$0, array, \" from \"); print array[2]}\' | cut -f1 -d' '");
-    my $fcontext_post = script_output("echo $file_info | awk \'{split(\$0, array, \" from \"); print array[2]}\'| cut -f3 -d' '");
+    # pick up a sample file to check the 'restore' feature
+    my $last_line = script_output("grep -i 'Would relabel' $file_output | tail -1");
+    my ($file_name, $fcontext_pre, $fcontext_post) = $last_line =~ m{^Would relabel\s+(.+?)\s+from\s+(\S+)\s+to\s+(\S+)$};
 
     # test `fixfiles restore`: run fixfiles restore on the test file and check the results
-    $self->fixfiles_restore("$file_name", "$fcontext_pre", "$fcontext_post");
+    $self->fixfiles_restore($file_name, $fcontext_pre, $fcontext_post);
 
     # test `fixfiles verify/check`: to double confirm, there should be nothing to do with $file_name
-    my $script_output = script_output("fixfiles verify $file_name", proceed_on_failure => 1);
-    if ($script_output =~ m/$file_name/) {
-        record_info("ERROR", "verify $file_name, it is not well restored: $script_output", result => "fail");
-        $self->result("fail");
+    for my $task (qw(verify check)) {
+        my $script_output = script_output("fixfiles $task $file_name", proceed_on_failure => 1);
+        die "$task $file_name, it is not well restored: $script_output" if ($script_output =~ m/$file_name/);
     }
-
-    $script_output = script_output("fixfiles check $file_name", proceed_on_failure => 1);
-    if ($script_output =~ m/$file_name/) {
-        record_info("ERROR", "check $file_name, it is not well restored: $script_output", result => "fail");
-        $self->result("fail");
-    }
+    # cleanup
+    assert_script_run "rm -f $file_output";
 }
 
 1;


### PR DESCRIPTION
Took the occasion to simplify the code a bit, keeping the same logic

- Related ticket: https://progress.opensuse.org/issues/186942
- Needles: nope
- Verification runs: 
  - https://openqa.suse.de/tests/19075944#step/fixfiles/11
  - https://openqa.suse.de/tests/19075890


