### PR TITLE
Kselftests: BPF: test_tcpnotify_user: Parse fail result line

### DIFF
--- a/lib/Kselftests/parsers/bpf/test_tcpnotify_user.pm
+++ b/lib/Kselftests/parsers/bpf/test_tcpnotify_user.pm
@@ -17,6 +17,8 @@ sub parse_line {
     my ($self, $test_ln) = @_;
     if ($test_ln =~ /# PASSED!/) {
         return "# ok 1 test_tcpnotify_user";
+    } elsif ($test_ln =~ /# FAILED:/) {
+        return "# not ok 1 test_tcpnotify_user";
     }
     return undef;
 }

--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -119,7 +119,7 @@ sub post_process_single {
         if (!$test_ln) {
             next;
         }
-        if ($test_ln =~ /^# not ok (\d+) (.*?)\s*(?=#|$)/) {
+        if ($test_ln =~ /^#?\s?not\sok\s(\d+)\s(.*?)\s*(?=#|$)/) {
             my $subtest_idx = $1;
             my $subtest_name = $2;
             my $wl_entry = $whitelist->find_whitelist_entry($env, $args{collection}, $subtest_name);


### PR DESCRIPTION
Verification runs:
- https://openqa.suse.de/tests/19278223 **before**
- https://rmarliere-openqa.qe.prg2.suse.org/tests/1611#step/selftests:bpf:test_tcpnotify_user/1 **after**
