### PR TITLE
Temporarily suspend suspend testing

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -38,7 +38,8 @@ sub load_maintenance_publiccloud_tests {
         loadtest('publiccloud/run_ltp', run_args => $args);
     } elsif (get_var('PUBLIC_CLOUD_FUNCTIONAL')) {
         loadtest('publiccloud/cloud_netconfig', run_args => $args);
-        loadtest('publiccloud/suspending', run_args => $args);
+        # Temporarily disabled due to poo#188670
+        #loadtest('publiccloud/suspending', run_args => $args);
     } elsif (check_var('PUBLIC_CLOUD_AHB', 1)) {
         loadtest('publiccloud/ahb', run_args => $args);
     } elsif (get_var('PUBLIC_CLOUD_NEW_INSTANCE_TYPE')) {
@@ -127,7 +128,8 @@ sub load_latest_publiccloud_tests {
         loadtest("publiccloud/registration", run_args => $args);
         if (get_var('PUBLIC_CLOUD_FUNCTIONAL')) {
             loadtest('publiccloud/cloud_netconfig', run_args => $args);
-            loadtest('publiccloud/suspending', run_args => $args);
+            # Temporarily disabled due to poo#188670
+            #loadtest('publiccloud/suspending', run_args => $args);
         } elsif (check_var('PUBLIC_CLOUD_AHB', 1)) {
             loadtest('publiccloud/ahb', run_args => $args);
         } elsif (get_var('PUBLIC_CLOUD_NEW_INSTANCE_TYPE')) {


### PR DESCRIPTION
Temporarily suspend testing of publiccloud/suspending because of recurring ongoing issues in the maintenance test runs. See poo#188670.

- Related ticket: https://progress.opensuse.org/issues/188670
- Verification run: https://openqa.suse.de/tests/19189108