### PR TITLE
install_ltp: Use bash for nobody user

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -292,6 +292,11 @@ sub run {
         assert_script_run("uname -v | grep -E '(/kGraft-|/${lp_tag})'");
     }
 
+    # poo#188250 on Tumbleweed defautl shell is /usr/sbin/nologin
+    record_info('nobody before', script_output('getent passwd nobody'));
+    assert_script_run('if ! getent passwd nobody | grep /bin/bash; then chsh -s /bin/bash nobody; fi');
+    record_info('nobody after', script_output('getent passwd nobody'));
+
     upload_logs('/boot/config-$(uname -r)', failok => 1);
     set_zypper_lock_timeout(300);
     add_we_repo_if_available;


### PR DESCRIPTION
At least in Tumbleweed nobody user has configured `/usr/sbin/nologin` as a default shell. This leads to failure for IMA tests:

    ima_conditionals 1 TINFO: verify measuring user files when requested via uid
    sudo: Account expired or PAM config lacks an "account" section for sudo, contact your system administrator
    sudo: a password is required

Switch to `bash`. Also log the setup.

- Related ticket: https://progress.opensuse.org/issues/188250

Verification run:
- **http://quasar.suse.cz/tests/704#step/install_ltp/52 (Tumbleweed)**
- http://quasar.suse.cz/tests/703 (sle16)
- http://quasar.suse.cz/tests/702 (sle-12-SP5)
- http://quasar.suse.cz/tests/701 (sle-15-SP2)
- http://quasar.suse.cz/tests/700 (Tumbleweed-JeOS)
