### PR TITLE
Replace patch_and_reboot with post_installation

### DIFF
--- a/schedule/qam/12-SP3/mau-userspace.yaml
+++ b/schedule/qam/12-SP3/mau-userspace.yaml
@@ -6,5 +6,5 @@ description: >
 schedule:
     - boot/boot_to_desktop
     - qa_automation/qaset_pre_patch_run
-    - qa_automation/patch_and_reboot
+    - console/post_installation
     - qa_automation/qaset_post_patch_run

--- a/schedule/qam/12-SP3/qam-allpatterns.yaml
+++ b/schedule/qam/12-SP3/qam-allpatterns.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/12-SP3/qam-gnome.yaml
+++ b/schedule/qam/12-SP3/qam-gnome.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/12-SP3/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP3/qam-minimal-base.yaml
@@ -3,7 +3,7 @@ name: qam-minimal-base
 schedule:
   - installation/bootloader_start
   - boot/boot_to_desktop
-  - qa_automation/patch_and_reboot
+  - console/post_installation
   - console/dracut
   - locale/keymap_or_locale
   - console/system_prepare

--- a/schedule/qam/12-SP3/qam-regression-installation.yaml
+++ b/schedule/qam/12-SP3/qam-regression-installation.yaml
@@ -8,7 +8,7 @@ schedule:
 - autoyast/installation
 - installation/first_boot
 - x11/x11_setup
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/hostname
 - console/force_scheduled_tasks
 - shutdown/grub_set_bootargs

--- a/schedule/qam/12-SP3/qam-textmode-autoyast.yaml
+++ b/schedule/qam/12-SP3/qam-textmode-autoyast.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network

--- a/schedule/qam/12-SP5/mau-userspace.yaml
+++ b/schedule/qam/12-SP5/mau-userspace.yaml
@@ -6,5 +6,5 @@ description: >
 schedule:
     - boot/boot_to_desktop
     - qa_automation/qaset_pre_patch_run
-    - qa_automation/patch_and_reboot
+    - console/post_installation
     - qa_automation/qaset_post_patch_run

--- a/schedule/qam/12-SP5/qam-allpatterns.yaml
+++ b/schedule/qam/12-SP5/qam-allpatterns.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/12-SP5/qam-gnome.yaml
+++ b/schedule/qam/12-SP5/qam-gnome.yaml
@@ -13,7 +13,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/handle_reboot
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/12-SP5/qam-minimal-base.yaml
+++ b/schedule/qam/12-SP5/qam-minimal-base.yaml
@@ -3,7 +3,7 @@ name: qam-minimal-base
 schedule:
   - installation/bootloader_start
   - boot/boot_to_desktop
-  - qa_automation/patch_and_reboot
+  - console/post_installation
   - console/dracut
   - locale/keymap_or_locale
   - console/system_prepare

--- a/schedule/qam/12-SP5/qam-regression-installation.yaml
+++ b/schedule/qam/12-SP5/qam-regression-installation.yaml
@@ -8,7 +8,7 @@ schedule:
 - autoyast/installation
 - installation/first_boot
 - x11/x11_setup
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/hostname
 - console/force_scheduled_tasks
 - shutdown/grub_set_bootargs

--- a/schedule/qam/12-SP5/qam-textmode-autoyast.yaml
+++ b/schedule/qam/12-SP5/qam-textmode-autoyast.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network

--- a/schedule/qam/15-SP2/mau-userspace.yaml
+++ b/schedule/qam/15-SP2/mau-userspace.yaml
@@ -6,6 +6,6 @@ description: >
 schedule:
     - boot/boot_to_desktop
     - qa_automation/qaset_pre_patch_run
-    - qa_automation/patch_and_reboot
+    - console/post_installation
     - qa_automation/qaset_post_patch_run
 ...

--- a/schedule/qam/15-SP2/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP2/qam-allpatterns.yaml
@@ -15,7 +15,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/15-SP2/qam-gnome.yaml
+++ b/schedule/qam/15-SP2/qam-gnome.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/handle_reboot
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/15-SP2/qam-minimal-base.yaml
+++ b/schedule/qam/15-SP2/qam-minimal-base.yaml
@@ -3,7 +3,7 @@ name: qam-minimal-base
 schedule:
   - installation/bootloader_start
   - boot/boot_to_desktop
-  - qa_automation/patch_and_reboot
+  - console/post_installation
   - console/dracut
   - locale/keymap_or_locale
   - console/system_prepare

--- a/schedule/qam/15-SP2/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP2/qam-regression-installation.yaml
@@ -8,7 +8,7 @@ schedule:
 - autoyast/installation
 - installation/first_boot
 - x11/x11_setup
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/hostname
 - console/force_scheduled_tasks

--- a/schedule/qam/15-SP2/qam-textmode.yaml
+++ b/schedule/qam/15-SP2/qam-textmode.yaml
@@ -22,7 +22,7 @@ schedule:
 - installation/reboot_after_installation
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network

--- a/schedule/qam/15-SP3/mau-userspace.yaml
+++ b/schedule/qam/15-SP3/mau-userspace.yaml
@@ -6,6 +6,6 @@ description: >
 schedule:
     - boot/boot_to_desktop
     - qa_automation/qaset_pre_patch_run
-    - qa_automation/patch_and_reboot
+    - console/post_installation
     - qa_automation/qaset_post_patch_run
 ...

--- a/schedule/qam/15-SP3/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP3/qam-allpatterns.yaml
@@ -15,7 +15,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/15-SP3/qam-gnome.yaml
+++ b/schedule/qam/15-SP3/qam-gnome.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/handle_reboot
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/15-SP3/qam-minimal-base.yaml
+++ b/schedule/qam/15-SP3/qam-minimal-base.yaml
@@ -3,7 +3,7 @@ name: qam-minimal-base
 schedule:
   - installation/bootloader_start
   - boot/boot_to_desktop
-  - qa_automation/patch_and_reboot
+  - console/post_installation
   - console/dracut
   - locale/keymap_or_locale
   - console/system_prepare

--- a/schedule/qam/15-SP3/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP3/qam-regression-installation.yaml
@@ -8,7 +8,7 @@ schedule:
 - autoyast/installation
 - installation/first_boot
 - x11/x11_setup
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/hostname
 - console/force_scheduled_tasks

--- a/schedule/qam/15-SP3/qam-textmode.yaml
+++ b/schedule/qam/15-SP3/qam-textmode.yaml
@@ -22,7 +22,7 @@ schedule:
 - installation/reboot_after_installation
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network

--- a/schedule/qam/15-SP4/mau-userspace.yaml
+++ b/schedule/qam/15-SP4/mau-userspace.yaml
@@ -6,6 +6,6 @@ description: >
 schedule:
     - boot/boot_to_desktop
     - qa_automation/qaset_pre_patch_run
-    - qa_automation/patch_and_reboot
+    - console/post_installation
     - qa_automation/qaset_post_patch_run
 ...

--- a/schedule/qam/15-SP4/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP4/qam-allpatterns.yaml
@@ -15,7 +15,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/15-SP4/qam-gnome.yaml
+++ b/schedule/qam/15-SP4/qam-gnome.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/handle_reboot
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/15-SP4/qam-minimal-base.yaml
+++ b/schedule/qam/15-SP4/qam-minimal-base.yaml
@@ -3,7 +3,7 @@ name: qam-minimal-base
 schedule:
   - installation/bootloader_start
   - boot/boot_to_desktop
-  - qa_automation/patch_and_reboot
+  - console/post_installation
   - console/dracut
   - locale/keymap_or_locale
   - console/system_prepare

--- a/schedule/qam/15-SP4/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP4/qam-regression-installation.yaml
@@ -7,7 +7,7 @@ schedule:
 - autoyast/installation
 - installation/first_boot
 - x11/x11_setup
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/hostname
 - console/force_scheduled_tasks

--- a/schedule/qam/15-SP4/qam-textmode.yaml
+++ b/schedule/qam/15-SP4/qam-textmode.yaml
@@ -22,7 +22,7 @@ schedule:
 - installation/reboot_after_installation
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network

--- a/schedule/qam/15-SP5/mau-userspace.yaml
+++ b/schedule/qam/15-SP5/mau-userspace.yaml
@@ -6,6 +6,6 @@ description: >
 schedule:
     - boot/boot_to_desktop
     - qa_automation/qaset_pre_patch_run
-    - qa_automation/patch_and_reboot
+    - console/post_installation
     - qa_automation/qaset_post_patch_run
 ...

--- a/schedule/qam/15-SP5/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP5/qam-allpatterns.yaml
@@ -15,7 +15,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/15-SP5/qam-gnome.yaml
+++ b/schedule/qam/15-SP5/qam-gnome.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/handle_reboot
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/15-SP5/qam-minimal-base.yaml
+++ b/schedule/qam/15-SP5/qam-minimal-base.yaml
@@ -3,7 +3,7 @@ name: qam-minimal-base
 schedule:
   - installation/bootloader_start
   - boot/boot_to_desktop
-  - qa_automation/patch_and_reboot
+  - console/post_installation
   - console/dracut
   - locale/keymap_or_locale
   - console/system_prepare

--- a/schedule/qam/15-SP5/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP5/qam-regression-installation.yaml
@@ -8,7 +8,7 @@ schedule:
   - autoyast/installation
   - installation/first_boot
   - x11/x11_setup
-  - qa_automation/patch_and_reboot
+  - console/post_installation
   - console/system_prepare
   - console/hostname
   - console/force_scheduled_tasks

--- a/schedule/qam/15-SP5/qam-textmode.yaml
+++ b/schedule/qam/15-SP5/qam-textmode.yaml
@@ -22,7 +22,7 @@ schedule:
 - installation/reboot_after_installation
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - locale/keymap_or_locale
 - console/system_prepare
 - console/chrony

--- a/schedule/qam/15-SP6/mau-userspace.yaml
+++ b/schedule/qam/15-SP6/mau-userspace.yaml
@@ -6,6 +6,6 @@ description: >
 schedule:
     - boot/boot_to_desktop
     - qa_automation/qaset_pre_patch_run
-    - qa_automation/patch_and_reboot
+    - console/post_installation
     - qa_automation/qaset_post_patch_run
 ...

--- a/schedule/qam/15-SP6/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP6/qam-allpatterns.yaml
@@ -15,7 +15,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/15-SP6/qam-gnome.yaml
+++ b/schedule/qam/15-SP6/qam-gnome.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/handle_reboot
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/15-SP6/qam-minimal-base.yaml
+++ b/schedule/qam/15-SP6/qam-minimal-base.yaml
@@ -3,7 +3,7 @@ name: qam-minimal-base
 schedule:
   - installation/bootloader_start
   - boot/boot_to_desktop
-  - qa_automation/patch_and_reboot
+  - console/post_installation
   - console/dracut
   - locale/keymap_or_locale
   - console/system_prepare

--- a/schedule/qam/15-SP6/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP6/qam-regression-installation.yaml
@@ -8,7 +8,7 @@ schedule:
 - autoyast/installation
 - installation/first_boot
 - x11/x11_setup
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/hostname
 - console/force_scheduled_tasks

--- a/schedule/qam/15-SP6/qam-textmode.yaml
+++ b/schedule/qam/15-SP6/qam-textmode.yaml
@@ -22,7 +22,7 @@ schedule:
 - installation/reboot_after_installation
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network

--- a/schedule/qam/15-SP7/mau-userspace.yaml
+++ b/schedule/qam/15-SP7/mau-userspace.yaml
@@ -6,6 +6,6 @@ description: >
 schedule:
     - boot/boot_to_desktop
     - qa_automation/qaset_pre_patch_run
-    - qa_automation/patch_and_reboot
+    - console/post_installation
     - qa_automation/qaset_post_patch_run
 ...

--- a/schedule/qam/15-SP7/qam-allpatterns.yaml
+++ b/schedule/qam/15-SP7/qam-allpatterns.yaml
@@ -15,7 +15,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/15-SP7/qam-gnome.yaml
+++ b/schedule/qam/15-SP7/qam-gnome.yaml
@@ -14,7 +14,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/handle_reboot
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/15-SP7/qam-minimal-base.yaml
+++ b/schedule/qam/15-SP7/qam-minimal-base.yaml
@@ -3,7 +3,7 @@ name: qam-minimal-base
 schedule:
   - installation/bootloader_start
   - boot/boot_to_desktop
-  - qa_automation/patch_and_reboot
+  - console/post_installation
   - console/dracut
   - locale/keymap_or_locale
   - console/system_prepare

--- a/schedule/qam/15-SP7/qam-regression-installation.yaml
+++ b/schedule/qam/15-SP7/qam-regression-installation.yaml
@@ -8,7 +8,7 @@ schedule:
 - autoyast/installation
 - installation/first_boot
 - x11/x11_setup
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/hostname
 - console/force_scheduled_tasks

--- a/schedule/qam/15-SP7/qam-textmode.yaml
+++ b/schedule/qam/15-SP7/qam-textmode.yaml
@@ -22,7 +22,7 @@ schedule:
 - installation/reboot_after_installation
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - locale/keymap_or_locale
 - console/system_prepare
 - console/check_network

--- a/schedule/qam/common/12-common_base_installation_ay.yaml
+++ b/schedule/qam/common/12-common_base_installation_ay.yaml
@@ -7,7 +7,7 @@ schedule:
   - installation/first_boot
   - '{{x11_setup}}'
   - console/system_prepare
-  - qa_automation/patch_and_reboot
+  - console/post_installation
   - console/hostname
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs

--- a/schedule/qam/common/15-common_base_installation_ay.yaml
+++ b/schedule/qam/common/15-common_base_installation_ay.yaml
@@ -7,7 +7,7 @@ schedule:
   - installation/first_boot
   - '{{x11_setup}}'
   - console/system_prepare
-  - qa_automation/patch_and_reboot
+  - console/post_installation
   - console/hostname
   - console/force_scheduled_tasks
   - shutdown/grub_set_bootargs

--- a/schedule/qam/common/qam-dracut-install@64bit.yaml
+++ b/schedule/qam/common/qam-dracut-install@64bit.yaml
@@ -10,7 +10,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/schedule/qam/common/qam-dracut-lvm-install@64bit.yaml
+++ b/schedule/qam/common/qam-dracut-lvm-install@64bit.yaml
@@ -10,7 +10,7 @@ schedule:
 - autoyast/autoyast_reboot
 - installation/grub_test
 - installation/first_boot
-- qa_automation/patch_and_reboot
+- console/post_installation
 - console/system_prepare
 - console/check_network
 - console/system_state

--- a/tests/console/post_installation.pm
+++ b/tests/console/post_installation.pm
@@ -1,0 +1,49 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Replacement of patch_and_reboot, does everything else but patch and reboot,
+#          adding repos and patching is not done as it's done during installation,
+#          thus reboot is not needed
+# - Stop packagekit service (unless DESKTOP is textmode)
+# - Disable nvidia repository
+# - Enable basesystem repository on TERADATA without SCC reg
+# - Upload kernel changelog
+#
+# Maintainer: QE Core <qe-core@suse.com>
+
+use base "opensusebasetest";
+use testapi;
+use utils qw(zypper_call quit_packagekit);
+use serial_terminal qw(select_serial_terminal);
+use registration qw(add_suseconnect_product get_addon_fullname);
+use version_utils qw(is_sle is_jeos);
+
+sub run {
+    select_serial_terminal;
+
+    quit_packagekit unless check_var('DESKTOP', 'textmode');
+
+    zypper_call(q{mr -d $(zypper lr | awk -F '|' '{IGNORECASE=1} /nvidia/ {print $2}')}, exitcode => [0, 3]);
+    zypper_call(q{mr -e $(zypper lr | awk -F '|' '/Basesystem-Module/ {print $2}')}, exitcode => [0, 3]) if get_var('FLAVOR') =~ /TERADATA/;
+
+    add_suseconnect_product(get_addon_fullname('phub')) if check_var('PATTERNS', 'all') && is_sle('15-SP6+') && is_sle('<16');
+
+    my $suffix = is_jeos ? '-base' : '';
+    assert_script_run("rpm -ql --changelog kernel-default$suffix > /tmp/kernel_changelog.log");
+    zypper_call("lr -u", log => 'repos_list.txt');
+    upload_logs('/tmp/kernel_changelog.log');
+    upload_logs('/tmp/repos_list.txt');
+
+    if (get_var('SAVE_LIST_OF_PACKAGES')) {
+        assert_script_run("rpm -qa > /tmp/rpm_packages_list_after_patch.txt");
+        upload_logs('/tmp/rpm_packages_list_after_patch.txt');
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
This should be QE-Core tests, only missing is qam-allpatterns+addons because
it uses main.pm with nice condition for few tests which run with WE
Migrating qam-allpatterns+addons to yaml would make it difficult
IMO the code from post_installation can be part of system_prepare, but that
does affect many tests of different squads, right now as first step I want to
do replace and final state would be removal of patch_and_reboot


- Related ticket: https://progress.opensuse.org/issues/189219
- Verification run: https://openqa.suse.de/tests/overview?build=jpupava_poo189219&distri=sle
