### PR TITLE
Wipe all disks before sle-micro installation

### DIFF
--- a/schedule/virt_autotest/kubevirt-tests-slem-pxe.yaml
+++ b/schedule/virt_autotest/kubevirt-tests-slem-pxe.yaml
@@ -14,7 +14,7 @@ vars:
   PATTERNS: default,kvm
   MAX_JOB_TIME: 10800
 schedule:
-  - "{{install_preparation}}"
+  - '{{install_preparation}}'
   - '{{barrier_setup}}'
   - '{{bootup_and_install}}'
   - '{{kubevirt_tests}}'
@@ -30,6 +30,7 @@ conditional_schedule:
   bootup_and_install:
     RUN_TEST_ONLY:
       0:
+        - virt_autotest/wipe_disks
         - installation/ipxe_install
         - microos/selfinstall
         - console/suseconnect_scc

--- a/tests/virt_autotest/wipe_disks.pm
+++ b/tests/virt_autotest/wipe_disks.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Leverage the test module 'ipxe_install' to wipe multiple disks and
+#          also the EFI boot partition before starting installation
+# Maintainer: Nan Zhang <nan.zhang@suse.com>, qe-virt@suse.de
+
+package wipe_disks;
+
+use testapi;
+use base "installbasetest";
+use utils;
+use File::Basename;
+
+BEGIN {
+    unshift @INC, dirname(__FILE__) . '/../installation';
+}
+use ipxe_install;
+
+sub run {
+    my $self = shift;
+
+    my $boot_hdd_image_tmp = get_var('BOOT_HDD_IMAGE');
+    my $install_hdd_image_tmp = get_var('INSTALL_HDD_IMAGE');
+    my $mirror_http_tmp = get_var('MIRROR_HTTP');
+
+    set_var('BOOT_HDD_IMAGE', '');
+    set_var('INSTALL_HDD_IMAGE', '');
+    set_var('MIRROR_HTTP', 'http://openqa.suse.de/assets/repo/fixed/SLE-15-SP7-Full-x86_64-GM-Media1');
+    set_var('HOST_INSTALL_AUTOYAST', '1');
+
+    record_info('Wipe all disks before installation');
+    $self->ipxe_install::run() if (check_var('IPXE', '1'));
+    reset_consoles;
+
+    set_var('BOOT_HDD_IMAGE', $boot_hdd_image_tmp);
+    set_var('INSTALL_HDD_IMAGE', $install_hdd_image_tmp);
+    set_var('MIRROR_HTTP', $mirror_http_tmp);
+    set_var('HOST_INSTALL_AUTOYAST', '');
+}
+
+1;


### PR DESCRIPTION
To fix booting OS problem, invoking ipxe_install module to wipe multi-disks and EFI boot partition before installation startup.

- Related ticket: https://progress.opensuse.org/issues/186176
- Verification run: https://openqa.suse.de/tests/19331060
