### PR TITLE
Fix 'Fail to get journal logs'

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -360,9 +360,18 @@ sub check_failures_in_journal {
     $cmd .= " > $logfile";
     $cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$machine " . "\"$cmd\"" if $machine ne 'localhost';
     if (script_run($cmd) != 0) {
-        $failures = "Fail to get journal logs from $machine";
-        record_info("Warning", "$failures when checking its health", result => 'softfail');
-        return $failures;
+        # Retry without cursor if it was invalid (e.g., after guest reboot)
+        if (defined($cursor)) {
+            delete $log_cursors{$machine};
+            $cmd = "journalctl --show-cursor > $logfile";
+            $cmd = "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root\@$machine " . "\"$cmd\"" if $machine ne 'localhost';
+            script_run($cmd);
+        }
+        if (script_run("test -s $logfile") != 0) {
+            $failures = "Fail to get journal logs from $machine";
+            record_info("Warning", "$failures when checking its health", result => 'softfail');
+            return $failures;
+        }
     }
 
     # Get the cursor of the journal log file


### PR DESCRIPTION
Problem: Journal cursor becomes invalid after guest reboot, causing 
health check failures with "Failed to seek to cursor" error.

Solution: Automatically retry without cursor if the first attempt fails.

Impact: Fixes false positives in guest health checks without affecting 
existing test behavior.


- Related ticket: https://progress.opensuse.org/issues/190881
- Needles: None
- Verification run: https://openqa.oqa.prg2.suse.org/tests/19668550
