### PR TITLE
podman_e2e: bsc#1248988 was fixed on Tumbleweed

### DIFF
--- a/tests/containers/podman_e2e.pm
+++ b/tests/containers/podman_e2e.pm
@@ -31,7 +31,7 @@ sub setup {
     select_serial_terminal;
 
     # Workaround for https://bugzilla.opensuse.org/show_bug.cgi?id=1248988 - catatonit missing in /usr/libexec/podman/
-    run_command "cp -f /usr/bin/catatonit /usr/libexec/podman/catatonit";
+    run_command "cp -f /usr/bin/catatonit /usr/libexec/podman/catatonit" if (script_run("test -f /usr/libexec/podman/catatonit") != 0);
     # rootless user needed for these tests
     run_command "useradd -m containers";
     run_command "usermod --add-subuids 100000-165535 containers";


### PR DESCRIPTION
bsc#1248988 was fixed on Tumbleweed

Failing job: https://openqa.opensuse.org/tests/5363116#step/podman_e2e/150