### PR TITLE
Use the version of the host

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -317,7 +317,8 @@ sub load_helm_chart_tests {
     } elsif ($chart =~ m/private-registry/) {
         loadtest 'containers/charts/privateregistry';
     } elsif ($chart =~ m/kiosk/) {
-        loadtest 'containers/charts/kiosk_firefox' if (is_sle(">=15-SP6") || is_sle_micro(">=6.0"));
+        my $version = get_var("HOST_VERSION", get_required_var("VERSION"));    # VERSION is the version of the container, not the host.
+        loadtest 'containers/charts/kiosk_firefox' if (is_sle(">=15-SP6", $version) || is_sle_micro(">=6.0", $version));
     }
     else {
         die "Unsupported HELM_CHART value or HOST_VERSION";


### PR DESCRIPTION
Make the dependent schedule use the version of the host, not the container under test.

* Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/23296

- Verification run: https://openqa.suse.de/tests/19124519
