### PR TITLE
Workaround k3s apparmor issue in sle12sp5

### DIFF
--- a/tests/containers/run_container_in_k3s.pm
+++ b/tests/containers/run_container_in_k3s.pm
@@ -47,13 +47,13 @@ sub run {
 
     # Staging does not have access to repositories, only to DVD
     # curl -sfL https://get.k3s.io is not supported on ppc poo#128456
-    if (!is_staging && !is_ppc64le) {
-        prepare_pod_yaml();
-        record_info('Test', 'kube apply');
-        assert_script_run('podman kube apply --kubeconfig ~/.kube/config -f pod.yaml', timeout => 180);
-        assert_script_run('kubectl wait --timeout=600s --for=condition=Ready pod/testing-pod', timeout => 610);
-        validate_script_output('kubectl exec testing-pod -- cat /etc/os-release', sub { m/SUSE Linux Enterprise Server/ }, timeout => 300);
-    }
+    return if (is_staging || is_ppc64le || get_var('HELM_CHART', ''));
+
+    prepare_pod_yaml();
+    record_info('Test', 'kube apply');
+    assert_script_run('podman kube apply --kubeconfig ~/.kube/config -f pod.yaml', timeout => 180);
+    assert_script_run('kubectl wait --timeout=600s --for=condition=Ready pod/testing-pod', timeout => 610);
+    validate_script_output('kubectl exec testing-pod -- cat /etc/os-release', sub { m/SUSE Linux Enterprise Server/ }, timeout => 300);
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
The apparmor profiles in sle12sp5 are too old for k3s, in such a case we need to boot with turned off apparmor. Otherwise we deal with hanging pods

```
  Warning  Failed     1s (x3 over 25s)     kubelet            (combined
from similar events): Error: failed to create containerd container: load
apparmor profile /tmp/cri-containerd.apparmor.d2752965126: parser
error("AppArmor parser error for
/tmp/cri-containerd.apparmor.d2752965126 in
/tmp/cri-containerd.apparmor.d2752965126 at line 14: syntax error,
unexpected TOK_OPENPAREN, expecting TOK_MODE"): exit status 1"")
```

The other part of the fix is to avoid testing busybox in k3s. We just need to test image of our interest.


- Verification run: http://kepler.suse.cz/tests/25284#step/run_container_in_k3s/30
