### PR TITLE
Create schedule file without validate_suseconnect_url

### DIFF
--- a/schedule/yam/agama_extensions_and_patterns_unattended_without_custom_url.yaml
+++ b/schedule/yam/agama_extensions_and_patterns_unattended_without_custom_url.yaml
@@ -1,0 +1,12 @@
+---
+name: agama_extensions_and_patterns_unattended_without_custom_url
+description: >
+  Prepare url for agama.auto boot parameter, perform auto-installation with extensions and software pattern selection without custom url.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_registered_products
+  - yam/validate/validate_installed_patterns
+  - console/validate_repos

--- a/schedule/yam/agama_extensions_and_patterns_unattended_without_custom_url_ppc64le.yaml
+++ b/schedule/yam/agama_extensions_and_patterns_unattended_without_custom_url_ppc64le.yaml
@@ -1,0 +1,12 @@
+---
+name: agama_extensions_and_patterns_unattended_without_custom_url_ppc64le.
+description: >
+  Prepare url for agama.auto boot parameter, perform auto-installation with extensions and software pattern selection on ppc64le without custom url.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_registered_products
+  - yam/validate/validate_installed_patterns

--- a/schedule/yam/agama_extensions_and_patterns_unattended_without_custom_url_s390x.yaml
+++ b/schedule/yam/agama_extensions_and_patterns_unattended_without_custom_url_s390x.yaml
@@ -1,0 +1,12 @@
+---
+name: agama_extensions_and_patterns_unattended_without_custom_url_s390x
+description: >
+  Prepare url for agama.auto boot parameter, perform auto-installation with extensions and software pattern selection on s390x without custom url.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - yam/validate/validate_registered_products
+  - yam/validate/validate_installed_patterns

--- a/schedule/yam/agama_extensions_and_patterns_without_custom_url.yaml
+++ b/schedule/yam/agama_extensions_and_patterns_without_custom_url.yaml
@@ -1,0 +1,14 @@
+---
+name: agama_extensions_and_patterns_without_custom_url
+description: >
+  Perform interactive installation with extensions and software pattern selection without custom url.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_arrange
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_registered_products
+  - yam/validate/validate_installed_patterns
+  - console/validate_repos

--- a/schedule/yam/agama_extensions_and_patterns_without_custom_url_s390x.yaml
+++ b/schedule/yam/agama_extensions_and_patterns_without_custom_url_s390x.yaml
@@ -1,0 +1,14 @@
+---
+name: agama_extensions_and_patterns_without_custom_url_s390x
+description: >
+  Perform interactive installation with extensions and software pattern selection for s390x without custom url.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_arrange
+  - yam/agama/import_agama_profile
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - yam/validate/validate_registered_products
+  - yam/validate/validate_installed_patterns


### PR DESCRIPTION
For SUSEConnect won't be created if not custom url in development group, refer to https://suse.slack.com/archives/C02AYV7UJSD/p1757326448201469 We need drop validate_suseconnect_url for development group.

- Related ticket: N/A
- Related MR:  https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/601
- Needles:N/A
- Verification run: https://openqa.suse.de/tests/overview?version=16.0&build=lemon-suse%2Fos-autoinst-distri-opensuse%23create-schedule-without-validate_suseconnect_url&distri=sle
