### PR TITLE
bats/podman: Backport PR#27152 to fix test race

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -187,12 +187,14 @@ podman:
   # https://github.com/containers/podman/pull/26017 is needed for 030-run
   # https://github.com/containers/podman/pull/26798 is needed for 505-networking-pasta
   # https://github.com/containers/podman/pull/26920 is needed to drop ncat
+  # https://github.com/containers/podman/pull/27152 is needed for 030-run
   opensuse-Tumbleweed:
     GITHUB_PATCHES:
     - 26017
     - 26798
     - 26920
     - 26921
+    - 27152
     BATS_IGNORE:
     BATS_IGNORE_ROOT_LOCAL:
     - "200-pod.bats::pod resource limits"

--- a/data/containers/patches/podman/27152.patch
+++ b/data/containers/patches/podman/27152.patch
@@ -1,0 +1,23 @@
+From 63c40feb8c9c276e0aa9f11b6c905c2c65168cc1 Mon Sep 17 00:00:00 2001
+From: Ricardo Branco <rbranco@suse.de>
+Date: Wed, 24 Sep 2025 18:30:40 +0200
+Subject: [PATCH] test: Fix test race in 030-run
+
+Signed-off-by: Ricardo Branco <rbranco@suse.de>
+---
+ test/system/030-run.bats | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/system/030-run.bats b/test/system/030-run.bats
+index 297191d672..5c4fdc44c4 100644
+--- a/test/system/030-run.bats
++++ b/test/system/030-run.bats
+@@ -78,7 +78,7 @@ echo $rand        |   0 | $rand
+     echo "$content" > $PODMAN_TMPDIR/tempfile
+ 
+     run_podman run --rm -i --preserve-fds=2 $IMAGE sh -c "cat <&4" 4<$PODMAN_TMPDIR/tempfile
+-    is "$output" "$content" "container read input from fd 4"
++    assert "$output" =~ "$content" "container read input from fd 4"
+ }
+ 
+ # 'run --preserve-fd' passes a list of additional file descriptors into the container


### PR DESCRIPTION
Backport https://github.com/containers/podman/pull/27152 to fix test race

- Failing test: https://openqa.opensuse.org/tests/5338518#external
- Verification run: https://openqa.opensuse.org/tests/5340073
