### PR TITLE
podman/bats: Drop PR#26920 & 26921 for podman 5.6.1

### DIFF
--- a/data/containers/bats/skip.yaml
+++ b/data/containers/bats/skip.yaml
@@ -187,13 +187,12 @@ podman:
   # https://github.com/containers/podman/pull/26017 is needed for 030-run
   # https://github.com/containers/podman/pull/26798 is needed for 505-networking-pasta
   # https://github.com/containers/podman/pull/26920 is needed to drop ncat
+  # https://github.com/containers/podman/pull/26921 is needed to drop socat
   # https://github.com/containers/podman/pull/27152 is needed for 030-run
   opensuse-Tumbleweed:
     GITHUB_PATCHES:
     - 26017
     - 26798
-    - 26920
-    - 26921
     - 27152
     BATS_IGNORE:
     BATS_IGNORE_ROOT_LOCAL:


### PR DESCRIPTION
These patches were merged in podman 5.6.1 (now available in Tumbleweed).

While applying these patches is a idempotent operation, we want to keep a minimal reproducer.