### PR TITLE
Fix wrong script_run invocations

### DIFF
--- a/tests/xfstests/generate_report.pm
+++ b/tests/xfstests/generate_report.pm
@@ -30,7 +30,7 @@ sub log_end {
     my $file = shift;
     my $cmd = "echo 'Test run complete' >> $file";
     send_key 'ret';
-    script_run($cmd, proceed_on_failure => 1);
+    script_run($cmd, timeout => 0);
 }
 
 # Compress all sub directories under $dir and upload them.

--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -98,7 +98,7 @@ sub log_create {
 sub collect_version {
     my $file = shift;
     my $cmd = "(rpm -qa xfsprogs xfsdump btrfsprogs e2fsprogs coreutils kernel-default " . join(' ', @PACKAGES) . "; uname -r; rpm -qi kernel-default) | tee $file";
-    script_run($cmd, proceed_on_failure => 1);
+    script_run($cmd, timeout => 0);
     upload_logs($file, timeout => 60, log_name => basename($file));
 }
 


### PR DESCRIPTION
The proceed_on_failure parameter is used only with the script_output family of functions.  Use zero timeout instead.

From https://open.qa/api/testapi/#_script_run

> script_run will throw an exception if the timeout has expired.
> Returns exit code received from $cmd or undef if $timeout is 0.
