### PR TITLE
Improve grub2 handler in aarch64 images

### DIFF
--- a/products/sle-micro/main.pm
+++ b/products/sle-micro/main.pm
@@ -34,7 +34,18 @@ $needle::cleanuphandler = sub {
     unregister_needle_tags("ENV-VERSION-11-SP4");
     unregister_needle_tags("ENV-12ORLATER-1");
     unregister_needle_tags("ENV-FLAVOR-Server-DVD");
+    unregister_needle_tags('ENV-15SP3ORLATER-1');
     unregister_needle_tags('ENV-OFW-1') unless get_var('OFW');
+    unregister_needle_tags('bootloader-shim-import-prompt');
+    unregister_needle_tags('ENV-15SP4');
+    unless (check_var('BOOTLOADER', 'grub2-bls')) {
+        unregister_needle_tags('bootloader-grub2-bls');
+        unregister_needle_tags('grub2-bls');
+    }
+    unless (get_var('FLAVOR', '') =~ /selfinstall/i) {
+        unregister_needle_tags('inst-bootmenu');
+        unregister_needle_tags('inst-oninstallation');
+    }
 };
 
 

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -96,7 +96,7 @@ sub run {
 
     # Some aach64 JeOS jobs take too long to match the first grub2 needle.
     # By pressing a random key, we stop the grub timeout
-    send_key 'backspace' if (is_jeos && is_aarch64);
+    send_key 'backspace' if (is_aarch64 && is_sle_micro('6.0+') || is_jeos);
 
     if (get_var('FLAVOR') =~ /VMware-Updates/) {
         # VMware guests have a short GRUB timeout, which can cause issues with needle matching.


### PR DESCRIPTION
A few aarch64 flavors have reduced grub2 timeout that openQA struggles
to handle.
There is an excessive amount of grub2 needles th

Verification runs

* https://openqa.suse.de/tests/19154370#step/bootloader_uefi/6
* https://openqa.suse.de/tests/19154312#
