### PR TITLE
Make qesap_az_get_resource_group die on undef job

### DIFF
--- a/lib/sles4sap/qesap/azure.pm
+++ b/lib/sles4sap/qesap/azure.pm
@@ -69,7 +69,8 @@ by the qe-sap-deployment
 
 sub qesap_az_get_resource_group {
     my (%args) = @_;
-    my $job_id = get_var('QESAP_DEPLOYMENT_IMPORT', get_current_job_id());    # in case existing deployment is used
+    my $job_id = get_var('QESAP_DEPLOYMENT_IMPORT', get_current_job_id());
+    die "Could not determine job ID to find the resource group" unless defined $job_id;
     my $all_rg = az_group_name_get();
     my @selected_rg = grep(/$job_id/, @$all_rg);
     @selected_rg = grep(/$args{substring}/, @selected_rg) if ($args{substring});

--- a/t/15_qesap_azure.t
+++ b/t/15_qesap_azure.t
@@ -85,6 +85,19 @@ subtest '[qesap_az_get_resource_group] az integrate' => sub {
     ok($result eq 'BOAT1234', "result:$result is like expected BOAT1234");
 };
 
+subtest '[qesap_az_get_resource_group] die when job_id is undef' => sub {
+    my $qesap = Test::MockModule->new('sles4sap::qesap::azure', no_auto => 1);
+    $qesap->redefine(az_group_name_get => sub { return ['BOAT1234']; });
+    # Mock get_current_job_id to return undef
+    $qesap->redefine(get_current_job_id => sub { return undef; });
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    # Ensure QESAP_DEPLOYMENT_IMPORT is not set
+    set_var('QESAP_DEPLOYMENT_IMPORT', undef);
+
+    dies_ok { qesap_az_get_resource_group() } 'croaks when job_id is not defined';
+};
+
 subtest '[qesap_az_setup_native_fencing_permissions] missing argument' => sub {
     my %mandatory_args = (
         vm_name => 'CaptainUsop',


### PR DESCRIPTION
The `qesap_az_get_resource_group` function did not validate its job ID, returned by get_current_job_id.
It leads to silent failures where it would select an incorrect Azure resource group if the ID was uninitialized.
This change introduces a `die` statement to ensure the function fails immediately if the job ID is not defined, preventing misleading errors in subsequent test steps.

- Related ticket: https://jira.suse.com/browse/TEAM-10651

# Verification run:
 - sle-15-SP7-Azure-SAP-BYOS-Updates-saptune-x86_64-Build20250928-1-sles4sap_gnome_saptune_delete_rename@az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/344551 :green_apple: 