### PR TITLE
HA/SAP: shutdown LPAR after test on PowerVM platform

### DIFF
--- a/lib/mr_test_lib.pm
+++ b/lib/mr_test_lib.pm
@@ -69,6 +69,12 @@ sub load_mr_tests {
         loadtest_mr_test('tests/publiccloud/ssh_interactive_end', run_args => $args);
         loadtest_mr_test('tests/sles4sap/publiccloud/qesap_cleanup', run_args => $args);
     }
+
+    # Load 'shutdown.pm' here instead of YAML schedule file,
+    # otherwise 'shutdown' will not be the last test step.
+    if (is_pvm_hmc()) {
+        autotest::loadtest('tests/shutdown/shutdown.pm');
+    }
 }
 
 1;

--- a/schedule/ha/bv/pvm_ha_priority_fencing.yaml
+++ b/schedule/ha/bv/pvm_ha_priority_fencing.yaml
@@ -48,6 +48,7 @@ schedule:
   - '{{cluster_setup}}'
   - ha/priority_fencing_delay
   - ha/check_logs
+  - shutdown/shutdown
 conditional_schedule:
   barrier_init:
     HA_CLUSTER_INIT:

--- a/schedule/ha/bv/pvm_ha_qdevice_node.yaml
+++ b/schedule/ha/bv/pvm_ha_qdevice_node.yaml
@@ -46,6 +46,7 @@ schedule:
   - ha/qnetd
   - '{{boot}}'
   - ha/check_after_reboot
+  - shutdown/shutdown
 conditional_schedule:
   barrier_init:
     HA_CLUSTER_INIT:

--- a/schedule/ha/bv/pvm_ha_qnetd_server.yaml
+++ b/schedule/ha/bv/pvm_ha_qnetd_server.yaml
@@ -34,3 +34,4 @@ schedule:
   - ha/firewall_disable
   - ha/setup_hosts_and_luns
   - ha/qnetd
+  - shutdown/shutdown

--- a/schedule/ha/bv/pvm_pacemaker_cts_regression.yaml
+++ b/schedule/ha/bv/pvm_pacemaker_cts_regression.yaml
@@ -27,3 +27,4 @@ schedule:
   - console/check_os_release
   - console/hostname
   - ha/pacemaker_cts_regression
+  - shutdown/shutdown

--- a/schedule/sles4sap/hana/pvm_hana_cluster_node_sle16.yaml
+++ b/schedule/sles4sap/hana/pvm_hana_cluster_node_sle16.yaml
@@ -64,6 +64,8 @@ schedule:
   - '{{boot_to_desktop_non_init}}'
   - ha/check_after_reboot
   - ha/check_logs
+  - ha/prepare_shutdown
+  - shutdown/shutdown
 conditional_schedule:
   barrier_init:
     HA_CLUSTER_INIT:


### PR DESCRIPTION
After test passed successfully on ppc64le-hmc workers, we should poweroff the system properly.

This change does not include YAML schedule files which are only used in 15SPx pre-release job groups.

- Related ticket: https://jira.suse.com/browse/TEAM-10556
- Needles: none
- Verification run:
saptune: https://openqa.suse.de/tests/19165321#step/shutdown/1
hanasr: https://openqa.suse.de/tests/19155427#step/shutdown/1
pacemaker_cts_regression: https://openqa.suse.de/tests/19154280#step/shutdown/1
diskless_sbd_qdevice: https://openqa.suse.de/tests/19156014#step/shutdown/1
priority_fencing: https://openqa.suse.de/tests/19040030#step/shutdown/1