### PR TITLE
[SDAF] Create VNET connection to IBSm

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -31,6 +31,7 @@ our @EXPORT = qw(
   az_group_exists
   az_network_vnet_create
   az_network_vnet_get
+  az_network_vnet_show
   az_network_vnet_subnet_update
   az_network_nsg_create
   az_network_nsg_rule_create
@@ -54,6 +55,7 @@ our @EXPORT = qw(
   az_vm_diagnostic_log_get
   az_nic_id_get
   az_nic_name_get
+  az_nic_list
   az_ipconfig_name_get
   az_ipconfig_update
   az_ipconfig_delete
@@ -66,6 +68,7 @@ our @EXPORT = qw(
   az_network_peering_create
   az_network_peering_list
   az_network_peering_delete
+  az_network_peering_exists
   az_disk_create
   az_resource_delete
   az_resource_list
@@ -73,6 +76,15 @@ our @EXPORT = qw(
   az_keyvault_list
   az_keyvault_secret_list
   az_keyvault_secret_show
+  az_network_dns_zone_create
+  az_network_dns_zone_list
+  az_network_dns_zone_delete
+  az_network_dns_zones_cleanup
+  az_network_dns_add_record
+  az_network_dns_link_create
+  az_network_dns_link_delete
+  az_network_dns_link_list
+  az_network_dns_links_cleanup
 );
 
 
@@ -120,7 +132,7 @@ sub az_group_create(%args) {
     my $ret = az_group_name_get();
 
 Get the name of all existing Resource Group in the current subscription.
-By defailt the output is an array of strings.
+By default the output is an array of strings.
 Output can be modified using B<$args{query}>.
 
 =over
@@ -1087,6 +1099,29 @@ sub az_nic_name_get(%args) {
     return az_nic_get(nic_id => $args{nic_id}, filter => 'name');
 }
 
+=head2 az_nic_list
+
+    az_nic_list(resource_group=>'resource group name' [, query=>'[].name']);
+
+Returns B<ARRAYREF> with all nic names located in resource group. Output can be modified using B<$args{query}>.
+
+=over
+
+=item B<resource_group> Resource group name
+
+=item B<query> Modify output filter using jmespath query. Default: value
+
+=back
+=cut
+
+sub az_nic_list {
+    my (%args) = @_;
+    croak "Missing mandatory argument: 'resource_group'" unless $args{resource_group};
+    $args{query} //= '[].name';
+    return
+      decode_json(script_output("az network nic list --resource-group $args{resource_group} --query \"$args{query}\""));
+}
+
 =head2 az_ipconfig_name_get
 
     my $ipconfig_name = az_ipconfig_name_get(
@@ -1426,6 +1461,35 @@ sub az_network_peering_delete(%args) {
         '--resource-group', $args{resource_group},
         '--vnet-name', $args{vnet});
     return script_run($az_cmd, timeout => $args{timeout});
+}
+
+=head2 az_network_peering_exists
+
+    az_network_peering_exists(resource_group=>'openqa-rg', vnet=>'openqa-this-vnet', name=>'openqa-fromVNET-toVNET');
+
+
+Returns 1 (true) if peering resource exists, 0 (false) if it was not found.
+
+=over
+
+=item B<resource_group> - existing resource group that contain vnet source of the peering
+
+=item B<vnet> - existing vnet in resource_group, used as source of the peering
+
+=item B<name> - name of the existing the network peering to search for
+
+=back
+=cut
+
+sub az_network_peering_exists (%args) {
+    foreach (qw(name resource_group vnet)) {
+        croak("Argument < $_ > missing") unless $args{$_};
+    }
+    return (az_network_peering_list(
+            resource_group => $args{resource_group},
+            vnet => $args{vnet},
+            query => "[?name=='$args{name}'] | length(@)"
+    ));
 }
 
 =head2 az_disk_create
@@ -1887,6 +1951,305 @@ Check if specified resource group exists. Returns B<true> or B<false>.
 sub az_group_exists(%args) {
     croak "Missing mandatory argument: 'resource_group'" unless $args{resource_group};
     return script_output("az group exists --resource-group $args{resource_group}", quiet => $args{quiet});
+}
+
+=head2 az_network_vnet_show
+
+    az_network_vnet_show(resource_group=>'resource group name', name=>'vnet01' [, query=>'[].name']);
+
+Returns B<HASHREF> with all NIC names located in resource group. Output can be modified using B<$args{query}>.
+
+=over
+
+=item B<resource_group> Resource group name
+
+=item B<name> VNET name
+
+=item B<query> Modify output filter using jmespath query. Default: undefined
+
+=back
+=cut
+
+sub az_network_vnet_show {
+    my (%args) = @_;
+    my @mandatory_args = qw(resource_group name);
+    foreach (@mandatory_args) {
+        croak "Missing mandatory argument: '$_'" unless $args{$_};
+    }
+    my @cmd = ('az network vnet show', "--resource-group $args{resource_group}", "--name $args{name}");
+    push @cmd, "--query \"$args{query}\"" if $args{query};
+
+    return decode_json(script_output(join(' ', @cmd)));
+}
+
+=head2 az_network_dns_zone_create
+
+    az_network_dns_zone_create(resource_group=>'resource group name', name=>'default.com');
+
+Creates private DNS zone within specified B<resource_group>.
+
+=over
+
+=item B<resource_group> Resource group name
+
+=item B<name> Private DNS zone name
+
+=back
+=cut
+
+sub az_network_dns_zone_create {
+    my (%args) = @_;
+    foreach ('resource_group', 'name') { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
+    my @cmd = ('az network private-dns zone create', "--resource-group $args{resource_group}", "--name $args{name}");
+
+    return assert_script_run(join(' ', @cmd));
+}
+
+=head2 az_network_dns_zone_delete
+
+    az_network_dns_zone_delete(resource_group=>'resource group name', zone_name=>'default.com');
+
+Deletes private DNS zone within B<resource_group> specified by B<zone_name>.
+
+=over
+
+=item B<resource_group> Resource group name
+
+=item B<zone_name> Private DNS zone name
+
+=back
+=cut
+
+sub az_network_dns_zone_delete {
+    my (%args) = @_;
+    foreach ('resource_group', 'zone_name') { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
+    my @cmd = ('az network private-dns zone delete',
+        "--resource-group $args{resource_group}",
+        "--name $args{zone_name}",
+        '--yes');
+
+    return assert_script_run(join(' ', @cmd));
+}
+
+=head2 az_network_dns_zone_list
+
+    az_network_dns_zone_list(resource_group=>'resource group name');
+
+Returns private DNS zone list as an B<ARRAYREF> existing within specified B<resource_group>.
+
+=over
+
+=item B<resource_group> Resource group name
+
+=item B<query> Modify output filter using jmespath query. Default: [].name
+
+=back
+=cut
+
+sub az_network_dns_zone_list {
+    my (%args) = @_;
+    croak "Missing mandatory argument: 'resource_group'" unless $args{resource_group};
+    $args{query} //= '[].name';
+    return decode_json(
+        script_output("az network private-dns zone list --resource-group $args{resource_group} --query \"$args{query}\"")
+    );
+}
+
+=head2 az_network_dns_add_record
+
+    az_network_dns_add_record(
+        resource_group=>'resource group name',
+        zone_name=>'opensuse.org',
+        record_name=>'openqa',
+        ip_addr=>'192.168.1.5'
+    );
+
+Creates a DNS record inside Private DNS zone B<$args{zone_name}>.
+
+=over
+
+=item B<resource_group> Resource group name
+
+=item B<zone_name> Private DNS zone name
+
+=item B<record_name> Private DNS zone record name
+
+=item B<ip_addr> DNS record IPv4 address
+
+=back
+=cut
+
+sub az_network_dns_add_record {
+    my (%args) = @_;
+    my @mandatory_args = qw(resource_group zone_name record_name ip_addr);
+    foreach (@mandatory_args) { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
+    my @cmd = (' ',
+        'az network private-dns record-set a add-record',    # 'a' here is not a typo
+        "--resource-group $args{resource_group}",
+        "--zone-name $args{zone_name}",
+        "--record-set-name $args{record_name}",
+        "--ipv4-address $args{ip_addr}"
+    );
+
+    return assert_script_run(join(' ', @cmd));
+}
+
+=head2 az_network_dns_link_create
+
+    az_network_dns_link_create(
+        resource_group=>'resource group name',
+        zone_name='opensuse.org',
+        vnet=>'vnet_rg',
+        name=>'link_to_rg_vnet'
+    );
+
+Creates private DNS zone link between VNET and DNS zone.
+
+=over
+
+=item B<resource_group> Resource group name
+
+=item B<zone_name> Private DNS zone name
+
+=item B<vnet> VNET name
+
+=item B<name> DNS link resource name
+
+=back
+=cut
+
+sub az_network_dns_link_create {
+    my (%args) = @_;
+    my @mandatory_args = qw(resource_group zone_name vnet name);
+    foreach (@mandatory_args) { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
+    my @cmd = (' ',
+        'az network private-dns link vnet create',
+        "--resource-group $args{resource_group}",
+        "--zone-name $args{zone_name}",
+        "--virtual-network $args{vnet}",
+        "--name $args{name}",
+        '--registration-enabled true'    # This updates all VMs A records immediately
+    );
+
+    return assert_script_run(join(' ', @cmd));
+}
+
+=head2 az_network_dns_link_delete
+
+    az_network_dns_link_delete(
+        resource_group=>'resource group name',
+        zone_name='opensuse.org',
+        link_name=>'link_to_rg_vnet'
+    );
+
+Deletes private DNS link between VNET and DNS zone.
+
+=over
+
+=item B<resource_group> Resource group name
+
+=item B<zone_name> Private DNS zone name
+
+=item B<link_name> DNS link resource name
+
+=back
+=cut
+
+sub az_network_dns_link_delete {
+    my (%args) = @_;
+    my @mandatory_args = qw(resource_group zone_name link_name);
+    foreach (@mandatory_args) { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
+    my @cmd = (' ',
+        'az network private-dns link vnet delete',
+        "--resource-group $args{resource_group}",
+        "--zone-name $args{zone_name}",
+        "--name $args{link_name}",
+        '--yes'    # autoconfirm
+    );
+
+    return assert_script_run(join(' ', @cmd));
+}
+
+=head2 az_network_dns_link_list
+
+    az_network_dns_link_list(resource_group=>'resource group name', zone_name='opensuse.org', query=>'[].id');
+
+Lists private DNS links withing specified B<resource_group> and B<zone_name>. Result is returned as B<ARRAYREF>.
+
+=over
+
+=item B<resource_group> Resource group name
+
+=item B<zone_name> Private DNS zone name
+
+=item B<query> Modify output filter using jmespath query. Default: [].name
+
+=back
+=cut
+
+sub az_network_dns_link_list {
+    my (%args) = @_;
+    $args{query} //= '[].name';
+    my @mandatory_args = qw(resource_group zone_name);
+    foreach (@mandatory_args) { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
+    my @cmd = (' ',
+        'az network private-dns link vnet list',
+        "--resource-group $args{resource_group}",
+        "--zone-name $args{zone_name}",
+        "--query \"$args{query}\""
+    );
+
+    return decode_json(script_output(join(' ', @cmd)));
+}
+
+=head2 az_network_dns_links_cleanup
+
+    az_network_dns_links_cleanup(resource_group=>'resource group name');
+
+Searches and deletes all DNS links within specified B<resource_group>. Intended for cleanup to remove nested resource.
+
+=over
+
+=item B<resource_group> Resource group name
+
+=back
+=cut
+
+sub az_network_dns_links_cleanup {
+    my (%args) = @_;
+    croak 'Missing mandatory argument: "$args{resource_group}"' unless $args{resource_group};
+    my @zones = @{az_network_dns_zone_list(resource_group => $args{resource_group})};
+
+    for my $zone (@zones) {
+        my @links = @{az_network_dns_link_list(resource_group => $args{resource_group}, zone_name => $zone)};
+        az_network_dns_link_delete(
+            resource_group => $args{resource_group}, zone_name => $zone, link_name => $_) foreach @links;
+        record_info('DNS cleanup',
+            "Following Private DNS links were deleted from DNS zone '$zone'\n" . join("\n", @links));
+    }
+}
+
+=head2 az_network_dns_zones_cleanup
+
+    az_network_dns_zones_cleanup(resource_group=>'resource group name');
+
+Searches and deletes all DNS zones within specified B<resource_group>.
+
+=over
+
+=item B<resource_group> Resource group name
+
+=back
+=cut
+
+sub az_network_dns_zones_cleanup {
+    my (%args) = @_;
+    croak 'Missing mandatory argument: "$args{resource_group}"' unless $args{resource_group};
+    my @zones = @{az_network_dns_zone_list(resource_group => $args{resource_group})};
+
+    for my $zone (@zones) {
+        az_network_dns_zone_delete(resource_group => $args{resource_group}, zone_name => $zone);
+    }
 }
 
 1;

--- a/lib/sles4sap/console_redirection/redirection_data_tools.pm
+++ b/lib/sles4sap/console_redirection/redirection_data_tools.pm
@@ -56,8 +56,7 @@ B<Example:>
 
 sub get_ensa2_hosts {
     my $self = shift;
-    my %result = map { %{$_} } ($self->{nw_ascs}, $self->{nw_ers});
-    return \%result;
+    return {map { %{$self->{$_}} } qw(nw_ascs nw_ers)};
 }
 
 =head2 get_nw_hosts
@@ -75,8 +74,7 @@ B<Example:>
 
 sub get_nw_hosts {
     my $self = shift;
-    my %result = map { %{$_} } ($self->{nw_ascs}, $self->{nw_ers}, $self->{nw_pas}, $self->{nw_aas});
-    return \%result;
+    return {map { %{$self->{$_}} } qw(nw_ascs nw_ers nw_pas nw_aas)};
 }
 
 =head2 get_pas_host
@@ -93,8 +91,25 @@ B<Example:>
 
 sub get_pas_host {
     my $self = shift;
-    my %result = map { %{$_} } ($self->{nw_pas});
-    return \%result;
+    return {map { %{$_} } ($self->{nw_pas})};
+}
+
+=head2 get_sap_hosts
+
+    get_sap_hosts();
+
+Returns B<ARRAYREF> containing connection data to all hosts related to SAP suite (Databases, instances, etc...).
+B<Example:>
+{
+    hostname_a => {ip_address => '192.168.0.2', ssh_user => 'username'}
+    hostname_b => {ip_address => '192.168.0.2', ssh_user => 'username'}
+};
+
+=cut
+
+sub get_sap_hosts {
+    my $self = shift;
+    return {map { %{$self->{$_}} } qw(nw_ascs nw_ers nw_pas nw_aas db_hana)};
 }
 
 1;

--- a/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
@@ -13,13 +13,14 @@ use strict;
 use warnings;
 use testapi;
 use Exporter qw(import);
-use sles4sap::sap_deployment_automation_framework::deployment qw(sdaf_cleanup az_login load_os_env_variables $output_log_file sdaf_upload_logs);
+use sles4sap::sap_deployment_automation_framework::deployment;
 use sles4sap::sap_deployment_automation_framework::deployment_connector;
 use sles4sap::sap_deployment_automation_framework::naming_conventions;
 use sles4sap::sap_deployment_automation_framework::inventory_tools;
 use sles4sap::console_redirection;
+use sles4sap::azure_cli;
 
-our @EXPORT = qw(full_cleanup $serial_regexp_playbook);
+our @EXPORT = qw(full_cleanup $serial_regexp_playbook ibsm_data_collect _sdaf_ibsm_teardown);
 our $serial_regexp_playbook = 0;
 
 =head1 SYNOPSIS
@@ -81,9 +82,11 @@ sub full_cleanup {
     if ($redirection_works) {
         load_os_env_variables();
         az_login();
+        _sdaf_ibsm_teardown() if get_var('IS_MAINTENANCE');
         sdaf_cleanup();
         disconnect_target_from_serial();    # Exist Deployer console since we are about to destroy it
     }
+
     # Do not make cleanup fail here, we still need to destroy deployer VM and its resources.
     record_info('SUT cleanup', 'Failed to set up redirection, skipping SDAF cleanup scripts.') unless $redirection_works;
 
@@ -103,9 +106,124 @@ sub full_cleanup {
     }
 }
 
+=head2 _sdaf_ibsm_teardown
+
+
+    _sdaf_ibsm_teardown();
+
+All existing peerings are deleted in 3 attempts. Function does not croak/die. Only reports about failure and
+lets other cleanup procedures to continue.
+
+=cut
+
+sub _sdaf_ibsm_teardown {
+    my $peerings = ibsm_data_collect();
+    for my $peering_type (keys %{$peerings}) {
+        my $peering_data = $peerings->{$peering_type};
+        my $attempt = 1;
+
+
+        record_info('PEERING DEL', <<"record_info"
+Following network peering will be deleted:
+Peering: $peering_data->{peering_name}
+Resource group: $peering_data->{source_resource_group}
+record_info
+        );
+
+        while ($peering_data->{exists}) {
+            record_info("Attempt #$attempt");
+            az_network_peering_delete(
+                name => $peering_data->{peering_name},
+                resource_group => $peering_data->{source_resource_group},
+                vnet => $peering_data->{source_vnet},
+                timeout => '120'
+            );
+            # 5 seconds between API calls
+            sleep 5;
+            # Check if peering was deleted
+            $peering_data->{exists} = az_network_peering_exists(
+                resource_group => $peering_data->{source_resource_group},
+                vnet => $peering_data->{source_vnet},
+                name => $peering_data->{peering_name}
+            );
+            # exit loop after 3rd attempt
+            last if $attempt == 3;
+            $attempt++;
+        }
+        if ($peering_data->{exists}) {
+            # only set `record_info` to fail, let the rest of cleanup continue.
+            record_info(
+                'DELETE FAIL', "Deleting peering '$peering_data->{peering_name}' failed after $attempt attempts",
+                result => 'fail'
+            );
+        }
+        else {
+            record_info('DELETE PASS', "Deleting peering '$peering_data->{peering_name}' successful");
+        }
+    }
+    my $workload_resource_group = get_workload_resource_group(deployment_id => find_deployment_id());
+    az_network_dns_links_cleanup(resource_group => $workload_resource_group);
+    az_network_dns_zones_cleanup(resource_group => $workload_resource_group);
+}
+
+=head2 ibsm_data_collect
+
+    ibsm_data_collect();
+
+
+Collects information about existing network peerings between B<IBSM mirror VNET> and B<test workload zone VNET>.
+Returns B<HASHREF> with all data collected in following format:
+
+{ peering_type = {
+    peering_name => 'peering_name',
+    source_resource_group => 'source_resource_group_name',
+    target_resource_group => 'target_resource_group_name',
+    source_vnet => 'source_vnet_game',
+    target_vnet => 'target_vnet_game',
+    exists => '<0/1>'
+  }
+}
+
+=cut
+
+sub ibsm_data_collect {
+    my $ibsm_rg = get_required_var('IBSM_RG');
+    my $ibsm_vnet_name = ${az_network_vnet_get(resource_group => $ibsm_rg)}[0];
+    my $workload_resource_group = get_workload_resource_group(deployment_id => find_deployment_id());
+    my $workload_vnet_name = ${az_network_vnet_get(resource_group => $workload_resource_group)}[0];
+    my $ibsm_peering_name = get_ibsm_peering_name(source_vnet => $ibsm_vnet_name, target_vnet => $workload_vnet_name);
+    my $workload_peering_name = get_ibsm_peering_name(source_vnet => $workload_vnet_name, target_vnet => $ibsm_vnet_name);
+
+    my %peerings = (
+        ibsm_peering => {
+            peering_name => $ibsm_peering_name,
+            source_resource_group => $ibsm_rg,
+            target_resource_group => $workload_resource_group,
+            source_vnet => $ibsm_vnet_name,
+            target_vnet => $workload_vnet_name,
+            exists => az_network_peering_exists(
+                resource_group => $ibsm_rg,
+                vnet => $ibsm_vnet_name,
+                name => $ibsm_peering_name)
+        },
+        workload_peering => {
+            peering_name => $workload_peering_name,
+            source_resource_group => $workload_resource_group,
+            target_resource_group => $ibsm_rg,
+            source_vnet => $workload_vnet_name,
+            target_vnet => $ibsm_vnet_name,
+            exists => az_network_peering_exists(
+                resource_group => $workload_resource_group,
+                vnet => $workload_vnet_name,
+                name => $workload_peering_name)
+        }
+    );
+    return (\%peerings);
+}
+
 sub post_fail_hook {
     my ($self, $run_args) = @_;
-    # Flag for uploading SUT losgs if sdaf_execute_playbook() failed
+    # Flag for uploading SUT logs if sdaf_execute_playbook() failed
     my $upload_SUT_logs = $serial_regexp_playbook;
 
     record_info('Post fail', 'Executing post fail hook');

--- a/lib/sles4sap/sap_deployment_automation_framework/naming_conventions.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/naming_conventions.pm
@@ -45,6 +45,7 @@ our @EXPORT = qw(
   get_sdaf_inventory_path
   get_sut_sshkey_path
   get_sizing_filename
+  get_ibsm_peering_name
 );
 
 =head2 %sdaf_region_matrix
@@ -439,4 +440,17 @@ sub get_sizing_filename {
     get_var('SDAF_DEPLOYMENT_SCENARIO') =~ 'ensa' ?
       return 'custom_sizes_S4HANA.json' :    # Customized for S4Hana deployment - required for ENSA2
       return 'custom_sizes_default.json';    # Minimal Hana sizing - good for sindgle DB, HanaSR or standard NW 7.5 setup
+}
+
+=head2 get_ibsm_peering_name
+
+    get_ibsm_peering_name();
+
+Returns ibsm peering name in format 'SDAF-<source_VNET>-<target_VNET>'
+
+=cut
+
+sub get_ibsm_peering_name {
+    my (%args) = @_;
+    return "SDAF-$args{source_vnet}-$args{target_vnet}";
 }

--- a/schedule/sles4sap/sap_deployment_automation_framework/sdaf_deployment.yml
+++ b/schedule/sles4sap/sap_deployment_automation_framework/sdaf_deployment.yml
@@ -11,8 +11,22 @@ schedule:
   - sles4sap/sap_deployment_automation_framework/configure_deployer
   - sles4sap/sap_deployment_automation_framework/deploy_workload_zone
   - sles4sap/sap_deployment_automation_framework/deploy_sap_systems
+  - '{{ibsm_setup}}'
   - sles4sap/sap_deployment_automation_framework/execute_playbooks
   - sles4sap/sap_deployment_automation_framework/prepare_ssh_config
   - sles4sap/redirection_tests/check_hana_database
   - sles4sap/redirection_tests/check_ensa2_cluster
   - sles4sap/redirection_tests/check_netweaver
+  - '{{ibsm_verify}}'
+
+conditional_schedule:
+  ibsm_setup:
+    IS_MAINTENANCE:
+      1:
+        # Configures VNET connection between SDAF SUT network and IBSM
+        - sles4sap/sap_deployment_automation_framework/ibsm_configure
+  ibsm_verify:
+    IS_MAINTENANCE:
+      1:
+        # Verify SUT being able to reach IBSM server
+        - sles4sap/sap_deployment_automation_framework/ibsm_verify

--- a/t/20_sdaf_deployment_library.t
+++ b/t/20_sdaf_deployment_library.t
@@ -610,4 +610,22 @@ subtest '[sdaf_upload_logs]' => sub {
     ok sdaf_upload_logs(hostname => $arguments{hostname}, sap_sid => $arguments{sap_sid});
 };
 
+subtest '[get_workload_resource_group]' => sub {
+    my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
+    $ms_sdaf->noop('record_info');
+    $ms_sdaf->redefine(az_group_name_get => sub { return ['Resource_group']; });
+
+    is get_workload_resource_group(deployment_id => '123'), 'Resource_group', 'Return exactly one RG';
+};
+
+subtest '[get_workload_resource_group]' => sub {
+    my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
+    $ms_sdaf->noop('record_info');
+    $ms_sdaf->redefine(az_group_name_get => sub { return []; });
+    dies_ok { get_workload_resource_group(deployment_id => '123') } 'Fail with empty result';
+
+    $ms_sdaf->redefine(az_group_name_get => sub { return ['First_result', 'Oh_no-second_one']; });
+    dies_ok { get_workload_resource_group(deployment_id => '123') } 'Fail with more than one results';
+};
+
 done_testing;

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -1152,4 +1152,189 @@ subtest '[az_group_exists] Compose command' => sub {
     ok(grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"');
 };
 
+subtest '[az_nic_list] Compose command' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(script_output => sub { @calls = $_[0]; return '[]'; });
+
+    az_nic_list(resource_group => 'Pantalone');
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok((any { /az network nic list/ } @calls), 'Correct composition of the main command');
+    ok(grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"');
+    ok(grep(/--query "\[].name"/, @calls), 'Check for default query');
+};
+
+subtest '[az_nic_list] Optional args' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(script_output => sub { @calls = $_[0]; return '[]'; });
+
+    az_nic_list(resource_group => 'Pantalone', query => '[].calzini');
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok(grep(/--query "\[].calzini"/, @calls), 'Check for optional argument "--query"');
+};
+
+
+subtest '[az_network_vnet_show] Compose command' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(script_output => sub { @calls = $_[0]; return '[]'; });
+
+    az_network_vnet_show(resource_group => 'Pantalone', name => 'calzini');
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok((any { /az network vnet show/ } @calls), 'Correct composition of the main command');
+    ok(grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"');
+    ok(grep(/--name calzini/, @calls), 'Check for argument "--name"');
+};
+
+subtest '[az_network_vnet_show] Optional arg' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(script_output => sub { @calls = $_[0]; return '[]'; });
+
+    az_network_vnet_show(resource_group => 'Pantalone', name => 'calzini', query => 'id');
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok(grep(/--query "id"/, @calls), 'Check for argument "--query"');
+};
+
+subtest '[az_network_dns_zone_create] Compose command' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(assert_script_run => sub { @calls = $_[0]; return; });
+
+    az_network_dns_zone_create(resource_group => 'Pantalone', name => 'calzini');
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok((any { /az network private-dns zone create/ } @calls), 'Correct composition of the main command');
+    ok(grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"');
+    ok(grep(/--name calzini/, @calls), 'Check for argument "--name"');
+};
+
+subtest '[az_network_dns_zone_delete] Compose command' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(assert_script_run => sub { @calls = $_[0]; return; });
+
+    az_network_dns_zone_delete(resource_group => 'Pantalone', zone_name => 'calzini');
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok((any { /az network private-dns zone delete/ } @calls), 'Correct composition of the main command');
+    ok(grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"');
+    ok(grep(/--name calzini/, @calls), 'Check for argument "--name"');
+    ok(grep(/--yes/, @calls), 'Autoapprove option "--yes"');
+};
+
+subtest '[az_network_dns_add_record] Compose command' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(assert_script_run => sub { @calls = $_[0]; return; });
+
+    az_network_dns_add_record(
+        resource_group => 'Pantalone',
+        zone_name => 'opensuse.org',
+        record_name => 'openqa',
+        ip_addr => '192.168.1.5'
+    );
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok((any { /az network private-dns record-set a add-record/ } @calls), 'Correct composition of the main command');
+    ok(grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"');
+    ok(grep(/--zone-name opensuse.org/, @calls), 'Check for argument "--zone-name"');
+    ok(grep(/--record-set-name openqa/, @calls), 'Check for argument "--record-set-name"');
+    ok(grep(/--ipv4-address 192.168.1.5/, @calls), 'Check for argument "--ipv4-address"');
+};
+
+subtest '[az_network_dns_link_create] Compose command' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(assert_script_run => sub { @calls = $_[0]; return; });
+
+    az_network_dns_link_create(
+        resource_group => 'Pantalone',
+        zone_name => 'opensuse.org',
+        vnet => 'vnet_rg',
+        name => 'link_to_rg_vnet'
+    );
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok((any { /az network private-dns link vnet create/ } @calls), 'Correct composition of the main command');
+    ok(grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"');
+    ok(grep(/--zone-name opensuse.org/, @calls), 'Check for argument "--zone-name"');
+    ok(grep(/--virtual-network vnet_rg/, @calls), 'Check for argument "--virtual-network"');
+    ok(grep(/--name link_to_rg_vnet/, @calls), 'Check for argument "--name"');
+    ok(grep(/--registration-enabled true/, @calls), 'Check for argument "--auto-registration"');
+};
+
+subtest '[az_network_dns_zone_list] Compose command' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(script_output => sub { @calls = $_[0]; return '["zone1", "zone2"]'; });
+
+    az_network_dns_zone_list(resource_group => 'Pantalone');
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok((any { /az network private-dns zone list/ } @calls), 'Correct composition of the main command');
+    ok(grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"');
+    ok(grep(/--query "\[].name"/, @calls), 'Check for default argument "--query" value');
+};
+
+subtest '[az_network_dns_zone_list] check custom query' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(script_output => sub { @calls = $_[0]; return '["zone1", "zone2"]'; });
+
+    az_network_dns_zone_list(resource_group => 'Pantalone', query => '[].id');
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok(grep(/--query "\[].id"/, @calls), 'Check for custom argument "--query" value');
+};
+
+subtest '[az_network_dns_link_list] Compose command' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(script_output => sub { @calls = $_[0]; return '["zone1", "zone2"]'; });
+
+    az_network_dns_link_list(resource_group => 'Pantalone', zone_name => 'opensuse.org');
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok((any { /az network private-dns link vnet list/ } @calls), 'Correct composition of the main command');
+    ok(grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"');
+    ok(grep(/--zone-name opensuse.org/, @calls), 'Check for argument "--zone-name"');
+    ok(grep(/--query "\[].name"/, @calls), 'Check for custom argument "--query" value');
+};
+
+subtest '[az_network_dns_link_list] Compose command' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(script_output => sub { @calls = $_[0]; return '["zone1", "zone2"]'; });
+
+    az_network_dns_link_list(resource_group => 'Pantalone', zone_name => 'opensuse.org', query => '[].id');
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok(grep(/--query "\[].id"/, @calls), 'Check for custom argument "--query" value');
+};
+
+subtest '[az_network_dns_link_delete] Compose command' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(assert_script_run => sub { @calls = $_[0]; return; });
+
+    az_network_dns_link_delete(
+        resource_group => 'Pantalone',
+        zone_name => 'opensuse.org',
+        link_name => 'link_to_rg_vnet'
+    );
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok((any { /az network private-dns link vnet delete/ } @calls), 'Correct composition of the main command');
+    ok(grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"');
+    ok(grep(/--zone-name opensuse.org/, @calls), 'Check for argument "--zone-name"');
+    ok(grep(/--name link_to_rg_vnet/, @calls), 'Check for argument "--name"');
+    ok(grep(/--yes/, @calls), 'Check for autoapprove argument "--yes"');
+};
+
 done_testing;

--- a/t/24_sdaf_naming_convention.t
+++ b/t/24_sdaf_naming_convention.t
@@ -155,4 +155,9 @@ subtest '[get_sizing_filename]' => sub {
     is get_sizing_filename(), 'custom_sizes_S4HANA.json', 'Return filename for ENSA2 scenario';
 };
 
+subtest '[get_ibsm_peering_name]' => sub {
+    is get_ibsm_peering_name(source_vnet => 'source', target_vnet => 'target'), 'SDAF-source-target', 'Check naming composition';
+};
+
+
 done_testing;

--- a/t/36_redirection_data_tools.t
+++ b/t/36_redirection_data_tools.t
@@ -82,4 +82,14 @@ subtest '[get_pas_host]' => sub {
     ok(grep(/$expected_host/, keys(%pas_host)), "NW list contains host '$expected_host'");
 };
 
+subtest '[get_sap_hosts]' => sub {
+    my $mockObject = sles4sap::console_redirection::redirection_data_tools->new($mock_data);
+    my %nw_hosts = %{$mockObject->get_sap_hosts()};
+    my @expected_hosts = qw(nw_ascs_01 nw_ers_02 nw_aas_01 nw_pas hanadb_a hanadb_b);
+    note('NW hosts found: ' . join(' ', keys %nw_hosts));
+    for my $host (@expected_hosts) {
+        ok(grep(/$host/, keys(%nw_hosts)), "SAP list contains host '$host'");
+    }
+};
+
 done_testing();

--- a/tests/sles4sap/sap_deployment_automation_framework/ibsm_configure.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/ibsm_configure.pm
@@ -1,0 +1,137 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Setup peering between SUT VNET and IBSm VNET
+
+use parent 'sles4sap::sap_deployment_automation_framework::basetest';
+
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use sles4sap::azure_cli;
+use sles4sap::sap_deployment_automation_framework::deployment_connector qw(find_deployment_id);
+use sles4sap::sap_deployment_automation_framework::basetest qw(ibsm_data_collect);
+use sles4sap::sap_deployment_automation_framework::naming_conventions;
+use sles4sap::sap_deployment_automation_framework::deployment;
+use sles4sap::console_redirection;
+
+=head1 NAME
+
+sles4sap/sap_deployment_automation_framework/ibsm_configure.pm - Setup connection between ISBM and Workload zone VNETs.
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=head1 DESCRIPTION
+
+Test module sets up network peering between tests workload zone and IBSm VNET.
+
+B<The key tasks performed by this module include:>
+
+=over
+
+=item * Verifies if test module was executed with 'IS_MAINTENANCE' OpenQA setting and returns if IBSm connection is not required.
+
+=item * Collects data required for creating network peerings
+
+=item * Creates resources for two way peering between two VNETs
+
+=item * Creates DNS zone and record for all SUTs to access ISBM host using FQDN defined by OpenQA setting B<'REPO_MIRROR_HOST'>
+
+=item * Verifies if peering resources were created
+
+=back
+
+=head1 OPENQA SETTINGS
+
+=over
+
+=item * B<IBSM_RG> : IBSm resource group name
+
+=item * B<IS_MAINTENANCE> : Define if test scenario includes applying maintenance updates
+
+=item * B<REPO_MIRROR_HOST> : IBSm repository hostname
+
+=back
+=cut
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+sub run {
+    unless (get_var('IS_MAINTENANCE')) {
+        # Just a safeguard for case the module is in schedule without 'IS_MAINTENANCE' OpenQA setting being set
+        record_info('MAINTENANCE OFF', 'OpenQA setting "IS_MAINTENANCE" is disabled, skipping IBSm setup');
+        return;
+    }
+
+    select_serial_terminal();
+    my $ibsm_rg = get_required_var('IBSM_RG');
+    my $nic_count = az_nic_list(resource_group => $ibsm_rg, query => 'length([].ipConfigurations)');
+
+    die <<"die_message"
+Current code implementation expects IBSM resource group to have only one NIC.
+Found : '$nic_count'
+Investigate what is the reason and adapt code changes if required.
+die_message
+      unless ($nic_count == 1);
+
+    my $peering_data = ibsm_data_collect();
+
+    for my $peering_type (keys %{$peering_data}) {
+        my $data = $peering_data->{$peering_type};
+        # There should not be an existing peering with the same name - might be leftover.
+        die "Network peering '$data->{peering_name}' already exists" if $data->{exists};
+
+        record_info('Peer create', "Peering name: $data->{peering_name}\n
+        Resource_group: $data->{source_resource_group}\n
+        Source VNET: $data->{source_vnet}\n
+        Target VNET: $data->{target_vnet}");
+
+        # Create two way network peering
+        az_network_peering_create(
+            name => $data->{peering_name},
+            source_rg => $data->{source_resource_group},
+            source_vnet => $data->{source_vnet},
+            target_rg => $data->{target_resource_group},
+            target_vnet => $data->{target_vnet}
+        );
+
+        die("Peering '$data->{peering_name}' not detected after creation")
+          unless az_network_peering_exists(
+            resource_group => $data->{source_resource_group},
+            vnet => $data->{source_vnet},
+            name => $data->{peering_name});
+        record_info('Peering OK', <<"record_info"
+Peering '$data->{peering_name}' created:
+Resource_group: $data->{source_resource_group}
+Source VNET: $data->{source_vnet}
+Target VNET: $data->{target_vnet}
+record_info
+        );
+    }
+
+    # Create DNS zone for maintenance repository mirror
+    my ($subdomain, $second_level, $tld) = split('\.', get_required_var('REPO_MIRROR_HOST'));
+    my $zone_name = "$second_level.$tld";
+    my $ibsm_ip = ${az_nic_list(resource_group => $ibsm_rg,
+            query => '"[].ipConfigurations[0].privateIPAddress"')}[0];
+    my $workload_resource_group = $peering_data->{workload_peering}{source_resource_group};
+    my $workload_vnet_name = $peering_data->{workload_peering}{source_vnet};
+
+    record_info(
+        'IBSm DNS', "Private DNS zone: $zone_name\nDNS record: $ibsm_ip -> " . get_required_var('REPO_MIRROR_HOST'));
+    az_network_dns_zone_create(resource_group => $workload_resource_group, name => $zone_name);
+    az_network_dns_add_record(
+        resource_group => $workload_resource_group, zone_name => $zone_name, record_name => $subdomain, ip_addr => $ibsm_ip);
+    az_network_dns_link_create(
+        resource_group => $workload_resource_group,
+        zone_name => $zone_name,
+        vnet => $workload_vnet_name,
+        name => $workload_vnet_name
+    );
+}
+1;

--- a/tests/sles4sap/sap_deployment_automation_framework/ibsm_verify.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/ibsm_verify.pm
@@ -1,0 +1,96 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Maintainer: QE-SAP <qe-sap@suse.de>
+# Summary: Verify connection between each SUT host and IBSm server IP.
+
+use parent 'sles4sap::sap_deployment_automation_framework::basetest';
+
+use testapi;
+use serial_terminal qw(select_serial_terminal);
+use sles4sap::sap_deployment_automation_framework::naming_conventions;
+use sles4sap::console_redirection;
+use sles4sap::sap_deployment_automation_framework::deployment;
+use sles4sap::console_redirection::redirection_data_tools;
+use sles4sap::azure_cli qw(az_nic_list);
+
+use sles4sap::sap_deployment_automation_framework::basetest;
+
+=head1 NAME
+
+sles4sap/sap_deployment_automation_framework/ibsm_verify.pm - Verify connection between each SUT host and IBSm server IP.
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=head1 DESCRIPTION
+
+Module is used to performs connection checks from each SUT host to IBSm server.
+NOTE: Test module expects the worker VM to have keyless access to each host prepared.
+- check `sles4sap/sap_deployment_automation_framework/prepare_ssh_config`
+
+B<The key tasks performed by this module include:>
+
+=over
+
+=item * Collects connection data to all SUT virtual machines required for console redirection
+
+=item * Connects to all SUT hosts and checks if ping to IBSm host is possible
+
+=item * Reports results
+
+=item * Terminates test if IBSm connection does not work for any of hosts
+
+=back
+
+=head1 OPENQA SETTINGS
+
+=over
+
+=item * B<IS_MAINTENANCE> : Define if test scenario includes applying maintenance updates
+
+=item * B<REPO_MIRROR_HOST> : IBSm repository hostname
+
+=back
+=cut
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+sub run {
+    my ($self, $run_args) = @_;
+    unless (get_var('IS_MAINTENANCE')) {
+        # Just a safeguard for case the module is in schedule without 'IS_MAINTENANCE' OpenQA setting being set
+        record_info('MAINTENANCE OFF', 'OpenQA setting "IS_MAINTENANCE" is disabled, skipping IBSm setup');
+        return;
+    }
+    select_serial_terminal();
+    my $redirection_data = sles4sap::console_redirection::redirection_data_tools->new($run_args->{redirection_data});
+    my $ibsm_fqdn = get_required_var('REPO_MIRROR_HOST');
+
+    my %sut_hosts = %{$redirection_data->get_sap_hosts};
+    my $fail_count;
+
+    for my $host (keys(%sut_hosts)) {
+        # Everything is now executed on SUT, not worker VM
+        my $ip_addr = $sut_hosts{$host}{ip_address};
+        my $user = $sut_hosts{$host}{ssh_user};
+        die "Redirection data missing. Got:\nIP: $ip_addr\nUSER: $user\n" unless $ip_addr and $user;
+
+        connect_target_to_serial(destination_ip => $ip_addr, ssh_user => $user, switch_root => 'yes');
+        if (script_run("ping -c 3 $ibsm_fqdn")) {
+            $fail_count++;
+            record_info('Ping test', "Ping test to IBSm IP '$ibsm_fqdn' FAILED", result => 'fail');
+        }
+        else {
+            record_info('Ping test', "Ping test to IBSm IP '$ibsm_fqdn' PASSED");
+        }
+        disconnect_target_from_serial();
+    }
+    die "There are $fail_count failed verification checks." if $fail_count;
+}
+
+1;


### PR DESCRIPTION
This PR creates module for setting up connection between SDAF SUT VNET and IBSM
VNET. IBSM setup modules are only activated with OpenQA setting 'IS_MAINTENANCE' and 'IBSM_RG' defined. 

- Ticket: https://jira.suse.com/browse/TEAM-10607

- Verification run: 
Hana SR:  https://openqaworker15.qa.suse.cz/tests/346464#dependencies
  IBSM configured: https://openqaworker15.qa.suse.cz/tests/346464#step/ibsm_configure/100
  IBSM connection check: https://openqaworker15.qa.suse.cz/tests/346464#step/ibsm_verify/17
  IBSM cleanup: https://openqaworker15.qa.suse.cz/tests/346466#step/cleanup/189

ENSA2 :  https://openqaworker15.qa.suse.cz/tests/346892#dependencies
  IBSM configured: https://openqaworker15.qa.suse.cz/tests/346892#step/ibsm_configure/100
  IBSM connection check: https://openqaworker15.qa.suse.cz/tests/346892#step/ibsm_verify/17
  IBSM cleanup: https://openqaworker15.qa.suse.cz/tests/346893#step/Kill_sapinstance_ASCS-takeover/748

