### PR TITLE
Add sles4sap_textmode_saptune_baremetal test for SLE 16.0 for SAP

### DIFF
--- a/data/sles4sap/agama/sles_sap_default_baremetal.jsonnet
+++ b/data/sles4sap/agama/sles_sap_default_baremetal.jsonnet
@@ -1,0 +1,47 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE_SLES4SAP}}',
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    sshPublicKey: 'enable ssh',
+  },
+  storage: {
+    drives: [
+      {
+        search: '/dev/sda',
+        partitions: [
+          { search: '*', delete: true },
+          { generate: 'default' },
+        ],
+      },
+    ],
+  },
+  scripts: {
+    pre: [
+      {
+        name: 'wipefs',
+        content: |||
+          #!/usr/bin/env bash
+          for i in `lsblk -n -l -o NAME -d -e 7,11,254`
+              do wipefs -af /dev/$i
+              sleep 1
+              sync
+          done
+        |||,
+      },
+    ],
+    post: [
+      {
+        name: 'enable root login',
+        chroot: true,
+        content: |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+        |||,
+      },
+    ],
+  },
+}

--- a/schedule/sles4sap/installation/sles4sap_gnome_saptune_baremetal_16.yaml
+++ b/schedule/sles4sap/installation/sles4sap_gnome_saptune_baremetal_16.yaml
@@ -1,0 +1,12 @@
+---
+name: sles4sap_gnome_saptune_baremetal
+description: >
+  saptune tests for SLES4SAP on baremetal
+vars:
+  MR_TEST: '%ARCH%'
+schedule:
+  - installation/ipxe_install
+  - installation/agama_reboot
+  - support_server/login
+  - console/system_prepare
+  - sles4sap/saptune/mr_test

--- a/tests/sles4sap/saptune/mr_test_run.pm
+++ b/tests/sles4sap/saptune/mr_test_run.pm
@@ -640,6 +640,9 @@ sub test_x86_64 {
     $result = "ok";
     $self->result("$result");
 
+    # automatically applied SAP_Base solution on SLE 16.0 for SAP
+    # we need to revert it first
+    $self->wrap_script_run("saptune revert all") if (is_sle('>=16'));
     # energy_perf_bias=6
     $self->wrap_script_run("cpupower set -b 6");
     # governor=powersave


### PR DESCRIPTION
Add saptune test for SLE 16.0 for SAP on bare metal, and this test only works at textmode on OSD because VNC connection is not good so far on SLE 16.0.
**Note**: Dawei provided the change about ipxe_install.pm module.

- Related ticket: https://jira.suse.com/browse/TEAM-10622
- Needles: None
- Verification run: https://openqa.suse.de/tests/19207749 (failed because mr_test code needs to update for SLE 16.0)
