### PR TITLE
containers: Centralize patches around skip.yaml

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -103,6 +103,14 @@ buildah:
     - "bud.bats::bud-git-context-subdirectory"
     - "run.bats::Check if containers run with correct open files/processes limits"
     BATS_IGNORE_USER:
+compose:
+  # Note on patches:
+  # https://github.com/docker/compose/pull/13214 - test: Set stop_signal to SIGTERM
+  opensuse-Tumbleweed:
+    GITHUB_PATCHES:
+  sle-16.0:
+    GITHUB_PATCHES:
+    - 13214
 conmon:
   # Note on patches:
   # https://github.com/containers/conmon/pull/579 is needed to enable tests
@@ -118,6 +126,29 @@ conmon:
     BATS_IGNORE:
     BATS_IGNORE_ROOT:
     BATS_IGNORE_USER:
+docker-py:
+  # Note on patches:
+  # https://github.com/docker/docker-py/pull/3199 - Bump default API version to 1.43 (Moby 24.0)
+  # https://github.com/docker/docker-py/pull/3203 - integration/commit: Don't check for deprecated fields
+  # https://github.com/docker/docker-py/pull/3206 - Update Ruff, fix some minor issues
+  # https://github.com/docker/docker-py/pull/3231 - Bump default API version to 1.44 (Moby 25.0)
+  # https://github.com/docker/docker-py/pull/3290 - tests/exec: expect 127 exit code for missing executable
+  # https://github.com/docker/docker-py/pull/3354 - tests: Fix deprecation warning for utcfromtimestamp()
+  opensuse-Tumbleweed:
+    GITHUB_PATCHES:
+    - 3290
+    - 3354
+  sle-16.0:
+    GITHUB_PATCHES:
+    - 3290
+    - 3354
+  sle-15-SP7:
+    GITHUB_PATCHES:
+    - 3199
+    - 3203
+    - 3206
+    - 3231
+    - 3290
 netavark:
   # Note on patches:
   # https://github.com/containers/netavark/pull/1191 is needed for 001-basic
@@ -211,6 +242,14 @@ podman:
     BATS_IGNORE_ROOT_REMOTE:
     BATS_IGNORE_USER_LOCAL:
     BATS_IGNORE_USER_REMOTE:
+podman-py:
+  # Note on patches:
+  # https://github.com/containers/podman-py/pull/572 - tests: Fix tests to reflect removal of rw as default option
+  # https://github.com/containers/podman-py/pull/575 - tests: Fix deprecation warning for utcfromtimestamp()
+  opensuse-Tumbleweed:
+    GITHUB_PATCHES:
+    - 572
+    - 575
 runc:
   # Note on patches:
   # https://github.com/opencontainers/runc/pull/4825 is needed for cgroups

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -27,7 +27,6 @@ use File::Basename;
 use Utils::Architectures;
 
 our @EXPORT = qw(
-  bats_patches
   bats_post_hook
   bats_setup
   bats_tests
@@ -444,8 +443,8 @@ sub bats_tests {
 }
 
 sub bats_settings {
+    my $package = shift;
     my $os_version = get_required_var("DISTRI") . "-" . get_required_var("VERSION");
-    my $package = get_required_var("BATS_PACKAGE");
 
     assert_script_run "curl -o /tmp/skip.yaml " . data_url("containers/bats/skip.yaml");
     my $text = script_output("cat /tmp/skip.yaml", quiet => 1);
@@ -454,18 +453,14 @@ sub bats_settings {
     return $yaml->{$package}{$os_version};
 }
 
-sub bats_patches {
-    $settings = bats_settings;
+sub patch_sources {
+    my ($package, $branch, $tests_dir) = @_;
+
+    $settings = bats_settings $package;
     my @patches = split(/\s+/, get_var("GITHUB_PATCHES", ""));
     if (!@patches && defined $settings->{GITHUB_PATCHES}) {
         @patches = @{$settings->{GITHUB_PATCHES}};
     }
-    return \@patches;
-}
-
-sub patch_sources {
-    my ($package, $branch, $tests_dir, $patches) = @_;
-    my @patches = @{$patches};
 
     my $github_org = "containers";
     if ($package eq "runc") {

--- a/tests/containers/bats/aardvark.pm
+++ b/tests/containers/bats/aardvark.pm
@@ -43,7 +43,7 @@ sub run {
 
     # Download aardvark sources
     my $aardvark_version = script_output "$aardvark --version | awk '{ print \$2 }'";
-    patch_sources "aardvark-dns", "v$aardvark_version", "test", bats_patches();
+    patch_sources "aardvark-dns", "v$aardvark_version", "test";
 
     my $errors = run_tests;
     die "ardvark-dns tests failed" if ($errors);

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -87,7 +87,7 @@ sub run {
 
     # Download buildah sources
     my $buildah_version = script_output "buildah --version | awk '{ print \$3 }'";
-    patch_sources "buildah", "v$buildah_version", "tests", bats_patches();
+    patch_sources "buildah", "v$buildah_version", "tests";
 
     # Patch mkdir to always use -p
     run_command "sed -i 's/ mkdir /& -p /' tests/*.bats tests/helpers.bash";

--- a/tests/containers/bats/conmon.pm
+++ b/tests/containers/bats/conmon.pm
@@ -49,7 +49,7 @@ sub run {
     record_info("conmon package version", script_output("rpm -q conmon"));
 
     # Download conmon sources
-    patch_sources "conmon", "v$conmon_version", "test", bats_patches();
+    patch_sources "conmon", "v$conmon_version", "test";
 
     my $errors = 0;
 

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -40,7 +40,7 @@ sub run {
 
     # Download netavark sources
     my $netavark_version = script_output "$netavark --version | awk '{ print \$2 }'";
-    patch_sources "netavark", "v$netavark_version", "test", bats_patches();
+    patch_sources "netavark", "v$netavark_version", "test";
 
     my $firewalld_backend = script_output "awk -F= '\$1 == \"FirewallBackend\" { print \$2 }' < /etc/firewalld/firewalld.conf";
     record_info("Firewalld backend", $firewalld_backend);

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -75,7 +75,7 @@ sub run {
 
     # Download podman sources
     my $podman_version = script_output "podman --version | awk '{ print \$3 }'";
-    patch_sources "podman", "v$podman_version", "test/system", bats_patches();
+    patch_sources "podman", "v$podman_version", "test/system";
 
     $oci_runtime = get_var("OCI_RUNTIME", script_output("podman info --format '{{ .Host.OCIRuntime.Name }}'"));
 

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -47,7 +47,7 @@ sub run {
 
     # Download runc sources
     my $runc_version = script_output "runc --version  | awk '{ print \$3 }'";
-    patch_sources "runc", "v$runc_version", "tests/integration", bats_patches();
+    patch_sources "runc", "v$runc_version", "tests/integration";
 
     # Compile helpers used by the tests
     my $helpers = script_output "find contrib/cmd tests/cmd -mindepth 1 -maxdepth 1 -type d ! -name _bin -printf '%f ' || true";

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -48,7 +48,7 @@ sub run {
 
     # Download skopeo sources
     my $skopeo_version = script_output "skopeo --version  | awk '{ print \$3 }'";
-    patch_sources "skopeo", "v$skopeo_version", "systemtest", bats_patches();
+    patch_sources "skopeo", "v$skopeo_version", "systemtest";
 
     # Upstream script gets GOARCH by calling `go env GOARCH`.  Drop go dependency for this only use of go
     my $goarch = script_output "podman version -f '{{.OsArch}}' | cut -d/ -f2";

--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -10,7 +10,6 @@
 use Mojo::Base 'containers::basetest', -signatures;
 use testapi;
 use serial_terminal qw(select_serial_terminal);
-use version_utils;
 use utils;
 use power_action_utils 'power_action';
 use containers::common qw(install_packages);
@@ -34,11 +33,7 @@ sub setup {
     my $version = script_output "$docker_compose version | awk '{ print \$4 }'";
     record_info("version", $version);
 
-    # https://github.com/docker/compose/pull/13214 - test: Set stop_signal to SIGTERM
-    my @patches = ();
-    # PR#13214 was merged on v2.39.4
-    push @patches, "13214" unless is_tumbleweed;
-    patch_sources "compose", "v$version", "pkg/e2e", \@patches;
+    patch_sources "compose", "v$version", "pkg/e2e";
 }
 
 

--- a/tests/containers/python_runtime.pm
+++ b/tests/containers/python_runtime.pm
@@ -74,21 +74,10 @@ sub setup {
     my $version = script_output "$python3 -c 'import $runtime; print($runtime.__version__)'";
     record_info("Version", $version);
 
-    # podman-py patches:
-    # - https://github.com/containers/podman-py/pull/572 - tests: Fix tests to reflect removal of rw as default option
-    # - https://github.com/containers/podman-py/pull/575 - tests: Fix deprecation warning for utcfromtimestamp()
-    # docker-py patches:
-    # - https://github.com/docker/docker-py/pull/3199 - Bump default API version to 1.43 (Moby 24.0)
-    # - https://github.com/docker/docker-py/pull/3203 - integration/commit: Don't check for deprecated fields
-    # - https://github.com/docker/docker-py/pull/3206 - Update Ruff, fix some minor issues
-    # - https://github.com/docker/docker-py/pull/3231 - Bump default API version to 1.44 (Moby 25.0)
-    # - https://github.com/docker/docker-py/pull/3290 - tests/exec: expect 127 exit code for missing executable
-    # - https://github.com/docker/docker-py/pull/3354 - tests: Fix deprecation warning for utcfromtimestamp()
-    my @patches = ($runtime eq "podman") ? qw(572 575) : (is_sle("<16") ? qw(3199 3203 3206 3231 3290) : qw(3290 3354));
     # podman-py uses v$version in tags while docker-py uses bare version
     $version = ($runtime eq "podman") ? "v$version" : $version;
     my $test_dir = ($runtime eq "podman") ? "podman/tests" : "tests";
-    patch_sources "$runtime-py", $version, $test_dir, \@patches;
+    patch_sources "$runtime-py", $version, $test_dir;
 
     if ($runtime eq "docker") {
         $api_version = get_var("DOCKER_API_VERSION", script_output 'make --eval=\'version: ; @echo $(TEST_API_VERSION)\' version');


### PR DESCRIPTION
Centralize patches around skip.yaml

This allows us to track the usage of patches in our tests, not just bats tests.

Verification runs:
- runc (bats): https://openqa.suse.de/tests/19205480
- podman_e2e: https://openqa.opensuse.org/tests/5337556