### PR TITLE
Fix SDAF NW WebGUI access sporadic failure on curl

### DIFF
--- a/tests/sles4sap/redirection_tests/ensa2_setup_Netweaver_WebGUI_access.pm
+++ b/tests/sles4sap/redirection_tests/ensa2_setup_Netweaver_WebGUI_access.pm
@@ -152,7 +152,7 @@ sub run {
         connect_target_to_serial(destination_ip => $ip_addr_client, ssh_user => $user, switch_root => 'yes');
         my $count = 60;
         for my $i (1 .. $count) {
-            my $output = script_output("curl --connect-timeout 1 --max-time 60 -I http://$ip_addr:8080/sap/bc/gui/sap/its/webgui", proceed_on_failure => 1, timeout => 300);
+            my $output = script_output("curl --connect-timeout 1 --max-time 300 -I http://$ip_addr:8080/sap/bc/gui/sap/its/webgui", proceed_on_failure => 1, timeout => 320);
             if ($output =~ /HTTP.* OK/) {
                 record_info("WebGUI access succeeded on $host");
                 last;


### PR DESCRIPTION
Fix SDAF ensa2_setup_Netweaver_WebGUI_access sporadic failure on curl: increase max-time to a bigger one

- Related ticket: [TEAM-10623](https://jira.suse.com/browse/TEAM-10623) - [SDAF] ensa2_setup_Netweaver_WebGUI_access sporadic fails
- Verification run:
http://openqaworker15.qa.suse.cz/tests/341381#step/ensa2_setup_Netweaver_WebGUI_access/190 (`curl` takes `119` seconds)
http://openqaworker15.qa.suse.cz/tests/341352#step/ensa2_setup_Netweaver_WebGUI_access/190 (`curl` takes `118` seconds)  
http://openqaworker15.qa.suse.cz/tests/341364#step/ensa2_setup_Netweaver_WebGUI_access/190 (`curl` takes `115` seconds)  
http://openqaworker15.qa.suse.cz/tests/341358#step/ensa2_setup_Netweaver_WebGUI_access/190 (`curl` takes `100` seconds)  
http://openqaworker15.qa.suse.cz/tests/341370#step/ensa2_setup_Netweaver_WebGUI_access/172 (`curl` takes `141` seconds)  
