### PR TITLE
Revert "prepare_system: Handle fallouts from boo#1250513"

### DIFF
--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -68,12 +68,6 @@ sub run {
         }
     }
 
-    my $nss_systemd = script_run('if [ -f /etc/nsswitch.conf ]; then grep passwd.*systemd /etc/nsswitch.conf; fi');
-    if ($nss_systemd) {
-        assert_script_run('rm /etc/nsswitch.conf');
-        record_soft_failure("boo#1250513 - /etc/nsswitch.conf does not handle nss_systemd");
-    }
-
     # bsc#997263 - VMware screen resolution defaults to 800x600 and longer GRUB_TIMEOUT for better needle detection
     # Also for HA ha_cluster_crash_test test cases
     if (check_var('VIRSH_VMM_FAMILY', 'vmware') || (check_var('CLUSTER_NAME', 'crashtest') && is_pvm)) {


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#23460

Reverting since it breaks most openqa tests 
https://progress.opensuse.org/issues/189744