### PR TITLE
softreboot: fix the condition of the message on stop-fail case

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -599,8 +599,8 @@ sub softreboot {
     # wait till ssh disappear
     my $out = $self->wait_for_ssh(timeout => $args{timeout}, wait_stop => 1, username => $args{username});
     # ok ssh port closed
-    record_info("Shutdown failed", "WARNING: while stopping the system, ssh port still open after timeout,\nreporting: $out")
-      if (defined $out);    # not ok port still open
+    record_info("Shutdown failed", "WARNING: while stopping the system, ssh port still open after timeout,\nreporting: $out", result => 'fail')
+      unless (defined $out);    # not ok port still open
 
     my $shutdown_time = time() - $start_time;
     die("Waiting for system down failed!") unless ($shutdown_time < $args{timeout});


### PR DESCRIPTION
In publiccloud `softreboot`, fix the condition of the message on stop-fail case:

The `wait_for_ssh` routine, when all ok, returns a defined value, as on starting as on stopping case. 
Then, in `softreboot`, when instance fails to stop in `wait_for_ssh`, the returned value is `not defined` and in that case message shall be printed and **not in ok pass** cases.

- VR, WAIT STOP OK, in:
  https://openqa.suse.de/tests/19159457#step/patch_and_reboot/193, sle-micro-6.0-GCE
  https://openqa.suse.de/tests/19159458#step/patch_and_reboot/84, sle-15-SP7-Azure
  https://openqa.suse.de/tests/19159760, sle-15-SP4-Azure-**SAP**
