### PR TITLE
Enable migration from 15 SP7 to 16 on powerVM

### DIFF
--- a/data/yam/autoyast/textmode_ppc64le.xml
+++ b/data/yam/autoyast/textmode_ppc64le.xml
@@ -133,4 +133,19 @@
             <timeout config:type="integer">0</timeout>
         </yesno_messages>
     </report>
+  <scripts t="map">
+    <post-scripts t="list">
+      <script t="map">
+        <filename>post.sh</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+#!/bin/sh
+# On 15SP5 need create directory of /etc/ssh/sshd_config.d/.
+mkdir -p /etc/ssh/sshd_config.d/
+echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+exit 0
+        ]]></source>
+      </script>
+    </post-scripts>
+  </scripts>
 </profile>

--- a/lib/bootloader_pvm.pm
+++ b/lib/bootloader_pvm.pm
@@ -150,7 +150,7 @@ sub enter_netboot_parameters {
     }
     # Skipping this setup due to it triggers general code for openSUSE that breaks powerVM scenario
     unless (is_agama) {
-        bootmenu_default_params;
+        bootmenu_default_params(in_grub_edit => 1);
         bootmenu_network_source;
         specific_bootmenu_params;
         type_string_slow remote_install_bootmenu_params;

--- a/tests/yam/migration/migration_unattended.pm
+++ b/tests/yam/migration/migration_unattended.pm
@@ -11,6 +11,7 @@ use testapi;
 use power_action_utils 'power_action';
 use utils qw(zypper_call reconnect_mgmt_console upload_folders);
 use Utils::Architectures 'is_s390x';
+use Utils::Backends 'is_pvm';
 use registration;
 
 sub run {
@@ -54,7 +55,8 @@ sub run {
     upload_logs("/boot/grub2/grub.cfg", failok => 1);
     upload_folders(folders => '/etc/zypp/repos.d/');
 
-    if (is_s390x) {
+    if (is_s390x || is_pvm) {
+        assert_script_run("echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf");
         enter_cmd '/usr/sbin/run_migration';
         reset_consoles;
         reconnect_mgmt_console(timeout => 600);

--- a/tests/yam/migration/migration_unattended.pm
+++ b/tests/yam/migration/migration_unattended.pm
@@ -22,6 +22,7 @@ sub run {
     # Add repo for devel:DMS when using proxy
     if ((get_var('SCC_URL', "") =~ /proxy/)) {
         my $repo_server = "https://download.opensuse.org/repositories/devel:/DMS/";
+        assert_script_run("echo 'url: " . get_var('SCC_URL') . "' > /etc/SUSEConnect");
         my $repo_url = $repo_server . "SLE_" . (get_var('VERSION_UPGRADE_FROM') =~ s/-/_/gr);
         zypper_call("ar --refresh -p 90 '$repo_url' Migration");
     }

--- a/tests/yam/migration/migration_unattended.pm
+++ b/tests/yam/migration/migration_unattended.pm
@@ -12,6 +12,7 @@ use power_action_utils 'power_action';
 use utils qw(zypper_call reconnect_mgmt_console upload_folders);
 use Utils::Backends qw(is_ipmi);
 use Utils::Architectures 'is_s390x';
+use Utils::Backends 'is_pvm';
 use registration;
 
 sub run {
@@ -71,10 +72,10 @@ sub run {
         assert_script_run("sed -i 's/set timeout=[0-9]*/set timeout=-1/' /etc/grub.d/99_migration");
         assert_script_run("grub2-mkconfig -o /boot/grub2/grub.cfg");
         power_action('reboot', textmode => 1, keepconsole => 1, first_reboot => 1);
-        reconnect_mgmt_console(timeout => 600) if is_ipmi;
+        reconnect_mgmt_console(timeout => 600) if (is_ipmi | is_pvm),;
         assert_screen('grub-menu-migration', is_ipmi ? 600 : 120);
         send_key 'ret';
-        assert_screen('migration-running', 60);
+        assert_screen('migration-running', 60) unless (is_pvm);
         assert_screen('grub2', 1200);
     }
 }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/189228
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/637
- Verification runs: 
  - VR on SLES 16.1 build 46.1: https://openqa.suse.de/tests/22852618 (failing for unknwon reasons)
  - Verifiation run on build 160.4: https://openqa.suse.de/tests/22851391 (passed, but fails because of CD repo in `validate_repos`
 
The code chang is minimal, just added some `reconnect_mgmt_console` to the path using the grub bootimage for migration so that we don't lose connection with the SUT. 
