### PR TITLE
Add reset_consoles after reboot for migration on s390x

### DIFF
--- a/tests/yam/migration/migration_unattended.pm
+++ b/tests/yam/migration/migration_unattended.pm
@@ -51,6 +51,7 @@ sub run {
 
     if (is_s390x()) {
         enter_cmd '/usr/sbin/run_migration';
+        reset_consoles;
         reconnect_mgmt_console;
     } else {
         power_action('reboot', textmode => 1, keepconsole => 1, first_reboot => 1);


### PR DESCRIPTION
Need add reset_consoles after reboot for migration test on s390x to make the console status correct.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/19165845#step/validate_migration_logs/3
