### PR TITLE
Use combustion's FDE in sle-micro 6.1

### DIFF
--- a/data/microos/butane/script
+++ b/data/microos/butane/script
@@ -104,7 +104,7 @@ fi
 sed -i "s,${luks_keyfile},/.virtual-root.key,g" /etc/crypttab
 sed -i "s,${luks_keyfile},/.virtual-root.key,g" /etc/dracut.conf.d/99-luks-boot.conf
 cryptsetup --key-file "${oldpass}" luksChangeKey --pbkdf pbkdf2 "${luks_dev}" "${newpass}"
-cryptsetup reencrypt --key-file "${newpass}" "${luks_dev}"
+cryptsetup reencrypt --key-slot 0 --key-file "${newpass}" "${luks_dev}"
 fdectl --passfile "${newpass}" regenerate-key
 systemctl enable fde-tpm-enroll.service
 transactional-update initrd grub.cfg

--- a/tests/microos/verify_setup.pm
+++ b/tests/microos/verify_setup.pm
@@ -317,7 +317,7 @@ sub run {
     }
 
     if (get_var('QEMUTPM', '')) {
-        my $device = (is_sle(">=16") || is_sle_micro(">=6.2")) ? "/dev/mapper/luks" : "/dev/mapper/cr_root";
+        my $device = (is_sle(">=16") || is_sle_micro(">=6.1")) ? "/dev/mapper/luks" : "/dev/mapper/cr_root";
         validate_script_output("cryptsetup status $device", qr/is active and is in use./);
     }
 


### PR DESCRIPTION
Backport slem 6.2 test suite to sle-micro 6.1 respin.

Test combustion image `combustion_new.qcow2`

##### Verification runs

* [slem 6.2](https://openqa.suse.de/tests/19242419#)
* [6.1](https://openqa.suse.de/tests/19242453#)
