### PR TITLE
slem: Use a different test package than jq

### DIFF
--- a/tests/publiccloud/slem_basic.pm
+++ b/tests/publiccloud/slem_basic.pm
@@ -55,7 +55,7 @@ sub run {
         record_info('Xen version', $instance->ssh_script_output('xen-detect'));
     }
 
-    my $test_package = get_var('TEST_PACKAGE', 'jq');
+    my $test_package = get_var('TEST_PACKAGE', 'socat');
     $instance->run_ssh_command(cmd => 'zypper lr -d', timeout => 600);
     $instance->run_ssh_command(cmd => 'systemctl is-enabled issue-generator');
     $instance->run_ssh_command(cmd => 'systemctl is-enabled transactional-update.timer');


### PR DESCRIPTION
Use a different test package than jq (which comes already installed).

Also dump list of installed packages in case we need to change this again.

- Related ticket: https://progress.opensuse.org/issues/190005
- Verification run: https://openqa.suse.de/tests/19277980

```
$ susepkg -p Micro socat
SUSE-MicroOS/5.2  socat  1.7.3.2-150000.6.3.1
SLE-Micro/5.3     socat  1.8.0.0-150400.14.6.1
SLE-Micro/5.4     socat  1.8.0.0-150400.14.6.1
SLE-Micro/5.5     socat  1.8.0.0-150400.14.6.1
SL-Micro/6.0      socat  1.7.4.3-2.9
SL-Micro/6.1      socat  1.7.4.3-slfo.1.1_1.2
SL-Micro/6.2      socat  1.8.0.2-160000.2.3
```