### PR TITLE
Move validate-product as first

### DIFF
--- a/schedule/yam/agama_migration_15sp7.yaml
+++ b/schedule/yam/agama_migration_15sp7.yaml
@@ -14,6 +14,6 @@ schedule:
   - yam/migration/migration_unattended
   - installation/grub_test
   - installation/first_boot
-  - yam/validate/validate_migration_logs
   - yam/validate/validate_product
   - console/validate_repos
+  - yam/validate/validate_migration_logs


### PR DESCRIPTION
Move validate-product as the first validation module.

- Related ticket: N/A
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/585
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=lemon-suse%2Fos-autoinst-distri-opensuse%23move-validata-product-first