### PR TITLE
Add reconnect for migration test on s390x

### DIFF
--- a/schedule/yam/agama_migration_15sp7_s390x.yaml
+++ b/schedule/yam/agama_migration_15sp7_s390x.yaml
@@ -1,0 +1,19 @@
+---
+name: agama_migration_15sp7_textmode.yaml
+description: >
+  Migration from SLES 15 SP7 equivalent to system role textmode.
+schedule:
+  - yam/migration/setup_upgrade_env
+  - autoyast/prepare_profile
+  - installation/bootloader_start
+  - autoyast/installation
+  - installation/first_boot
+  - yam/migration/restore_upgrade_env
+  - console/system_prepare
+  - console/hostname
+  - yam/migration/migration_unattended
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - yam/validate/validate_migration_logs
+  - yam/validate/validate_product
+  - console/validate_repos


### PR DESCRIPTION

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/19153659#step/migration_unattended/21 Failed for wicked2nm issue.
