### PR TITLE
bats/runc: Drop PR#4893 on TW with runc 1.3.2

### DIFF
--- a/data/containers/patches.yaml
+++ b/data/containers/patches.yaml
@@ -274,10 +274,10 @@ podman-py:
 runc:
   # Note on patches:
   # https://github.com/opencontainers/runc/pull/4825 is needed for cgroups
+  # https://github.com/opencontainers/runc/pull/4893 is needed for ppc64le issue fixed in runc 1.3.2
   opensuse-Tumbleweed:
     GITHUB_PATCHES:
     - 4825
-    - 4893
     BATS_IGNORE:
     BATS_IGNORE_ROOT:
     BATS_IGNORE_USER:


### PR DESCRIPTION
Drop PR#4893 on TW with runc 1.3.2

While applying these patches is an idempotent operation, we want a minimal reproducer.
