### PR TITLE
python_docker: ~/.docker may already exist

### DIFF
--- a/tests/containers/python_docker.pm
+++ b/tests/containers/python_docker.pm
@@ -48,7 +48,7 @@ cp ca.pem cert.pem key.pem /etc/docker/
 openssl genrsa -out key.pem 4096
 openssl req -new -key key.pem -subj "/CN=docker-client" -out client.csr
 openssl x509 -req -days 7 -sha256 -in client.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out cert.pem -extfile <(printf "extendedKeyUsage=clientAuth")
-mkdir -m 700 /root/.docker/
+mkdir -m 700 /root/.docker/ || true
 mv ca.pem cert.pem key.pem /root/.docker/
 EOF
     write_sut_file('/tmp/gencerts', $gencerts);


### PR DESCRIPTION
Do not fail when creating /root/.docker

Failing test: https://openqa.opensuse.org/tests/5345844#step/python_docker/12