### PR TITLE
k3s interferes with BCI testing

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -108,6 +108,7 @@ sub run {
 
     # For some containers we need to fake the OS version to distinguish them
     my $os_version = get_var('BCI_OS_VERSION');
+    script_run('systemctl stop k3s.service');
 
     my $engine = $args->{runtime};
     my $bci_devel_repo = get_var('BCI_DEVEL_REPO');


### PR DESCRIPTION
The k3s running in the background be a performance hit when building `go` app in the container.

OOM is invoked with running BCI go tests.

```
Out of memory - Serial error: [ 2857.746684][T28191] Out of memory:
Killed process 2417 (traefik) total-vm:1438420kB, anon-rss:27692kB,
file-rss:0kB, shmem-rss:0kB, UID:65532 pgtables:500kB oom_score_adj:1000
]
```

- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
