### PR TITLE
Update Maintainer tag

### DIFF
--- a/lib/publiccloud/acr.pm
+++ b/lib/publiccloud/acr.pm
@@ -10,7 +10,7 @@
 
 # Summary: Helper class for Azure Container Registry (ACR)
 #
-# Maintainer: Ivan Lausuch <ilausuch@suse.de>, qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::acr;
 use Mojo::Base 'publiccloud::k8s_provider';

--- a/lib/publiccloud/aks.pm
+++ b/lib/publiccloud/aks.pm
@@ -5,7 +5,7 @@
 
 # Summary: Helper class for Azure Kubernetes Service (AKS)
 #
-# Maintainer: Ivan Lausuch <ilausuch@suse.de>, qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 # Documentation: https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html
 
 package publiccloud::aks;

--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -5,7 +5,7 @@
 
 # Summary: Helper class for amazon connection and authentication
 #
-# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>, qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::aws_client;
 use Mojo::Base -base;

--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -5,7 +5,7 @@
 
 # Summary: helper class for azure
 #
-# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::azure;
 use Mojo::Base 'publiccloud::provider';

--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -5,7 +5,7 @@
 
 # Summary: Helper class for Azure connection and authentication
 #
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::azure_client;
 use Mojo::Base -base;

--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -5,7 +5,7 @@
 
 # Summary: Base class for publiccloud tests
 #
-# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::basetest;
 use base 'opensusebasetest';

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -5,7 +5,7 @@
 
 # Summary: Helper class for amazon ec2
 #
-# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>, qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::ec2;
 use Mojo::Base 'publiccloud::provider';

--- a/lib/publiccloud/ecr.pm
+++ b/lib/publiccloud/ecr.pm
@@ -10,7 +10,7 @@
 
 # Summary: Helper class for Amazon Elastic Container Registry (ECR)
 #
-# Maintainer: Ivan Lausuch <ilausuch@suse.de>, qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 # Documentation: https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html
 
 package publiccloud::ecr;

--- a/lib/publiccloud/eks.pm
+++ b/lib/publiccloud/eks.pm
@@ -5,7 +5,7 @@
 
 # Summary: Helper class for Amazon Elastic Container Registry (ECR)
 #
-# Maintainer: Ivan Lausuch <ilausuch@suse.de>, qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 # Documentation: https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html
 
 package publiccloud::eks;

--- a/lib/publiccloud/existing.pm
+++ b/lib/publiccloud/existing.pm
@@ -5,7 +5,7 @@
 
 # Summary: Helper class for existing instance connection
 #
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::existing;
 use Mojo::Base -base;

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -5,9 +5,7 @@
 
 # Summary: Helper class for Google Cloud Platform Computer Engine
 #
-# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>
-#             Jose Lausuch <jalausuch@suse.de>
-#             qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::gce;
 use Mojo::Base 'publiccloud::provider';

--- a/lib/publiccloud/gcp_client.pm
+++ b/lib/publiccloud/gcp_client.pm
@@ -5,7 +5,7 @@
 
 # Summary: Helper class for google connection and authentication
 #
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::gcp_client;
 use Mojo::Base -base;

--- a/lib/publiccloud/gcr.pm
+++ b/lib/publiccloud/gcr.pm
@@ -10,7 +10,7 @@
 
 # Summary: Helper class for Google Container Registry (GCR)
 #
-# Maintainer: Ivan Lausuch <ilausuch@suse.de>, qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 # Documentation: https://cloud.google.com/container-registry/docs/pushing-and-pulling
 
 package publiccloud::gcr;

--- a/lib/publiccloud/gke.pm
+++ b/lib/publiccloud/gke.pm
@@ -5,7 +5,7 @@
 
 # Summary: Helper class for Google Container Registry (GCR)
 #
-# Maintainer: Ivan Lausuch <ilausuch@suse.de>, qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 # Documentation: https://cloud.google.com/container-registry/docs/pushing-and-pulling
 
 package publiccloud::gke;

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -5,7 +5,7 @@
 
 # Summary: Base class for public cloud instances
 #
-# Maintainer: qa-c@suse.de
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::instance;
 use testapi;

--- a/lib/publiccloud/instances.pm
+++ b/lib/publiccloud/instances.pm
@@ -5,7 +5,7 @@
 
 # Summary: Base class for the public cloud namespace
 #
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::instances;
 use testapi;

--- a/lib/publiccloud/k8s_provider.pm
+++ b/lib/publiccloud/k8s_provider.pm
@@ -5,7 +5,7 @@
 
 # Summary: Helper class for amazon connection and authentication
 #
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::k8s_provider;
 use Mojo::Base -base;

--- a/lib/publiccloud/k8sbasetest.pm
+++ b/lib/publiccloud/k8sbasetest.pm
@@ -5,7 +5,7 @@
 
 # Summary: Base class for publiccloud tests
 #
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::k8sbasetest;
 use Mojo::Base 'publiccloud::basetest';

--- a/lib/publiccloud/noprovider.pm
+++ b/lib/publiccloud/noprovider.pm
@@ -5,7 +5,7 @@
 
 # Summary: Helper class for dummy provider
 #
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::noprovider;
 use Mojo::Base 'publiccloud::provider';

--- a/lib/publiccloud/openstack.pm
+++ b/lib/publiccloud/openstack.pm
@@ -5,7 +5,7 @@
 
 # Summary: Helper class for OpenStack
 #
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::openstack;
 use Mojo::Base 'publiccloud::provider';

--- a/lib/publiccloud/openstack_client.pm
+++ b/lib/publiccloud/openstack_client.pm
@@ -5,7 +5,7 @@
 
 # Summary: Helper class for OpenStack connection and authentication
 #
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::openstack_client;
 use Mojo::Base -base;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -5,7 +5,7 @@
 
 # Summary: Base helper class for public cloud
 #
-# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::provider;
 use testapi qw(is_serial_terminal :DEFAULT);

--- a/lib/publiccloud/ssh_interactive.pm
+++ b/lib/publiccloud/ssh_interactive.pm
@@ -5,7 +5,7 @@
 
 # Summary: Class with helpers related to SSH Interactive mode
 #
-# Maintainer: qa-c@suse.de
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::ssh_interactive;
 use base Exporter;

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Public cloud utilities
-# Maintainer: Felix Niederwanger <felix.niederwanger@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::utils;
 

--- a/tests/containers/k3s_helm_install.pm
+++ b/tests/containers/k3s_helm_install.pm
@@ -7,7 +7,7 @@
 # Summary: Ensure that k3s and helm is installed in the system
 # - check if k3s is installed; if not, install k3s
 # - check if helm is installed; if not, install helm
-# Maintainer: qe-c <qe-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'containers::basetest';
 use testapi;

--- a/tests/containers/podman_remote.pm
+++ b/tests/containers/podman_remote.pm
@@ -5,7 +5,7 @@
 
 # Package: podman
 # Summary: Test podman-remote functionality
-# Maintainer: qe-c <qe-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'containers::basetest';
 use testapi;

--- a/tests/containers/privileged_mode.pm
+++ b/tests/containers/privileged_mode.pm
@@ -5,7 +5,7 @@
 
 # Package: podman
 # Summary: Test container runtime privileged mode
-# Maintainer: qa-c@suse.de
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'containers::basetest';
 use testapi;

--- a/tests/containers/realtime.pm
+++ b/tests/containers/realtime.pm
@@ -5,7 +5,7 @@
 
 # Package: podman, docker
 # Summary: Test RT workload in a container
-# Maintainer: qa-c@suse.de
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base qw(containers::basetest);
 use testapi;

--- a/tests/containers/scc_login_to_registry.pm
+++ b/tests/containers/scc_login_to_registry.pm
@@ -7,7 +7,7 @@
 #          and (optionally) Helm registry login if HELM_CHART is defined.
 # - login to registry.suse.com using docker|podman login
 # - if HELM_CHART is defined, also run: helm registry login
-# Maintainer: qe-c <qe-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'containers::basetest';
 use testapi;

--- a/tests/publiccloud/aws_cli.pm
+++ b/tests/publiccloud/aws_cli.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Create VM in EC2 using aws binary
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;

--- a/tests/publiccloud/az_accelerated_net.pm
+++ b/tests/publiccloud/az_accelerated_net.pm
@@ -6,7 +6,7 @@
 # Package: azure-cli
 # Summary: Network performance for Azure Accelerated NICs
 #
-# Maintainer: Jose Lausuch <jalausuch@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use base "publiccloud::basetest";
 use testapi;

--- a/tests/publiccloud/azure_aitl.pm
+++ b/tests/publiccloud/azure_aitl.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Create VM in Azure using azure-cli binary
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;

--- a/tests/publiccloud/azure_cli.pm
+++ b/tests/publiccloud/azure_cli.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Create VM in Azure using azure-cli binary
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;

--- a/tests/publiccloud/azure_more_cli.pm
+++ b/tests/publiccloud/azure_more_cli.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Create VM in Azure using azure-cli binary
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use utils 'zypper_call';

--- a/tests/publiccloud/azure_nfs.pm
+++ b/tests/publiccloud/azure_nfs.pm
@@ -9,7 +9,7 @@
 # - perform basic file checks there (see check_nfs_share)
 # This test uses the data/publiccloud/terraform/azure_nfstest.tf terraform profile
 # to create a VM and a storage account in its own resource group. All resources are disposed after execution
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use base 'consoletest';
 use testapi;

--- a/tests/publiccloud/bsc_1205002.pm
+++ b/tests/publiccloud/bsc_1205002.pm
@@ -5,7 +5,7 @@
 
 # Summary: Test to check for bsc#1205002
 #
-# Maintainer: <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use base "publiccloud::basetest";
 use testapi;

--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -8,7 +8,7 @@
 # https://github.com/SUSE-Enceladus/cloud-regionsrv-client/blob/master/integration_test-process.txt
 # Leave system in *registered* state
 #
-# Maintainer: <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use version_utils;

--- a/tests/publiccloud/check_services.pm
+++ b/tests/publiccloud/check_services.pm
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Check public cloud specific services
-# Maintainer: qa-c <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use base 'publiccloud::basetest';
 use serial_terminal 'select_serial_terminal';

--- a/tests/publiccloud/cloud_netconfig.pm
+++ b/tests/publiccloud/cloud_netconfig.pm
@@ -9,7 +9,7 @@
 # This test only contains minimal functionality that needs to be
 # extended in future.
 #
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use Test::Assert qw(assert_equals assert_not_equals);

--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -5,7 +5,7 @@
 
 # Summary: Download repositores from the internal server
 #
-# Maintainer: qa-c <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use base 'consoletest';
 use registration;

--- a/tests/publiccloud/flavor_check.pm
+++ b/tests/publiccloud/flavor_check.pm
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Run the instance-flavor-check
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use base 'consoletest';
 use testapi;

--- a/tests/publiccloud/hardened.pm
+++ b/tests/publiccloud/hardened.pm
@@ -5,7 +5,7 @@
 
 # Summary: Test public cloud hardened images
 #
-# Maintainer: <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use base 'consoletest';
 use testapi;

--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -6,7 +6,7 @@
 # Package: python3-img-proof
 # Summary: Use img-proof framework to test public cloud SUSE images
 #
-# Maintainer: <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -8,7 +8,7 @@
 # We just register the system, install random package, see the system and network configuration
 # This test module will fail at the end to prove that the test run will continue without rollback
 #
-# Maintainer: qa-c <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use base 'publiccloud::basetest';
 use registration;

--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -6,7 +6,7 @@
 # Package: zypper
 # Summary: Refresh repositories, apply patches and reboot
 #
-# Maintainer: qa-c <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use registration;

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -7,7 +7,7 @@
 # Summary: This tests will deploy the public cloud instance, create user,
 #   prepare ssh config and permit password login
 #
-# Maintainer: <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use publiccloud::ssh_interactive qw(select_host_console);

--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -7,7 +7,7 @@
 # python3-img-proof azure-cli
 # Summary: Install IPA tool
 #
-# Maintainer: qa-c team <qa-c@suse.de>, QE-SAP <qe-sap@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>, QE-SAP <qe-sap@suse.de>
 
 use base "opensusebasetest";
 use testapi;

--- a/tests/publiccloud/registration.pm
+++ b/tests/publiccloud/registration.pm
@@ -7,7 +7,7 @@
 # Summary: Register addons in the remote system
 #   Registration is in registercloudguest test module
 #
-# Maintainer: <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use Feature::Compat::Try;

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -6,7 +6,7 @@
 # Package: perl-base ltp
 # Summary: Use perl script to run LTP on public cloud
 #
-# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>, qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;

--- a/tests/publiccloud/sev.pm
+++ b/tests/publiccloud/sev.pm
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Test AMD-SEV
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use base 'consoletest';
 use testapi;

--- a/tests/publiccloud/slem_basic.pm
+++ b/tests/publiccloud/slem_basic.pm
@@ -5,7 +5,7 @@
 
 # Summary: Basic test of SLE Micro in public cloud
 #
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;

--- a/tests/publiccloud/slem_prepare.pm
+++ b/tests/publiccloud/slem_prepare.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Prepare SLEM on PC for testing
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;

--- a/tests/publiccloud/smoketest.pm
+++ b/tests/publiccloud/smoketest.pm
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Run basic smoketest on publiccloud test instance
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use base 'consoletest';
 use testapi;

--- a/tests/publiccloud/ssh_interactive_end.pm
+++ b/tests/publiccloud/ssh_interactive_end.pm
@@ -5,7 +5,7 @@
 
 # Summary: This test will leave the SSH interactive session, kill the SSH tunnel and destroy the public cloud instance
 #
-# Maintainer: Pavel Dostal <pdostal@suse.cz>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use publiccloud::ssh_interactive 'select_host_console';

--- a/tests/publiccloud/ssh_interactive_start.pm
+++ b/tests/publiccloud/ssh_interactive_start.pm
@@ -6,7 +6,7 @@
 # Package: openssh
 # Summary: This tests will establish the tunnel and enable the SSH interactive console
 #
-# Maintainer: qa-c@suse.de
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;

--- a/tests/publiccloud/suspending.pm
+++ b/tests/publiccloud/suspending.pm
@@ -8,7 +8,7 @@
 #
 # Test that a VM can be suspended and resumed without successfully
 #
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use Test::Assert qw(assert_equals assert_not_equals);

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -6,7 +6,7 @@
 # Package: rsync
 # Summary: Transfer repositories to the public cloud instasnce
 #
-# Maintainer: <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use registration;

--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -5,7 +5,7 @@
 
 # Summary: Testmodule to upload images to CSP
 #
-# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use base "publiccloud::basetest";
 use testapi;

--- a/tests/publiccloud/validate_repos.pm
+++ b/tests/publiccloud/validate_repos.pm
@@ -5,7 +5,7 @@
 
 # Summary: Download repositores from the internal server
 #
-# Maintainer: qa-c <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use base 'consoletest';
 use registration;

--- a/tests/publiccloud/xen.pm
+++ b/tests/publiccloud/xen.pm
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Run basic xen smoketest on a publiccloud test instance
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use base 'consoletest';
 use testapi;

--- a/tests/publiccloud/xfsprepare.pm
+++ b/tests/publiccloud/xfsprepare.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Install xfstests and prepare secondary disk
-# Maintainer: qa-c team <qa-c@suse.de>
+# Maintainer: QE-C team <qa-c@suse.de>
 
 use Mojo::Base 'consoletest';
 use testapi;


### PR DESCRIPTION
Unify the maintainer tag accross QE-C's responsability.

No functional changes, only the maintainer tag in the comment headers are updated.