### PR TITLE
Fix Elemental2 sporadic timeout

### DIFF
--- a/tests/elemental/container_validation.pm
+++ b/tests/elemental/container_validation.pm
@@ -47,7 +47,7 @@ sub run {
     $img_filename =~ tr/\/#/_/;
 
     # Define timeouts based on the architecture
-    my $timeout = (is_aarch64) ? 480 : 240;
+    my $timeout = (is_aarch64) ? 960 : 480;
 
     # Set SELinux in permissive mode, as there is an issue with Enforcing mode and Elemental doesn't support it
     assert_script_run("setenforce Permissive");
@@ -56,7 +56,7 @@ sub run {
     assert_script_run("mkdir -p $shared");
 
     if (lc($flavor) =~ m/image/) {
-        assert_script_run("podman pull $image");
+        assert_script_run("podman pull $image", $timeout);
         assert_script_run("podman run --name $cnt_name -v $shared:/host:Z -dt $image sleep infinity");
 
         record_info('Kernel', 'Test that kernel files are present');
@@ -113,7 +113,7 @@ sub run {
     if (lc($flavor) =~ m/iso/) {
         # Create and upload ISO image
         record_info('ISO', 'Generate and upload ISO');
-        assert_script_run("podman run --rm -v $shared:/host:Z $image /bin/sh -c 'busybox cp /elemental-iso/*.iso /host/$img_filename.iso'");
+        assert_script_run("podman run --rm -v $shared:/host:Z $image /bin/sh -c 'busybox cp /elemental-iso/*.iso /host/$img_filename.iso'", $timeout);
         upload_asset("$shared/$img_filename.iso", 1);
     }
 }


### PR DESCRIPTION
With some images we can see timeout during the image pulling. Increasing the timeout fixes the issue.

- Related ticket: N/A
- Needles: N/A
- Verification run: Validated on my local lab with 6.2 OS images
<img width="1033" height="457" alt="Screenshot From 2025-09-19 10-01-49" src="https://github.com/user-attachments/assets/414053fe-4c15-4619-94d9-b1f827ed66d4" />
