### PR TITLE
PC: Remove useless poo155116

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -542,8 +542,7 @@ sub upload_boot_diagnostics {
     my $asset_path = "/tmp/console-$time.txt";
     script_run("timeout 110 az vm boot-diagnostics get-boot-log $names | jq -Mr '.' > $asset_path", timeout => 120);
     if (script_output("du $asset_path | cut -f1") < 8) {
-        record_soft_failure("poo#155116 - The console log is empty.");
-        record_info($asset_path, script_output("cat $asset_path"));
+        record_info("EMPTY", "The console log is empty. `cat $asset_path`:\n" . script_output("cat $asset_path"));
     } else {
         upload_logs($asset_path, failok => 1);
     }

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -171,8 +171,7 @@ sub upload_boot_diagnostics {
     my $asset_path = "/tmp/console-$time.txt";
     script_run("aws ec2 get-console-output --latest --color=off --no-paginate --output text --instance-id $instance_id &> $asset_path", proceed_on_failure => 1);
     if (script_output("du $asset_path | cut -f1") < 8) {
-        record_soft_failure('poo#155116 - The console log is empty.');
-        record_info($asset_path, script_output("cat $asset_path"));
+        record_info("EMPTY", "The console log is empty. `cat $asset_path`:\n" . script_output("cat $asset_path"));
     } elsif (check_var('PUBLIC_CLOUD_INSTANCE_TYPE', 'i3.large')) {
         record_info('UNSUPPORTED_INSTANCE', "The 'i3.large' instance doesn't support serial terminal.");
     } else {


### PR DESCRIPTION
This `record_soft_failure` is useless as nobody will work on it until somebody needs it.

And every time I needed log from Azure or EC2 it was there.

I also suspect that there might be cases this is triggered false-positively in situations such as SUT does not exists.

- Related ticket: [poo#155116](https://progress.opensuse.org/issues/155116)
- Verification run: 
[Build20251007-1](https://pdostal-server.suse.cz/tests/overview?build=20251007-1&distri=sle&version=15-SP7) of sle-15-SP7-Azure-BYOS-Updates.aarch64	[publiccloud_consoletests@64bit](https://pdostal-server.suse.cz/tests/10821)
[Build20251007-1](https://pdostal-server.suse.cz/tests/overview?build=20251007-1&distri=sle&version=15-SP7) of sle-15-SP7-EC2-Updates.x86_64	[publiccloud_consoletests@64bit](https://pdostal-server.suse.cz/tests/10822)
