### PR TITLE
Match leap flavors during installation on s390

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -51,7 +51,7 @@ sub prepare_parmfile {
         if (get_var('AGAMA')) {
             my $host = "ftp://" . get_var('REPO_HOST', 'openqa');
             my $root_line = " root=live:" . ((get_var('FLAVOR') =~ /^(Full|agama-installer|offline-installer|online-installer)$/) ?
-                  shorten_url($host . '/' . get_required_var('REPO_0') . "/LiveOS/squashfs.img") :
+                  $host . '/' . get_required_var('REPO_0') . "/LiveOS/squashfs.img" :
                   $host . '/' . get_var('REPO_999'));
             $params .= $root_line;
 


### PR DESCRIPTION
This is to fix root=live parameter not having the full url: https://openqa.opensuse.org/tests/5309273/logfile?filename=autoinst-log.txt#line-3167
VR:
- Leap https://openqa.opensuse.org/tests/5317086#step/bootloader_start/55
- SLES: https://openqa.suse.de/tests/19148369#step/boot_agama/55

Failure in Leap is because there's no VNC session available on s390, will be handled with: https://progress.opensuse.org/issues/188931


