### PR TITLE
Support running development VT test on PRG1 MU machines with IPXE_SET_HDD_BOOTSCRIPT

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -371,6 +371,7 @@ sub run {
         enter_o3_ipxe_boot_entry if get_var('IPXE_STATIC');
         check_screen([qw(load-linux-kernel load-initrd)], 80);
         assert_screen([qw(network-config-created loading-installation-system sshd-server-started autoyast-installation)], 300);
+        set_bootscript_hdd if get_var('IPXE_SET_HDD_BOOTSCRIPT');
         return if get_var('AUTOYAST');
         wait_still_screen(stilltime => 12, similarity_level => 60, timeout => 30) unless check_screen('sshd-server-started', timeout => 60);
         save_screenshot;


### PR DESCRIPTION
To allow PRG1 lab moved MU test machines capable to run development VT test in autoyast mode, `IPXE_SET_HDD_BOOTSCRIPT` needs to be supported. This PR adds this capability in code.

Related ticket: https://progress.opensuse.org/issues/184291

Verification run: 
- jarjarbinks,worker37:51 (supports 12sp5)
  - development 15sp7 xen: https://openqa.suse.de/tests/19144133#, cancel after key rebooting after installation validated(with fix of support IPXE_SET_HDD_BOOTSCRIPT in autoyast VIRT_AUTOTEST installation)

- briza(supports sriov), worker37:49
  - MU kvm sriov(15sp6): https://openqa.suse.de/tests/19131848, pass
  - MU xen sriov(15sp6): https://openqa.suse.de/tests/19132175, pass
  - development 15sp7 kvm: https://openqa.suse.de/tests/19144194 , pass

- regression test with existing OSD machines for development test
  - 15sp7 developing kvm test :  https://openqa.suse.de/tests/19144195, pass
  - sle micro 6.2:  https://openqa.suse.de/tests/19144244#, pass
  - sle16: https://openqa.suse.de/tests/19145161#, pass