### PR TITLE
Avoid killall

### DIFF
--- a/tests/fips/gnutls/gnutls_base_check.pm
+++ b/tests/fips/gnutls/gnutls_base_check.pm
@@ -88,7 +88,7 @@ sub ensure_self_signed_cerificate_fails {
     else {
         die('Certificate should be invalid');
     }
-    assert_script_run('killall gnutls-serv');
+    assert_script_run('kill $(pidof gnutls-serv)');
 }
 
 sub run {


### PR DESCRIPTION
Avoid killall, sometimes it's not installed. 

- Related ticket: https://progress.opensuse.org/issues/188508
- Verification runs: 
  - https://openqa.suse.de/tests/19277659
  - https://openqa.opensuse.org/tests/5364903 