### PR TITLE
Schedule SSSD test in maintenance

### DIFF
--- a/schedule/qam/common/mau-extratests1.yaml
+++ b/schedule/qam/common/mau-extratests1.yaml
@@ -43,6 +43,7 @@ schedule:
   - console/tar
   - console/ruby
   - console/tcpdump
+  - console/sssd_389ds_functional
   - '{{version_specific}}'
   - console/coredump_collect
 conditional_schedule:


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/189780
- Needles: NO
- Verification run: 
15-SP7: [aarch64](https://openqa.suse.de/tests/19309731#step/sssd_389ds_functional/12) | [s390x](https://openqa.suse.de/tests/19309736#step/sssd_389ds_functional/12) | [x86_64](https://openqa.suse.de/tests/19308595#step/sssd_389ds_functional/12)
15-SP6: [aarch64](https://openqa.suse.de/tests/19309739#step/sssd_389ds_functional/12) | [s390x](https://openqa.suse.de/tests/19309740#step/sssd_389ds_functional/12) | [x86_64](https://openqa.suse.de/tests/19309741#step/sssd_389ds_functional/12)
15-SP5: [aarch64](https://openqa.suse.de/tests/19309742#step/sssd_389ds_functional/12) | [s390x](https://openqa.suse.de/tests/19309743#step/sssd_389ds_functional/12) | [x86_64](https://openqa.suse.de/tests/19309744#step/sssd_389ds_functional/12)
15-SP4: [aarch64](https://openqa.suse.de/tests/19310107#step/sssd_389ds_functional/12) | [s390x](https://openqa.suse.de/tests/19310112#step/sssd_389ds_functional/12) | [x86_64](https://openqa.suse.de/tests/19310113#step/sssd_389ds_functional/12)
15-SP3: [aarch64](https://openqa.suse.de/tests/19310126#step/sssd_389ds_functional/12) | [s390x](https://openqa.suse.de/tests/19314793#step/sssd_389ds_functional/12) | [x86_64](https://openqa.suse.de/tests/19310128#step/sssd_389ds_functional/12)
15-SP2: [x86_64](https://openqa.suse.de/tests/19310131#step/sssd_389ds_functional/12)
12-SP5: [x86_64](https://openqa.suse.de/tests/19310132#step/sssd_389ds_functional/12)