### PR TITLE
Use sysstat as test package

### DIFF
--- a/tests/microos/toolbox.pm
+++ b/tests/microos/toolbox.pm
@@ -165,7 +165,7 @@ sub run {
             assert_script_run 'toolbox run -c devel -- zypper -n ref -s', timeout => 300;
         }
         assert_script_run 'toolbox run -c devel -- zypper lr -u', timeout => 180;
-        assert_script_run 'toolbox run -c devel -- zypper -n in zip', timeout => 180;
+        assert_script_run 'toolbox run -c devel -- zypper -n in sysstat', timeout => 180;
     }
     assert_script_run 'podman rm devel';
 


### PR DESCRIPTION
zip is not available on SLEM 6.0 so we need to use a different package. sysstat appears to be available on all SLEM versions and is not part of the toolbox container.

- Related ticket: https://progress.opensuse.org/issues/189153
- Related failure: https://openqa.suse.de/tests/19182629#step/toolbox/86
- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/23295
- Verification run: https://duck-norris.qe.suse.de/tests/15002
