### PR TITLE
Add patch step for Staging and Increments

### DIFF
--- a/schedule/jeos/sle/minimalvm-main.yaml
+++ b/schedule/jeos/sle/minimalvm-main.yaml
@@ -35,6 +35,10 @@ conditional_schedule:
         FLAVOR:
             'JeOS-for-kvm-and-xen-Updates':
                 - qa_automation/patch_and_reboot
+            'Minimal-VM-for-kvm-and-xen-Updates-Staging':
+                - qa_automation/patch_and_reboot
+            'Minimal-VM-for-kvm-and-xen-Updates-Increments':
+                - qa_automation/patch_and_reboot
     wizard:
         FIRST_BOOT_CONFIG:
             'wizard':


### PR DESCRIPTION
Both flavors for 16.0 MinimalVM images were missing a patch step

### Verification runs

 - sle-15.99-Minimal-VM-for-kvm-and-xen-Updates-Increments-x86_64-Build11.15-minimalvm-main@uefi-virtio-vga -> https://openqa.suse.de/tests/19295811
 - sle-15.99-Minimal-VM-for-kvm-and-xen-Updates-Staging-x86_64-Build:333:kernel-source-minimalvm-main@uefi-virtio-vga -> https://openqa.suse.de/tests/19295813
