### PR TITLE
Support efi guests only when testing sev-snp

### DIFF
--- a/lib/virt_autotest/common.pm
+++ b/lib/virt_autotest/common.pm
@@ -273,7 +273,7 @@ if (get_var("REGRESSION", '') =~ /xen/) {
     } elsif (is_sle('=15-SP7')) {
         my @allowed_guests = qw(sles12sp5 sles15sp6 sles15sp7);
         # For SEV-SNP guest verification, use specific guest sets
-        if (get_var('ENABLE_SEV_SNP', 1)) {
+        if (check_var('ENABLE_SEV_SNP', '1')) {
             @allowed_guests = qw(sles15sp6efi sles15sp7efi);
         }
         foreach my $guest (keys %guests) {


### PR DESCRIPTION
Support efi guests only when testing sev-snp

- Related ticket: https://progress.opensuse.org/issues/189042
- Needles: n/a
- Verification run: 
[MU sles15SP7 non-sev-snp tesitng](https://openqa.suse.de/tests/19166415)
[MU sles15sp7 sev-snp testing](https://openqa.suse.de/tests/19169740)
