### PR TITLE
Remove softfail for kdump and crash test module

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -176,8 +176,6 @@ sub handle_warning_install_os_prober {
 # use yast2 kdump to enable the kdump service
 sub activate_kdump {
     my (%args) = @_;
-    # increase kdump memory when bsc#1161421 applies
-    my $increase_kdump_memory = $args{increase_kdump_memory} // 1;
     # restart info will appear only when change has been done
     my $expect_restart_info = 0;
 
@@ -202,17 +200,6 @@ sub activate_kdump {
         # enable kdump
         send_key('alt-u');
         assert_screen('yast2-kdump-enabled');
-        $expect_restart_info = 1;
-    }
-    # ppcl64e and aarch64 needs increased kdump memory bsc#1161421
-    # migration regression test cases need increase kdump memory since lot of services start
-    if (is_ppc64le || is_aarch64 || get_var('FLAVOR') =~ /Regression/) {
-        if ($increase_kdump_memory) {
-            send_key('alt-y');
-            type_string $memory_kdump;
-            wait_screen_change(sub { send_key 'ret' }, 10) for (1 .. 2);
-            record_soft_failure 'default kdump memory size is too small for ppc64le and aarch64, see bsc#1161421';
-        }
         $expect_restart_info = 1;
     }
     # enable and verify fadump settings

--- a/tests/console/yast2_kdump.pm
+++ b/tests/console/yast2_kdump.pm
@@ -27,7 +27,7 @@ sub run {
     zypper_call('in yast2-kdump');
 
     # Kdump configuration with YaST module
-    kdump_utils::activate_kdump(increase_kdump_memory => 0);
+    kdump_utils::activate_kdump();
 
     # check service (without restarting)
     systemctl('is-enabled kdump');


### PR DESCRIPTION
Remove softfail for kdump and crash test module
ppcl64e and aarch64 doesn't need increased kdump memory refer bsc#1161421

- Related ticket: https://progress.opensuse.org/issues/187467
- Verification run: https://openqa.suse.de/tests/19144398#
                                https://openqa.opensuse.org/tests/5318463#step/kdump_and_crash/31 (TW)