### PR TITLE
Upload logs when execute_playbooks failed

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
@@ -105,6 +105,9 @@ sub full_cleanup {
 
 sub post_fail_hook {
     my ($self, $run_args) = @_;
+    # Flag for uploading SUT losgs if sdaf_execute_playbook() failed
+    my $upload_SUT_logs = $serial_regexp_playbook;
+
     record_info('Post fail', 'Executing post fail hook');
     if (testapi::is_serial_terminal()) {
         # In case playbook/script times out, it will keep occupying the command line,
@@ -138,8 +141,8 @@ sub post_fail_hook {
     disconnect_target_from_serial if check_serial_redirection();
     az_login();
 
-    # Update logs (except deployment VM logs) before cleanup
-    if (get_required_var('TEST') !~ /_deploy_/) {
+    # Upload logs before cleanup
+    if (get_required_var('TEST') !~ /_deploy_/ || $upload_SUT_logs) {
         # Upload logs appearing in deployer VM
         record_info('Upload logs appearing in deloyer VM');
         # Prepare deployer logs path


### PR DESCRIPTION
Upload logs when execute_playbooks failed

Related ticket:
[TEAM-10644](https://jira.suse.com/browse/TEAM-10644) - Enabled SDAF HanaSR and SDAF ENSA2 Tests in Nightly Run for 15-SP7
[TEAM-10648](https://jira.suse.com/browse/TEAM-10648) - [SDAF] upload logs when execute_playbooks failed

Verification run:
 HanaSR, when execute_playbooks failed the logs are uploaded:
http://openqaworker15.qa.suse.cz/tests/343716#downloads
http://openqaworker15.qa.suse.cz/tests/343723#downloads

 ENSA2, when execute_playbooks failed the logs are uploaded:
http://openqaworker15.qa.suse.cz/tests/343717#downloads
