### PR TITLE
PC: Add ConnectTimeout, ServerAlive to ssh config

### DIFF
--- a/data/publiccloud/ssh_config
+++ b/data/publiccloud/ssh_config
@@ -6,3 +6,6 @@ HostKeyAlgorithms +ssh-rsa
 IdentityFile %SSH_KEY%
 LogLevel VERBOSE
 PasswordAuthentication no
+ConnectTimeout 15
+ServerAliveInterval 5
+ServerAliveCountMax 5


### PR DESCRIPTION
From [ssh_config manual page](https://man7.org/linux/man-pages/man5/ssh_config.5.html):

> ConnectTimeout
>   Specifies the timeout (in seconds) used when connecting to
>   the SSH server, instead of using the default system TCP
>   timeout.  This timeout is applied both to establishing the
>   connection and to performing the initial SSH protocol
>   handshake and key exchange.

I add this as we when we establish SSH connection we already use `wait_for_ssh()`.

> ServerAliveCountMax
>   Sets the number of server alive messages (see below) which
>   may be sent without ssh(1) receiving any messages back
>   from the server.  If this threshold is reached while
>   server alive messages are being sent, ssh will disconnect
>   from the server, terminating the session.  It is important
>   to note that the use of server alive messages is very
>   different from TCPKeepAlive (below).  The server alive
>   messages are sent through the encrypted channel and
>   therefore will not be spoofable.  The TCP keepalive option
>   enabled by TCPKeepAlive is spoofable.  The server alive
>   mechanism is valuable when the client or server depend on
>   knowing when a connection has become unresponsive.
> 
>   The default value is 3.  If, for example,
>   ServerAliveInterval (see below) is set to 15 and
>   ServerAliveCountMax is left at the default, if the server
>   becomes unresponsive, ssh will disconnect after
>   approximately 45 seconds.

> ServerAliveInterval
>   Sets a timeout interval in seconds after which if no data
>   has been received from the server, ssh(1) will send a
>   message through the encrypted channel to request a
>   response from the server.  The default is 0, indicating
>   that these messages will not be sent to the server.

I use those two options to quickly detect frozen SSH connections. This freeze happens when network drops or SUT reboots without prior notice.

Currently when hiccup happens the command line freezes which openQA does not detect and tries to type anyway and then times out hiding the real problem. This should improve the readability.

 * Verification runs:
[Build0775](https://pdostal-server.suse.cz/tests/overview?build=0775&distri=sle&version=16.0) of sle-16.0-GCE-BYOS.x86_64	[publiccloud_img_proof@gce_n1_standard_2](https://pdostal-server.suse.cz/tests/10835)
[Build0816](https://pdostal-server.suse.cz/tests/overview?build=0816&distri=sle&version=16.0) of sle-16.0-Azure-BYOS.aarch64	[publiccloud_extratests@64bit](https://pdostal-server.suse.cz/tests/10836)
[Build0818](https://pdostal-server.suse.cz/tests/overview?build=0818&distri=sle&version=16.0) of sle-16.0-EC2.x86_64	[publiccloud_img_proof@ec2_m5d.large](https://pdostal-server.suse.cz/tests/10833)
[Build20251023-1](https://pdostal-server.suse.cz/tests/overview?build=20251023-1&distri=sle&version=15-SP7) of sle-15-SP7-Azure-Basic-Updates.x86_64	[publiccloud_img_proof@64bit](https://pdostal-server.suse.cz/tests/10828)
[Build20251023-1](https://pdostal-server.suse.cz/tests/overview?build=20251023-1&distri=sle&version=15-SP7) of sle-15-SP7-Azure-BYOS-Updates.aarch64	[publiccloud_cloud_functional@64bit](https://pdostal-server.suse.cz/tests/10827)
[Build20251023-1](https://pdostal-server.suse.cz/tests/overview?build=20251023-1&distri=sle&version=15-SP7) of sle-15-SP7-GCE-Updates.aarch64	[publiccloud_cloud_functional@64bit](https://pdostal-server.suse.cz/tests/10830)
[Build20251023-1](https://pdostal-server.suse.cz/tests/overview?build=20251023-1&distri=sle&version=12-SP5) of sle-12-SP5-EC2-BYOS-Updates.x86_64	[publiccloud_cloud_functional@64bit](https://pdostal-server.suse.cz/tests/10829)
[Build20251023-1](https://pdostal-server.suse.cz/tests/overview?build=20251023-1&distri=sle&version=12-SP5) of sle-12-SP5-EC2-Updates.x86_64	[publiccloud_consoletests@64bit](https://pdostal-server.suse.cz/tests/10832)