### PR TITLE
record_avc_selinux_alerts: Use Bash builtin instead of grep

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -392,7 +392,7 @@ sub record_avc_selinux_alerts {
         return;
     }
 
-    if (script_run('grep -q selinux /sys/kernel/security/lsm 2> /dev/null') != 0) {
+    if (script_run('test -d /sys/fs/selinux') != 0) {
         return;
     }
 


### PR DESCRIPTION
Use Bash builtin instead of grep to avoid spawning a new process.

- Related ticket: https://progress.opensuse.org/issues/187572