### PR TITLE
Remove 'patch_and_reboot' for aggregate installation tests

### DIFF
--- a/schedule/qam/12-SP3/qam-allpatterns.yaml
+++ b/schedule/qam/12-SP3/qam-allpatterns.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/check_network
 - console/system_state
@@ -25,7 +25,6 @@ schedule:
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
-- console/zypper_lr
 - console/zypper_ref
 - console/ncurses
 - console/yast2_lan

--- a/schedule/qam/12-SP3/qam-gnome.yaml
+++ b/schedule/qam/12-SP3/qam-gnome.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/check_network
 - console/system_state
@@ -25,7 +25,6 @@ schedule:
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
-- console/zypper_lr
 - console/zypper_ref
 - console/ncurses
 - console/yast2_lan

--- a/schedule/qam/12-SP3/qam-regression-installation.yaml
+++ b/schedule/qam/12-SP3/qam-regression-installation.yaml
@@ -8,7 +8,7 @@ schedule:
 - autoyast/installation
 - installation/first_boot
 - x11/x11_setup
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/hostname
 - console/force_scheduled_tasks
 - shutdown/grub_set_bootargs

--- a/schedule/qam/12-SP5/qam-allpatterns.yaml
+++ b/schedule/qam/12-SP5/qam-allpatterns.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/check_network
 - console/system_state
@@ -25,7 +25,6 @@ schedule:
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
-- console/zypper_lr
 - console/zypper_ref
 - console/ncurses
 - console/yast2_lan

--- a/schedule/qam/12-SP5/qam-gnome.yaml
+++ b/schedule/qam/12-SP5/qam-gnome.yaml
@@ -13,7 +13,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/handle_reboot
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/check_network
 - console/system_state
@@ -25,7 +25,6 @@ schedule:
 - console/hostname
 - console/installation_snapshots
 - '{{x86_64_tests}}'
-- console/zypper_lr
 - console/zypper_ref
 - console/ncurses
 - console/yast2_lan

--- a/schedule/qam/12-SP5/qam-regression-installation.yaml
+++ b/schedule/qam/12-SP5/qam-regression-installation.yaml
@@ -8,7 +8,7 @@ schedule:
 - autoyast/installation
 - installation/first_boot
 - x11/x11_setup
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/hostname
 - console/force_scheduled_tasks
 - shutdown/grub_set_bootargs

--- a/schedule/qam/15-SP2/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP2/qam-allpatterns.yaml
@@ -15,7 +15,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/check_network
 - console/system_state
@@ -25,7 +25,6 @@ schedule:
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
-- console/zypper_lr
 - console/zypper_ref
 - console/ncurses
 - console/yast2_lan

--- a/schedule/qam/15-SP2/qam-gnome.yaml
+++ b/schedule/qam/15-SP2/qam-gnome.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/handle_reboot
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/check_network
 - console/system_state
@@ -26,7 +26,6 @@ schedule:
 - console/hostname
 - console/installation_snapshots
 - '{{console_tests}}'
-- console/zypper_lr
 - console/zypper_ref
 - console/ncurses
 - console/yast2_lan

--- a/schedule/qam/15-SP2/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP2/qam-regression-installation.yaml
@@ -8,7 +8,7 @@ schedule:
 - autoyast/installation
 - installation/first_boot
 - x11/x11_setup
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/hostname
 - console/force_scheduled_tasks

--- a/schedule/qam/15-SP2/qam-textmode.yaml
+++ b/schedule/qam/15-SP2/qam-textmode.yaml
@@ -22,7 +22,7 @@ schedule:
 - installation/reboot_after_installation
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network
@@ -36,7 +36,6 @@ schedule:
 - console/installation_snapshots
 - console/zypper_in
 - console/zypper_lifecycle
-- console/zypper_lr
 - console/zypper_ref
 - console/firewall_enabled
 - console/glibc_sanity

--- a/schedule/qam/15-SP3/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP3/qam-allpatterns.yaml
@@ -15,7 +15,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/check_network
 - console/system_state
@@ -25,7 +25,6 @@ schedule:
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
-- console/zypper_lr
 - console/zypper_ref
 - console/ncurses
 - console/yast2_lan

--- a/schedule/qam/15-SP3/qam-gnome.yaml
+++ b/schedule/qam/15-SP3/qam-gnome.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/handle_reboot
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/check_network
 - console/system_state
@@ -25,7 +25,6 @@ schedule:
 - console/hostname
 - console/installation_snapshots
 - '{{console_tests}}'
-- console/zypper_lr
 - console/zypper_ref
 - console/ncurses
 - console/yast2_lan

--- a/schedule/qam/15-SP3/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP3/qam-regression-installation.yaml
@@ -8,7 +8,7 @@ schedule:
 - autoyast/installation
 - installation/first_boot
 - x11/x11_setup
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/hostname
 - console/force_scheduled_tasks

--- a/schedule/qam/15-SP3/qam-textmode.yaml
+++ b/schedule/qam/15-SP3/qam-textmode.yaml
@@ -22,7 +22,7 @@ schedule:
 - installation/reboot_after_installation
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network
@@ -36,7 +36,6 @@ schedule:
 - console/installation_snapshots
 - console/zypper_in
 - console/zypper_lifecycle
-- console/zypper_lr
 - console/zypper_ref
 - console/firewall_enabled
 - console/glibc_sanity

--- a/schedule/qam/15-SP4/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP4/qam-allpatterns.yaml
@@ -15,7 +15,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/check_network
 - console/system_state
@@ -25,7 +25,6 @@ schedule:
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
-- console/zypper_lr
 - console/zypper_ref
 - console/ncurses
 - console/yast2_lan

--- a/schedule/qam/15-SP4/qam-gnome.yaml
+++ b/schedule/qam/15-SP4/qam-gnome.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/handle_reboot
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/check_network
 - console/system_state
@@ -25,7 +25,6 @@ schedule:
 - console/hostname
 - console/installation_snapshots
 - '{{console_tests}}'
-- console/zypper_lr
 - console/zypper_ref
 - console/ncurses
 - console/yast2_lan

--- a/schedule/qam/15-SP4/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP4/qam-regression-installation.yaml
@@ -7,7 +7,7 @@ schedule:
 - autoyast/installation
 - installation/first_boot
 - x11/x11_setup
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/hostname
 - console/force_scheduled_tasks

--- a/schedule/qam/15-SP4/qam-textmode.yaml
+++ b/schedule/qam/15-SP4/qam-textmode.yaml
@@ -22,7 +22,7 @@ schedule:
 - installation/reboot_after_installation
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network
@@ -36,7 +36,6 @@ schedule:
 - console/installation_snapshots
 - console/zypper_in
 - console/zypper_lifecycle
-- console/zypper_lr
 - console/zypper_ref
 - console/firewall_enabled
 - console/glibc_sanity

--- a/schedule/qam/15-SP5/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP5/qam-allpatterns.yaml
@@ -15,7 +15,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/check_network
 - console/system_state
@@ -25,7 +25,6 @@ schedule:
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
-- console/zypper_lr
 - console/zypper_ref
 - console/ncurses
 - console/yast2_lan

--- a/schedule/qam/15-SP5/qam-gnome.yaml
+++ b/schedule/qam/15-SP5/qam-gnome.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/handle_reboot
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/check_network
 - console/system_state
@@ -25,7 +25,6 @@ schedule:
 - console/hostname
 - console/installation_snapshots
 - '{{console_tests}}'
-- console/zypper_lr
 - console/zypper_ref
 - console/ncurses
 - console/yast2_lan

--- a/schedule/qam/15-SP5/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP5/qam-regression-installation.yaml
@@ -8,7 +8,7 @@ schedule:
   - autoyast/installation
   - installation/first_boot
   - x11/x11_setup
-  - qa_automation/patch_and_reboot
+  - console/zypper_lr
   - console/system_prepare
   - console/hostname
   - console/force_scheduled_tasks

--- a/schedule/qam/15-SP5/qam-textmode.yaml
+++ b/schedule/qam/15-SP5/qam-textmode.yaml
@@ -22,7 +22,7 @@ schedule:
 - installation/reboot_after_installation
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - locale/keymap_or_locale
 - console/system_prepare
 - console/chrony
@@ -36,7 +36,6 @@ schedule:
 - console/installation_snapshots
 - console/zypper_in
 - console/zypper_lifecycle
-- console/zypper_lr
 - console/zypper_ref
 - console/firewall_enabled
 - console/glibc_sanity

--- a/schedule/qam/15-SP6/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP6/qam-allpatterns.yaml
@@ -15,7 +15,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/check_network
 - console/system_state
@@ -25,7 +25,6 @@ schedule:
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
-- console/zypper_lr
 - console/zypper_ref
 - console/ncurses
 - console/yast2_lan

--- a/schedule/qam/15-SP6/qam-gnome.yaml
+++ b/schedule/qam/15-SP6/qam-gnome.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/handle_reboot
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/check_network
 - console/system_state
@@ -25,7 +25,6 @@ schedule:
 - console/hostname
 - console/installation_snapshots
 - '{{console_tests}}'
-- console/zypper_lr
 - console/zypper_ref
 - console/ncurses
 - console/yast2_lan

--- a/schedule/qam/15-SP6/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP6/qam-regression-installation.yaml
@@ -8,7 +8,7 @@ schedule:
 - autoyast/installation
 - installation/first_boot
 - x11/x11_setup
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/hostname
 - console/force_scheduled_tasks

--- a/schedule/qam/15-SP6/qam-textmode.yaml
+++ b/schedule/qam/15-SP6/qam-textmode.yaml
@@ -22,7 +22,7 @@ schedule:
 - installation/reboot_after_installation
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network
@@ -36,7 +36,6 @@ schedule:
 - console/installation_snapshots
 - console/zypper_in
 - console/zypper_lifecycle
-- console/zypper_lr
 - console/zypper_ref
 - console/firewall_enabled
 - console/glibc_sanity

--- a/schedule/qam/15-SP7/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP7/qam-allpatterns.yaml
@@ -15,7 +15,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/check_network
 - console/system_state
@@ -25,7 +25,6 @@ schedule:
 - console/textinfo
 - console/hostname
 - console/installation_snapshots
-- console/zypper_lr
 - console/zypper_ref
 - console/ncurses
 - console/yast2_lan

--- a/schedule/qam/15-SP7/qam-gnome.yaml
+++ b/schedule/qam/15-SP7/qam-gnome.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/handle_reboot
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/check_network
 - console/system_state
@@ -25,7 +25,6 @@ schedule:
 - console/hostname
 - console/installation_snapshots
 - '{{console_tests}}'
-- console/zypper_lr
 - console/zypper_ref
 - console/ncurses
 - console/yast2_lan

--- a/schedule/qam/15-SP7/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP7/qam-regression-installation.yaml
@@ -8,7 +8,7 @@ schedule:
 - autoyast/installation
 - installation/first_boot
 - x11/x11_setup
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - console/system_prepare
 - console/hostname
 - console/force_scheduled_tasks

--- a/schedule/qam/15-SP7/qam-textmode.yaml
+++ b/schedule/qam/15-SP7/qam-textmode.yaml
@@ -22,7 +22,7 @@ schedule:
 - installation/reboot_after_installation
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/zypper_lr
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network
@@ -36,7 +36,6 @@ schedule:
 - console/installation_snapshots
 - console/zypper_in
 - console/zypper_lifecycle
-- console/zypper_lr
 - console/zypper_ref
 - console/firewall_enabled
 - console/glibc_sanity

--- a/schedule/qam/common/12-common_base_installation_ay.yaml
+++ b/schedule/qam/common/12-common_base_installation_ay.yaml
@@ -7,7 +7,7 @@ schedule:
   - installation/first_boot
   - '{{x11_setup}}'
   - console/system_prepare
-  - qa_automation/patch_and_reboot
+  - console/zypper_lr
   - console/hostname
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs

--- a/schedule/qam/common/15-common_base_installation_ay.yaml
+++ b/schedule/qam/common/15-common_base_installation_ay.yaml
@@ -7,7 +7,7 @@ schedule:
   - installation/first_boot
   - '{{x11_setup}}'
   - console/system_prepare
-  - qa_automation/patch_and_reboot
+  - console/zypper_lr
   - console/hostname
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs


### PR DESCRIPTION
https://progress.opensuse.org/issues/189219

All incident repos and self_update repo are added/active during the installation phase, so we don't need to patch the system once again.

- Verification run: [regression](http://openqa.suse.de/tests/overview?distri=sle&version=15-SP7&build=rfan0924)