### PR TITLE
zypper_search: Fix code on SLE11-SP4

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1004,7 +1004,8 @@ sub zypper_search {
         @fields = ('status', 'name', 'type', 'version', 'arch', 'repository');
     }
 
-    my $output = script_output("zypper -in se $params");
+    zypper_call("search $params", log => 'zypper.log', exitcode => [0, 104]);
+    my $output = script_output('cat /tmp/zypper.log');
     return parse_zypper_table($output, \@fields);
 }
 


### PR DESCRIPTION
`--ignore-unknown` (`-i`) parameter to `zypper search` was added in zypper 1.8.7 in commit
    https://github.com/openSUSE/zypper/commit/cdf3877d5fc2c8fd5ee0d51cbfca07ce6f27a625

SLE11-SP4 has older zypper 1.6.340, option is not supported on SLE11  (https://openqa.suse.de/tests/19156089#step/update_kernel/30):
```    
Unknown option 'i'
SCRIPT_FINISHEDPZEFL-2- at /usr/lib/os-autoinst/distribution.pm line 305.
		distribution::script_output(Distribution::Opensuse::Tumbleweed=HASH(0x555acb862038), "zypper -in se -s -t package -r kernel-update-0", "timeout", undef, "quiet", undef, "type_command", undef, ...) called at /usr/lib/os-autoinst/testapi.pm line 1102
		testapi::script_output("zypper -in se -s -t package -r kernel-update-0") called at sle/lib/utils.pm line 953

```
We still support SLE11-SP4 LTEC on kernel, where it is used. Add it only for newer SLES.

Fixes: 27da75aa8e ("zypper_search: Properly handle empty package list (#23353)")

Verification run:
**- http://quasar.suse.cz/tests/694#step/update_kernel/30 (sle11-sp4 - the main verification, NOTE: this still fails, but due `Valid metadata not found at specified URL(s)`, which is IMHO better. Or is there a way to fix it?)**
- http://quasar.suse.cz/tests/696 (sle16, check for a possible regression)
- http://quasar.suse.cz/tests/695 (sle-12-SP5, check for a possible regression)
- http://quasar.suse.cz/tests/698 (sle-15-SP2, check for a possible regression)
- http://quasar.suse.cz/tests/699 (Tumbleweed-JeOS, check for a possible regression)
- http://quasar.suse.cz/tests/697 (Tumbleweed, check for a possible regression)