### PR TITLE
containers/podman-py: Move test to podman_e2e

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -184,10 +184,6 @@ sub load_host_tests_podman {
     load_compose_tests($run_args);
     loadtest('containers/seccomp', run_args => $run_args, name => $run_args->{runtime} . "_seccomp") unless is_sle('<15');
     loadtest('containers/isolation', run_args => $run_args, name => $run_args->{runtime} . "_isolation") unless (is_public_cloud || is_transactional);
-    # python3-podman is not available on SLES - https://bugzilla.suse.com/show_bug.cgi?id=1248415
-    unless (is_jeos || is_public_cloud || is_staging || is_transactional || get_var("OCI_RUNTIME")) {
-        loadtest('containers/python_runtime', run_args => $run_args, name => "python_podman") if (is_tumbleweed && (is_aarch64 || is_x86_64));
-    }
     loadtest('containers/podmansh') if (is_tumbleweed && !is_staging && !is_transactional);
 }
 


### PR DESCRIPTION
Move podman-py test to its own job aptly named `podman_e2e` that will also hold the podman e2e tests.

The reasons for grouping these:
- Having all upstream tests in their own jobs.
- They all use JUnit XML for logging and will benefit from an upcoming update to [openqa-bats-review](https://github.com/os-autoinst/scripts/blob/master/openqa-bats-review) to tag failed jobs as passed is the set intersection of all failures in retried jobs is empty.

Verification run: https://openqa.opensuse.org/tests/5334771
Related PR: https://github.com/os-autoinst/opensuse-jobgroups/pull/737
Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2461