### PR TITLE
PC New LTP env variables injection

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -578,8 +578,14 @@ sub prepare_ltp_cmd {
     $sut .= ':host=' . $instance->public_ip;
     $sut .= ':reset_cmd=\'' . $reset_cmd . '\'';
 
+    my $env_prefix = '';
+    if (defined $env && $env ne '') {
+        my @vars = split /:/, $env;
+        $env_prefix = join(' ', @vars) . ' ';
+    }
+
     my $python_exec = get_python_exec();
-    my $cmd = "$python_exec kirk ";
+    my $cmd = "$env_prefix$python_exec kirk ";
     $cmd .= '--verbose ';
     $cmd .= '--exec-timeout=' . $exec_timeout . ' ';
     $cmd .= '--suite-timeout=' . $ltp_timeout . ' ';
@@ -587,7 +593,6 @@ sub prepare_ltp_cmd {
     $cmd .= '--skip-tests \'' . $skip_tests . '\' ' if $skip_tests;
     $cmd .= '--sut default:com=ssh ';
     $cmd .= '--com=ssh' . $sut . ' ';
-    $cmd .= '--env ' . $env . ' ' if ($env);
     return $cmd;
 }
 


### PR DESCRIPTION
Due to:
```
Remove --env option that was created to support multiple frameworks. Now that we support LTP environment only, we can fetch them directly from the OS environment like it was for runltp.

For instance, this will permits to do:

MYENV1=val1 MYENV2=val2 kirk --run-suite syscalls

instead of:

kirk --run-suite syscalls --env MYENV1=val1:MYENV2=val2

Closes: https://github.com/linux-test-project/kirk/issues/72
```

we need to adapt to new way we execute the LTP
- Related ticket: https://progress.opensuse.org/issues/188928
- Verification run:  https://openqa.suse.de/tests/21426762#step/run_ltp/344