### PR TITLE
supportconfig: improve logs collection and timeout management

### DIFF
--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -185,6 +185,7 @@ sub _upload_logs {
 
     my @instance_logs = ('/var/log/cloudregister', '/etc/hosts', '/var/log/zypper.log', '/etc/zypp/credentials.d/SCCcredentials');
     for my $instance_log (@instance_logs) {
+        next if ($self->{run_args}->{my_instance}->ssh_script_run("test -f " . $instance_log, quiet => 1));
         $self->{run_args}->{my_instance}->ssh_script_run("sudo chmod a+r " . $instance_log, timeout => 0, quiet => 1);
         $self->{run_args}->{my_instance}->upload_log($instance_log, failok => 1, log_name => $instance_log . ".txt");
     }


### PR DESCRIPTION
Improve timeout management of the execution of `supportconfig`, to consider also blocking cases, when the tool stop running, until timeout.
2 new parameters added for debugging scope.

See more details in the below ticket's note.

- Related ticket: https://progress.opensuse.org/issues/187440#note-13
- Verification run: see in PR posts.
