### PR TITLE
Move validate_migration_logs to first

### DIFF
--- a/schedule/yam/agama_migration_15sp7.yaml
+++ b/schedule/yam/agama_migration_15sp7.yaml
@@ -14,6 +14,6 @@ schedule:
   - yam/migration/migration_unattended
   - installation/grub_test
   - installation/first_boot
+  - yam/validate/validate_migration_logs
   - yam/validate/validate_product
   - console/validate_repos
-  - yam/validate/validate_migration_logs


### PR DESCRIPTION
Move validate_migration_logs to first validation module, rename it to upload_* to make it clear meaning.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
