### PR TITLE
Revert "python_docker: Set UNKNOWN_DOCKER_SSH_HOST"

### DIFF
--- a/tests/containers/python_docker.pm
+++ b/tests/containers/python_docker.pm
@@ -137,7 +137,6 @@ sub test ($target) {
         DOCKER_TEST_API_VERSION => $api_version,
         # Fix docker-py test issues with datetimes on different timezones by using UTC
         TZ => "UTC",
-        UNKNOWN_DOCKER_SSH_HOST => "ssh://hola:123",
     );
     my $env = join " ", map { "$_=$env{$_}" } sort keys %env;
     my $pytest_args = "-vv --capture=tee-sys -o junit_logging=all --junit-xml $target.xml $ignore $deselect";


### PR DESCRIPTION
We can safely skip this [test](https://github.com/docker/docker-py/blob/main/tests/ssh/connect_test.py#L13)
