### PR TITLE
P.C. supportconfig: skip run for successful tests

### DIFF
--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -216,8 +216,8 @@ sub _upload_logs {
             $self->{run_args}->{my_instance}->ssh_script_run("sudo chmod a+r " . $instance_log, timeout => 0, quiet => 1, proceed_on_failure => 1);
             $self->{run_args}->{my_instance}->upload_log($instance_log, failok => 1, log_name => $instance_log . ".txt");
         }
-        # collect supportconfig logs
-        $self->{run_args}->{my_instance}->upload_supportconfig_log();
+        # collect supportconfig logs, only when test failed:
+        $self->{run_args}->{my_instance}->upload_supportconfig_log() if ($self->{result} eq 'fail');
     } else {
         diag($start_text . 'instance unavailable or run_args undefined (ref.: $self->{run_args}->{my_instance}). Possible that the test died before the instance was created.');
         return;


### PR DESCRIPTION
Pub.Cl. `supportconfig`: skip supportconfig execution and its logs collection for successful tests or modules, only let it run when test failed, in post_fail_hooks.

This in particular useful for `SLE-12-SP5` versions, able to consume very long time to run such command.

- Related ticket: https://progress.opensuse.org/issues/187440

- Verification run: TBD