### PR TITLE
bats/runc: Backport PR#4893 to re-enable cgroups test on ppc64le

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -180,12 +180,14 @@ runc:
   opensuse-Tumbleweed:
     GITHUB_PATCHES:
     - 4825
+    - 4893
     BATS_IGNORE:
     BATS_IGNORE_ROOT:
     BATS_IGNORE_USER:
   sle-16.0:
     GITHUB_PATCHES:
     - 4825
+    - 4893
     BATS_IGNORE:
     BATS_IGNORE_ROOT:
     BATS_IGNORE_USER:

--- a/data/containers/patches/runc/4893.patch
+++ b/data/containers/patches/runc/4893.patch
@@ -1,0 +1,54 @@
+From 830c479ae2a027ce671816a8f353a1264973dd25 Mon Sep 17 00:00:00 2001
+From: donettom-1 <donettom@linux.ibm.com>
+Date: Tue, 16 Sep 2025 17:17:40 +0530
+Subject: [PATCH] tests/int/cgroups: Use 64K aligned limits for memory.max
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When a non–page-aligned value is written to memory.max, the kernel aligns it
+down to the nearest page boundary. On systems with a page size greater
+than 4K (e.g., 64K), this caused failures because the configured
+memory.max value was not 64K aligned.
+
+This patch fixes the issue by explicitly aligning the memory.max value
+to 64K. Since 64K is also a multiple of 4K, the value is correctly
+aligned on both 4K and 64K page size systems.
+
+However, this approach will still fail on systems where the hardcoded
+memory.max value is not aligned to the system page size.
+
+Fixes: https://github.com/opencontainers/runc/issues/4841
+
+Signed-off-by: Vishal Chourasia <vishalc@linux.ibm.com>
+Signed-off-by: Donet Tom <donettom@linux.ibm.com>
+---
+ tests/integration/cgroups.bats | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tests/integration/cgroups.bats b/tests/integration/cgroups.bats
+index 082d48cc745..b21c0efc58f 100644
+--- a/tests/integration/cgroups.bats
++++ b/tests/integration/cgroups.bats
+@@ -362,7 +362,7 @@ convert_hugetlb_size() {
+ 
+ 	set_cgroups_path
+ 	update_config ' .linux.resources.unified |= {
+-				"memory.max": "20484096",
++				"memory.max": "20512768",
+ 				"memory.swap.max": "20971520"
+ 			}'
+ 
+@@ -373,10 +373,10 @@ convert_hugetlb_size() {
+ 	[ "$status" -eq 0 ]
+ 	echo "$output"
+ 
+-	echo "$output" | grep -q '^memory.max:20484096$'
++	echo "$output" | grep -q '^memory.max:20512768$'
+ 	echo "$output" | grep -q '^memory.swap.max:20971520$'
+ 
+-	check_systemd_value "MemoryMax" 20484096
++	check_systemd_value "MemoryMax" 20512768
+ 	check_systemd_value "MemorySwapMax" 20971520
+ }
+ 

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -55,8 +55,6 @@ sub run {
     run_command "make $helpers || true";
 
     unless (get_var("BATS_TESTS")) {
-        # Skip this test due to https://github.com/opencontainers/runc/issues/4841
-        run_command "rm -f tests/integration/cgroups.bats" if is_ppc64le;
         # Skip this test due to https://bugzilla.suse.com/show_bug.cgi?id=1247568
         run_command "rm -f tests/integration/no_pivot.bats" if is_ppc64le;
         # Skip this test due to https://bugzilla.suse.com/show_bug.cgi?id=1247567


### PR DESCRIPTION
Backport https://github.com/opencontainers/runc/pull/4893 to re-enable cgroups test on ppc64le

Verification runs:
- SLES 16.0: https://openqa.suse.de/tests/19137322
- Tumbleweed: https://openqa.opensuse.org/tests/5313598