### PR TITLE
pc: Increase timeout for installing docker

### DIFF
--- a/tests/publiccloud/check_registercloudguest.pm
+++ b/tests/publiccloud/check_registercloudguest.pm
@@ -177,7 +177,7 @@ sub test_container_runtimes {
 
     record_info('Test docker');
     $instance->ssh_assert_script_run("sudo rm -f /root/.docker/config.json");    # workaround for https://bugzilla.suse.com/show_bug.cgi?id=1231185
-    $instance->ssh_assert_script_run("sudo zypper install -y docker", timeout => 300);
+    $instance->ssh_assert_script_run("sudo zypper install -y docker", timeout => 600);
     $instance->ssh_assert_script_run("sudo systemctl start docker.service");
     record_info("systemctl status docker.service", $instance->ssh_script_output("systemctl status docker.service"));
     $instance->ssh_script_retry("sudo docker pull $image", retry => 3, delay => 60, timeout => 600);


### PR DESCRIPTION
Increase timeout for installing docker in register_cloudguest.

Failing job: https://openqa.suse.de/tests/19310893#step/check_registercloudguest/116
Verification run: https://openqa.suse.de/tests/19312076