### PR TITLE
zypper_search: Properly handle empty package list

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -950,7 +950,7 @@ sub zypper_search {
         @fields = ('status', 'name', 'type', 'version', 'arch', 'repository');
     }
 
-    my $output = script_output("zypper -n se $params");
+    my $output = script_output("zypper -in se $params");
     return parse_zypper_table($output, \@fields);
 }
 


### PR DESCRIPTION
Add the `--ignore-unknown` (`-i`) parameter to `zypper search` commands so that empty repositories or missing packages don't result in error exit code.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/19154369
