### PR TITLE
Restrict scheduling and expand rmt chart test coverage

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -305,13 +305,13 @@ sub load_helm_chart_tests {
     );
 
     loadtest 'containers/scc_login_to_registry' if (is_sle() && $spr_credentials_defined);
+    my $host_version = get_var("HOST_VERSION", get_required_var("VERSION"));    # VERSION is the version of the container, not the host.
     if ($chart =~ m/rmt-helm$/) {
-        loadtest 'containers/charts/rmt';
+        loadtest 'containers/charts/rmt' if ($host_version =~ "15-SP[4,5,6,7]|16\..*|slem-.*");
     } elsif ($chart =~ m/private-registry/) {
         loadtest 'containers/charts/privateregistry';
     } elsif ($chart =~ m/kiosk/) {
-        my $version = get_var("HOST_VERSION", get_required_var("VERSION"));    # VERSION is the version of the container, not the host.
-        loadtest 'containers/charts/kiosk_firefox' if ($version =~ "15-SP[4,5,6,7]|16\..*|slem-.*");
+        loadtest 'containers/charts/kiosk_firefox' if ($host_version =~ "15-SP[4,5,6,7]|16\..*|slem-.*");
     }
     else {
         die "Unsupported HELM_CHART value or HOST_VERSION";

--- a/tests/containers/charts/rmt.pm
+++ b/tests/containers/charts/rmt.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2022-2025 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Test deploy a helm chart in a k3s
@@ -22,14 +22,10 @@ use containers::k8s qw(install_kubectl install_helm);
 
 sub run {
     my ($self) = @_;
+
     select_serial_terminal;
     my $helm_chart = get_required_var('HELM_CHART');
     my $helm_values = get_var('HELM_CONFIG');
-
-    return unless (helm_is_supported());
-
-    install_kubectl();
-    install_helm();
 
     helm_install_chart($helm_chart, $helm_values, "rmt", split_image_registry => 0);
 


### PR DESCRIPTION
Restricts RMT chart test only to compatible SLE and SLEM versions and enables it for SLEM.
Bypasses [poo#189084](https://progress.opensuse.org/issues/189084).

Related: https://gitlab.suse.de/qac/container-release-bot/-/merge_requests/494

- Related ticket: https://progress.opensuse.org/issues/189084
- Needles: N/A
- Verification runs:
  - slem6.1: https://openqa.suse.de/tests/19148697#step/rmt/1
  - 15-SP3: https://openqa.suse.de/tests/19148698 (disabled)
  - 15-SP7: https://openqa.suse.de/tests/19148699#step/rmt/1
  
