### PR TITLE
Upload ipaddr2 logs on failure

### DIFF
--- a/tests/sles4sap/ipaddr2/cluster_create.pm
+++ b/tests/sles4sap/ipaddr2/cluster_create.pm
@@ -62,7 +62,8 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_bastion_pubip
   ipaddr2_cluster_create
   ipaddr2_cluster_check_version
-  ipaddr2_cleanup);
+  ipaddr2_cleanup
+  ipaddr2_logs_collect);
 
 sub run {
     my ($self) = @_;
@@ -101,6 +102,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    ipaddr2_logs_collect();
     ipaddr2_cleanup(
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1),

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -59,7 +59,8 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_bastion_pubip
   ipaddr2_internal_key_accept
   ipaddr2_internal_key_gen
-  ipaddr2_cleanup);
+  ipaddr2_cleanup
+  ipaddr2_logs_collect);
 
 sub run {
     my ($self) = @_;
@@ -89,6 +90,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    ipaddr2_logs_collect();
     ipaddr2_cleanup(
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1));

--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -78,7 +78,8 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_cloudinit_create
   ipaddr2_infra_deploy
   ipaddr2_deployment_sanity
-  ipaddr2_cleanup);
+  ipaddr2_cleanup
+  ipaddr2_logs_collect);
 
 sub run {
     my ($self) = @_;
@@ -141,6 +142,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    ipaddr2_logs_collect();
     ipaddr2_cleanup(diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1));
     $self->SUPER::post_fail_hook;

--- a/tests/sles4sap/ipaddr2/destroy.pm
+++ b/tests/sles4sap/ipaddr2/destroy.pm
@@ -62,7 +62,9 @@ use sles4sap::ibsm qw( ibsm_network_peering_azure_delete );
 use sles4sap::ipaddr2 qw(
   ipaddr2_infra_destroy
   ipaddr2_azure_resource_group
-  ipaddr2_cleanup);
+  ipaddr2_cleanup
+  ipaddr2_logs_collect
+  ipaddr2_cloudinit_logs);
 
 sub run {
     my ($self) = @_;
@@ -79,6 +81,7 @@ sub run {
             ibsm_rg => $ibsm_rg);
     }
     ipaddr2_cloudinit_logs() unless (check_var('IPADDR2_CLOUDINIT', 0));
+    ipaddr2_logs_collect();
     ipaddr2_infra_destroy();
 }
 
@@ -88,6 +91,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    ipaddr2_logs_collect();
     ipaddr2_cleanup(
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1),

--- a/tests/sles4sap/ipaddr2/network_peering.pm
+++ b/tests/sles4sap/ipaddr2/network_peering.pm
@@ -59,7 +59,8 @@ use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
   ipaddr2_network_peering_create
   ipaddr2_repos_add_server_to_hosts
-  ipaddr2_cleanup);
+  ipaddr2_cleanup
+  ipaddr2_logs_collect);
 
 sub run {
     my ($self) = @_;
@@ -81,6 +82,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    ipaddr2_logs_collect();
     ipaddr2_cleanup(
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1),

--- a/tests/sles4sap/ipaddr2/patch_system.pm
+++ b/tests/sles4sap/ipaddr2/patch_system.pm
@@ -56,7 +56,8 @@ use testapi;
 use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
   ipaddr2_patch_system
-  ipaddr2_cleanup);
+  ipaddr2_cleanup
+  ipaddr2_logs_collect);
 
 sub run {
     my ($self) = @_;
@@ -70,6 +71,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    ipaddr2_logs_collect();
     ipaddr2_cleanup(
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1),

--- a/tests/sles4sap/ipaddr2/registration.pm
+++ b/tests/sles4sap/ipaddr2/registration.pm
@@ -68,7 +68,8 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_repo_refresh
   ipaddr2_repo_list
   ipaddr2_bastion_pubip
-  ipaddr2_cleanup);
+  ipaddr2_cleanup
+  ipaddr2_logs_collect);
 
 sub run {
     my ($self) = @_;
@@ -123,6 +124,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    ipaddr2_logs_collect();
     ipaddr2_cleanup(
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1),

--- a/tests/sles4sap/ipaddr2/sanity_cluster.pm
+++ b/tests/sles4sap/ipaddr2/sanity_cluster.pm
@@ -59,7 +59,8 @@ use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
   ipaddr2_bastion_pubip
   ipaddr2_cluster_sanity
-  ipaddr2_cleanup);
+  ipaddr2_cleanup
+  ipaddr2_logs_collect);
 
 sub run {
     my ($self) = @_;
@@ -79,6 +80,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    ipaddr2_logs_collect();
     ipaddr2_cleanup(
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1),

--- a/tests/sles4sap/ipaddr2/sanity_os.pm
+++ b/tests/sles4sap/ipaddr2/sanity_os.pm
@@ -65,7 +65,8 @@ use serial_terminal qw( select_serial_terminal );
 use sles4sap::ipaddr2 qw(
   ipaddr2_bastion_pubip
   ipaddr2_os_sanity
-  ipaddr2_cleanup);
+  ipaddr2_cleanup
+  ipaddr2_logs_collect);
 
 sub run {
     my ($self) = @_;
@@ -90,6 +91,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    ipaddr2_logs_collect();
     ipaddr2_cleanup(
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1),

--- a/tests/sles4sap/ipaddr2/test_move_resource.pm
+++ b/tests/sles4sap/ipaddr2/test_move_resource.pm
@@ -57,7 +57,8 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_test_master_vm
   ipaddr2_test_other_vm
   ipaddr2_wait_for_takeover
-  ipaddr2_cleanup);
+  ipaddr2_cleanup
+  ipaddr2_logs_collect);
 
 sub run {
     my ($self) = @_;
@@ -125,6 +126,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
+    ipaddr2_logs_collect();
     ipaddr2_cleanup(
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1),


### PR DESCRIPTION
This change introduces a new subroutine `ipaddr2_logs_collect` that
collects and uploads logs when a job fails.

The following logs are collected:
- crm report
- y2_logs
- supportconfig

The `post_fail_hook` in all the `ipaddr2` tests is modified to call
this new subroutine.
The implementation also include an internal function similar to
qesap_cluster_log_cmd, to eventaully be able to merge then in a
dedicated log related library in the future.

- Related ticket: https://jira.suse.com/browse/TEAM-10643

# Verification run:
- http://openqaworker15.qa.suse.cz/tests/343822 :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/343848 :green_circle:
- http://openqaworker15.qa.suse.cz/tests/343939 :green_circle:
