### PR TITLE
Print os-release before update in update_host.pm

### DIFF
--- a/tests/containers/update_host.pm
+++ b/tests/containers/update_host.pm
@@ -28,6 +28,8 @@ sub disable_selinux {
 sub run {
     my ($self) = @_;
     select_serial_terminal;
+    record_info('uname', script_output('uname -a'));
+    record_info('os-release', script_output('cat /etc/os-release'));
     my $update_timeout = 1200;
 
     my ($version, $sp, $host_distri) = get_os_release;


### PR DESCRIPTION
Needed to check if version changes between updates and current version
- Related ticket: https://progress.opensuse.org/issues/192403
- Verification run: [openqa.mypersonalinstance.de/tests/xyz#step/module/x](https://openqa.suse.de/tests/20144073#step/update_host/30)
