### PR TITLE
Fix qesap-regression console redirection timed out

### DIFF
--- a/schedule/sles4sap/qesapdeploy/qesap.yml
+++ b/schedule/sles4sap/qesapdeploy/qesap.yml
@@ -12,4 +12,5 @@ schedule:
     - sles4sap/qesapdeployment/test_cluster
     - sles4sap/qesapdeployment/test_mirror
     - sles4sap/qesapdeployment/test_crash
+    - sles4sap/qesapdeployment/test_console_redirection
     - sles4sap/qesapdeployment/destroy

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -16,6 +16,12 @@ use sles4sap::ibsm;
 
 sub run {
     my ($self) = @_;
+    # Workaround for 'TEAM-10520 - Console redirection timing out sporadically'.
+    # Preselect 'log-console' to login earlier before doing deployment.
+    # This will avoid sporadic issue of 'backend got TERM' when doing select_console('log-console') at the first time after deployment.
+    # After deployment if 'backend got TERM' happened test case will exceed MAX_JOB_TIME and 'post_fail_hook' will not be invoked.
+    record_info('Workaround: TEAM-10520');
+    select_console('log-console');
     select_serial_terminal;
 
     # Init all the PC gears (ssh keys)


### PR DESCRIPTION
Fix qesap-regression Console redirection timing out sporadically
This issue might be a backend bug of tool's team (see ticket for more details)
So, I would like to add a workaround ATM and let's see if this issue still existing in following ow15 nightly triggers.
Of course added sles4sap/qesapdeployment/test_console_redirection back as it was disabled before.

- Related ticket: [TEAM-10520](https://jira.suse.com/browse/TEAM-10520) - [timeboxed][qesap-regression] Console redirection timing out sporadically
- Verification run:
https://openqaworker15.qa.suse.cz/tests/344507#step/configure/5 (login to log-console tty5)
https://openqaworker15.qa.suse.cz/tests/344507#step/test_console_redirection/9 (at here no need to login to log-console tty5 anymore) (executed `test_crash` then `test_console_redirection` for 30 times, all test modules are passed)
More VRs:
https://openqaworker15.qa.suse.cz/tests/344532#step/test_console_redirection/10  (executed `test_crash` then `test_console_redirection` for 30 times, all test modules are passed)
https://openqaworker15.qa.suse.cz/tests/344533#step/configure/1