### PR TITLE
autoyast: set default target for autoyast_opensuse/autoyast_btrfs_luks2

### DIFF
--- a/data/autoyast_opensuse/autoyast_btrfs_luks2.xml
+++ b/data/autoyast_opensuse/autoyast_btrfs_luks2.xml
@@ -133,4 +133,7 @@
       <username>root</username>
     </user>
   </users>
+  <services-manager>
+    <default_target>graphical</default_target>
+  </services-manager>
 </profile>


### PR DESCRIPTION
Autoyast is 'dying' - but contains business logic to switch to graphical.target
whenever xdm is being installed

with GMOME 49, GNOME became Wayland-only, making the presence of Xorg, and also xdm,
less of a common thing. Installing the default gnome-pattern will result in
a system running gdm directly via systemd service instead of relying on the xdm
wrapper.

- Related ticket: https://progress.opensuse.org/issues/189723
- Needles: N/A
- Verification run:

openqa: clone https://openqa.opensuse.org/tests/5723493
