### PR TITLE
P.C. supportconfig logs: fix breaking failures

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -401,6 +401,7 @@ PUBLIC_CLOUD_SCC_ENDPOINT | string | "registercloudguest" | Name of binary which
 PUBLIC_CLOUD_SKIP_MU | boolean | false | Run tests without downloading/applying maintenance updates.
 PUBLIC_CLOUD_SLES4SAP | boolean | false | If set, sles4sap test module is added to the job.
 PUBLIC_CLOUD_STORAGE_ACCOUNT | string | "" | Storage account used e.g. for custom disk and container images
+PUBLIC_CLOUD_SUPPORTCONFIG_EXCLUDE | string | "" | List of comma-separated features to exclude from 'supportconfig' execution
 PUBLIC_CLOUD_TERRAFORM_DIR | string | "/root/terraform" | Override default root path to terraform directory
 PUBLIC_CLOUD_TERRAFORM_FILE | string | "" | If defined, use this terraform file (from the `data/` directory) instead the CSP default
 PUBLIC_CLOUD_TERRAFORM_RUNNER | string | "tofu" | Override terraform runner container. Can be either "tofu" or "terraform".


### PR DESCRIPTION
Pub.Cloid `supportconfig`, fix breaking failures:
  - Fix timeout management in supportconfig upload,avoiding stop run 
  - Skip log upload when supportconfig failed
  - Fix supportconfig exclusion tokens (w.a. [bsc#1250310](https://bugzilla.suse.com/show_bug.cgi?id=1250310#c2)
  - Add log messages in post/hooks to clarify the cleanup type in logs

The `supportconfig` tool resulted to have a fatal stop at `Updates` token for `SLE 12-SP5` images(at least); excluded for that version, being the solution in charge to bsc#1250310.

- Related ticket:[187440](https://progress.opensuse.org/issues/187440)
- Verification run: 

sle-12-SP5-GCE-Updates publiccloud_containers
https://openqa.suse.de/tests/19277561#step/ssh_interactive_end/116
sle-12-SP5-EC2-Updates publiccloud_img_proof
https://openqa.suse.de/tests/19277591#step/img_proof/179
sle-micro-5.4-EC2-BYOS-Updates slem_basic
https://openqa.suse.de/tests/19277593#step/slem_basic/385
