### PR TITLE
Handle openSUSE and Gnome Tour windows

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -562,25 +562,36 @@ sub untick_welcome_on_next_startup {
 
  handle_welcome_screen([timeout => $timeout]);
 
-openSUSE Welcome window should be auto-launched.
+For now are two flows, one for old openSUSE Welcome and a new one for gnome-tour+openSUSE Tour
+in both cases the aplication is launched at startup.
+
 Disable auto-launch on next boot and close application (If the checkbox is present)
-Also handle workarounds when needed.
 
 =cut
 
 sub handle_welcome_screen {
     my (%args) = @_;
     assert_screen([qw(opensuse-welcome opensuse-welcome-gnome40-activities)], $args{timeout});
-    send_key 'esc' if match_has_tag('opensuse-welcome-gnome40-activities');
-    # The checkbox to start on boot is now dropped, but we need to care for it
-    # in the case of older installs where the autostart is still there.
-    check_screen('opensuse-welcome-show-on-boot');
-    if (match_has_tag('opensuse-welcome-show-on-boot')) {
-        untick_welcome_on_next_startup;
+    if (match_has_tag('opensuse-gnome-tour-activities')) {
+        send_key 'esc';    # close gnome tour
+        assert_screen('opensuse-welcome-gnome40-activities');
+        send_key 'esc';    # exit gnome-activities
+        assert_screen('opensuse-welcome-tour');
+        send_key 'esc';    # close the openSUSE tour
     } else {
-        assert_and_click_until_screen_change('opensuse-welcome-close', 5, 5);
-        assert_screen("generic-desktop");
+        send_key 'esc' if match_has_tag('opensuse-welcome-gnome40-activities');
+        send_key 'esc';    # exit gnome-activities
+        check_screen('opensuse-welcome-show-on-boot');
+        # The checkbox to start on boot is now dropped, but we need to care for it
+        # in the case of older installs where the autostart is still there.
+        if (match_has_tag('opensuse-welcome-show-on-boot')) {
+            untick_welcome_on_next_startup;
+        } else {
+            assert_and_click_until_screen_change('opensuse-welcome-close', 5, 5);
+        }
     }
+
+    assert_screen("generic-desktop");
 }
 
 =head2 start_root_shell_in_xterm


### PR DESCRIPTION
There is a new application replacing openSUSE Welcome which goes
together with the wrapper, now we have a gnome tour window on top of the
openSUSE Tour both of which add a new flow to the handler for the
welcome screen

Failure: https://openqa.opensuse.org/tests/5364929#step/opensuse_welcome/4
VR: https://openqa.opensuse.org/tests/overview?version=Staging%3AI&distri=opensuse&build=foursixnine%2Fos-autoinst-distri-opensuse%2323514

Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/849
