### PR TITLE
Add cmd_run() and handle exit code in zypper_search()

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1006,7 +1006,10 @@ sub zypper_search {
         @fields = ('status', 'name', 'type', 'version', 'arch', 'repository');
     }
 
-    my $output = script_output("zypper -in se $params");
+    my ($ret, $output) = cmd_run("zypper -n se $params");
+
+    die 'zypper search failed unexpectedly'
+      unless defined($ret) && ($ret == 0 || $ret == 104);
     return parse_zypper_table($output, \@fields);
 }
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -136,6 +136,8 @@ our @EXPORT = qw(
   render_autoinst_url
   is_agama_guest
   upload_folders
+  cmd_run
+  assert_cmd_run
 );
 
 our @EXPORT_OK = qw(
@@ -3451,6 +3453,102 @@ sub upload_folders {
         upload_logs("$args{store}/$file.tar.gz", failok => $args{failok});
         script_run("rm -f -r $args{store}/$file.tar.gz") if ($args{cleanup});
     }
+}
+
+sub _flush_console {
+    my $buf;
+    my $ret = '';
+
+    while ($buf = wait_serial(qr/.+/s, timeout => 1, quiet => 1, record_output => 1)) {
+        $ret .= $buf;
+    }
+
+    return $ret;
+}
+
+sub _cmd_run_impl {
+    my ($cmd, %args) = @_;
+
+    $args{timeout} //= $bmwqemu::default_timeout;
+    die "Terminator '&' found in cmd_run call. cmd_run can not check script success. Use 'background_script_run' instead."
+      if $cmd =~ m/(?<!\\)&\s*$/;
+
+    if (is_serial_terminal()) {
+        wait_serial(serial_terminal::serial_term_prompt(), no_regex => 1, quiet => 1, timeout => 5) or die 'Terminal not ready';
+    }
+
+    my $marker = hashed_string("CR" . $cmd . $args{timeout});
+    my $preface = "echo $marker";
+    my $delim = "echo $marker-\$?-";
+
+    unless (is_serial_terminal()) {
+        $preface .= " >/dev/$testapi::serialdev";
+        $cmd = "( $cmd ) | tee /dev/$testapi::serialdev";
+        $delim = "echo $marker-\${PIPESTATUS[0]}- >/dev/$testapi::serialdev";
+    }
+
+    $cmd = "$preface; $cmd; $delim";
+    type_string($cmd);
+
+    if (is_serial_terminal()) {
+        wait_serial($cmd, no_regex => 1, timeout => 1, quiet => 1, buffer_size => length($cmd) + 64) or die 'Terminal echo mismatch';
+        type_string("\n");
+    }
+    else {
+        send_key('ret');
+    }
+
+    my $output = wait_serial("$marker-\\d+-", timeout => $args{timeout}, quiet => 1, record_output => 1);
+    $autotest::current_test->take_screenshot() unless is_serial_terminal();
+
+    unless ($output) {
+        wait_serial(qr/$marker\r?\n/s, timeout => 1, quiet => 1);
+        die 'Command timed out';
+    }
+
+    $output =~ m/$marker\n(.*)$marker-(\d+)-/s;
+    return ($2, $1);
+}
+
+=head2 cmd_run
+
+ cmd_run($cmd [, timeout => $timeout])
+
+Run I<$cmd> in console and wait for its completion. In scalar context, return
+command exit code. In array context, return tuple (exit code, console output).
+
+=cut
+
+sub cmd_run {
+    my ($cmd, %args) = @_;
+    my $output = "Command: $cmd\n";
+    my @ret;
+
+    eval {
+        @ret = _cmd_run_impl($cmd, %args);
+    };
+
+    if ($@) {
+        my $log = _flush_console();
+
+        $output .= "Error: $@\n\nConsole output:\n$log";
+        $autotest::current_test->record_resultfile($cmd, $output, result => 'fail');
+        return wantarray ? (undef, undef) : undef;
+    }
+
+    $output .= "Exit code: ${ret[0]}\n\nConsole output:\n${ret[1]}";
+    $autotest::current_test->record_resultfile($cmd, $output, result => ($args{assert} && $ret[0] != 0) ? 'fail' : 'ok');
+    return wantarray ? @ret : $ret[0];
+}
+
+sub assert_cmd_run {
+    my ($cmd, %args) = @_;
+    $args{assert} = 1;
+    my @ret = cmd_run($cmd, %args);
+
+    die "Command '$cmd' timed out" unless defined $ret[0];
+    die "Command '$cmd' failed" unless $ret[0] == 0;
+    return wantarray ? @ret : $ret[0];
 }
 
 1;


### PR DESCRIPTION
Add `cmd_run()` and `assert_cmd_run()` helper functions which work like a combination of `script_run()`, `assert_script_run()` and `script_output()` functions but with less clutter in test result details.

Also remove the `-i` parameter from `zypper_search()` and handle exit code 104 explicitly instead using the above functions.

- Related ticket: N/A
- Needles: N/A
- Verification runs:
  - `cmd_run()` feature demonstration: https://openqa.suse.de/tests/19271934 (expected to fail)
  - SLE-15SP7 `zypper_search()` for missing package: https://openqa.suse.de/tests/19271935
  - SLE-11SP4 `zypper_search()`: https://openqa.suse.de/tests/19271936
