### PR TITLE
Add validation modules for agama_s390x.yaml

### DIFF
--- a/schedule/yam/agama_remote_s390x.yaml
+++ b/schedule/yam/agama_remote_s390x.yaml
@@ -10,6 +10,12 @@ schedule:
   - yam/agama/agama
   - boot/reconnect_mgmt_console
   - installation/first_boot
+  - yam/validate/validate_selinux
   - yam/validate/validate_base_product
   - yam/validate/validate_product
+  - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
+  - yam/validate/validate_snapshots
+  - yam/validate/validate_registered_products
+  - console/validate_repos


### PR DESCRIPTION


- Related ticket: quick PR
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/19093120#  failed for selinux mode is not enforcing on s390x
