### PR TITLE
Extend usage of azure_cli

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -89,6 +89,7 @@ our @EXPORT = qw(
   az_network_dns_link_list
   az_network_dns_links_cleanup
   az_role_definition_list
+  az_role_assignment_create
 );
 
 # Workaround for bsc#1261229 - az-cli-cmd 'Launching flake' message breaks JSON output format
@@ -299,13 +300,8 @@ sub az_network_vnet_subnet_update(%args) {
     push @az_cmd_list, '--resource-group', $args{resource_group};
     push @az_cmd_list, '--vnet-name', $args{vnet};
     push @az_cmd_list, '--name', $args{snet};
+    push @az_cmd_list, '--nat-gateway', $args{nat_gateway} if ($args{nat_gateway});
 
-    # at the moment nat_gateway is optional,
-    # so without this argument the command is
-    # executed anyway, but probably it will not do so much.
-    if ($args{nat_gateway}) {
-        push @az_cmd_list, '--nat-gateway', $args{nat_gateway};
-    }
     assert_script_run(join(' ', @az_cmd_list));
 }
 
@@ -1927,7 +1923,7 @@ sub az_storage_blob_lease_acquire(%args) {
         "--account-name $args{storage_account_name}",
         "--blob-name $args{blob_name}",
         "--lease-duration $args{lease_duration}",
-        '--output tsv'    # Json output won't work here.
+        '--output tsv'    # Json output not work here.
                           # If it is not possible to acquire lease command will return a message which is not in json format.
                           # decode_json() would cause function to fail instead of just returning
     );
@@ -2111,7 +2107,7 @@ sub az_keyvault_secret_show(%args) {
     }
 
     $args{query} //= 'value';
-    # 'tsv' is default because json mangles newlines. It's easier to use output directly.
+    # 'tsv' is default because json mangles newlines. It is easier to use output directly.
     $args{output} //= 'tsv';
 
     my @az_cmd = ('az keyvault secret show',
@@ -2477,6 +2473,147 @@ sub az_role_definition_list {
     my $roleid = decode_json(script_output($az_cmd));
     croak "Role definition '$args{name}' not found" unless @$roleid;
     return $roleid->[0];
+}
+
+=head2 az_role_assignment_create
+
+  az_role_assignment_create(
+        vm_id => '123456',
+        role_id => 'aaa-bbb-ccc',
+        subscription_id => 'f0123-a0123',
+        resource_group => 'hanasr-jobid12345');
+
+    Assigne role to a VM
+
+=over
+
+=item B<VM_ID> - ID of the VM assignee, can be obtained with az_vm_identity_assign
+
+=item B<ROLE_ID> - ID of the role
+
+=item B<SUBSCRIPTION_ID> - subscription ID
+
+=item B<RESOURCE_GROUP> - resource group resource belongs to
+
+=back
+=cut
+
+sub az_role_assignment_create {
+    my (%args) = @_;
+    foreach (qw(vm_id role_id subscription_id resource_group)) {
+        croak "Missing argument: '$_'" unless defined($args{$_});
+    }
+
+    my $az_cmd = join(' ', 'az role assignment create',
+        #       '--only-show-errors',
+        '--assignee-object-id', $args{vm_id},
+        '--assignee-principal-type ServicePrincipal',
+        "--role '$args{role_id}'",
+        "--scope '/subscriptions/$args{subscription_id}/resourceGroups/$args{resource_group}'");
+    assert_script_run($az_cmd);
+}
+
+=head2 qesap_az_create_sas_token
+
+Generate a SAS URI token for a storage container of choice
+
+Return the token string
+
+=over
+
+=item B<STORAGE> - Storage account name used fur the --account-name argument in az commands
+
+=item B<CONTAINER> - container name within the storage account
+
+=item B<KEYNAME> - name of the access key within the storage account
+
+=item B<PERMISSION> - access permissions. Syntax is what documented in
+                      'az storage container generate-sas --help'.
+                      Some of them of interest: (a)dd (c)reate (d)elete (e)xecute (l)ist (m)ove (r)ead (w)rite.
+                      Default is 'r'
+
+=item B<LIFETIME> - life time of the token in minutes, default is 10min
+
+=back
+=cut
+
+sub qesap_az_create_sas_token {
+    my (%args) = @_;
+    foreach (qw(storage container keyname)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
+    $args{lifetime} //= 10;
+    $args{permission} //= 'r';
+    croak "$args{permission} : not supported permission in openQA" unless ($args{permission} =~ /^(?:r|l|rl|lr)$/);
+
+    # Generated command is:
+    #
+    # az storage container generate-sas  --account-name <STORAGE_NAME> \
+    #     --account-key $(az storage account keys list --account-name <STORAGE_NAME> --query "[?contains(keyName,'<KEY_NAME>')].value" -o tsv) \
+    #     --name <CONTAINER_NAME> \
+    #     --permissions r \
+    #     --expiry $(date -u -d "10 minutes" '+%Y-%m-%dT%H:%MZ')
+    my $account_name = "--account-name $args{storage}";
+    my $cmd_keys = join(' ',
+        'az storage account keys list',
+        $account_name,
+        '--query', "\"[?contains(keyName,'" . $args{keyname} . "')].value\"",
+        '-o tsv'
+    );
+    my $cmd_expiry = join(' ', 'date', '-u', '-d', "\"$args{lifetime} minutes\"", "'+%Y-%m-%dT%H:%MZ'");
+    my $cmd = join(' ',
+        'az storage container generate-sas',
+        $account_name,
+        '--account-key', '$(', $cmd_keys, ')',
+        '--name', $args{container},
+        '--permission', $args{permission},
+        '--expiry', '$(', $cmd_expiry, ')',
+        '-o', 'tsv');
+    record_info('GENERATE-SAS', $cmd);
+    return script_output($cmd);
+}
+
+=head2 qesap_az_list_container_files
+
+Returns a list of the files that exist inside a given path in a given container
+in Azure storage.
+
+Generated command looks like this:
+
+az storage blob list 
+--account-name <account_name> 
+--container-name <container_name> 
+--sas-token "<my_token>" 
+--prefix <path_inside_container> 
+--query "[].{name:name}" --output tsv
+
+=over
+
+=item B<STORAGE> - Storage account name used fur the --account-name argument in az commands
+
+=item B<CONTAINER> - container name within the storage account
+
+=item B<TOKEN> - name of the SAS token to access the account (needs to have l permission)
+
+=item B<PREFIX> - the local path inside the container (to list file inside a folder named 'dir', this would be 'dir')
+
+=back
+=cut
+
+sub qesap_az_list_container_files {
+    my (%args) = @_;
+    foreach (qw(storage container token prefix)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
+    my $cmd = join(' ',
+        'az storage blob list',
+        '--account-name', $args{storage},
+        '--container-name', $args{container},
+        '--sas-token', "'$args{token}'",
+        '--prefix', $args{prefix},
+        '--query "[].{name:name}" --output tsv');
+    my $ret = script_output($cmd);
+    if ($ret && $ret ne ' ') {
+        my @files = split(/\n/, $ret);
+        return join(',', @files);
+    }
+    croak 'The list azure files command output is empty or undefined.';
 }
 
 1;

--- a/lib/sles4sap/ibsm.pm
+++ b/lib/sles4sap/ibsm.pm
@@ -164,7 +164,8 @@ This function is symmetrical to ibsm_network_peering_azure_create.
 
 =item B<sut_rg> - Azure resource group of the SUT
 
-=item B<sut_vnet> - substring in the SUT vnet. Optional and only needed if only one specific VNET has to be considered. Most of the time it is get_current_job_id()
+=item B<sut_vnet> - substring in the SUT vnet. Optional and only needed if only one specific VNET
+                    has to be considered. Most of the time it is get_current_job_id()
 
 =item B<timeout> - default is 5 mins
 
@@ -176,7 +177,7 @@ This function is symmetrical to ibsm_network_peering_azure_create.
 sub ibsm_network_peering_azure_delete {
     my (%args) = @_;
     foreach (qw(sut_rg ibsm_rg)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
-    $args{timeout} //= bmwqemu::scale_timeout(300);
+    $args{timeout} //= 300;
 
     my %vnet_names;
     my @peerings = (

--- a/lib/sles4sap/qesap/azure.pm
+++ b/lib/sles4sap/qesap/azure.pm
@@ -42,7 +42,6 @@ our @EXPORT = qw(
   qesap_az_get_resource_group
   qesap_az_clean_old_peerings
   qesap_az_setup_native_fencing_permissions
-  qesap_az_get_tenant_id
   qesap_az_create_sas_token
   qesap_az_list_container_files
   qesap_az_diagnostic_log
@@ -157,48 +156,18 @@ sub qesap_az_setup_native_fencing_permissions {
     }
 
     # Enable system assigned identity
-    my $vm_id = script_output(join(' ',
-            'az vm identity assign',
-            '--only-show-errors',
-            "-g '$args{resource_group}'",
-            "-n '$args{vm_name}'",
-            "--query 'systemAssignedIdentity'",
-            '-o tsv'));
-    die "Returned output '$vm_id' does not match ID pattern" if (!az_validate_uuid_pattern(uuid => $vm_id));
+    my $vm_id = az_vm_identity_assign(name => $args{vm_name}, resource_group => $args{resource_group});
 
     # Assign role
     my $subscription_id = script_output('az account show --query "id" -o tsv');
     my $role_id = az_role_definition_list(name => "Linux Fence Agent Role");
-    my $az_cmd = join(' ', 'az role assignment',
-        'create --only-show-errors',
-        "--assignee-object-id $vm_id",
+    my $az_cmd = join(' ', 'az role assignment create',
+        '--only-show-errors',
+        '--assignee-object-id', $vm_id,
         '--assignee-principal-type ServicePrincipal',
         "--role '$role_id'",
         "--scope '/subscriptions/$subscription_id/resourceGroups/$args{resource_group}'");
     assert_script_run($az_cmd);
-}
-
-=head2 qesap_az_get_tenant_id
-
-    qesap_az_get_tenant_id( subscription_id => $subscription_id )
-
-    Returns tenant ID related to the specified subscription ID.
-
-=over
-
-=item B<SUBSCRIPTION_ID> - valid azure subscription
-
-=back
-=cut
-
-sub qesap_az_get_tenant_id {
-    my (%args) = @_;
-    croak 'Missing < subscription_id > argument' unless $args{subscription_id};
-    my $az_cmd = 'az account show --only-show-errors';
-    $az_cmd .= " --subscription $args{subscription_id} --query 'tenantId' -o tsv";
-    my $tenant_id = script_output($az_cmd);
-    die "Returned output '$tenant_id' does not match ID pattern" unless (az_validate_uuid_pattern(uuid => $tenant_id));
-    return $tenant_id;
 }
 
 =head2 qesap_az_create_sas_token

--- a/t/15_qesap_azure.t
+++ b/t/15_qesap_azure.t
@@ -146,18 +146,6 @@ subtest '[qesap_az_setup_native_fencing_permissions] invalid UUID' => sub {
     dies_ok { ok qesap_az_setup_native_fencing_permissions(%mandatory_args) } 'PASS with all args defined';
 };
 
-subtest '[qesap_az_get_tenant_id] missing arguments' => sub {
-    dies_ok { qesap_az_get_tenant_id() } 'Expected failure: missing mandatory arg';
-};
-
-subtest '[qesap_az_get_tenant_id]' => sub {
-    my $qesap = Test::MockModule->new('sles4sap::qesap::azure', no_auto => 1);
-    my $valid_uuid = 'c0ffeeee-c0ff-eeee-1234-123456abcdef';
-    $qesap->redefine(script_output => sub { return $valid_uuid; });
-
-    is qesap_az_get_tenant_id(subscription_id => $valid_uuid), 'c0ffeeee-c0ff-eeee-1234-123456abcdef', 'Returned value is a valid UUID';
-};
-
 subtest '[qesap_az_clean_old_peerings]' => sub {
     my $qesap_az = Test::MockModule->new('sles4sap::qesap::azure', no_auto => 1);
     my @delete_calls;

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -1608,4 +1608,17 @@ subtest '[az_role_definition_list]' => sub {
     ok(($ret eq 'Pantalone'), 'Ret is the expected value, of type string');
 };
 
+subtest '[az_role_assignment_create]' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(assert_script_run => sub { @calls = $_[0]; return; });
+    az_role_assignment_create(
+        vm_id => '123456',
+        role_id => 'aaa-bbb-ccc',
+        subscription_id => 'f0123-a0123',
+        resource_group => 'hanasr-jobid12345');
+    note("\n --> " . join("\n --> ", @calls));
+    ok((any { /az role assignment create/ } @calls), 'Correct composition of the main command');
+};
+
 done_testing;

--- a/tests/sles4sap/cloud_netconfig/destroy.pm
+++ b/tests/sles4sap/cloud_netconfig/destroy.pm
@@ -44,6 +44,7 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use mmapi 'get_current_job_id';
 use serial_terminal 'select_serial_terminal';
+use sles4sap::azure_cli;
 
 use constant DEPLOY_PREFIX => 'clne';
 
@@ -55,8 +56,7 @@ sub run {
 
     select_serial_terminal;
 
-    my $rg = DEPLOY_PREFIX . get_current_job_id();
-    assert_script_run("az group delete --name $rg -y", timeout => 600);
+    az_group_delete(name => DEPLOY_PREFIX . get_current_job_id(), timeout => 600);
 }
 
 sub test_flags {

--- a/tests/sles4sap/publiccloud/azure_fence_agents_test.pm
+++ b/tests/sles4sap/publiccloud/azure_fence_agents_test.pm
@@ -89,8 +89,8 @@ sub run {
         push @bashrc_vars, "export SPN_APPLICATION_ID=$spn_application_id";
         push @bashrc_vars, "export SPN_APP_PASSWORD=$spn_application_password";
 
-        my $tenant_id = qesap_az_get_tenant_id(subscription_id => $subscription_id);
-        die 'Tenant ID is required in case of Azure SPN fencing' unless $tenant_id;
+        my $tenant_id = az_account_show(query => 'tenantId');
+        die "Returned output '$tenant_id' does not match ID pattern" unless (az_validate_uuid_pattern(uuid => $tenant_id));
         push @bashrc_vars, "export TENANT_ID=$tenant_id";
 
         push @fence_agent_cmd_list,


### PR DESCRIPTION
Move more SAP libraries to use azure_cli library.
Adapt the az_vm_create arguments to what is needed by SDAF. Adapt unit tests.


- Related ticket: 

# Verification run:

sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-cloud_netconfig_azure_test
 - http://openqaworker15.qa.suse.cz/tests/351666
  - http://openqaworker15.qa.suse.cz/tests/351671

sle-12-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE12_5_PAYG-qesap_azure_ltss_test
- http://openqaworker15.qa.suse.cz/tests/351672