### PR TITLE
rebootmgr: Support soft reboot

### DIFF
--- a/lib/microos.pm
+++ b/lib/microos.pm
@@ -40,15 +40,19 @@ sub microos_login {
 # Process reboot with an option to trigger it
 sub microos_reboot {
     my $trigger = shift // 0;
+    # aka expected_grub from process_reboot
+    my $bootloader_expected = shift // 1;
     power_action('reboot', observe => !$trigger, keepconsole => 1);
 
-    # sol console has to be selected for ipmi backend before asserting grub needle.
-    select_console 'sol', await_console => 0 if is_ipmi();
-    # No grub bootloader on xen-pv
-    # grub2 needle is unreliable (stalls during timeout) - poo#28648
-    assert_screen(get_default_bootloader(), 300);
-    send_key('ret') unless get_var('KEEP_GRUB_TIMEOUT');
-    unlock_if_encrypted if need_unlock_after_bootloader;
+    if ($bootloader_expected) {
+        # sol console has to be selected for ipmi backend before asserting grub needle.
+        select_console 'sol', await_console => 0 if is_ipmi();
+
+        assert_screen(get_default_bootloader(), 300);
+        send_key('ret') unless get_var('KEEP_GRUB_TIMEOUT');
+        unlock_if_encrypted if need_unlock_after_bootloader;
+    }
+
     microos_login;
 }
 

--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -91,7 +91,7 @@ sub process_reboot {
 
     # Switch to root-console as we need VNC to check for grub and for login prompt
     my $prev_console = current_console();
-    select_console 'root-console', await_console => 0;
+    select_console 'root-console', await_console => 0 unless ($prev_console eq 'root-console');
 
     handle_first_grub if ($args{automated_rollback});
 

--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -96,7 +96,7 @@ sub process_reboot {
     handle_first_grub if ($args{automated_rollback});
 
     if (!is_s390x && (is_microos || is_sle_micro('<6.0'))) {
-        microos_reboot $args{trigger};
+        microos_reboot($args{trigger}, $args{expected_grub});
         record_kernel_audit_messages();
     } elsif (is_backend_s390x) {
         prepare_system_shutdown;

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -511,10 +511,12 @@ sub is_released {
 
 =head2 is_staging
 
-Returns true if called in staging
+Returns true if called in staging, checks for a particular staging if argument is passed
 =cut
 
 sub is_staging {
+    my $staging = shift;
+    return check_var('STAGING', $staging) if $staging;
     return get_var('STAGING');
 }
 

--- a/t/01_version_utils.t
+++ b/t/01_version_utils.t
@@ -241,4 +241,14 @@ subtest 'bootloader_tests' => sub {
     ok get_default_bootloader eq 'grub2', "Forcing bootloader works";
 };
 
+subtest 'is_staging tests' => sub {
+    use version_utils qw(is_staging);
+    is is_staging, undef, "No staging variable means it isn't staging";
+
+    set_var('STAGING', 'foo');
+    ok is_staging, "foo is a staging project";
+    isnt is_staging('bar'), 0, "bar is not this staging";
+    is is_staging('foo'), 1, "foo is the current staging";
+};
+
 done_testing;

--- a/tests/transactional/rebootmgr.pm
+++ b/tests/transactional/rebootmgr.pm
@@ -65,8 +65,8 @@ sub check_strategy_instantly {
     rbm_call "set-strategy instantly";
     trup_call "reboot ptf install" . rpmver('interactive');
 
-    my $expect_bootloader = !is_soft_reboot_requested();
-    process_reboot(expected_grub => $expect_bootloader, trigger => !$expect_bootloader);
+    my @reboot_args = is_soft_reboot_requested() ? (expected_grub => 0) : ();
+    process_reboot(@reboot_args);
 
     rbm_call "get-strategy | grep instantly";
 }
@@ -80,8 +80,8 @@ sub check_strategy_maint_window {
     rbm_set_window '-5minutes', '20m';
     trup_call "reboot pkg install" . rpmver('feature');
 
-    my $expect_bootloader = !is_soft_reboot_requested();
-    process_reboot(expected_grub => $expect_bootloader, trigger => !$expect_bootloader);
+    my @reboot_args = is_soft_reboot_requested() ? (expected_grub => 0) : ();
+    process_reboot(@reboot_args);
 
     # Trigger reboot and wait for maintenance window
     rbm_set_window '+2minutes', '1m';

--- a/tests/transactional/rebootmgr.pm
+++ b/tests/transactional/rebootmgr.pm
@@ -50,7 +50,14 @@ sub check_strategy_instantly {
     select_console('root-console');
     rbm_call "set-strategy instantly";
     trup_call "reboot ptf install" . rpmver('interactive');
-    process_reboot(expected_grub => 1);
+    my $expected_grub = 1;
+    my $regex = qr/Minimally required reboot level:\s(.*)[\r\n]/;
+    my $output = wait_serial($regex, timeout => $args{timeout}) or die "transactional-update didn't finish";
+    if ($output =~ $regex) {
+        $expected_grub = ($1 eq "soft-reboot") ? 0 : 1;
+        record_info($1, "'$1'");
+    }
+    process_reboot(expected_grub => $expected_grub);
     rbm_call "get-strategy | grep instantly";
 }
 

--- a/tests/transactional/rebootmgr.pm
+++ b/tests/transactional/rebootmgr.pm
@@ -45,19 +45,28 @@ sub rbm_set_window {
     rbm_call "set-window \$(date -d $time +%T) $duration";
 }
 
+# Soft reboot only triggers a full reboot when installing a new kernel
+# update of the bootloader or any command like rollback, grub.cfg, bootloader, run or shell
+sub is_soft_reboot_requested {
+    my $soft_reboot_requested;
+    my $regex = qr/Minimally required reboot level:\s(.*)[\r\n]/;
+    my $output = wait_serial($regex, timeout => 300) or die "Could not capture reboot type";
+    if ($output =~ $regex) {
+        $soft_reboot_requested = ($1 eq "soft-reboot") ? 1 : 0;
+        record_info("Reboot strategy: $1");
+    }
+    return $soft_reboot_requested;
+}
+
 #1 Test instant reboot
 sub check_strategy_instantly {
     select_console('root-console');
     rbm_call "set-strategy instantly";
     trup_call "reboot ptf install" . rpmver('interactive');
-    my $expected_grub = 1;
-    my $regex = qr/Minimally required reboot level:\s(.*)[\r\n]/;
-    my $output = wait_serial($regex, timeout => $args{timeout}) or die "transactional-update didn't finish";
-    if ($output =~ $regex) {
-        $expected_grub = ($1 eq "soft-reboot") ? 0 : 1;
-        record_info($1, "'$1'");
-    }
-    process_reboot(expected_grub => $expected_grub);
+
+    my $expect_bootloader = !is_soft_reboot_requested();
+    process_reboot(expected_grub => $expect_bootloader, trigger => !$expect_bootloader);
+
     rbm_call "get-strategy | grep instantly";
 }
 
@@ -69,7 +78,9 @@ sub check_strategy_maint_window {
     # Trigger reboot during maint-window
     rbm_set_window '-5minutes', '20m';
     trup_call "reboot pkg install" . rpmver('feature');
-    process_reboot(expected_grub => 1);
+
+    my $expect_bootloader = !is_soft_reboot_requested();
+    process_reboot(expected_grub => $expect_bootloader, trigger => !$expect_bootloader);
 
     # Trigger reboot and wait for maintenance window
     rbm_set_window '+2minutes', '1m';

--- a/tests/transactional/rebootmgr.pm
+++ b/tests/transactional/rebootmgr.pm
@@ -47,16 +47,17 @@ sub rbm_set_window {
 
 # Soft reboot only triggers a full reboot when installing a new kernel
 # update of the bootloader or any command like rollback, grub.cfg, bootloader, run or shell
-sub is_soft_reboot_requested {
-    return 0 if is_sle_micro;
-    my $soft_reboot_requested;
-    my $regex = qr/Minimally required reboot level:\s(.*)[\r\n]/;
-    my $output = wait_serial($regex, timeout => 300) or die "Could not capture reboot type";
-    if ($output =~ $regex) {
-        $soft_reboot_requested = ($1 eq "soft-reboot") ? 1 : 0;
-        record_info("Reboot strategy: $1");
+sub check_reboot_strategy_and_reboot {
+    my @reboot_args;
+    if (!is_sle_micro) {
+        my $regex = qr/Minimally required reboot level:\s(.*)[\r\n]/;
+        my $output = wait_serial($regex, timeout => 300) or die "Could not capture reboot type";
+        if ($output =~ $regex) {
+            @reboot_args = (expected_grub => 0) if $1 eq 'soft-reboot';
+            record_info("Reboot strategy: $1");
+        }
     }
-    return $soft_reboot_requested;
+    process_reboot(@reboot_args);
 }
 
 #1 Test instant reboot
@@ -64,10 +65,7 @@ sub check_strategy_instantly {
     select_console('root-console');
     rbm_call "set-strategy instantly";
     trup_call "reboot ptf install" . rpmver('interactive');
-
-    my @reboot_args = is_soft_reboot_requested() ? (expected_grub => 0) : ();
-    process_reboot(@reboot_args);
-
+    check_reboot_strategy_and_reboot();
     rbm_call "get-strategy | grep instantly";
 }
 
@@ -75,14 +73,10 @@ sub check_strategy_instantly {
 sub check_strategy_maint_window {
     select_console('root-console');
     rbm_call "set-strategy maint-window";
-
     # Trigger reboot during maint-window
     rbm_set_window '-5minutes', '20m';
     trup_call "reboot pkg install" . rpmver('feature');
-
-    my @reboot_args = is_soft_reboot_requested() ? (expected_grub => 0) : ();
-    process_reboot(@reboot_args);
-
+    check_reboot_strategy_and_reboot();
     # Trigger reboot and wait for maintenance window
     rbm_set_window '+2minutes', '1m';
     rbm_call 'reboot';

--- a/tests/transactional/rebootmgr.pm
+++ b/tests/transactional/rebootmgr.pm
@@ -12,7 +12,7 @@ use Mojo::Base 'consoletest';
 use testapi;
 use transactional;
 use utils;
-use version_utils qw(is_tumbleweed is_sle_micro);
+use version_utils qw(is_tumbleweed is_sle_micro is_staging);
 use Utils::Backends 'is_pvm';
 use serial_terminal 'select_serial_terminal';
 
@@ -49,7 +49,7 @@ sub rbm_set_window {
 # update of the bootloader or any command like rollback, grub.cfg, bootloader, run or shell
 sub check_reboot_strategy_and_reboot {
     my @reboot_args;
-    if (!is_sle_micro) {
+    if (!is_sle_micro && is_staging('J')) {
         my $regex = qr/Minimally required reboot level:\s(.*)[\r\n]/;
         my $output = wait_serial($regex, timeout => 300) or die "Could not capture reboot type";
         if ($output =~ $regex) {

--- a/tests/transactional/rebootmgr.pm
+++ b/tests/transactional/rebootmgr.pm
@@ -12,7 +12,7 @@ use Mojo::Base 'consoletest';
 use testapi;
 use transactional;
 use utils;
-use version_utils 'is_tumbleweed';
+use version_utils qw(is_tumbleweed is_sle_micro);
 use Utils::Backends 'is_pvm';
 use serial_terminal 'select_serial_terminal';
 
@@ -48,6 +48,7 @@ sub rbm_set_window {
 # Soft reboot only triggers a full reboot when installing a new kernel
 # update of the bootloader or any command like rollback, grub.cfg, bootloader, run or shell
 sub is_soft_reboot_requested {
+    return 0 if is_sle_micro;
     my $soft_reboot_requested;
     my $regex = qr/Minimally required reboot level:\s(.*)[\r\n]/;
     my $output = wait_serial($regex, timeout => 300) or die "Could not capture reboot type";


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/163352

Version [6.X](https://build.opensuse.org/request/show/1345664) of transactional-update enables soft-reboot by default.

~Current tests fail in staging due to a possible duplicate of [bsc#1231986](https://bugzilla.suse.com/show_bug.cgi?id=1231986)~

The only obvious modification so far needed is in rebootmgr, namely the calls with `transactional-update reboot $foo`, where t-u nicely prints a message of the minimally required reboot.

openqa: clone https://openqa.opensuse.org/tests/5841891
openqa: clone https://openqa.opensuse.org/tests/5841892
openqa: clone https://openqa.opensuse.org/tests/5841893
openqa: clone https://openqa.opensuse.org/tests/5841874

Additional VRs:
- SL Micro 6.2: https://openqa.suse.de/tests/21823616
#### Results from cloned jobs:
- [![https://openqa.opensuse.org/tests/5852764](https://openqa.opensuse.org/tests/5852764/badge)](https://openqa.opensuse.org/tests/5852764)
- [![https://openqa.opensuse.org/tests/5852765](https://openqa.opensuse.org/tests/5852765/badge)](https://openqa.opensuse.org/tests/5852765)
- [![https://openqa.opensuse.org/tests/5852766](https://openqa.opensuse.org/tests/5852766/badge)](https://openqa.opensuse.org/tests/5852766)
- [![https://openqa.opensuse.org/tests/5852767](https://openqa.opensuse.org/tests/5852767/badge)](https://openqa.opensuse.org/tests/5852767)

<sub>The above list is generated with a script from the "clone_mentioned_job" workflow.</sub>
