### PR TITLE
Add a new test to verify zypper

### DIFF
--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -43,6 +43,7 @@ schedule:
   - console/tar
   - console/ruby
   - console/tcpdump
+  - console/zypper_update
   - '{{version_specific}}'
   - console/coredump_collect
 conditional_schedule:

--- a/tests/console/zypper_update.pm
+++ b/tests/console/zypper_update.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: libzypp zypper
+# Summary: Ensure the latest versions of libzypp and zypper are
+# installed, and confirm that they function as expected
+# Maintainer: QE Core <qe-core@suse.de>
+
+use base "consoletest";
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils;
+
+sub run {
+    select_serial_terminal;
+    assert_script_run('zypper ref', timeout => 180);
+    # Install latest zypper and libzypp
+    zypper_call 'in zypper libzypp';
+    assert_script_run('rpm -q zypper libzypp', timeout => 180);
+
+    # Search and Install vim package for zypper verifcation
+    zypper_call('se vim');
+    zypper_call 'in vim';
+}
+1;


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/187302
- Needles: No
- Verification run: 
  15-SP6: [aarch64](https://openqa.suse.de/tests/19117985#step/zypper_update/6) | [s390x](https://openqa.suse.de/tests/19117986#step/zypper_update/6) | [x86_64](https://openqa.suse.de/tests/19117987#step/zypper_update/6)
15-SP5: [aarch64](https://openqa.suse.de/tests/19117988#step/zypper_update/6) | [s390x](https://openqa.suse.de/tests/19117989#step/zypper_update/6) | [x86_64](https://openqa.suse.de/tests/19117990#step/zypper_update/6)
