### PR TITLE
update_kernel: Allow adding GRUB params from job settings

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -14,6 +14,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use version_utils qw(is_sle is_sle_micro is_transactional package_version_cmp);
+use bootloader_setup 'add_grub_cmdline_settings';
 use qam;
 use kernel;
 use klp;
@@ -500,7 +501,9 @@ sub run {
 
     my $repo = is_sle_micro('>=6.0') ? get_var('OS_TEST_REPOS') : get_var('KOTD_REPO');
     my $incident_id = undef;
+    my $grub_param = get_var('APPEND_GRUB_PARAMS');
 
+    add_grub_cmdline_settings($grub_param) if defined $grub_param;
     add_extra_customer_repositories;
     zypper_call('al kernel-rt_debug') if check_var('SLE_PRODUCT', 'slert');
 


### PR DESCRIPTION
The `install_ltp` test module already supports adding new boot choices to GRUB menu with different boot options. The `APPEND_GRUB_PARAMS` will modify the common command line options which apply to all boot menu choices. The boot params will also be added before the first reboot in `update_kernel` to allow applying workarounds if the kernel to be installed cannot boot with default settings.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/19207742
