### PR TITLE
Minor BATS fixes with Junit

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -61,7 +61,6 @@ buildah:
     BATS_IGNORE_ROOT:
     - "bud.bats::bud-git-context"
     - "bud.bats::bud-git-context-subdirectory"
-    - "bud.bats::bud-multiple-platform-no-partial-manifest-list"
     - "bud.bats::bud using gitrepo and branch"
     - "bud.bats::bud with --cgroup-parent"
     - "run.bats::Check if containers run with correct open files/processes limits"
@@ -74,7 +73,6 @@ buildah:
     BATS_IGNORE_ROOT:
     - "bud.bats::bud-git-context"
     - "bud.bats::bud-git-context-subdirectory"
-    - "bud.bats::bud-multiple-platform-no-partial-manifest-list"
     - "bud.bats::bud using gitrepo and branch"
     - "bud.bats::bud with --cgroup-parent"
     - "run.bats::Check if containers run with correct open files/processes limits"
@@ -84,12 +82,12 @@ buildah:
     - 5495
     - 6226
     BATS_IGNORE:
-    - "bud.bats::bud-git-context"
-    - "bud.bats::bud-git-context-subdirectory"
     - "bud.bats::bud-multiple-platform-no-partial-manifest-list"
+    BATS_IGNORE_ROOT:
     - "bud.bats::bud using gitrepo and branch"
     - "bud.bats::bud with --cgroup-parent"
-    BATS_IGNORE_ROOT:
+    - "bud.bats::bud-git-context"
+    - "bud.bats::bud-git-context-subdirectory"
     - "run.bats::Check if containers run with correct open files/processes limits"
     BATS_IGNORE_USER:
   sle-15-SP4:
@@ -97,12 +95,12 @@ buildah:
     - 5495
     - 6226
     BATS_IGNORE:
-    - "bud.bats::bud-git-context"
-    - "bud.bats::bud-git-context-subdirectory"
     - "bud.bats::bud-multiple-platform-no-partial-manifest-list"
+    BATS_IGNORE_ROOT:
     - "bud.bats::bud using gitrepo and branch"
     - "bud.bats::bud with --cgroup-parent"
-    BATS_IGNORE_ROOT:
+    - "bud.bats::bud-git-context"
+    - "bud.bats::bud-git-context-subdirectory"
     - "run.bats::Check if containers run with correct open files/processes limits"
     BATS_IGNORE_USER:
 conmon:

--- a/data/containers/bats/xfails.py
+++ b/data/containers/bats/xfails.py
@@ -87,9 +87,6 @@ def patch_xml(file: str, xfails: Dict[str, List[str]]) -> None:
         # Update failures counter
         if adjusted != failures:
             testsuite.set("failures", str(adjusted))
-            # This suite was expected to fail but passed
-            if suitename in xfails and not xfails[suitename] and adjusted == 0:
-                print(prefix + suitename)
 
     tree.write(file, encoding="utf-8", xml_declaration=True)
 


### PR DESCRIPTION
- Fine-tune BATS_IGNORE variables
- No need to print suitename in xfails.