### PR TITLE
bats: Do not fail when removing temp dir

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -337,7 +337,7 @@ sub bats_post_hook {
     assert_script_run "mkdir -p $log_dir || true";
     assert_script_run "cd $log_dir";
 
-    script_run "rm -rf $test_dir" unless ($test_dir eq "/var/tmp/");
+    script_run("rm -rf $test_dir", timeout => 300, proceed_on_failure => 1) unless ($test_dir eq "/var/tmp/");
 
     collect_calltraces;
     collect_coredumps;


### PR DESCRIPTION
Do not fail when removing temp directory.

- Failed job: https://openqa.suse.de/tests/19148290#step/podman/566