### PR TITLE
Remove wireshark install after it tested

### DIFF
--- a/tests/console/command_not_found.pm
+++ b/tests/console/command_not_found.pm
@@ -40,6 +40,7 @@ sub run {
     if (is_sle('15+')) {
         # test for https://fate.suse.com/323424 if cnf works for non-registered modules
         $not_installed_pkg = 'wireshark';    # wireshark is in desktop module which is not registered here
+        assert_script_run "! rpm -q $not_installed_pkg";
         if (script_run(qq{echo "\$(cnf $not_installed_pkg 2>&1 | tee /dev/stderr)" | grep -q "zypper install $not_installed_pkg"}) != 0) {
             record_soft_failure "https://fate.suse.com/323424 - cnf doesn't cover non-registered modules";
         }

--- a/tests/console/wireshark_cli.pm
+++ b/tests/console/wireshark_cli.pm
@@ -37,6 +37,7 @@ sub run {
     assert_script_run("kill \$(cat $pid_file)");
     assert_script_run("wait \$(cat $pid_file)");
     record_info('Captured packets', script_output("tshark -r $cap_file"));
+    zypper_call('rm -u wireshark');
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Remove wireshark install after it tested

- Related ticket: https://progress.opensuse.org/issues/188730
- Verification run: https://openqa.suse.de/tests/19098108#step/command_not_found/19