### PR TITLE
Set correct validation for zFCP scenario

### DIFF
--- a/schedule/yam/agama_zfcp_s390x.yaml
+++ b/schedule/yam/agama_zfcp_s390x.yaml
@@ -1,0 +1,22 @@
+---
+name: agama_zfcp
+description: >
+  Perform interactive installation with agama for s390x using zfcp and validate it.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_arrange
+  - yam/agama/import_agama_profile
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - yam/validate/validate_selinux
+  - yam/validate/validate_base_product
+  - yam/validate/validate_product
+  - yam/validate/validate_connectivity
+  - yam/validate/validate_first_user
+  - yam/validate/validate_snapshots
+  - yam/validate/validate_registered_products
+  - console/validate_repos
+  - console/validate_zfcp
+  - console/validate_zfcp_multipath


### PR DESCRIPTION
We have added the same zfcp validations as SP7.

- Related ticket: https://progress.opensuse.org/issues/188451
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/19095084
