### PR TITLE
Publiccloud: fix missing instance on-error  in finalize

### DIFF
--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -196,8 +196,8 @@ sub upload_boot_diagnostics {
     my $project = $self->get_terraform_output('.project.value');
     my $instance_id = $self->get_terraform_output(".vm_name.value[0]");
     return if (check_var('PUBLIC_CLOUD_SLES4SAP', 1));
-    unless (defined($instance_id) && defined($region)) {
-        record_info('UNDEF. diagnostics', 'upload_boot_diagnostics: on gce, undefined instance or region');
+    unless (defined($instance_id) && defined($region) && defined($availability_zone)) {
+        record_info('UNDEF. diagnostics', 'upload_boot_diagnostics: on gce, undefined instance or region or availability zone');
         return;
     }
     my $dt = DateTime->now;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -378,7 +378,6 @@ C<proceed_on_failure>  Same as timeout.
 sub create_instances {
     my ($self, %args) = @_;
     $args{check_connectivity} //= 1;
-    $args{check_guestregister} //= 1;
     $args{upload_boot_diagnostics} //= 1;
     my @vms = $self->terraform_apply(%args);
     my $url = get_var('PUBLIC_CLOUD_PERF_DB_URI', 'http://larry.qe.suse.de:8086');
@@ -386,11 +385,11 @@ sub create_instances {
     foreach my $instance (@vms) {
         record_info("INSTANCE", $instance->{instance_id});
         if ($args{check_connectivity}) {
+            # An error in VM-up causes test to stop
             $instance->wait_for_ssh(timeout => $args{timeout},
                 proceed_on_failure => $args{proceed_on_failure}, scan_ssh_host_key => 1);
         }
-        # check guestregister conditional, default yes:
-        $instance->wait_for_guestregister() if ($args{check_guestregister});
+
         $self->upload_boot_diagnostics() if ($args{upload_boot_diagnostics});
 
         $self->show_instance_details();

--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -37,7 +37,8 @@ sub run {
         $instance = $self->{my_instance} = $args->{my_instance};
     } else {
         $provider = $args->{my_provider} = $self->provider_factory();
-        $instance = $self->{my_instance} = $args->{my_instance} = $provider->create_instance(check_guestregister => is_openstack ? 0 : 1);
+        $instance = $self->{my_instance} = $args->{my_instance} = $provider->create_instance();
+        $instance->wait_for_guestregister() if (is_ondemand());
     }
 
     if (check_var('PUBLIC_CLOUD_SCC_ENDPOINT', 'SUSEConnect')) {

--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -88,7 +88,8 @@ sub run {
 
     unless ($args->{my_provider} && $args->{my_instance}) {
         $args->{my_provider} = $self->provider_factory();
-        $args->{my_instance} = $args->{my_provider}->create_instance(check_guestregister => is_ondemand ? 1 : 0);
+        $args->{my_instance} = $args->{my_provider}->create_instance();
+        $args->{my_instance}->wait_for_guestregister() if (is_ondemand);
     }
     $instance = $args->{my_instance};
     $provider = $args->{my_provider};

--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -40,6 +40,7 @@ sub run {
     select_serial_terminal();
     my $provider = $args->{my_provider};
     my $instance = $provider->create_instance();
+    $instance->wait_for_guestregister() if (is_ondemand);
     registercloudguest($instance) if is_byos();
     register_addons_in_pc($instance);
 

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -39,6 +39,7 @@ sub run {
     $instance_args{use_extra_disk} = {size => $additional_disk_size, type => $additional_disk_type} if ($additional_disk_size > 0);
     $args->{my_provider} = $self->provider_factory();
     $args->{my_instance} = $args->{my_provider}->create_instance(%instance_args);
+    $args->{my_instance}->wait_for_guestregister() if (is_ondemand);
     my $provider = $args->{my_provider};
     my $instance = $args->{my_instance};
 

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -18,7 +18,7 @@ use Mojo::UserAgent;
 use LTP::utils qw(get_ltproot prepare_whitelist_environment);
 use LTP::install qw(get_required_build_dependencies get_maybe_build_dependencies get_submodules_to_rebuild);
 use LTP::WhiteList;
-use publiccloud::utils qw(is_byos is_gce registercloudguest register_openstack install_in_venv get_python_exec venv_activate zypper_install_remote zypper_install_available_remote zypper_add_repo_remote);
+use publiccloud::utils qw(is_byos is_ondemand is_gce registercloudguest register_openstack install_in_venv get_python_exec venv_activate zypper_install_remote zypper_install_available_remote zypper_add_repo_remote);
 use publiccloud::ssh_interactive 'select_host_console';
 use Data::Dumper;
 use version_utils;
@@ -252,7 +252,8 @@ sub prepare_instance {
     my ($self, $args) = @_;
     unless ($args->{my_provider} && $args->{my_instance}) {
         $args->{my_provider} = $self->provider_factory();
-        $args->{my_instance} = $args->{my_provider}->create_instance(check_guestregister => is_openstack ? 0 : 1);
+        $args->{my_instance} = $args->{my_provider}->create_instance();
+        $args->{my_instance}->wait_for_guestregister() if (is_ondemand());
     }
     return ($args->{my_provider}, $args->{my_instance});
 }


### PR DESCRIPTION
Fix missing _instance_ on-error in post-fail-`finalize`.

CSP instance available in create instance after terraform_apply,
then in wait_for_ssh on-error is lost and 'finalize' cannot use it:
recover in 'finalize' the saved instance.

In gce::upload_boot_diagnostics added check of availability zone too.

- Related ticket: https://progress.opensuse.org/issues/188586
 
- Verification run: 
  https://openqa.suse.de/tests/19234580
  https://openqa.suse.de/tests/19234580/logfile?filename=autoinst-log.txt#line-2659
  [fake error added in wait_for_ssh after systemcheck loop, to trigger finalize; removed after VR].
  https://openqa.suse.de/tests/19234579#step/prepare_instance/1
  [successful version]


