### PR TITLE
Migrate from rcnetwork to systemctl restart network

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -19,6 +19,7 @@ use version_utils qw(is_sle is_leap is_tumbleweed);
 use y2_module_guitest 'launch_yast2_module_x11';
 use x11utils 'turn_off_gnome_screensaver';
 use serial_terminal qw(select_serial_terminal);
+use Utils::Systemd qw(systemctl);
 
 use base 'consoletest';
 
@@ -199,7 +200,7 @@ Set up mail server with Postfix and Dovecot:
 
 =over
 
-=item * 1. Setting Postfix for outgoing mail by: setting hostname and domain, restart rcnetwork services, double check the setting
+=item * 1. Setting Postfix for outgoing mail by: setting hostname and domain, restart network services, double check the setting
 
 =item * 2. Setting mail sender/recipient as needed
 
@@ -229,8 +230,8 @@ sub setup_mail_server_postfix_dovecot {
     assert_script_run("echo $ip $hostname.$testdomain $hostname >> /etc/hosts");
     set_hostname($hostname);
 
-    # Restart rcnetwork services:
-    assert_script_run("rcnetwork restart");
+    # Restart network services:
+    systemctl 'restart network';
 
     # Double check the setting
     validate_script_output("hostname --short", sub { m/$hostname/ });

--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -9,6 +9,7 @@ use Exporter;
 use testapi;
 use version_utils 'is_opensuse';
 use Utils::Architectures 'is_aarch64';
+use Utils::Systemd qw(systemctl);
 
 our @EXPORT = qw(configure_hostname get_host_resolv_conf is_networkmanager restart_networking
   configure_static_ip configure_dhcp configure_default_gateway configure_static_dns
@@ -99,7 +100,7 @@ sub configure_dhcp {
     type_string("echo \"STARTMODE='auto'\nBOOTPROTO='dhcp'\n\" > /etc/sysconfig/network/ifcfg-\$NIC;");
     enter_cmd 'done';
     save_screenshot;
-    assert_script_run "rcnetwork restart";
+    systemctl 'restart network';
     assert_script_run "ip addr";
     save_screenshot;
 }
@@ -244,7 +245,7 @@ sub restart_networking {
             assert_script_run "timeout 90 bash -c \"until nmcli networking connectivity check | tee /dev/stderr | grep -E '$expected_nm_connectivity'; do sleep 10; done\"";
         }
     } else {
-        assert_script_run 'rcnetwork restart';
+        systemctl 'restart network';
     }
 
     record_info('network cfg', script_output('ip address show; echo; ip route show; echo; grep -v "^#" /etc/resolv.conf', proceed_on_failure => 1));

--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -71,7 +71,7 @@ sub setup_static_network {
     assert_script_run("echo default $gw - - > /etc/sysconfig/network/routes");
     my $iface = iface();
     assert_script_run qq(echo -e "\\nSTARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$ip'\\nMTU='$mtu'">/etc/sysconfig/network/ifcfg-$iface);
-    assert_script_run 'rcnetwork restart';
+    systemctl 'restart network';
     assert_script_run 'ip addr';
     assert_script_run "ping -c 1 $gw", fail_message => 'Gateway is not reachable, please check your network configuration and setups';
     assert_script_run "ip -6 addr add $args{ipv6} dev $iface" if exists $args{ipv6};


### PR DESCRIPTION
rcFOO scripts, including rcnetwork, are SUSE specific and are deprecated in favor
of the standard systemctl commands

- Related ticket: https://progress.opensuse.org/issues/189687
- Needles: N/A
- Verification run: 

openqa: clone https://openqa.opensuse.org/tests/5351249
