### PR TITLE
Use run_cmd_retry to run cs_wait_for_idle command

### DIFF
--- a/lib/sles4sap_publiccloud.pm
+++ b/lib/sles4sap_publiccloud.pm
@@ -1501,7 +1501,7 @@ sub wait_for_idle {
     my ($self, %args) = @_;
     my $timeout = $args{timeout} // 240;
 
-    my $rc = $self->run_cmd(cmd => 'cs_wait_for_idle --sleep 5', timeout => $timeout, rc_only => 1, proceed_on_failure => 1);
+    my $rc = $self->run_cmd_retry(cmd => 'cs_wait_for_idle --sleep 5', timeout => $timeout, rc_only => 1);
     if ($rc == 124) {
         record_info('WARN cs_wait_for_idle', "cs_wait_for_idle timed out after $timeout. Gathering info and retrying");
         $self->run_cmd(cmd => 'cs_clusterstate', proceed_on_failure => 1);


### PR DESCRIPTION
timeout issue happened when running cs_wait_for_idle command, the return code is 255, this is probably same to the ticket [team-10617](https://jira.suse.com/browse/TEAM-10617
) , that is a complicated issue, but I take **run_cmd_retry** to replace **run_cmd**, this will reduce the timeout issue at least.

- Related ticket: https://jira.suse.com/browse/TEAM-10537
- Needles: None
- Verification run:
    https://openqa.suse.de/tests/19153609
    https://openqa.suse.de/tests/19153610
    https://openqa.suse.de/tests/19153611
    https://openqa.suse.de/tests/19153612
    https://openqa.suse.de/tests/19153613
    https://openqa.suse.de/tests/19153616
