### PR TITLE
Fix for the check_services function

### DIFF
--- a/tests/publiccloud/check_services.pm
+++ b/tests/publiccloud/check_services.pm
@@ -48,7 +48,7 @@ sub run {
             record_soft_failure("bsc#1249902 - systemd-vconsole-setup.service failed to load:\n$log_output");
             next;
         }
-        record_info("SVC $service FAILED:\n$log_output", screenshot => 0);
+        record_info("Failing services!", "SVC $service FAILED:\n$log_output");
         $failed = 1;
     }
 


### PR DESCRIPTION
Previous #23348 had a `screenshot` argument in the `record_info` function:

- Verification run: https://openqa.suse.de/tests/19157957#step/check_services/32 --> Fails as expected :)
