### PR TITLE
Disable timeout for migration grub menu

### DIFF
--- a/tests/yam/migration/migration_unattended.pm
+++ b/tests/yam/migration/migration_unattended.pm
@@ -55,8 +55,13 @@ sub run {
         reset_consoles;
         reconnect_mgmt_console;
     } else {
+        # disable timeout for migration grub menu
+        assert_script_run("sed -i 's/set timeout=[0-9]*/set timeout=-1/' /etc/grub.d/99_migration");
+        assert_script_run("grub2-mkconfig -o /boot/grub2/grub.cfg");
         power_action('reboot', textmode => 1, keepconsole => 1, first_reboot => 1);
-        assert_screen([qw(grub-menu-migration migration-running)], 90);
+        assert_screen('grub-menu-migration', 120);
+        send_key 'ret';
+        assert_screen('migration-running');
         assert_screen('grub2', 600);
     }
 }


### PR DESCRIPTION
The default timeout is set to 1s for the migration grub menu which is too short to catch the menu needle. So disable timeout for migration grub menu.

- Related ticket: https://progress.opensuse.org/issues/187626#note-18
- Verification run: [verification_runs_link](https://openqa.suse.de/tests/overview?build=chcao_grub2&distri=sle&version=16.0)