### PR TITLE
Minor BATS fixes

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -286,7 +286,7 @@ EOF
 
     delegate_controllers;
 
-    if (check_var("ENABLE_SELINUX", "0") && script_output("getenforce") eq "Enforcing") {
+    if (check_var("SELINUX_ENFORCE", "0") && script_output("getenforce") eq "Enforcing") {
         record_info("Disabling SELinux");
         run_command "sed -i 's/^SELINUX=.*/SELINUX=permissive/' /etc/selinux/config";
         run_command "setenforce 0";

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -20,7 +20,6 @@ The tests rely on some variables:
 | `BATS_PACKAGE` | `aardvark-dns` `buildah` `conmon` `netavark` `podman` `runc` `skopeo` |
 | `BATS_TESTS` | Run only the specified tests |
 | `BATS_VERSION` | Version of [bats](https://github.com/bats-core/bats-core) to use |
-| `BUILDAH_STORAGE_DRIVER` | Storage driver used for buildah: `vfs` or `overlay` |
 | `ENABLE_SELINUX` | Set to `0` to put SELinux in permissive mode |
 | `GITHUB_PATCHES` | List of github PR id's containing upstream test patches |
 | `GITHUB_REPO` | Repo & branch in the form `[<GITHUB_ORG>]#<BRANCH>` |

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -20,10 +20,10 @@ The tests rely on some variables:
 | `BATS_PACKAGE` | `aardvark-dns` `buildah` `conmon` `netavark` `podman` `runc` `skopeo` |
 | `BATS_TESTS` | Run only the specified tests |
 | `BATS_VERSION` | Version of [bats](https://github.com/bats-core/bats-core) to use |
-| `ENABLE_SELINUX` | Set to `0` to put SELinux in permissive mode |
 | `GITHUB_PATCHES` | List of github PR id's containing upstream test patches |
 | `GITHUB_REPO` | Repo & branch in the form `[<GITHUB_ORG>]#<BRANCH>` |
 | `OCI_RUNTIME` | OCI runtime to use: `runc` or `crun` |
+| `SELINUX_ENFORCE` | Set to `0` to put SELinux in permissive mode |
 | `TEST_PACKAGES` | List of optional package URL's |
 | `TEST_REPOS` | List of optional test repositories |
 

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -20,7 +20,6 @@ sub run_tests {
     return 0 if check_var($skip_tests, "all");
 
     my $storage_driver = $rootless ? "vfs" : script_output("buildah info --format '{{ .store.GraphDriverName }}'");
-    $storage_driver = get_var("BUILDAH_STORAGE_DRIVER", $storage_driver);
     record_info("storage driver", $storage_driver);
 
     my $oci_runtime = get_var('OCI_RUNTIME', script_output("buildah info --format '{{ .host.OCIRuntime }}'"));

--- a/variables.md
+++ b/variables.md
@@ -39,7 +39,6 @@ BCI_OS_VERSION | string | | Set the environment variable OS_VERSION to this valu
 BOOTLOADER | string | grub2 | Which bootloader is used by the image or will be selected during installation, e.g. `grub2`, `grub2-bls`, `systemd-boot`
 BTRFS | boolean | false | Indicates btrfs filesystem. Deprecated, use FILESYSTEM instead.
 BUILD | string  |       | Indicates build number of the product under test.
-BUILDAH_STORAGE_DRIVER | string | | Storage driver used for buildah: vfs or overlay.
 CASEDIR | string | | Path to the directory which contains tests.
 CHECK_RELEASENOTES | boolean | false | Loads `installation/releasenotes` test module.
 CHECKSUM_* | string | | SHA256 checksum of the * medium. E.g. CHECKSUM_ISO_1 for ISO_1.


### PR DESCRIPTION
- Drop useless `BUILDAH_STORAGE_DRIVER` variable
- Rename oddly named `ENABLE_SELINUX` variable to `SELINUX_ENFORCING` since its only use is to disable enforcing.

No functional change.