### PR TITLE
patch_junit: Adapt prefix to OCI_RUNTIME

### DIFF
--- a/data/containers/patch_junit.py
+++ b/data/containers/patch_junit.py
@@ -15,7 +15,10 @@ from typing import Dict, List
 
 
 # Use "(root|user)-(local|remote)" prefix in testsuite based on the filename
-PREFIX = re.compile(r"-((?:root|user)(?:-(?:local|remote))?)\.xml$")
+BATS_PACKAGES = r"(?:aardvark|buildah|conmon|netavark|podman|runc|skopeo)"
+PREFIX = re.compile(
+    rf"({BATS_PACKAGES}(?:-(?:crun|runc))?(?:-(?:root|user))?(?:-(?:local|remote))?)\.xml$"
+)
 
 
 def get_xfails(args: List[str]) -> Dict[str, List[str]]:


### PR DESCRIPTION
Adapt prefix to OCI_RUNTIME.

Verification runs:
- aardvark-dns: https://openqa.opensuse.org/tests/5348071
- conmon: https://openqa.opensuse.org/tests/5348065
- runc: https://openqa.opensuse.org/tests/5348069