### PR TITLE
wicked: use systemctl to restart wicked

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -295,8 +295,8 @@ sub reset_wicked {
     assert_script_run("netconfig -f update");
 
     # Restart services
-    assert_script_run('rcwickedd restart');
-    assert_script_run('rcwicked restart');
+    systemctl('restart wickedd');
+    systemctl('restart wicked');
 }
 
 


### PR DESCRIPTION
With jsc#PED-266 we also dropped System-V compatibility in tumbleweed and SLE-16+.

Use systemctl always, as it is the recommend way.

