### PR TITLE
Bump timeout for migration_unattended grub needle

### DIFF
--- a/tests/yam/migration/migration_unattended.pm
+++ b/tests/yam/migration/migration_unattended.pm
@@ -41,7 +41,7 @@ sub run {
     } else {
         power_action('reboot', textmode => 1, keepconsole => 1, first_reboot => 1);
         assert_screen([qw(grub-menu-migration migration-running)]);
-        assert_screen('grub2', 400);
+        assert_screen('grub2', 600);
     }
 }
 


### PR DESCRIPTION
- Looks like we need to wait longer for GRUB to appear.
- Verification run: https://openqa.suse.de/tests/19154328
