### PR TITLE
Remove use of STORAGE_ACCOUNT_NAME

### DIFF
--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -47,7 +47,6 @@ sub run {
         $variables{OS_VER} = get_var('QESAPDEPLOY_CLUSTER_OS_VER');
     }
     elsif ($provider_setting eq 'AZURE') {
-        $variables{STORAGE_ACCOUNT_NAME} = get_required_var('STORAGE_ACCOUNT_NAME');
         $variables{OS_URI} = $provider->get_blob_uri(get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION'));
     }
     else


### PR DESCRIPTION
Remove get_required_var for a no more used variable. In particular the variable was written on a template variable `$variables{STORAGE_ACCOUNT_NAME}` never used in any config.yaml file.

- Related ticket: https://jira.suse.com/browse/TEAM-10654

# Verification run:
http://openqaworker15.qa.suse.cz/tests/344605
http://openqaworker15.qa.suse.cz/tests/344758

Both fails but later than the fix and due to a JobGroup configuration 