### PR TITLE
Remove validate_hostname from s390x schedule

### DIFF
--- a/schedule/yam/agama_remote_s390x.yaml
+++ b/schedule/yam/agama_remote_s390x.yaml
@@ -15,7 +15,6 @@ schedule:
   - yam/validate/validate_product
   - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
-  - yam/validate/validate_hostname
   - yam/validate/validate_snapshots
   - yam/validate/validate_registered_products
   - console/validate_repos


### PR DESCRIPTION
On s390x, the hostname is worker name while not a static name such as 'local host', we'd better to remove it from schedule file.

- Related ticket: quick PR
- Needles:  N/A
- Verification run:  N/A
