### PR TITLE
Allow HanaSR cloud test to use NCC

### DIFF
--- a/data/sles4sap/qe_sap_deployment/sles4sap_gcp_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_gcp_generic.yaml
@@ -24,6 +24,7 @@ terraform:
     ibsm_vpc_name: '%IBSM_VPC_NAME%'
     ibsm_subnet_name: '%IBSM_SUBNET_NAME%'
     ibsm_subnet_region: '%IBSM_SUBNET_REGION%'
+    ibsm_hub_name: '%IBSM_NCC_HUB%'
 
     # REMOTE PYTHON
     hana_remote_python: '%ANSIBLE_REMOTE_PYTHON%'

--- a/tests/sles4sap/publiccloud/qesap_terraform.pm
+++ b/tests/sles4sap/publiccloud/qesap_terraform.pm
@@ -94,9 +94,12 @@ sub run {
         set_var('IBSM_RG', '') unless (get_var('IBSM_RG'));
         set_var('IBSM_VNET', '') unless (get_var('IBSM_VNET'));
     } elsif (is_gce()) {
+        die "Pering with NCC and using network_peering cannot be both active in the same config"
+          if ((get_var('IBSM_VPC_NAME') || get_var('IBSM_SUBNET_NAME') || get_var('IBSM_SUBNET_REGION')) && get_var('IBSM_NCC_HUB'));
         set_var('IBSM_VPC_NAME', '') unless (get_var('IBSM_VPC_NAME'));
         set_var('IBSM_SUBNET_NAME', '') unless (get_var('IBSM_SUBNET_NAME'));
         set_var('IBSM_SUBNET_REGION', '') unless (get_var('IBSM_SUBNET_REGION'));
+        set_var('IBSM_NCC_HUB', '') unless (get_var('IBSM_NCC_HUB'));
     } elsif (is_ec2()) {
         set_var('IBSM_PRJ_TAG', '') unless (get_var('IBSM_PRJ_TAG'));
     }


### PR DESCRIPTION
Add terraform variables needed to enable IBSm peering using NCC. Variables are controlled by a new openQA setting/variable.

- Related ticket: https://jira.suse.com/browse/TEAM-10455

# Verification run: