### PR TITLE
Delete obsolete configuration for initrd

### DIFF
--- a/data/microos/butane/script
+++ b/data/microos/butane/script
@@ -102,6 +102,7 @@ else
 fi
 
 sed -i "s,${luks_keyfile},/.virtual-root.key,g" /etc/crypttab
+sed -i "s,${luks_keyfile},/.virtual-root.key,g" /etc/dracut.conf.d/99-luks-boot.conf
 cryptsetup --key-file "${oldpass}" luksChangeKey --pbkdf pbkdf2 "${luks_dev}" "${newpass}"
 cryptsetup reencrypt --key-file "${newpass}" "${luks_dev}"
 fdectl --passfile "${newpass}" regenerate-key


### PR DESCRIPTION
The combustion fde test suite for sle-micro need to remove obsolete luks config that is being read by dracut when rebuilding the initrd image.

- Verification run: https://openqa.suse.de/tests/19041592#step/journal_check/20
