### PR TITLE
xfstests: Add fsgqa user in NFS krb5 scenario

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -448,6 +448,17 @@ includedir  /etc/krb5.conf.d
 END
     script_run("echo '$content' > \"/etc/krb5.conf\"");
 
+    #Config idmapd.conf
+    $content = <<END;
+[General]
+Domain = susetest.com
+
+[Mapping]
+Nobody-User = nobody
+Nobody-Group = nobody
+END
+    script_run("echo '$content' > \"/etc/idmapd.conf\"");
+
     #create KDC database, start service and setup key
     script_run('kdb5_util create -s -P susetest -r SUSETEST.COM');
     script_run('systemctl start krb5kdc kadmind; systemctl enable krb5kdc kadmind');
@@ -470,6 +481,9 @@ END
     script_run('klist');
     script_run('kinit -k nfs/$(hostname -f)@SUSETEST.COM');
     script_run('klist');
+
+    script_run("systemctl restart nfs-idmapd");
+    script_run("systemctl restart rpc-gssd");
 }
 
 sub setup_nfs_server {

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -455,6 +455,12 @@ END
     script_run('kadmin.local -q "addprinc -randkey nfs/$(hostname -f)@SUSETEST.COM"');
     script_run('kadmin.local -q "ktadd -k /etc/krb5.keytab nfs/$(hostname -f)@SUSETEST.COM"');
 
+    #create fsgqa/fsgqa2 users for some xfstests
+    script_run('kadmin.local -q "addprinc -randkey fsgqa@SUSETEST.COM"');
+    script_run('kadmin.local -q "addprinc -randkey fsgqa2@SUSETEST.COM"');
+    script_run('kadmin.local -q "ktadd -k /etc/krb5.keytab fsgqa@SUSETEST.COM"');
+    script_run('kadmin.local -q "ktadd -k /etc/krb5.keytab fsgqa2@SUSETEST.COM"');
+
     #verify the key
     script_run('klist -kte /etc/krb5.keytab');
     script_run('kadmin.local -q "getprinc nfs/$(hostname -f)@SUSETEST.COM"');


### PR DESCRIPTION
The fsgqa/fsgqa2 user added by ibs as a normal user, but didn't add in krb5 scenario.

- Related ticket: https://progress.opensuse.org/issues/188853
- Verification run: 
- https://openqa.suse.de/tests/19132345#step/partition/93
- https://openqa.suse.de/tests/19154322
- The test fail is OK, it's because of bsc#1249996, but the lack of configure was find during debugging the issue.