### PR TITLE
Toolbox - Install package which is not part of the container

### DIFF
--- a/tests/microos/toolbox.pm
+++ b/tests/microos/toolbox.pm
@@ -165,7 +165,7 @@ sub run {
             assert_script_run 'toolbox run -c devel -- zypper -n ref -s', timeout => 300;
         }
         assert_script_run 'toolbox run -c devel -- zypper lr -u', timeout => 180;
-        assert_script_run 'toolbox run -c devel -- zypper -n in python3', timeout => 180;
+        assert_script_run 'toolbox run -c devel -- zypper -n in zip', timeout => 180;
     }
     assert_script_run 'podman rm devel';
 


### PR DESCRIPTION
I install `bat` instead of `python3` because `python3-base` is already preinstalled and was causing dependency issues.

- Related ticket: [poo#187746](https://progress.opensuse.org/issues/187746)
- Verification run:
[Build20250910-1](https://pdostal-server.suse.cz/tests/overview?build=20250910-1&distri=sle-micro&version=5.5) of sle-micro-5.5-DVD-Updates.x86_64	[slem_installation_podman@64bit](https://pdostal-server.suse.cz/tests/10042)
[Build20250910-1](https://pdostal-server.suse.cz/tests/overview?build=20250910-1&distri=sle-micro&version=5.3) of sle-micro-5.3-DVD-Updates.x86_64	[slem_installation_podman@64bit](https://pdostal-server.suse.cz/tests/10044)
[Build20250910-1](https://pdostal-server.suse.cz/tests/overview?build=20250910-1&distri=sle-micro&version=5.4) of sle-micro-5.4-DVD-Updates.x86_64	[slem_installation_podman@64bit](https://pdostal-server.suse.cz/tests/10043)
[Build20250910-1](https://pdostal-server.suse.cz/tests/overview?build=20250910-1&distri=sle-micro&version=5.2) of sle-micro-5.2-DVD-Updates.x86_64	[slem_installation_podman@64bit](https://pdostal-server.suse.cz/tests/10045)
[Build20250910](https://pdostal-server.suse.cz/tests/overview?build=20250910&distri=microos&version=Tumbleweed&groupid=1) of microos-Tumbleweed-DVD.x86_64	[container_host@64bit-2G](https://pdostal-server.suse.cz/tests/10047)
[Build15.56](https://pdostal-server.suse.cz/tests/overview?build=15.56&distri=sle-micro&version=6.2) of sle-micro-6.2-Default-qcow.x86_64	[slem_podman@64bit](https://pdostal-server.suse.cz/tests/10046)