### PR TITLE
bats: Export install_ncat

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -29,6 +29,7 @@ use Utils::Architectures;
 our @EXPORT = qw(
   bats_post_hook
   bats_tests
+  install_ncat
   mount_tmp_vartmp
   patch_junit
   patch_sources
@@ -229,12 +230,6 @@ sub setup_pkgs {
 
     enable_modules if is_sle("<16");
 
-    my $install_ncat = 0;
-    if (grep { $_ eq "ncat" } @pkgs) {
-        $install_ncat = 1;
-        @pkgs = grep { $_ ne "ncat" } @pkgs;
-    }
-
     # Install tests dependencies
     my $oci_runtime = get_var("OCI_RUNTIME", "");
     if ($oci_runtime && !grep { $_ eq $oci_runtime } @pkgs) {
@@ -245,8 +240,6 @@ sub setup_pkgs {
     run_command "zypper --gpg-auto-import-keys -n install @pkgs", timeout => 600;
 
     configure_oci_runtime $oci_runtime;
-
-    install_ncat if $install_ncat;
 
     return if $rebooted;
 

--- a/tests/containers/bats/aardvark.pm
+++ b/tests/containers/bats/aardvark.pm
@@ -16,6 +16,8 @@ use version_utils qw(is_sle);
 my $aardvark = "";
 
 sub run_tests {
+    return 0 if check_var("BATS_IGNORE", "all");
+
     my $netavark = script_output "rpm -ql netavark | grep podman/netavark";
 
     my %env = (

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -16,6 +16,8 @@ use version_utils qw(is_sle);
 my $netavark;
 
 sub run_tests {
+    return 0 if check_var("BATS_IGNORE", "all");
+
     my %env = (
         NETAVARK => $netavark,
     );

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -30,10 +30,11 @@ sub run {
     select_serial_terminal;
 
     my @pkgs = qw(aardvark-dns cargo firewalld iproute2 make protobuf-devel netavark);
-    push @pkgs, "ncat" if is_sle;
     push @pkgs, is_sle("<16") ? qw(dbus-1) : qw(dbus-1-daemon);
 
     $self->setup_pkgs(@pkgs);
+
+    install_ncat if is_sle;
 
     $netavark = script_output "rpm -ql netavark | grep podman/netavark";
     record_info("netavark version", script_output("$netavark --version"));


### PR DESCRIPTION
netavark is now the only consumer so call it externally.

- Verification run: https://openqa.suse.de/tests/19299974