### PR TITLE
Add selective delay before image pull

### DIFF
--- a/tests/containers/bci_version_check.pm
+++ b/tests/containers/bci_version_check.pm
@@ -42,6 +42,10 @@ sub run {
         die('No valid container engines defined in CONTAINER_RUNTIMES variable!');
     }
 
+    # Avoid unnecessary load on IBS by holding back all test runs except 15-SP7, so that registry.suse.de can load the images into the cache
+    # This is a temporary workaround until https://progress.opensuse.org/issues/189813 is done.
+    sleep(300) unless check_var('HOST_VERSION', '15-SP7');
+
     die "Pulling container image '$image' timed out. Likely a new build is already being prepared. Look for a new build and ignore this test run.\n"
       if script_run("timeout 300 $engine pull -q $image", timeout => 330) == 124;
     script_retry("$engine pull -q $image", timeout => 300, delay => 60, retry => 2);


### PR DESCRIPTION
Add a 5 minute delay before pulling the image on all hosts except 15-SP7 so that we allow registry.suse.de to get the cache warm.

The [IBS team discovered](https://suse.slack.com/archives/C02BX1X92HM/p1759330072361649) that our test runs impose a heavy load on the IBS infrastructure, because a good portion of the test runs hit registry.suse.de at the same time, thus causing cache misses. This causes about 50 test runs in parallel to miss the cache and directly hit IBS.

- Related ticket: https://progress.opensuse.org/issues/189813

## Verification runs

* [15-SP7](https://duck-norris.qe.suse.de/tests/15004)
* [15-SP6](https://duck-norris.qe.suse.de/tests/15005) (bci_version_check takes 5 minutes)
