### PR TITLE
Quckfix for registering sle-module-development-tools

### DIFF
--- a/data/yam/autoyast/create_hdd_textmode_x86_64.xml
+++ b/data/yam/autoyast/create_hdd_textmode_x86_64.xml
@@ -337,6 +337,13 @@
         <release_type>nil</release_type>
         <version>{{VERSION}}</version>
       </addon>
+      <addon t="map">
+        <arch>{{ARCH}}</arch>
+        <name>sle-module-development-tools</name>
+        <reg_code/>
+        <release_type>nil</release_type>
+        <version>{{VERSION}}</version>
+      </addon>      
     </addons>
     <do_registration t="boolean">true</do_registration>
     <email/>


### PR DESCRIPTION
The SLE 15 support images for textmode lack of repos for development tools. This made the following tests fail because of missing dependencies:
- https://openqa.suse.de/tests/19122646#step/generate_dud/24
- https://openqa.suse.de/tests/19122639#step/generate_dud/25

This quickfix enables the development module.

- Verification run: 
  - https://openqa.suse.de/tests/19125640 created a support image with development tools enabled
  - https://openqa.suse.de/tests/19125658 previously failed MU job now works