### PR TITLE
autoyast: set default target for opensuse_gnome

### DIFF
--- a/data/autoyast_opensuse/opensuse_gnome.xml
+++ b/data/autoyast_opensuse/opensuse_gnome.xml
@@ -41,4 +41,7 @@
       <username>root</username>
     </user>
   </users>
+  <services-manager>
+    <default_target>graphical</default_target>
+  </services-manager>
 </profile>


### PR DESCRIPTION
Autoyast is 'dying' - but contains business logic to switch to graphical.target
whenever xdm is being installed

with GMOME 49, GNOME became Wayland-only, making the presence of Xorg, and also xdm,
less of a common thing. Installing the default gnome-pattern will result in
a system running gdm directly via systemd service instead of relying on the xdm
wrapper.

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1250672
- Needles: N/A
- Verification run: TBD
