### PR TITLE
SLES4SAP: add retry mechanism in 'qesap_venv_cmd_exec'

### DIFF
--- a/lib/sles4sap/qesap/qesapdeployment.pm
+++ b/lib/sles4sap/qesap/qesapdeployment.pm
@@ -35,7 +35,7 @@ use YAML::PP;
 use Exporter 'import';
 use Scalar::Util 'looks_like_number';
 use File::Basename;
-use utils qw(file_content_replace);
+use utils qw(file_content_replace script_retry);
 use version_utils 'is_sle';
 use publiccloud::utils qw(get_credentials);
 use sles4sap::qesap::aws;
@@ -204,6 +204,8 @@ sub qesap_create_ansible_section {
 
 =item B<LOG_FILE> - optional argument that results in changing the command to redirect the output to a log file
 
+=item B<RETRY> - number of retry attempts, default is 1
+
 =back
 =cut
 
@@ -212,23 +214,25 @@ sub qesap_venv_cmd_exec {
     croak 'Missing mandatory cmd argument' unless $args{cmd};
     $args{timeout} //= bmwqemu::scale_timeout(90);
     croak "Invalid timeout value $args{timeout}" unless $args{timeout} > 0;
+    my $retry = $args{retry} // 1;
 
-    my $cmd = '';
+    my $cmd = $args{cmd};
     # pipefail is needed as at the end of the command line there could be a pipe
     # to redirect all output to a log_file.
     # pipefail allow script_run always getting the exit code of the cmd command
     # and not only the one from tee
-    $cmd .= 'set -o pipefail ; ' if $args{log_file};
-    $cmd .= join(' ', 'timeout', $args{timeout}, $args{cmd});
-    # always use tee in append mode
-    $cmd .= " |& tee -a $args{log_file}" if $args{log_file};
+    if ($args{log_file}) {
+        script_run 'set -o pipefail';
+        # always use tee in append mode
+        $cmd .= " |& tee -a $args{log_file}";
+    }
 
     my $ret = script_run('source ' . QESAPDEPLOY_VENV . '/bin/activate');
     if ($ret) {
         record_info('qesap_venv_cmd_exec error', "source .venv ret:$ret");
         return $ret;
     }
-    $ret = script_run($cmd, timeout => ($args{timeout} + 10));
+    $ret = script_retry($cmd, timeout => $args{timeout}, retry => $retry, die => 0);
 
     # deactivate python virtual environment
     script_run('deactivate');
@@ -281,6 +285,7 @@ sub qesap_pip_install {
     my $ret = qesap_venv_cmd_exec(
         cmd => $pip_ints_cmd,
         timeout => 720,
+        retry => 3,
         log_file => $pip_install_log);
 
     # here it is possible to retry in case of exit code 124
@@ -308,6 +313,7 @@ sub qesap_galaxy_install {
     my $ret = qesap_venv_cmd_exec(
         cmd => $ans_galaxy_cmd,
         timeout => 720,
+        retry => 3,
         log_file => $galaxy_install_log);
 
     # here it is possible to retry in case of exit code 124

--- a/t/14_qesap_ansible.t
+++ b/t/14_qesap_ansible.t
@@ -55,9 +55,8 @@ subtest '[qesap_ansible_cmd] integration' => sub {
     my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
-    $qesap->redefine(script_run => sub {
-            push @calls, $_[0];
-            return 0; });
+    $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $qesap->redefine(script_retry => sub { push @calls, $_[0]; return 0; });
     $qesap->redefine(qesap_get_inventory => sub { return '/SIDNEY'; });
 
     qesap_ansible_cmd(cmd => 'FINDING', provider => 'OCEAN');
@@ -125,9 +124,8 @@ subtest '[qesap_ansible_cmd] filter and user' => sub {
     my @calls;
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $qesap->redefine(qesap_get_inventory => sub { return '/SIDNEY'; });
-    $qesap->redefine(script_run => sub {
-            push @calls, $_[0];
-            return 0; });
+    $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $qesap->redefine(script_retry => sub { push @calls, $_[0]; return 0; });
 
     qesap_ansible_cmd(cmd => 'FINDING', provider => 'OCEAN', filter => 'NEMO', user => 'DARLA');
 
@@ -165,6 +163,7 @@ subtest '[qesap_ansible_script_output] integration' => sub {
     my @calls;
     $qesap->redefine(qesap_get_inventory => sub { return '/CRUSH'; });
     $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $qesap->redefine(script_retry => sub { push @calls, $_[0]; return 0; });
     $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
     $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
     $qesap->redefine(data_url => sub { return '/BRUCE'; });
@@ -299,6 +298,7 @@ subtest '[qesap_ansible_script_output_file] integrate with qesap_venv_cmd_exec a
     my @calls;
     $qesap->redefine(qesap_get_inventory => sub { return '/CRUSH'; });
     $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $qesap->redefine(script_retry => sub { push @calls, $_[0]; return 0; });
     $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
     $qesap->redefine(data_url => sub { return '/BRUCE'; });
     $qesap->redefine(script_output => sub { push @calls, $_[0]; });
@@ -428,6 +428,7 @@ subtest '[qesap_ansible_script_output_file] custom user integrate with qesap_ven
 
     $qesap->redefine(qesap_get_inventory => sub { return '/CRUSH'; });
     $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $qesap->redefine(script_retry => sub { push @calls, $_[0]; return 0; });
     $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
     $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
     $qesap->redefine(data_url => sub { return '/BRUCE'; });
@@ -445,6 +446,7 @@ subtest '[qesap_ansible_script_output_file] root integrate with qesap_venv_cmd_e
 
     $qesap->redefine(qesap_get_inventory => sub { return '/CRUSH'; });
     $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $qesap->redefine(script_retry => sub { push @calls, $_[0]; return 0; });
     $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
     $qesap->redefine(enter_cmd => sub { push @calls, $_[0]; });
     $qesap->redefine(data_url => sub { return '/BRUCE'; });
@@ -508,6 +510,7 @@ subtest '[qesap_ansible_fetch_file] integration' => sub {
     $qesap->redefine(qesap_get_inventory => sub { return '/SIDNEY'; });
     $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
     $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $qesap->redefine(script_retry => sub { push @calls, $_[0]; return 0; });
     $qesap->redefine(data_url => sub { return '/BRUCE'; });
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 


### PR DESCRIPTION
This PR adds a new option "retry" for function `qesap_venv_cmd_exec`.

The core change is to replace `script_run` with `script_retry`.

As a result, the `timeout` part is run inside `script_retry`, and some unit tests are deleted because of it.

- Related ticket: https://jira.suse.com/browse/TEAM-10585
- Needles: none
- Verification run:
EC2: https://openqa.suse.de/tests/19239653#step/qesap_terraform/147
https://openqa.suse.de/tests/19239592#step/qesap_terraform/162
Azure: https://openqa.suse.de/tests/19239633#step/deploy_qesap_terraform/111