### PR TITLE
Install libxml2-tools instead of xmllint by path

### DIFF
--- a/tests/security/openscap/oscap_setup.pm
+++ b/tests/security/openscap/oscap_setup.pm
@@ -13,7 +13,7 @@ use version_utils 'is_opensuse';
 
 sub run {
 
-    zypper_call("in openscap-utils libxslt-tools wget /usr/bin/xmllint");
+    zypper_call("in openscap-utils libxslt-tools wget libxml2-tools");
 
     oscap_get_test_file("oval.xml");
     oscap_get_test_file("xccdf.xml");


### PR DESCRIPTION
Failure https://openqa.suse.de/tests/19093658#step/oscap_setup/6
Ticket: https://progress.opensuse.org/issues/188640

VR: 
- 15-SP4 https://openqa.suse.de/tests/19094165#step/oscap_setup/8
- 15-SP7 https://openqa.suse.de/tests/19094179#step/oscap_setup/8


