### PR TITLE
Upload logs after migration

### DIFF
--- a/tests/yam/migration/migration_unattended.pm
+++ b/tests/yam/migration/migration_unattended.pm
@@ -55,7 +55,7 @@ sub run {
         reconnect_mgmt_console;
     } else {
         power_action('reboot', textmode => 1, keepconsole => 1, first_reboot => 1);
-        assert_screen([qw(grub-menu-migration migration-running)]);
+        assert_screen([qw(grub-menu-migration migration-running)], 90);
         assert_screen('grub2', 600);
     }
 }

--- a/tests/yam/validate/validate_migration_logs.pm
+++ b/tests/yam/validate/validate_migration_logs.pm
@@ -3,7 +3,6 @@
 # Copyright 2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-
 # Summary: Validate logs after migration to sle 16.
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
@@ -15,6 +14,13 @@ sub run {
     select_console 'root-console';
 
     upload_logs("/var/log/distro_migration.log", failok => 1);
+    script_run 'tar zcvf /tmp/cache_wicked_config.tar.gz /var/cache/wicked_config/*';
+    upload_logs("/tmp/cache_wicked_config.tar.gz", failok => 1);
+    script_run 'tar zcvf /tmp/cache_udev_rules.tar.gz /var/cache/udev_rules/*';
+    upload_logs("/tmp/cache_udev_rules.tar.gz", failok => 1);
+    script_run("tar czvf /tmp/udev_rules.tar.gz /etc/udev/rules.d/*", {timeout => 60});
+    upload_logs("/tmp/udev_rules.tar.gz", failok => 1);
+
     if (script_run("cat /var/log/distro_migration.log | grep -i -E \"migration failed|aborting migration\"") == 0) {
         record_info("Migration failed", script_output("cat /var/log/distro_migration.log | grep -i -E \"migration failed|aborting migration\" -B50"), result => 'fail');
         die("Migration failed");

--- a/tests/yam/validate/validate_product.pm
+++ b/tests/yam/validate/validate_product.pm
@@ -26,4 +26,8 @@ sub run {
     }
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
+
 1;


### PR DESCRIPTION
Need upload logs of /var/cache/wicked_config, /var/cache/udev_rules and /etc/udev/rules.d after migration.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
https://openqa.suse.de/tests/19181392#details s390x kvm
https://openqa.suse.de/tests/19166313#live regression test on power 10 kvm
