### PR TITLE
Drop zypper_lr from migration test

### DIFF
--- a/schedule/yam/agama_migration_15sp7.yaml
+++ b/schedule/yam/agama_migration_15sp7.yaml
@@ -14,7 +14,6 @@ schedule:
   - yam/migration/migration_unattended
   - installation/grub_test
   - installation/first_boot
-  - console/zypper_lr
   - yam/validate/validate_migration_logs
   - yam/validate/validate_product
   - console/validate_repos


### PR DESCRIPTION
We have validate_repos, so no need for zypper_lr any more.
https://openqa.suse.de/tests/19083370#step/zypper_lr/9
https://openqa.suse.de/tests/19083370#step/validate_repos/5


- Related ticket: quick PR
- Needles: N/A
- Verification run: N/A
