### PR TITLE
console/consoletest_setup.pm: More reliable ssh-keyscan invocation

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -46,7 +46,7 @@ sub run {
         assert_script_run('touch ~/.ssh/{authorized_keys,known_hosts}');
         assert_script_run('chmod 600 ~/.ssh/*');
         assert_script_run('cat ~/.ssh/id_rsa.pub | tee -a ~/.ssh/authorized_keys');
-        assert_script_run("ssh-keyscan localhost 127.0.0.1 ::1 | tee -a ~/.ssh/known_hosts");
+        assert_script_run("(set -o pipefail; ssh-keyscan -T 20 localhost 127.0.0.1 ::1 | tee -a ~/.ssh/known_hosts)");
     }
     else {
         assert_script_run("mkdir -pv ~/.ssh ~$user/.ssh");
@@ -55,7 +55,7 @@ sub run {
         assert_script_run("chmod 600 ~{,$user}/.ssh/*");
         assert_script_run("chown -R bernhard ~$user/.ssh");
         assert_script_run("cat ~/.ssh/id_rsa.pub | tee -a ~{,$user}/.ssh/authorized_keys");
-        assert_script_run("ssh-keyscan localhost 127.0.0.1 ::1 | tee -a ~{,$user}/.ssh/known_hosts");
+        assert_script_run("(set -o pipefail; ssh-keyscan -T 20 localhost 127.0.0.1 ::1 | tee -a ~{,$user}/.ssh/known_hosts)");
     }
 
     # Stop serial-getty on serial console to avoid serial output pollution with login prompt


### PR DESCRIPTION
- Use a higher timeout to succeed even on *very* slow machines like RISC-V with -cpu max
- Use pipefail to detect failure

- Failure: https://openqa.opensuse.org/tests/5292893#step/consoletest_setup/30 (there is no output)
- Verification run: https://openqa.opensuse.org/tests/5297451
