### PR TITLE
console/sudo.pm: Wait for sudo_test prompt before typing commands

### DIFF
--- a/tests/console/sudo.pm
+++ b/tests/console/sudo.pm
@@ -92,7 +92,7 @@ sub full_test {
     enter_cmd 'exit';
     sudo_with_pw 'sudo sed -i "s/^Defaults\[\[\:space\:\]\]*targetpw/Defaults\ !targetpw/" /etc/sudoers';
     sudo_with_pw 'sudo sed -i "s/^ALL\[\[\:space\:\]\]*ALL/#ALL ALL/" /etc/sudoers';
-    sudo_with_pw 'sudo su - sudo_test';
+    sudo_with_pw 'sudo su - sudo_test', expected_screen => 'sudo_test-console';
     test_sudoers $test_password;
     sudo_with_pw 'bash -c "sudo su - sudo_test 2>check_err.log"', password => "$test_password", expected_screen => 'user-console';
     sleep 1;


### PR DESCRIPTION
Typing before the prompt appears might lose some key presses.

- Failure: https://openqa.opensuse.org/tests/5320574#step/sudo/178
- Needles: Created on o3 already
- Verification run: https://openqa.opensuse.org/tests/5326572
