### PR TITLE
Fix upload_supportconfig_log

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -924,7 +924,7 @@ sub upload_supportconfig_log {
     my $logs = "/var/tmp/scc_supportconfig";
     # poo#187440 Workaround applied inject newline in ssh supportconfig to prevent hang cases, while bsc#1250310 open
     my $cmd = "echo | timeout $timeout sudo supportconfig -R " . dirname($logs) . " -B supportconfig -x AUDIT";
-    my $err = $self->ssh_script_run(cmd => "$cmd", timeout => ($timeout + 60), proceed_on_failure => 1);
+    my $err = $self->ssh_script_run(cmd => $cmd, timeout => ($timeout + 60), proceed_on_failure => 1);
     $self->ssh_script_run(cmd => "sudo chmod 0644 $logs.txz", proceed_on_failure => 1);
     $self->upload_log("$logs.txz", failok => 1, timeout => $timeout);
     record_info('supportconfig done', ($err) ? 'Failed after ' . time() - $start . "sec." : "OK Log $logs.txz", result => ($err) ? 'fail' : 'ok');


### PR DESCRIPTION
- Use `echo` instead of `printf` to avoid using single-quote around newline char.
- Remove redundant double quotes.

openQA chokes on the single quote here:
https://openqa.suse.de/tests/19235743#step/img_proof/156