### PR TITLE
prepare_system: Handle fallouts from boo#1250513

### DIFF
--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -68,6 +68,12 @@ sub run {
         }
     }
 
+    my $nss_systemd = script_run('if [ -f /etc/nsswitch.conf ]; then grep passwd.*systemd /etc/nsswitch.conf; fi');
+    if ($nss_systemd) {
+        assert_script_run('rm /etc/nsswitch.conf');
+        record_soft_failure("boo#1250513 - /etc/nsswitch.conf does not handle nss_systemd");
+    }
+
     # bsc#997263 - VMware screen resolution defaults to 800x600 and longer GRUB_TIMEOUT for better needle detection
     # Also for HA ha_cluster_crash_test test cases
     if (check_var('VIRSH_VMM_FAMILY', 'vmware') || (check_var('CLUSTER_NAME', 'crashtest') && is_pvm)) {


### PR DESCRIPTION
/etc/nsswitch.conf on Leap 15.x did not yet contain systemd to handle
hosts/passwd/shadow lookups.

As we don't really deviate from the default template, we can simply
drop the local file and have the system fall backto /usr/etc/nsswitch.conf

The underlying bug - have nsswitch.conf fixed up by packages - will take some
more thought to get a reliable setup

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1250513
- Needles: N/A
- Verification run: Run by clone

openqa: clone https://openqa.opensuse.org/tests/5351099
