### PR TITLE
Restore schedules for InfiniBand

### DIFF
--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -2,12 +2,11 @@ name:           ibtest-master
 description:    >
     The master node for the infiniband testsuite (hpc-testing)
 vars:
-    AGAMA: 1
-    AGAMA_PRODUCT_ID: SLES
-    INST_AUTO: yam/agama/auto/sles_default.jsonnet
     DESKTOP: textmode
     GRUB_TIMEOUT: 300
     IBTESTS: 1
+    IBTEST_GITBRANCH: master
+    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_MASTER
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
@@ -18,8 +17,24 @@ vars:
 schedule:
     - kernel/ibtests_barriers
     - installation/ipxe_install
-    - installation/agama_reboot
-    - installation/grub_test
+    - installation/welcome
+    - installation/scc_registration
+    - installation/addon_products_sle
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_graphics
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - installation/handle_reboot
     - installation/first_boot
     - kernel/mellanox_config
     - kernel/ibtests_prepare

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -2,12 +2,11 @@ name:           ibtest-slave
 description:    >
     The slave node for the infiniband testsuite (hpc-testing)
 vars:
-    AGAMA: 1
-    AGAMA_PRODUCT_ID: SLES
-    INST_AUTO: yam/agama/auto/sles_default.jsonnet
     DESKTOP: textmode
     GRUB_TIMEOUT: 300
     IBTESTS: 1
+    IBTEST_GITBRANCH: master
+    IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_SLAVE
     IPXE: 1
     IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
@@ -18,8 +17,24 @@ vars:
     SCC_ADDONS: sdk
 schedule:
     - installation/ipxe_install
-    - installation/agama_reboot
-    - installation/grub_test
+    - installation/welcome
+    - installation/scc_registration
+    - installation/addon_products_sle
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_graphics
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - installation/handle_reboot
     - installation/first_boot
     - kernel/mellanox_config
     - kernel/ibtests_prepare


### PR DESCRIPTION
We don't want any Agama-related settings or modules in this schedule, as we have a seperate one. Make sure we can install an run the tests on SLE 15 with these schedules.

Related Ticket: https://progress.opensuse.org/issues/186630