### PR TITLE
containers: No need for log-console to log stuff we already have

### DIFF
--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -182,11 +182,6 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = @_;
-    if ($self->{runtime} eq 'podman') {
-        select_console 'log-console';
-        script_run "podman version | tee /dev/$serialdev";
-        script_run "podman info --debug | tee /dev/$serialdev";
-    }
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
No need for log-console to log stuff we already have like `podman info` & `podman version`.

- Related ticket: https://progress.opensuse.org/issues/189915
- Failed job: https://openqa.suse.de/tests/19310881#step/podman/336
- Verification run: https://openqa.suse.de/tests/19313369