### PR TITLE
firstrun: Update condition matching flavor for disk type

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -123,7 +123,7 @@ sub verify_partition_label {
     # The RPi firmware needs MBR. s390x images also use MBR.
     # Note: JeOS-for-RaspberryPi means "kiwi-templates-Minimal" and JeOS-for-RPi means "community JeOS".
     # In sle-micro the raw aarch64 images are used for RPi, hence they have contain `dos`
-    if (is_s390x || get_var('FLAVOR', '') =~ /JeOS-for-RaspberryPi/ || check_var('FLAVOR', 'JeOS-for-RPi') || (is_sle_micro("<6.2") && is_aarch64 && get_var('FLAVOR', '') =~ /(^Base$|^Default$)/)) {
+    if (is_s390x || get_var('FLAVOR', '') =~ /RaspberryPi/ || check_var('FLAVOR', 'JeOS-for-RPi') || (is_sle_micro("<6.2") && is_aarch64 && get_var('FLAVOR', '') =~ /(^Base$|^Default$)/)) {
         $label = 'dos';
     }
 


### PR DESCRIPTION
- Related ticket: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=33.1&groupid=580&flavor=Minimal-VM-for-RaspberryPi
- Verification run: https://openqa.suse.de/tests/19098873