### PR TITLE
Switch to NCC gcp peering for regression

### DIFF
--- a/data/sles4sap/qe_sap_deployment/qesap_gcp_peering.yaml
+++ b/data/sles4sap/qe_sap_deployment/qesap_gcp_peering.yaml
@@ -24,6 +24,7 @@ terraform:
     ibsm_vpc_name: '%IBSM_VPC_NAME%'
     ibsm_subnet_name: '%IBSM_SUBNET_NAME%'
     ibsm_subnet_region: '%IBSM_SUBNET_REGION%'
+    ibsm_hub_name: '%IBSM_NCC_HUB%'
     ip_cidr_range: '%MAIN_ADDRESS_RANGE%'
 ansible:
   roles_path: '%ANSIBLE_ROLES%'

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -132,6 +132,7 @@ sub run {
         $variables{IBSM_VPC_NAME} = get_var('QESAPDEPLOY_IBSM_VPC_NAME', '');
         $variables{IBSM_SUBNET_NAME} = get_var('QESAPDEPLOY_IBSM_SUBNET_NAME', '');
         $variables{IBSM_SUBNET_REGION} = get_var('QESAPDEPLOY_IBSM_SUBNET_REGION', '');
+        $variables{IBSM_NCC_HUB} = get_var('QESAPDEPLOY_IBSM_NCC_HUB', '');
     }
 
     if (($provider_setting eq 'AZURE' && get_var('QESAPDEPLOY_IBSM_VNET') && get_var('QESAPDEPLOY_IBSM_RG')) ||


### PR DESCRIPTION
This pr enables running NCC gcp peering in qesap-regression.

- Related ticket: https://jira.suse.com/browse/TEAM-10455
- Verification run: https://openqaworker15.qa.suse.cz/tests/344788 (later failure unrelated)
