### PR TITLE
pc/ssh_interactive_end: Ignore failure on module

### DIFF
--- a/tests/publiccloud/ssh_interactive_end.pm
+++ b/tests/publiccloud/ssh_interactive_end.pm
@@ -18,4 +18,8 @@ sub run {
     select_host_console(force => 1);
 }
 
+sub test_flags {
+    return {ignore_failure => 1};
+}
+
 1;


### PR DESCRIPTION
`ssh_interactive_end` is the last module on some Public Cloud jobs, doesn't test anything and should NOT mark the job as failed.

Failed job: https://openqa.suse.de/tests/19235692#step/ssh_interactive_end/92