### PR TITLE
bats: Increase timeout for installing packages

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -250,7 +250,7 @@ sub bats_setup {
     # We use xz to compress core files
     push @pkgs, "xz";
     @pkgs = uniq sort @pkgs;
-    run_command "zypper --gpg-auto-import-keys -n install @pkgs", timeout => 300;
+    run_command "zypper --gpg-auto-import-keys -n install @pkgs", timeout => 600;
 
     configure_oci_runtime $oci_runtime;
 


### PR DESCRIPTION
Increase timeout for installing packages.

Failing test: https://openqa.opensuse.org/tests/5342172#step/podman/47