### PR TITLE
Support sles16 virt MU testing

### DIFF
--- a/data/virtualization/agama_virt_auto/sle_virt_default_staging.jsonnet
+++ b/data/virtualization/agama_virt_auto/sle_virt_default_staging.jsonnet
@@ -1,0 +1,94 @@
+local repo = '{{INCIDENT_REPO}}';
+local urls = if repo != '' then std.split(repo, ',') else [];
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE}}',
+    addons: []
+  },
+  bootloader: {
+    stopOnBootMenu: true,
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$0bUrc6YvA/qw$h1Z3pzadaxmc/KgcHRSEcYoU1ShVNymoXBaRAQZJ4ozVhTbCvdAMbGQrQAAX7cC9cLRybhsvDio3kBX/IB3xj/',
+    hashedPassword: true,
+    userName: 'bernhard'
+  },
+  root: {
+    password: '$6$0bUrc6YvA/qw$h1Z3pzadaxmc/KgcHRSEcYoU1ShVNymoXBaRAQZJ4ozVhTbCvdAMbGQrQAAX7cC9cLRybhsvDio3kBX/IB3xj/',
+    hashedPassword: true,
+    sshPublicKey: '{{_SECRET_RSA_PUB_KEY}}'
+  },
+  software: {
+    packages: [],
+    patterns: [
+      'base',
+      'kvm_server',
+      'kvm_tools'
+    ],
+    extraRepositories:
+      if std.length(urls) > 0 then
+        [
+          {
+            alias: 'TEST_' + std.toString(i),
+            url: urls[i],
+            allowUnsigned: true
+          }
+          for i in std.range(0, std.length(urls) -1)
+        ]
+      else
+        [],
+    onlyRequired: false
+  },
+  questions: {
+    policy: 'auto',
+    answers: [
+      {
+        answer: 'Trust',
+        class: 'software.import_gpg'
+      }
+    ]
+  },
+  scripts: {
+    post: [
+      {
+        name: 'config_ssh',
+        chroot: true,
+        content: |||
+          #!/usr/bin/env bash
+          # Configure SSH for passwordless access to guests
+          # Note: authorized_keys is already configured by Agama via root.sshPublicKey
+          
+          # 1. Setup SSH server (sshd) - configure server first
+          systemctl enable sshd
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+          sshd_config_file="/etc/ssh/sshd_config.d/01-virt-test.conf"
+          echo -e "TCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 60" > $sshd_config_file
+          
+          # 2. Setup SSH client keys and config - configure client after server
+          mkdir -p -m 700 /root/.ssh
+          
+          # Write private key (use 9A as newline placeholder, same as host_15.xml.ep)
+          cat > /root/.ssh/id_rsa << 'EOF'
+          {{_SECRET_RSA_PRIV_KEY}}
+          EOF
+          # Use perl for more reliable newline replacement (sed may have issues in some shells)
+          perl -pi -e 's/9A/\n/g' /root/.ssh/id_rsa
+          chmod 600 /root/.ssh/id_rsa
+          
+          # Write public key (for reference, Agama may have already created this)
+          echo '{{_SECRET_RSA_PUB_KEY}}' > /root/.ssh/id_rsa.pub
+          
+          # Configure SSH client settings
+          cat > /root/.ssh/config << 'EOF'
+          StrictHostKeyChecking no
+          HostKeyAlgorithms ssh-rsa,ssh-ed25519
+          PreferredAuthentications publickey,password
+          EOF
+          chmod 600 /root/.ssh/config
+        |||
+      }
+    ]
+  }
+}

--- a/data/virtualization/agama_virt_auto/sle_virt_guest_staging.jsonnet
+++ b/data/virtualization/agama_virt_auto/sle_virt_guest_staging.jsonnet
@@ -1,0 +1,80 @@
+local repo = '{{INCIDENT_REPO}}';
+local urls = if repo != '' then std.split(repo, ',') else [];
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE}}',
+    addons: []
+  },
+  bootloader: {
+    stopOnBootMenu: false,
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$0bUrc6YvA/qw$h1Z3pzadaxmc/KgcHRSEcYoU1ShVNymoXBaRAQZJ4ozVhTbCvdAMbGQrQAAX7cC9cLRybhsvDio3kBX/IB3xj/',
+    hashedPassword: true,
+    userName: 'bernhard'
+  },
+  root: {
+    password: '$6$0bUrc6YvA/qw$h1Z3pzadaxmc/KgcHRSEcYoU1ShVNymoXBaRAQZJ4ozVhTbCvdAMbGQrQAAX7cC9cLRybhsvDio3kBX/IB3xj/',
+    hashedPassword: true,
+    sshPublicKey: '{{_SECRET_RSA_PUB_KEY}}'
+  },
+  software: {
+    packages: [],
+    patterns: [
+      'base'
+    ],
+    extraRepositories:
+      if std.length(urls) > 0 then
+        [
+          {
+            alias: 'TEST_' + std.toString(i),
+            url: urls[i],
+            allowUnsigned: true
+          }
+          for i in std.range(0, std.length(urls) -1)
+        ]
+      else
+        [],
+    onlyRequired: false
+  },
+  questions: {
+    policy: 'auto',
+    answers: [
+      {
+        answer: 'Trust',
+        class: 'software.import_gpg'
+      }
+    ]
+  },
+  scripts: {
+    post: [
+      {
+        name: 'setup_sshd',
+        chroot: true,
+        content: |||
+          #!/usr/bin/env bash
+          systemctl enable sshd
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+          sshd_config_file="/etc/ssh/sshd_config.d/01-virt-test.conf"
+          echo -e "TCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 60" > $sshd_config_file
+        |||
+      },
+      {
+        name: 'report_ip_address',
+        chroot: false,
+        content: |||
+          #!/usr/bin/env bash
+          # Report IP address to test host using guest name
+          # Try eth0 first (most common), then fallback to first available interface
+          ip a | grep eth0 | grep -Po '(?<=inet )[\d.]+' > /root/{{GUEST}} || \
+          ip -4 addr show | grep -E "inet.*scope global" | head -1 | grep -Po '(?<=inet )[\d.]+' > /root/{{GUEST}}
+          logger "SLES16 Guest {{GUEST}} IP is written into file: $(cat /root/{{GUEST}} 2>/dev/null || echo 'FAILED')"
+          curl -k -u root:{{PASS}} -T /root/{{GUEST}} sftp://{{SUT_IP}}/tmp/guests_ip/ --ftp-create-dirs
+          exit 0
+        |||
+      }
+    ]
+  }
+}

--- a/data/virtualization/autoyast/guest_12.xml.ep
+++ b/data/virtualization/autoyast/guest_12.xml.ep
@@ -333,7 +333,7 @@
 #!/bin/bash
 mkdir -p -m 700 /root/.ssh
 echo <%= $get_var->('_SECRET_RSA_PUB_KEY') %> >> /root/.ssh/authorized_keys
-chmod 600 /root/.ssh/authorized_key
+chmod 600 /root/.ssh/authorized_keys
 cat > /etc/init.d/after.local<< EOF
 #!/bin/sh
 ip a | grep eth0 | grep -Po '(?<=inet )[\d.]+' > /root/$(hostname)

--- a/data/virtualization/autoyast/guest_15.xml.ep
+++ b/data/virtualization/autoyast/guest_15.xml.ep
@@ -353,7 +353,7 @@
 #!/bin/bash
 mkdir -p -m 700 /root/.ssh
 echo <%= $get_var->('_SECRET_RSA_PUB_KEY') %> >> /root/.ssh/authorized_keys
-chmod 600 /root/.ssh/authorized_key
+chmod 600 /root/.ssh/authorized_keys
 ]]></source>
 </script>
 <script>

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -97,6 +97,7 @@ our @EXPORT = qw(
   load_virtualization_tests
   load_x11tests
   load_hypervisor_tests
+  load_sles16_mu_virt_tests
   load_yast2_gui_tests
   load_zdup_tests
   logcurrentenv
@@ -111,6 +112,7 @@ our @EXPORT = qw(
   rescuecdstep_is_applicable
   set_defaults_for_username_and_password
   set_mu_virt_vars
+  set_sles16_mu_virt_vars
   setup_env
   snapper_is_applicable
   ssh_key_import
@@ -2411,6 +2413,70 @@ sub check_and_load_mu_virt_features {
     }
 }
 
+sub get_virt_features_definition {
+    # Common virtualization features definition shared between load_hypervisor_tests and load_sles16_mu_virt_tests
+    return (
+        ENABLE_SAVE_AND_RESTORE => {
+            modules => ['virtualization/universal/save_and_restore'],
+        },
+        ENABLE_GUEST_MANAGEMENT => {
+            modules => ['virtualization/universal/guest_management'],
+        },
+        ENABLE_FINAL => {
+            modules => ['virtualization/universal/ssh_final', 'virtualization/universal/virtmanager_final', 'virtualization/universal/smoketest', 'virtualization/universal/stresstest', 'console/perf'],
+        },
+        ENABLE_STORAGE => {
+            modules => ['virtualization/universal/storage'],
+        },
+        ENABLE_WINDOWS => {
+            modules => ['virtualization/universal/download_image', 'virtualization/universal/windows'],
+        },
+        ENABLE_DOM_METRICS => {
+            modules => ['virtualization/universal/virsh_stop', 'virtualization/universal/xl_create', 'virtualization/universal/dom_install', 'virtualization/universal/dom_metrics', 'virtualization/universal/xl_stop', 'virtualization/universal/virsh_start'],
+            hypervisor => 'xen',
+        },
+        ENABLE_IRQBALANCE => {
+            modules => ['virt_autotest/xen_guest_irqbalance'],
+            hypervisor => 'xen',
+        },
+        ENABLE_VIR_NET => {
+            modules => ['virt_autotest/libvirt_host_bridge_virtual_network', 'virt_autotest/libvirt_nated_virtual_network', 'virt_autotest/libvirt_isolated_virtual_network'],
+        },
+        ENABLE_NATED_VIR_NET => {
+            modules => ['virt_autotest/libvirt_nated_virtual_network'],
+        },
+        ENABLE_VIRTMANAGER => {
+            modules => ['virtualization/universal/virtmanager_init', 'virtualization/universal/virtmanager_offon', 'virtualization/universal/virtmanager_add_devices', 'virtualization/universal/virtmanager_rm_devices'],
+        },
+        ENABLE_HOTPLUGGING => {
+            modules => ['virtualization/universal/hotplugging_guest_preparation', 'virtualization/universal/hotplugging_network_interfaces', 'virtualization/universal/hotplugging_HDD', 'virtualization/universal/hotplugging_vCPUs', 'virtualization/universal/hotplugging_memory', 'virtualization/universal/hotplugging_cleanup'],
+        },
+        ENABLE_SNAPSHOTS => {
+            modules => ['virt_autotest/virsh_internal_snapshot', 'virt_autotest/virsh_external_snapshot'],
+            hypervisor => 'kvm',
+        },
+        ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH => {
+            modules => ['virt_autotest/sriov_network_card_pci_passthrough'],
+        },
+        ENABLE_SEV_SNP => {
+            modules => ['virt_autotest/sev_snp_validation'],
+        },
+    );
+}
+
+sub load_guest_migration_tests {
+    # Common guest migration tests logic shared between hypervisor test functions
+    if (check_var('VIRT_NEW_GUEST_MIGRATION_SOURCE', '1')) {
+        loadtest "virt_autotest/login_console";
+        loadtest "virt_autotest/parallel_guest_migration_source";
+    }
+    if (check_var('VIRT_NEW_GUEST_MIGRATION_DST', '1')) {
+        loadtest "virt_autotest/parallel_guest_migration_barrier";
+        loadtest "virt_autotest/login_console";
+        loadtest "virt_autotest/parallel_guest_migration_destination";
+    }
+}
+
 sub load_host_installation_modules {
     loadtest "installation/welcome";
     loadtest "installation/scc_registration";
@@ -2528,6 +2594,78 @@ sub set_mu_virt_vars {
     bmwqemu::save_vars();
 }
 
+sub set_sles16_mu_virt_vars {
+    # SLES16 MU testing only supports staging mode
+    # - FLAVOR contains "staging" AND INCIDENT_REPO is set → Staging mode
+
+    if (get_var('FLAVOR', '') =~ /staging/i && get_var('INCIDENT_REPO')) {
+        # Staging mode: Use dedicated virt staging profile for KVM patterns
+        set_var('INST_AUTO', 'virtualization/agama_virt_auto/sle_virt_default_staging.jsonnet');
+        diag("Staging mode detected (FLAVOR contains staging and INCIDENT_REPO is set): using virtualization/agama_virt_auto/sle_virt_default_staging.jsonnet for installation");
+    } else {
+        # No valid mode detected, exit test immediately
+        die("SLES16 MU test requires staging mode - FLAVOR must contain 'staging' with INCIDENT_REPO set");
+    }
+
+    # Parse BUILD variable and set UPDATE_PACKAGE (format example: BUILD=:345:qemu)
+    # This logic is the same as set_mu_virt_vars() to maintain consistency
+    if (!get_var('UPDATE_PACKAGE') && (my $BUILD = get_var('BUILD'))) {
+        $BUILD =~ /^:(\d+):([^:]+)$/im;
+        die "BUILD value is $BUILD, but does not match required format." unless $2;
+
+        set_var('UPDATE_PACKAGE', $2);
+        diag("BUILD is $BUILD, UPDATE_PACKAGE is set to " . get_var('UPDATE_PACKAGE', ''));
+    }
+
+    # Parse and set the target package for host installation verification
+    # Package name transformation logic (same as SLES12/15 MU testing)
+    my $_pkg = get_var('UPDATE_PACKAGE', '');
+    my $_update_package = '';
+
+    if ($_pkg) {
+        if ($_pkg =~ /none/) {
+            # 'none' is for ease of functional testing when no package update is needed
+            $_update_package = '';
+        } elsif ($_pkg =~ /qemu|virt-manager|libguestfs|libslirp|open-vm-tools|snphost|dnsmasq/) {
+            # Direct package name usage (SLES16 currently supports KVM/QEMU only)
+            $_update_package = $_pkg;
+        } elsif ($_pkg =~ /snpguest/) {
+            # SNP guest testing requires patching workflow
+            $_update_package = $_pkg;
+            set_var('PATCH_ON_GUEST', 1);
+        } elsif ($_pkg =~ /libvirt/) {
+            # Special case: libvirt maps to libvirt-client
+            $_update_package = 'libvirt-client';
+        } elsif ($_pkg =~ /xen/) {
+            # Xen support will return in SLES16.2
+            die "Xen testing is not supported in SLES16 (will return in SLES16.2)";
+        } else {
+            # Default to kernel-default for other cases
+            $_update_package = 'kernel-default';
+            set_var('PATCH_ON_GUEST', 1);
+        }
+
+        # Set the parsed package name for later use in test modules
+        set_var('UPDATE_PACKAGE', $_update_package) if $_update_package;
+        diag("SLES16 MU: UPDATE_PACKAGE is set to $_update_package") if $_update_package;
+    }
+
+    # Set SLES16 guest configuration variables
+    my $install_type = get_var('SLES16_MU_INSTALL_TYPE', 'online');
+
+    set_var('SLES16_MU_TEST_MODE', 'staging');
+    set_var('SLES16_MU_INSTALL_TYPE', $install_type);
+
+    set_var('ENABLE_HOST_INSTALLATION', '1') unless get_var('ENABLE_HOST_INSTALLATION');
+    set_var('ENABLE_VM_INSTALL', '1') unless get_var('ENABLE_VM_INSTALL');
+
+    diag("SLES16 MU variables configured: test_mode=staging, install_type=$install_type, host_install=" .
+          get_var('ENABLE_HOST_INSTALLATION') . ", vm_install=" . get_var('ENABLE_VM_INSTALL'));
+
+    # Save vars
+    bmwqemu::save_vars();
+}
+
 sub load_hypervisor_tests {
     return unless (get_var('HOST_HYPERVISOR') =~ /xen|kvm|qemu/);
 
@@ -2568,53 +2706,7 @@ sub load_hypervisor_tests {
         loadtest "virtualization/universal/finish";
     }
 
-    my %virt_features = (
-        ENABLE_SAVE_AND_RESTORE => {
-            modules => ['virtualization/universal/save_and_restore'],
-        },
-        ENABLE_GUEST_MANAGEMENT => {
-            modules => ['virtualization/universal/guest_management'],
-        },
-        ENABLE_FINAL => {
-            modules => ['virtualization/universal/ssh_final', 'virtualization/universal/virtmanager_final', 'virtualization/universal/smoketest', 'virtualization/universal/stresstest', 'console/perf'],
-        },
-        ENABLE_STORAGE => {
-            modules => ['virtualization/universal/storage'],
-        },
-        ENABLE_WINDOWS => {
-            modules => ['virtualization/universal/download_image', 'virtualization/universal/windows'],
-        },
-        ENABLE_DOM_METRICS => {
-            modules => ['virtualization/universal/virsh_stop', 'virtualization/universal/xl_create', 'virtualization/universal/dom_install', 'virtualization/universal/dom_metrics', 'virtualization/universal/xl_stop', 'virtualization/universal/virsh_start'],
-            hypervisor => 'xen',
-        },
-        ENABLE_IRQBALANCE => {
-            modules => ['virt_autotest/xen_guest_irqbalance'],
-            hypervisor => 'xen',
-        },
-        ENABLE_VIR_NET => {
-            modules => ['virt_autotest/libvirt_host_bridge_virtual_network', 'virt_autotest/libvirt_nated_virtual_network', 'virt_autotest/libvirt_isolated_virtual_network'],
-        },
-        ENABLE_NATED_VIR_NET => {
-            modules => ['virt_autotest/libvirt_nated_virtual_network'],
-        },
-        ENABLE_VIRTMANAGER => {
-            modules => ['virtualization/universal/virtmanager_init', 'virtualization/universal/virtmanager_offon', 'virtualization/universal/virtmanager_add_devices', 'virtualization/universal/virtmanager_rm_devices'],
-        },
-        ENABLE_HOTPLUGGING => {
-            modules => ['virtualization/universal/hotplugging_guest_preparation', 'virtualization/universal/hotplugging_network_interfaces', 'virtualization/universal/hotplugging_HDD', 'virtualization/universal/hotplugging_vCPUs', 'virtualization/universal/hotplugging_memory', 'virtualization/universal/hotplugging_cleanup'],
-        },
-        ENABLE_SNAPSHOTS => {
-            modules => ['virt_autotest/virsh_internal_snapshot', 'virt_autotest/virsh_external_snapshot'],
-            hypervisor => 'kvm',
-        },
-        ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH => {
-            modules => ['virt_autotest/sriov_network_card_pci_passthrough'],
-        },
-        ENABLE_SEV_SNP => {
-            modules => ['virt_autotest/sev_snp_validation'],
-        },
-    );
+    my %virt_features = get_virt_features_definition();
 
     for my $test (keys %virt_features) {
         next if $test eq 'ENABLE_SNAPSHOTS';
@@ -2634,16 +2726,104 @@ sub load_hypervisor_tests {
     # Load ENABLE_SNAPSHOTS at the end
     check_and_load_mu_virt_features('ENABLE_SNAPSHOTS', $virt_features{ENABLE_SNAPSHOTS}{modules}, $virt_features{ENABLE_SNAPSHOTS}{hypervisor});
 
-    # Guest migration tests
-    if (check_var('VIRT_NEW_GUEST_MIGRATION_SOURCE', '1')) {
+    # Guest migration tests - use common function
+    load_guest_migration_tests();
+}
+
+sub load_sles16_mu_virt_tests {
+    # Currently only KVM/QEMU supported with Agama installer
+    # Xen testing will return in SLES16.2
+    return unless (get_var('HOST_HYPERVISOR') =~ /xen|kvm|qemu/);
+
+    diag("SLES16 MU Virt: Loading SLES16 MU virtualization test suite (staging mode only)");
+
+    # Set SLES16 MU virtualization variables
+    set_sles16_mu_virt_vars();
+
+    # Host installation phase
+    if (check_var('ENABLE_HOST_INSTALLATION', 1)) {
+        # Load SLES16 host installation sequence
+        if (get_var("IPXE")) {
+            loadtest "installation/ipxe_install";
+        }
+        loadtest "installation/agama_reboot";
         loadtest "virt_autotest/login_console";
-        loadtest "virt_autotest/parallel_guest_migration_source";
+        loadtest "installation/bridge_br0";
+        # For SLES16 MU tests, repositories are already configured during agama installation
+        # Run zypper_lr to verify installed repositories
+        loadtest "console/zypper_lr";
+        # Host always needs package installation check and install if missing
+        loadtest "virtualization/universal/install_update_package";
+
     }
-    if (check_var('VIRT_NEW_GUEST_MIGRATION_DST', '1')) {
-        loadtest "virt_autotest/parallel_guest_migration_barrier";
+
+    # Guest installation phase
+    if (check_var('ENABLE_VM_INSTALL', 1)) {
         loadtest "virt_autotest/login_console";
-        loadtest "virt_autotest/parallel_guest_migration_destination";
+        # Skip guest installation for migration destination - guests will be migrated from source
+        unless (check_var('VIRT_NEW_GUEST_MIGRATION_DST', '1')) {
+            # Parallel guest installation using the enhanced prepare_guests
+            loadtest "virtualization/universal/prepare_guests";
+            # Wait for all guest installations to complete
+            loadtest "virtualization/universal/waitfor_guests";
+        }
+
+        # Guest patching workflow (controlled by PATCH_ON_GUEST)
+        # Skip patching for migration destination - no guests installed yet
+        unless (check_var('VIRT_NEW_GUEST_MIGRATION_DST', '1')) {
+            if (check_var('PATCH_ON_GUEST', 1)) {
+                my $update_pkg = get_var('UPDATE_PACKAGE', '');
+                if ($update_pkg) {
+                    loadtest "virt_autotest/login_console";
+                    loadtest "virtualization/universal/list_guests";
+                    loadtest "virtualization/universal/patch_guests";
+                }
+            }
+            loadtest "virtualization/universal/finish";
+        }
     }
+
+    # SLES16 MU Virtualization Features Support
+    # Features are loaded after basic guest installation and patching
+    my %virt_features = get_virt_features_definition();
+
+    # Process virtualization features - skip SNAPSHOTS for now, load it at the end
+    for my $test (keys %virt_features) {
+        next if $test eq 'ENABLE_SNAPSHOTS';
+        my $feature = $virt_features{$test};
+        my $modules = $feature->{modules};
+        my $hypervisor = $feature->{hypervisor};
+
+        # SLES16 specific feature restrictions
+        # Skip Xen-specific features as Xen support returns in SLES16.2
+        if ($hypervisor && $hypervisor eq 'xen') {
+            diag("SLES16 MU: Skipping Xen feature $test (Xen support returns in SLES16.2)");
+            next;
+        }
+
+        # SRIOV tests - keep same version restrictions as original
+        if ($test eq 'ENABLE_SRIOV_NETWORK_CARD_PCI_PASSTHROUGH') {
+            next unless is_sle('>=15-sp3');
+        }
+
+        # SEV-SNP tests are available from SLE15-SP7 onwards and SLE16+
+        if ($test eq 'ENABLE_SEV_SNP') {
+            next unless (is_sle('>=15-sp7') || is_sle('>=16'));
+        }
+
+        # Load the feature using existing function
+        check_and_load_mu_virt_features($test, $modules, $hypervisor);
+    }
+
+    # Load ENABLE_SNAPSHOTS at the end (KVM only, supported in SLES16)
+    if (get_var('HOST_HYPERVISOR') =~ /kvm|qemu/) {
+        check_and_load_mu_virt_features('ENABLE_SNAPSHOTS', $virt_features{ENABLE_SNAPSHOTS}{modules}, $virt_features{ENABLE_SNAPSHOTS}{hypervisor});
+    }
+
+    # Guest migration tests support - independent of ENABLE_VM_INSTALL - use common function
+    load_guest_migration_tests();
+
+    diag("SLES16 MU Loaded: Test suite loaded for staging mode with features support");
 }
 
 sub load_extra_tests_syscontainer {

--- a/lib/virt_autotest/common.pm
+++ b/lib/virt_autotest/common.pm
@@ -232,6 +232,21 @@ if (get_var("REGRESSION", '') =~ /xen/) {
             distro => 'SLE_15',
             location => 'http://mirror.suse.cz/install/SLP/SLE-15-SP7-Full-GM/x86_64/DVD1/',
             boot_firmware => 'efi',    # EFI version of SLES 15 SP7
+        },
+        sles16efi_online => {
+            name => 'sles16efi_online',
+            extra_params => '--os-variant sles16',    # Use SLES16 variant
+            distro => 'SLE_16',
+            iso_url => 'http://openqa.suse.de/assets/iso/SLES-16.0-Online-x86_64-Build135.5.install.iso',    # ISO download URL
+            boot_firmware => 'efi',    # SLES16 only supports EFI guests, no BIOS support
+        },
+        sles16efi_full => {
+            name => 'sles16efi_full',
+            extra_params => '--os-variant sles16',    # Use SLES16 variant
+            distro => 'SLE_16',
+            location => 'http://openqa.suse.de/assets/repo/SLES-16.0-Full-x86_64-Build135.5.install/',    # Network location for live OS
+            install_url => 'http://openqa.suse.de/assets/repo/SLES-16.0-x86_64-Build135.5/',    # Install repository URL
+            boot_firmware => 'efi',    # SLES16 only supports EFI guests, no BIOS support
         }
     );
     # Filter out guests not allowed for the detected SLE version
@@ -276,6 +291,13 @@ if (get_var("REGRESSION", '') =~ /xen/) {
         if (check_var('ENABLE_SEV_SNP', '1')) {
             @allowed_guests = qw(sles15sp6efi sles15sp7efi);
         }
+        foreach my $guest (keys %guests) {
+            delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
+        }
+    } elsif (is_sle('>=16')) {
+        # SLES16+ support - only EFI guests are supported, no BIOS guests
+        my @allowed_guests = qw(sles15sp7 sles15sp7efi sles16efi_online sles16efi_full);
+        # Both online and full installation types supported for SLES16 EFI guests
         foreach my $guest (keys %guests) {
             delete $guests{$guest} unless grep { $_ eq $guest } @allowed_guests;
         }

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -39,6 +39,7 @@ our @EXPORT = qw(
   is_xen_host
   is_kvm_host
   is_sles_mu_virt_test
+  is_sles16_mu_virt_test
   is_monolithic_libvirtd
   turn_on_libvirt_debugging_log
   restart_libvirtd
@@ -190,9 +191,15 @@ sub is_hyperv_virtualization {
     return get_var("REGRESSION", '') =~ /hyperv/;
 }
 
-# Return 1 if it is SLES MU virt test, otherwise return 0
+# Return 1 if it is SLES MU virt test (SLES15 and earlier), otherwise return 0
 sub is_sles_mu_virt_test {
-    return is_sle && get_var('REGRESSION', '') =~ /xen|kvm|qemu|hyperv|vmware/ && !get_var("VIRT_AUTOTEST");
+    return is_sle && !is_sle('>=16') && get_var('REGRESSION', '') =~ /xen|kvm|qemu|hyperv|vmware/ && !get_var("VIRT_AUTOTEST");
+}
+
+# Return 1 if it is SLES16 MU virt test, otherwise return 0
+sub is_sles16_mu_virt_test {
+    return is_sle('>=16') && get_var('REGRESSION', '') =~ /xen|kvm|qemu|hyperv|vmware/ && !get_var("VIRT_AUTOTEST");
+    # Note: Xen will be tested from SLES16.2
 }
 
 #return 1 if it is a fv guest judging by name
@@ -577,6 +584,8 @@ sub create_guest {
 
     my $name = $guest->{name};
     my $location = $guest->{location};
+    my $iso_url = $guest->{iso_url};
+    my $install_url = $guest->{install_url};
     my $autoyast = $guest->{autoyast};
     my $macaddress = $guest->{macaddress};
     my $on_reboot = $guest->{on_reboot} // "restart";    # configurable on_reboot policy
@@ -589,18 +598,115 @@ sub create_guest {
     my $extra_args = get_var("VIRTINSTALL_EXTRA_ARGS", "") . " " . get_var("VIRTINSTALL_EXTRA_ARGS_" . uc($name), "");
     $extra_args = trim($extra_args);
 
+    # Handle installation method: SLES16 online uses ISO download, sle16 full use network location too
+    my $install_method = "location";    # Default to network installation (preserves SLES12/15 behavior)
+    my $install_source = $location;    # Default source (preserves SLES12/15 behavior)
+
+    # SLES16-specific ISO download logic (only when all conditions are met)
+    # Simplified SLES16 installation configuration
+    if (is_sles16_mu_virt_test() &&
+        $name =~ /sles16/i &&
+        $guest->{distro} && $guest->{distro} eq 'SLE_16') {
+
+        # For SLES16, determine installation method based on available configuration
+        if (defined($iso_url)) {
+            # Try ISO download and extraction for --install method
+            my $local_iso_path = download_installation_iso($iso_url);
+            my $extract_result = $local_iso_path ? extract_kernel_initrd_from_iso($local_iso_path, $name) : undef;
+
+            if ($extract_result) {
+                $install_method = "install";
+                $install_source = $extract_result;
+                record_info("SLES16 Install", "Using --install method with extracted kernel/initrd");
+            } else {
+                my $error_msg = $local_iso_path ? "Kernel extraction failed" : "ISO download failed";
+                record_info("SLES16 Error", "$error_msg for online installation", result => 'fail');
+                die "SLES16 guest $name: $error_msg. Online installation cannot proceed.";
+            }
+        } elsif (defined($location)) {
+            # Use network location (full installation tree)
+            $install_method = "location";
+            $install_source = $location;
+            record_info("SLES16 Network", "Using network location: $location");
+        } else {
+            die "SLES16 guest $name requires either iso_url or location to be defined";
+        }
+    }
+
     if ($method eq 'virt-install') {
         send_key 'ret';    # Make some visual separator
 
         # Run unattended installation for selected guest
-        my ($autoyastURL, $diskformat, $virtinstall);
-        $autoyastURL = $autoyast;
+        my ($autoinstall_url, $diskformat, $virtinstall);
+        $autoinstall_url = $autoyast;    # Can be autoyast XML or Agama jsonnet URL
         $diskformat = get_var("VIRT_QEMU_DISK_FORMAT") // "qcow2";
-        $extra_args = "autoyast=$autoyastURL $extra_args";
+
+        # For SLES16 MU virtualization tests, use inst.auto instead of autoyast parameter (Agama format)
+        if (is_sles16_mu_virt_test() && $name =~ /sles16/i) {
+            # SLES16 uses Agama installer - adjust parameters based on installation method
+            my $sles16_args = "inst.auto=$autoinstall_url";
+
+            if ($install_method eq "install") {
+                # ISO installation: use inst.finish=reboot for automatic restart
+                $sles16_args .= " inst.finish=reboot";
+            } elsif ($install_method eq "location") {
+                # Network installation: add live root and install_url parameters (matching reference)
+                $sles16_args .= " root=live:$install_source/LiveOS/squashfs.img";
+                # Use install_url from guest configuration if available
+                if (defined($install_url)) {
+                    $sles16_args .= " inst.install_url=$install_url";
+                }
+                $sles16_args .= " inst.finish=reboot";
+            }
+
+            # Combine with existing extra_args from environment variables
+            $extra_args = "$sles16_args $extra_args";
+            my $method_info = $install_method eq "install" ? "ISO with inst.finish=reboot" : "network with install source";
+            record_info("SLES16 Guest", "Creating SLES16 guest with Agama inst.auto ($method_info)");
+        } else {
+            # Traditional guests use autoyast
+            $extra_args = "autoyast=$autoinstall_url $extra_args";
+        }
         $extra_args = trim($extra_args);
         $virtinstall = "virt-install $v_type $guest->{osinfo} --name $name --vcpus=$vcpus,maxvcpus=$maxvcpus --memory=$memory,maxmemory=$maxmemory --vnc";
         $virtinstall .= " --disk path=/var/lib/libvirt/images/$name.$diskformat,size=20,format=$diskformat --noautoconsole";
-        $virtinstall .= " --network bridge=br0 --autostart --location=$location --wait -1";
+        $virtinstall .= " --network bridge=br0 --autostart";
+
+        # Add installation source based on method
+        if ($install_method eq "cdrom") {
+            $virtinstall .= " --cdrom $install_source";
+            record_info("Install Method", "Using CD-ROM installation: $install_source");
+        } elsif ($install_method eq "install") {
+            # Use --install method with extracted kernel and initrd
+            my $kernel_path = $install_source->{kernel};
+            my $initrd_path = $install_source->{initrd};
+            my $iso_path = $install_source->{iso_path};
+
+            $virtinstall .= " --install kernel=$kernel_path,initrd=$initrd_path";
+
+            # For SLES16, add root=live: parameter using squashfs.img URL instead of full ISO
+            if (is_sles16_mu_virt_test() && $name =~ /sles16/i && defined($iso_url)) {
+                # Convert ISO URL to squashfs.img URL for better memory efficiency
+                my $squashfs_url = $iso_url;
+                $squashfs_url =~ s/\/iso\//\/repo\//;    # Change /iso/ to /repo/
+                $squashfs_url =~ s/\.iso$/\/LiveOS\/squashfs.img/;    # Replace .iso with /LiveOS/squashfs.img
+                $extra_args = "root=live:$squashfs_url $extra_args";
+                record_info("SLES16 Root Live", "Added root=live parameter with squashfs.img: $squashfs_url");
+            }
+
+            record_info("Install Method", "Using --install with kernel: $kernel_path, initrd: $initrd_path");
+        } else {
+            # For SLES16 network installation, use format with explicit kernel/initrd paths
+            if (is_sles16_mu_virt_test() && $name =~ /sles16/i) {
+                $virtinstall .= " --location $install_source,kernel=boot/x86_64/loader/linux,initrd=boot/x86_64/loader/initrd";
+                record_info("Install Method", "Using SLES16 network location with explicit kernel/initrd");
+            } else {
+                $virtinstall .= " --location=$install_source";
+                record_info("Install Method", "Using network location: $install_source");
+            }
+        }
+
+        $virtinstall .= " --wait -1";
         # Configure boot firmware based on guest configuration
         if ($guest->{boot_firmware} && $guest->{boot_firmware} eq 'efi') {
             $virtinstall .= " --boot firmware=efi";
@@ -691,9 +797,11 @@ sub ensure_online {
             if (script_run("ssh $guest ip r s | grep default") != 0) {
                 assert_script_run("ssh $guest ip r a default via $hypervisor");
             }
-            # Check if we can ping hypervizor from the guest
+            # Check if we can ping hypervisor/gateway from the guest (dynamic gateway detection for bridged networking)
             unless ($skip_ping == 1) {
-                die "Pinging hypervisor failed for $guest" if (script_retry("ssh $guest ping -c 3 $hypervisor", delay => 1, retry => 10, timeout => 90) != 0);
+                # For bridged networking, use guest's actual default gateway instead of hardcoded hypervisor IP
+                my $gateway_test = "ssh $guest 'ping -c 3 \$(ip route | grep default | awk \"{print \\\$3}\" | head -1)' 2>/dev/null || ssh $guest ping -c 3 $hypervisor";
+                die "Pinging gateway/hypervisor failed for $guest" if (script_retry($gateway_test, delay => 1, retry => 10, timeout => 90) != 0);
             }
             # Check also if name resolution works - restart libvirtd if not
             if (script_run("ssh $guest ping -c 3 -w 120 $dns_host", timeout => 180) != 0) {
@@ -1643,6 +1751,114 @@ sub check_kvm_modules {
         }
     }
     record_info("KVM", "kvm modules are loaded!");
+}
+
+sub extract_kernel_initrd_from_iso {
+    my ($iso_path, $guest_name) = @_;
+
+    my $extract_dir = "/var/lib/libvirt/images/${guest_name}";
+    my $mount_point = "/mnt/iso_extract_$$";
+
+    # Create directories and mount ISO
+    script_run("mkdir -p $extract_dir $mount_point");
+    if (script_run("mount -o loop,ro '$iso_path' $mount_point") != 0) {
+        record_info("ISO Mount Failed", "Cannot mount ISO: $iso_path", result => 'fail');
+        script_run("rmdir $mount_point");
+        return undef;
+    }
+
+    # SLES16 specific paths
+    my %files = (
+        kernel => "boot/x86_64/loader/linux",
+        initrd => "boot/x86_64/loader/initrd"
+    );
+
+    # Extract both files in one operation
+    my $success = 1;
+    for my $type (keys %files) {
+        my $src = "$mount_point/$files{$type}";
+        my $dst_name = ($type eq 'kernel') ? 'linux' : $type;    # Keep 'linux' naming for kernel
+        my $dst = "$extract_dir/$dst_name";
+
+        if (script_run("cp '$src' '$dst'") != 0) {
+            record_info("Extract Failed", "Cannot copy $type from ISO", result => 'fail');
+            $success = 0;
+            last;
+        }
+    }
+
+    # Cleanup mount
+    script_run("umount $mount_point && rmdir $mount_point");
+
+    return $success ? {
+        kernel => "$extract_dir/linux",
+        initrd => "$extract_dir/initrd",
+        iso_path => $iso_path
+    } : undef;
+}
+
+=head2 download_installation_iso
+
+Download installation ISO to local directory with caching and error handling.
+Based on existing download_vm_import_disks pattern with proper retry logic.
+
+    my $local_path = download_installation_iso($iso_url, $target_dir);
+
+Returns local path on success, undef on failure.
+
+=cut
+
+sub download_installation_iso {
+    my ($iso_url, $target_dir) = @_;
+
+    $target_dir //= "/var/lib/libvirt/images";
+
+    # Validate URL accessibility first (same as download_vm_import_disks)
+    unless (head($iso_url)) {
+        record_info("ISO URL Check Failed", "URL is not accessible: $iso_url", result => 'softfail');
+        return undef;
+    }
+
+    # Extract filename from URL
+    my $iso_filename = basename($iso_url);
+    my $local_iso_path = "$target_dir/$iso_filename";
+
+    # Create target directory if needed
+    script_run("mkdir -p $target_dir");
+
+    # Check if ISO already exists locally
+    if (script_run("test -f $local_iso_path") == 0) {
+        record_info("ISO Cache Hit", "Using existing ISO: $local_iso_path");
+        return $local_iso_path;
+    }
+
+    # Check available disk space before download
+    my $available_space = script_output("df -BM $target_dir | tail -1 | awk '{print \$4}' | sed 's/M//'");
+    record_info("ISO Download", "Downloading $iso_url to $local_iso_path (Available space: ${available_space}MB)");
+
+    # Download ISO using retry logic (same pattern as download_vm_import_disks)
+    my $download_cmd = "curl -L --connect-timeout 60 --max-time 1800 '$iso_url' -o '$local_iso_path'";
+
+    my $download_success = eval {
+        script_retry($download_cmd, retry => 2, delay => 10, timeout => 1800, die => 1);
+        return 1;
+    };
+
+    if ($download_success && script_run("test -f $local_iso_path") == 0) {
+        # Verify downloaded file is not empty
+        my $file_size = script_output("stat -c%s '$local_iso_path'");
+        if ($file_size > 1024) {    # At least 1KB
+            record_info("ISO Download Success", "Downloaded $iso_filename ($file_size bytes)");
+            return $local_iso_path;
+        } else {
+            record_info("ISO Download Failed", "Downloaded file is too small: $file_size bytes", result => 'softfail');
+            script_run("rm -f '$local_iso_path'");    # Clean up invalid file
+        }
+    } else {
+        record_info("ISO Download Failed", "Download command failed for: $iso_url", result => 'softfail');
+    }
+
+    return undef;
 }
 
 1;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -24,7 +24,7 @@ use main_publiccloud;
 use main_security;
 use Utils::Architectures;
 use DistributionProvider;
-use virt_autotest::utils qw(is_registered_sles is_sles_mu_virt_test);
+use virt_autotest::utils qw(is_registered_sles is_sles_mu_virt_test is_sles16_mu_virt_test);
 
 BEGIN {
     unshift @INC, dirname(__FILE__) . '/../../lib';
@@ -655,11 +655,7 @@ testapi::set_distribution(DistributionProvider->provide());
 $testapi::distri->set_expected_serial_failures(create_list_of_serial_failures());
 $testapi::distri->set_expected_autoinst_failures(create_list_of_autoinst_failures());
 
-# Do it only for SLES MU virt test before loadtest
-if (is_sles_mu_virt_test) {
-    set_mu_virt_vars;
-    diag "Set necessary variables for SLES MU virtualization test before loadtest is done!";
-}
+
 
 if (load_yaml_schedule) {
     if (YuiRestClient::is_libyui_rest_api) {
@@ -705,7 +701,21 @@ elsif (get_var("NFV")) {
 }
 elsif (get_var("REGRESSION")) {
     load_common_x11;
-    load_hypervisor_tests if (get_var("REGRESSION") =~ /xen|kvm|qemu/);
+    if (get_var("REGRESSION") =~ /xen|kvm|qemu/) {
+        # Check if it's SLES16 MU virtualization test
+        if (is_sles16_mu_virt_test) {
+            # SLES16 MU virtualization specific logic
+            set_sles16_mu_virt_vars;
+            load_sles16_mu_virt_tests;
+        } elsif (is_sles_mu_virt_test) {
+            # Traditional SLES MU virtualization logic (SLES15 and earlier)
+            set_mu_virt_vars;
+            load_hypervisor_tests;
+        } else {
+            # Standard hypervisor tests logic - should not reach here for MU tests
+            die "Unexpected virtualization test configuration: neither SLES16 MU nor traditional SLES MU test detected";
+        }
+    }
     load_suseconnect_tests if check_var("REGRESSION", "suseconnect");
     load_yast2_registration_tests if check_var("REGRESSION", "yast2_registration");
 }

--- a/tests/installation/bridge_br0.pm
+++ b/tests/installation/bridge_br0.pm
@@ -1,0 +1,76 @@
+# oSUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Setup and verify br0 bridge network for SLES16 virtualization host
+# This module calls create_host_bridge_nm() to create a bridge interface using NetworkManager
+# for KVM/QEMU guests, then performs additional verification and connectivity testing.
+# Expected to be executed after agama_reboot for SLES16 virtualization hosts.
+
+# Maintainer: QE Virtualization <qe-virt@suse.de>
+
+use base "opensusebasetest";
+use testapi;
+use utils;
+use version_utils qw(is_sle);
+use Utils::Architectures qw(is_s390x);
+use utils qw(zypper_call script_retry);
+use virt_autotest::virtual_network_utils;
+
+sub run {
+    my ($self) = @_;
+
+    # Only run on SLES16 non-s390x systems for virtualization
+    unless (is_sle('=16') && !is_s390x) {
+        record_info("Skip bridge setup", "Bridge setup only required for SLES16 non-s390x virtualization hosts");
+        return;
+    }
+
+    # Check if this is a virtualization test
+    unless (get_var('HOST_HYPERVISOR') =~ /kvm|qemu/) {
+        record_info("Skip bridge setup", "Not a virtualization test, bridge not needed");
+        return;
+    }
+
+    # Ensure we're on the installed system
+    select_console 'root-console';
+
+    record_info("Bridge Setup", "Creating br0 bridge for SLES16 virtualization host using create_host_bridge_nm");
+
+    # Check if bridge configuration already exists (quick check before calling function)
+    my $host_bridge = "br0";
+    my $config_path = "/etc/NetworkManager/system-connections/$host_bridge.nmconnection";
+    if (script_run("[[ -f $config_path ]]") == 0) {
+        record_info("Bridge config exists", "br0 NetworkManager configuration already exists");
+        script_run("ip addr show br0");
+        script_run("ip route show");
+        # Still run verification steps below
+    } else {
+        # Call the shared bridge creation function
+        record_info("Creating bridge", "Calling create_host_bridge_nm function");
+        virt_autotest::virtual_network_utils::create_host_bridge_nm();
+    }
+
+    # Additional verification and testing (beyond what create_host_bridge_nm provides)
+    record_info("Bridge verification", "Verifying bridge network configuration");
+    script_run("ip r");
+    my $bridge_info = script_output("ip a show br0", proceed_on_failure => 1, timeout => 60);
+    record_info("Bridge interface", $bridge_info);
+
+    # Test network connectivity
+    if (script_run("ping -c 3 8.8.8.8") == 0) {
+        record_info("Network test", "Network connectivity verified after bridge setup");
+    } else {
+        record_info("Network test", "Network connectivity test failed after bridge setup", result => 'fail');
+    }
+
+    # Save final screenshot
+    save_screenshot;
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 0};
+}
+
+1;

--- a/tests/virt_autotest/sev_snp_validation.pm
+++ b/tests/virt_autotest/sev_snp_validation.pm
@@ -466,6 +466,12 @@ sub check_sev_snp_on_guest {
     my $guest_name = $args{guest_name};
     my $guest_type = 'unknown';    # Will be set to 'sev-snp' if verification passes
 
+    # SEV-SNP requires UEFI support - skip guests that don't have 'efi' in their name
+    if ($guest_name !~ /efi/) {
+        record_info("SEV-SNP Skip Guest", "Skipping SEV-SNP test for guest $guest_name - SEV-SNP requires UEFI (guest name must contain 'efi')", result => 'ok');
+        return 1;    # Return success but skip the test
+    }
+
     record_info("Check SEV-SNP on guest", "Verifying SEV-SNP support status on guest $guest_name");
 
     # Configure guest for SEV-SNP if not already configured

--- a/tests/virtualization/universal/install_update_package.pm
+++ b/tests/virtualization/universal/install_update_package.pm
@@ -1,0 +1,59 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Install and verify UPDATE_PACKAGE on host system
+#          Simple package installation check without full patching workflow
+# Maintainer: QE-Virtualization <qe-virt@suse.de, Roy.Cai@suse.com>
+
+use base 'consoletest';
+use testapi;
+use utils;
+use serial_terminal 'select_serial_terminal';
+
+sub run {
+    my $self = shift;
+    select_serial_terminal;
+
+    # Get the target package name
+    my $target_package = get_var('UPDATE_PACKAGE', '');
+
+    # Skip if no target package is set or package is 'none' (functional testing)
+    unless ($target_package && $target_package ne 'none') {
+        my $reason = $target_package ? "UPDATE_PACKAGE is 'none'" : "No target package specified";
+        record_info("Skip Package Install", "$reason, skipping package installation");
+        return;
+    }
+
+    record_info("Package Install Check", "Checking and installing package: $target_package");
+
+    # Check if package is installed and from TEST_ repository
+    my $is_installed = script_run("rpm -q $target_package") == 0;
+    my $from_test_repo = script_run("zypper if $target_package | grep -qE 'Repository.*TEST_[0-9]+'") == 0;
+
+    unless ($is_installed && $from_test_repo) {
+        # Need to install/reinstall package from TEST_ repository
+        # While the TEST repository is set up during system installation, the target package is not a required component and might not be pre-installed
+        record_info("Installing Package", "Installing $target_package from TEST repository");
+        assert_script_run("zypper -n in $target_package", timeout => 100);
+    }
+
+    # Show current package status
+    my $version = script_output("rpm -q $target_package");
+    my $status = ($is_installed && $from_test_repo) ? "already installed" : "successfully installed";
+    record_info("Package Ready", "$target_package is $status from TEST repository: $version");
+
+    # Final validation: ensure package comes from TEST_ repository and is up-to-date
+    validate_script_output("zypper if $target_package", sub { m/(?=.*TEST_\d+)(?=.*up-to-date)/s });
+    record_info("Package Validated", "$target_package confirmed from TEST repository and up-to-date");
+
+    # Show package details for debugging
+    script_run("rpm -qi $target_package | head -20");
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -20,9 +20,70 @@ use serial_terminal 'select_serial_terminal';
 use utils;
 use File::Copy 'copy';
 use File::Path 'make_path';
+use virt_autotest::utils qw(is_sles16_mu_virt_test);
+use autoyast qw(expand_agama_secrets);
 
-sub create_profile {
+sub create_agama_profile {
     my ($vm_name, $arch, $mac, $ip) = @_;
+
+    # Determine the appropriate Agama configuration for SLES16 guests
+    # Note: Full vs Online difference is handled by virt-install location parameter,
+    # not by different Agama configurations
+    # Only staging mode is supported
+    my $test_mode = 'staging';
+
+    # Select appropriate Agama configuration file (only staging supported)
+    my $agama_config_file = "sle_virt_guest_staging.jsonnet";
+    my $config_path = "virtualization/agama_virt_auto/$agama_config_file";
+
+    record_info("SLES16 Agama Profile", "Using config: $agama_config_file for guest: $vm_name");
+
+    # Get the Agama configuration template
+    my $profile = get_test_data($config_path);
+
+    # Expand Agama secrets ({{_SECRET_RSA_PUB_KEY}} and {{_SECRET_RSA_PRIV_KEY}})
+    $profile = expand_agama_secrets($profile);
+    record_info("SSH Key Injection", "Expanded Agama secrets for SSH public key authentication");
+
+    # Replace placeholders with actual values needed by Agama jsonnet
+
+    # Set Agama product ID for SLES16
+    my $agama_product_id = get_var('AGAMA_PRODUCT_ID', 'SLES');
+    $profile =~ s/\{\{AGAMA_PRODUCT_ID\}\}/$agama_product_id/g;
+
+    # Handle SCC registration for SLES16
+    if (my $scc_code = get_var("SCC_REGCODE")) {
+        $profile =~ s/\{\{SCC_REGCODE\}\}/$scc_code/g;
+    }
+
+    # Handle password and SUT_IP for IP reporting script
+    my $sut_ip = get_required_var("SUT_IP");
+    $profile =~ s/\{\{PASS\}\}/$testapi::password/g;
+    $profile =~ s/\{\{SUT_IP\}\}/$sut_ip/g;
+    $profile =~ s/\{\{GUEST\}\}/$vm_name/g;
+
+    # Handle repositories - only staging mode supported
+    my $incident_repo = get_var('INCIDENT_REPO', '');
+    $profile =~ s/\{\{INCIDENT_REPO\}\}/$incident_repo/g;
+    record_info("Staging Repos", "Using INCIDENT_REPO: $incident_repo") if $incident_repo;
+
+    # Save the generated Agama profile
+    my $profile_filename = "${vm_name}_agama.jsonnet";
+    save_tmp_file($profile_filename, $profile);
+
+    # Copy profile to ulogs directory for debugging
+    make_path('ulogs');
+    copy(hashed_string($profile_filename), "ulogs/$profile_filename");
+
+    record_info("Agama Profile Generated", "Created profile: $profile_filename");
+
+    return autoinst_url . "/files/$profile_filename";
+}
+
+sub create_autoyast_profile {
+    my ($vm_name, $arch, $mac, $ip) = @_;
+
+    # Original autoyast profile creation logic
     my $version = $vm_name =~ /sp/ ? $vm_name =~ s/\D*(\d+)sp(\d)\D*/$1.$2/r : $vm_name =~ s/\D*(\d+)\D*/$1/r;
     my $path = $version >= 15 ? "virtualization/autoyast/guest_15.xml.ep" : "virtualization/autoyast/guest_12.xml.ep";
     my $scc_code = get_required_var("SCC_REGCODE");
@@ -40,13 +101,14 @@ sub create_profile {
     $profile =~ s/\{\{CA_STR\}\}/$ca_str/g;
     $profile =~ s/\{\{PASS\}\}/$testapi::password/g;
     $profile =~ s/\{\{SUT_IP\}\}/$sut_ip/g;
-    # Change bootloader to grub2-efi for UEFI boot if this specific guest should use UEFI
-    # Check the guest configuration from virt_autotest::common
+
+    # Handle EFI boot configuration for UEFI guests
     my %guests = %virt_autotest::common::guests;
     if (exists $guests{$vm_name} && exists $guests{$vm_name}->{boot_firmware} && $guests{$vm_name}->{boot_firmware} eq 'efi') {
         $profile =~ s/<loader_type>grub2<\/loader_type>/<loader_type>grub2-efi<\/loader_type>/;
         record_info("UEFI Config", "Modified autoyast profile for $vm_name to use grub2-efi for UEFI boot");
     }
+
     my $host_os_version = get_var('DISTRI') . "s" . lc(get_var('VERSION') =~ s/-//r);
     my $incident_repos = "";
     $incident_repos = get_var('INCIDENT_REPO', '') if ($vm_name eq $host_os_version || $vm_name eq "${host_os_version}PV" || $vm_name eq "${host_os_version}HVM");
@@ -66,21 +128,48 @@ sub create_profile {
     return autoinst_url . "/files/$vm_name.xml";
 }
 
+sub create_profile {
+    my ($vm_name, $arch, $mac, $ip) = @_;
+
+    # Intelligent profile selection: use Agama for SLES16 MU tests, autoyast for others
+    if (is_sles16_mu_virt_test() && $vm_name =~ /sles16/i) {
+        record_info("Profile Selection", "Using Agama profile for SLES16 guest: $vm_name");
+        return create_agama_profile($vm_name, $arch, $mac, $ip);
+    } else {
+        record_info("Profile Selection", "Using AutoYaST profile for guest: $vm_name");
+        return create_autoyast_profile($vm_name, $arch, $mac, $ip);
+    }
+}
+
 sub gen_osinfo {
     my ($vm_name) = @_;
     my $h_version = get_var("VERSION") =~ s/-SP/./r;
     my $g_version = $vm_name =~ /sp/ ? $vm_name =~ s/\D*(\d+)sp(\d)\D*/$1.$2/r : $vm_name =~ s/\D*(\d+)\D*/$1/r;
     my $info_op = $h_version > 15.2 ? "--osinfo" : "--os-variant";
-    my $info_val = $g_version > 12.5 ? $vm_name =~ s/HVM|PV|efi//r =~ s/sles/sle/r : $vm_name =~ s/PV|HVM|efi//r;
-    if ($h_version == 12.3) {
-        $info_val = "sle15-unknown" if ($g_version > 15.1);
-        $info_val = "sles12-unknown" if ($g_version == 12.5);
-    } elsif ($h_version == 12.4) {
-        $info_val = "sle15-unknown" if ($g_version > 15.2);
-    } elsif ($h_version == 15) {
-        $info_val = "sle15-unknown" if ($g_version > 15.1);
+
+    # Clean VM name by removing virtualization type suffixes (order matters: longer matches first)
+    my $clean_name = $vm_name =~ s/(efi_online|efi_full|HVM|PV|efi)$//r;
+
+    # Generate OS identifier based on guest version
+    my $info_val;
+    if ($g_version >= 16) {
+        # SLES16 series: keep sles prefix, support SP versions
+        # sles16efi_online -> sles16
+        # sles16sp1efi -> sles16sp1
+        # sles16sp2efi_full -> sles16sp2
+        $info_val = $clean_name;    # Keep original sles16[spX] format
+    } elsif ($g_version > 12.5) {
+        $info_val = $clean_name =~ s/sles/sle/r;    # SLES15: convert sles->sle
+    } else {
+        $info_val = $clean_name;    # SLES12: keep as-is
     }
-    # Return osinfo parameters (--osinfo/--variant OSNAME) for virt-install depends on supported status on different host os versions.
+
+    # Handle host/guest version compatibility issues
+    if ($h_version == 12.3 && $g_version > 15.1) { $info_val = "sle15-unknown"; }
+    if ($h_version == 12.3 && $g_version == 12.5) { $info_val = "sles12-unknown"; }
+    if ($h_version == 12.4 && $g_version > 15.2) { $info_val = "sle15-unknown"; }
+    if ($h_version == 15 && $g_version > 15.1) { $info_val = "sle15-unknown"; }
+
     return "$info_op $info_val";
 }
 


### PR DESCRIPTION
Progress ticket: https://progress.opensuse.org/issues/186173
Related MR: 
[metadata](https://gitlab.suse.de/qa-maintenance/metadata/-/merge_requests/1530)
[openqa-job-group-yaml](https://gitlab.suse.de/qa-testsuites/openqa-job-group-yaml/-/merge_requests/304)

No increment testing in this PR.
For virt feature testing, will add them in this PR, but features testing still need more debugging to make it stable.
Add new function:
sles16 host ssh to sles16 guest without password
sles16 host ssh to sles12/15 guest without password

Host Installation Flow:
1. Boot → Agama Installer
2. Load profile: sle_virt_default_{staging|increment}.jsonnet
For staging, will install repo during installation, the same as sle16 guest staging installation.
3. Install SLES16 with KVM patterns
5. Reboot → Login
6. Bridge Setup (bridge_br0.pm)
   └─ Create br0 using NetworkManager
   
   
Guest Installation Flow:
1. prepare_guests.pm
2. Generate profile: sle_virt_guest_staging.jsonnet
3. Guest-specific profile with {{GUEST}} placeholder replacement
4. virt-install with appropriate method:
Online ISO: --install (ISO with kernel/initrd extraction)
Full repo: --location (network with live OS)
```shell
virt-install  \
--osinfo sles16 \
--name sles16efi_online \
--vcpus=2,maxvcpus=3 \
--memory=2048,maxmemory=3584 \
--vnc \
--disk path=/var/lib/libvirt/images/sles16efi_online.qcow2,size=20,format=qcow2 \
--noautoconsole \
--network bridge=br0 \
--autostart \
--install kernel=/var/lib/libvirt/images/sles16efi_online/linux,initrd=/var/lib/libvirt/images/sles16efi_online/initrd \
--wait -1 \
--boot firmware=efi \
--events on_reboot=restart \
--extra-args 'root=live:http://openqa.suse.de/assets/repo/SLES-16.0-Online-x86_64-Build135.5.install/LiveOS/squashfs.img inst.auto=http://worker34.oqa.prg2.suse.org:20093/f9yCSLdvOkXqX6iF/files/sles16efi_online_agama.jsonnet inst.finish=stop'
``` 
```shell
virt-install  \
--osinfo sles16 \
--name sles16efi_full \
--vcpus=2,maxvcpus=3 \
--memory=2048,maxmemory=3584 \
--vnc \
--disk path=/var/lib/libvirt/images/sles16efi_full.qcow2,size=20,format=qcow2 \
--noautoconsole \
--network bridge=br0 \
--autostart \
--location http://openqa.suse.de/assets/repo/SLES-16.0-Full-x86_64-Build135.5.install/,kernel=boot/x86_64/loader/linux,initrd=boot/x86_64/loader/initrd \
--wait -1 \
--boot firmware=efi \
--events on_reboot=restart \
--extra-args 'inst.auto=http://worker36.oqa.prg2.suse.org:20623/fTE8M1lkSOKXCZp7/files/sles16efi_full_agama.jsonnet root=live:http://openqa.suse.de/assets/repo/SLES-16.0-Full-x86_64-Build135.5.install//LiveOS/squashfs.img inst.install_url=http://openqa.suse.de/assets/repo/SLES-16.0-x86_64-Build135.5/ inst.finish=stop'
``` 
5. IP address auto-reporting to /tmp/guests_ip/
7. waitfor_guests.pm
8. if need, will install package on guests, it is meaningful. For example: kernel-default, snpguest.
9. Add features testing, sriov testing, sev-snp testing and migration testing.

[sle-16-Online-VIRT-Kernel-Updates-Staging-x86_64-Build:518:none-qam-kvm-install-and-sev-snp-test](https://openqa.oqa.prg2.suse.org/tests/19434719#)
[sle-16-Online-VIRT-Kernel-Updates-Staging-x86_64-Build:502:samba-qam-kvm-install-test(patching host and guest](https://openqa.suse.de/tests/19420934)
[sle-16-Online-VIRT-Core-Updates-Staging-x86_64-Build:1111:none-qam-kvm-install-test](https://openqa.suse.de/tests/19419501)
[Online-VIRT-Kernel-Updates-Staging](https://openqa.suse.de/tests/19344264)
[Online-VIRT-Tools-CoCo-Updates-Staging](https://openqa.suse.de/tests/19344227)
[Online-VIRT-Tools-Updates-Staging](https://openqa.suse.de/tests/19344226)
[sle-15-SP5-Server-DVD-Incidents-VIRT-Kernel-x86_64-Build:41033:none-qam-kvm-install-and-sriov-test@64bit-ipmi-sriov](https://openqa.suse.de/tests/19425179)
[sle-12-SP5-Server-DVD-Incidents-VIRT-Kernel-x86_64-Build:41049:none-qam-kvm-install-and-sriov-test@64bit-ipmi-legacy-boot](https://openqa.suse.de/tests/19419403)

Features testing issue we are still facing, will fix one by one in the following PR.
[hotplugging_guest_preparation](https://openqa.oqa.prg2.suse.org/tests/19421282#step/hotplugging_guest_preparation/54)
[virtmanager_final](https://openqa.suse.de/tests/19421279#step/virtmanager_final/4)
[virtmanager_init](https://openqa.oqa.prg2.suse.org/tests/19421281#step/virtmanager_init/4)
[libvirt_host_bridge_virtual_network](https://openqa.oqa.prg2.suse.org/tests/19421283#step/libvirt_host_bridge_virtual_network/102)
[virsh_internal_snapshot](https://openqa.oqa.prg2.suse.org/tests/19421292#step/virsh_internal_snapshot/20)
[parallel_guest_migration_destination](https://openqa.suse.de/tests/19421269#step/parallel_guest_migration_destination/61)
[sriov_network_card_pci_passthrough](https://openqa.oqa.prg2.suse.org/tests/19421271#step/sriov_network_card_pci_passthrough/232)