### PR TITLE
HA/SAP: shutdown LPAR after test on PowerVM platform for SLE15

### DIFF
--- a/schedule/sles4sap/hana/pvm_hana.yaml
+++ b/schedule/sles4sap/hana/pvm_hana.yaml
@@ -36,6 +36,7 @@ schedule:
   - sles4sap/patterns
   - sles4sap/hana_install
   - sles4sap/hana_test
+  - shutdown/shutdown
 conditional_schedule:
   multipath:
     MULTIPATH:

--- a/schedule/sles4sap/hana/pvm_hana_cluster_node.yaml
+++ b/schedule/sles4sap/hana/pvm_hana_cluster_node.yaml
@@ -81,6 +81,8 @@ schedule:
   - '{{boot_to_desktop_non_init}}'
   - ha/check_after_reboot
   - ha/check_logs
+  - ha/prepare_shutdown
+  - shutdown/shutdown
 conditional_schedule:
   multipath:
     MULTIPATH:

--- a/schedule/sles4sap/installation/install_sles4sap_pvm.yaml
+++ b/schedule/sles4sap/installation/install_sles4sap_pvm.yaml
@@ -24,6 +24,7 @@ schedule:
   - installation/first_boot
   - console/system_prepare
   - '{{test_sles4sap}}'
+  - shutdown/shutdown
 conditional_schedule:
   test_sles4sap:
     TEST_SLES4SAP:


### PR DESCRIPTION
This is a followup of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/23366, adding shutdown test step for SLE15SP7 QR job groups.

- Related ticket: https://jira.suse.com/browse/TEAM-10556
- Needles: none
- Verification run:
install_sles4sap_pvm.yaml: https://openqa.suse.de/tests/19216450#step/shutdown/1
pvm_hana_cluster_node.yaml: https://openqa.suse.de/tests/19216015#step/shutdown/1
pvm_hana.yaml: only used in WDF, no corresponding job in osd. But it is similar to `install_sles4sap_pvm.yaml`, so this change should not cause trouble.