### PR TITLE
samba_adcli: restore original network config before exiting

### DIFF
--- a/tests/network/samba/samba_adcli.pm
+++ b/tests/network/samba/samba_adcli.pm
@@ -195,15 +195,14 @@ sub run {
     # - smbclient //$AD_hostname/openQA as geekouser is permitted (read-only), but as berhard it is denied
     # - delete the computer OU after the test is done in post_run_hook
     # - test winbind (samba?) authentication
-
-    # Restore the network config files, poo#156427
-    assert_script_run("cp /etc/sysconfig/network/config{.bak,}") unless $NetworkManager;
-    assert_script_run("cp /etc/resolv.conf{.bak,}");
 }
 
 sub post_run_hook {
     my ($self) = shift;
     enable_ipv6();
+    # Restore the network config files
+    assert_script_run("cp /etc/sysconfig/network/config{.bak,}") unless $NetworkManager;
+    assert_script_run("cp /etc/resolv.conf{.bak,}");
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/188754
VRs:
* 15-SP5: https://openqa.suse.de/tests/19145033
* 15-SP4: https://openqa.suse.de/tests/19145032
* 15-SP2: https://openqa.suse.de/tests/19145031