### PR TITLE
Move temporary serial login regex for s390x BCI slem

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -122,6 +122,11 @@ wait_serial(get_login_message(), 300);
 
 sub get_login_message {
     my $arch = get_required_var("ARCH");
+
+    # this is only a temporary measure for BCI s390x tests that run on slem 6.0 and 6.1
+    if (is_s390x && get_var('BCI_TESTS', '') && get_var('HOST_VERSION', '') =~ /slem/i) {
+        return qr/Welcome to SUSE Linux Micro 6.[01].*\(s390x\)/;
+    }
     return is_sle() ? qr/Welcome to SUSE Linux Enterprise .*\($arch\)/
       : is_sle_micro() ? qr/Welcome to SUSE Linux.* Micro .*\($arch\)/
       : is_leap() ? qr/Welcome to openSUSE Leap.*/


### PR DESCRIPTION
Follow up for
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/23291 There is another place where this hack is needed
https://openqa.suse.de/tests/19094829#step/host_configuration/75

- ticket: [[BCI] Add SLEM test runs](https://progress.opensuse.org/issues/178993)
- Verification run: https://openqa.suse.de/tests/19094958#
