### PR TITLE
Checks if non-root user run 'crm configure show' successfully

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -1170,7 +1170,7 @@ sub sdaf_upload_logs {
     upload_logs("${crm_report_log}.tar.gz");
 
     record_info('Uploading crm configure log');
-    script_run("sudo crm configure show > $crm_cfg_log", timeout => 120);
+    record_info('crm configure show', 'Failed to run "crm configure show"', result => 'fail') if (script_run("sudo crm configure show > $crm_cfg_log", timeout => 120));
     upload_logs("$crm_cfg_log");
 
     # Upload zypper log

--- a/tests/sles4sap/hana_cluster.pm
+++ b/tests/sles4sap/hana_cluster.pm
@@ -137,6 +137,9 @@ sub run {
     $self->check_hanasr_attr;
     $self->check_landscape;
     assert_script_run 'cs_clusterstate';
+
+    # Check getting crm configuration by <sid>adm
+    check_crm_nonroot($sapadm);
 }
 
 1;


### PR DESCRIPTION
1. Check the return value for script_run('crm configure show'), if fails, record a failure, but this doesn't affect the whole job result.
2. Check if non-root user could run `crm configure show`, fail return error.

Related: https://jira.suse.com/browse/TEAM-6899

VRs (all VRs passed):

sle16: 
x86:  https://openqa.suse.de/tests/19239665#step/hana_cluster/266
ppc64le:  https://openqa.suse.de/tests/19239660#step/hana_cluster/348

12-SP5: https://openqa.suse.de/tests/19239612#step/hana_cluster/209

15-SP3:  https://openqa.suse.de/tests/19239617#step/hana_cluster/209

15-SP4: https://openqa.suse.de/tests/19239608#step/hana_cluster/224

15-SP5:  https://openqa.suse.de/tests/19239676#step/hana_cluster/224

15-SP6: https://openqa.suse.de/tests/19239619#step/hana_cluster/266

15-SP7:  https://openqa.suse.de/tests/19239668#step/hana_cluster/266