### PR TITLE
nvidia: Mutually exclude other variants' repositories

### DIFF
--- a/lib/nvidia_utils.pm
+++ b/lib/nvidia_utils.pm
@@ -72,7 +72,7 @@ sub install
     record_info("NVIDIA Version", $version);
 
     my $workaround;
-    if ($version < 580) {
+    if ($version < 580 && $args{variant} eq 'cuda') {
         $workaround = "nvidia-persistenced == $version";
         record_soft_failure("bsc#1249098 - workaround for Nvidia driver dependency issue");
     }


### PR DESCRIPTION
Verification runs:
- https://openqa.suse.de/tests/19247930 (Micro 6.1)
- https://openqa.suse.de/tests/19247946 (SLE15-SP6 baremetal)
- https://openqa.suse.de/tests/19189361#step/nvidia/50 (SLE15-SP5 Public Cloud *BEFORE* - pulls package from wrong repo)
- https://openqa.suse.de/tests/19247948#step/nvidia/51 (SLE15-SP5 Public Cloud *AFTER* - fails correctly as the package is not found)
