### PR TITLE
HA: on PowerVM test environment, shutdown cluster before poweroff

### DIFF
--- a/schedule/ha/bv/pvm_cluster.yaml
+++ b/schedule/ha/bv/pvm_cluster.yaml
@@ -40,7 +40,6 @@ schedule:
   - console/system_prepare
   - ha/check_hae_active.py
   - ha/wait_barriers
-  - console/system_prepare
   - console/consoletest_setup
   - console/check_os_release
   - console/hostname
@@ -65,6 +64,7 @@ schedule:
   - '{{remove_node}}'
   - '{{graceful_shutdown}}'
   - ha/check_logs
+  - ha/prepare_shutdown
   - shutdown/shutdown
 conditional_schedule:
   barrier_init:


### PR DESCRIPTION
I see that there's already a test module called `ha/prepare_shutdown` and it is used in `schedule/ha/bv/basic_cluster_node.yaml`.

It shuts down the cluster before machine shutdown.

- Related ticket: https://jira.suse.com/browse/TEAM-10635
- Needles: none
- Verification run:
https://openqa.suse.de/tests/19093305 to
https://openqa.suse.de/tests/19097029 (See history, here's 6 passed jobs and 2 unrelated failures)