### PR TITLE
Disable original repos before migration

### DIFF
--- a/tests/yam/migration/migration_unattended.pm
+++ b/tests/yam/migration/migration_unattended.pm
@@ -28,6 +28,10 @@ sub run {
     # install the migration image and active it
     zypper_call("--gpg-auto-import-keys -n in suse-migration-sle16-activation");
 
+    # Disable repos of the product to migrate from due to proxySCC is not serving SLES 15 SP*
+    my $version = get_var('VERSION_UPGRADE_FROM');
+    $version =~ s/-/_/;
+    script_run('for s in $(zypper -t ls | grep _Module_' . "$version" . ' | sed -e \'s,|.*,,g\'); do zypper modifyservice --disable $s; done');
     power_action('reboot', textmode => 1, keepconsole => 1, first_reboot => 1);
 
     assert_screen([qw(grub-menu-migration migration-running)], 150);


### PR DESCRIPTION
As https://bugzilla.suse.com/show_bug.cgi?id=1248998#c17, disable repos of the product to migrate from due to proxySCC is not serving SLES 15 SP*.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/19144207#step/migration_unattended/10
