### PR TITLE
containers/podmansh.pm: Give the podmansh container more time to start

### DIFF
--- a/tests/containers/podmansh.pm
+++ b/tests/containers/podmansh.pm
@@ -39,6 +39,10 @@ AddDevice=/dev/ttyS0
 
 Exec=sleep infinity
 
+[Service]
+# Slow systems need more than the default 1min 30s
+TimeoutStartSec=5min
+
 [Quadlet]
 # avoid infinite waiting for network by podman-user-wait-network-online.service
 # https://github.com/systemd/systemd/issues/28762


### PR DESCRIPTION
On software emulated hosts, this can take longer than 1min30s.

- Failure: https://openqa.opensuse.org/tests/5299366#step/podmansh/119
- Verification run: https://openqa.opensuse.org/tests/5304641