### PR TITLE
Use GitHub releases instead of pushing the bundler files to repo

### DIFF
--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -6,12 +6,19 @@
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
 use base Yam::Agama::patch_agama_base;
-use testapi qw(assert_script_run get_required_var select_console);
+use testapi qw(assert_script_run get_required_var select_console script_run);
 
 sub run {
     select_console 'install-shell';
+    my $agama_test = get_required_var("AGAMA_TEST");
     my ($repo, $branch) = split /#/, get_required_var('YUPDATE_GIT');
-    assert_script_run("AGAMA_TEST=" . get_required_var('AGAMA_TEST') . " yupdate patch $repo $branch", timeout => 60);
+    my $destination = "/usr/share/agama/system-tests";
+
+    script_run("curl -L -o dist.tar.gz https://github.com/$repo/releases/download/tag-$branch/dist.tar.gz");
+    script_run("tar -xzf dist.tar.gz");
+    script_run("mkdir -p $destination");
+    script_run("cp dist/vendor.js $destination");
+    script_run("cp dist/$agama_test* $destination");
 }
 
 1;

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -10,18 +10,20 @@ use testapi qw(assert_script_run get_required_var select_console script_run reco
 
 sub run {
     select_console 'install-shell';
-    my $agama_test = get_required_var("AGAMA_TEST");
-    my ($repo, $branch) = split /#/, get_required_var('YUPDATE_GIT');
     my $tar_name = 'dist.tar.gz';
     my $destination = "/usr/share/agama/system-tests";
     my $podman_command = "podman run --rm -v ./:/tmp/output " .
           "docker.io/okynos/agama-integration-test-webpack-builder:latest " .
           get_required_var('YUPDATE_GIT');
 
+    record_info('command', $podman_command);
     my $podman_output = qx{$command 2>&1};
     my $podman_exit_code = $? >> 8;
     record_info('podman', $podman_output);
     record_info('exit', $podman_exit_code);
+
+    my $folder_ls = `ls -lah`;
+    record_info('folder', $folder_ls);
 
     my $tar_data = `cat $tar_name`;
     save_tmp_file($tar_name, $tar_data);

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -14,10 +14,11 @@ sub run {
     my ($repo, $branch) = split /#/, get_required_var('YUPDATE_GIT');
     my $tar_name = 'dist.tar.gz';
     my $destination = "/usr/share/agama/system-tests";
-
-    my $podman_output = `podman run --rm -v ./:/tmp/output ` .
-          `okynos/agama-integration-test-webpack-builder:latest ` .
+    my $podman_command = "podman run --rm -v ./:/tmp/output " .
+          "okynos/agama-integration-test-webpack-builder:latest " .
           get_required_var('YUPDATE_GIT');
+
+    my $podman_output = qx{$command};
     record_info('podman', $podman_output);
 
     my $tar_data = `cat $tar_name`;

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -23,7 +23,7 @@ sub run {
     record_info('command', $podman_command);
     my $podman_output = qx{$command 2>&1};
     my $podman_exit_code = $? >> 8;
-    my $podman_version = qx{/usr/bin/podman --version 2>&1};
+    my $podman_version = qx{/usr/bin/podman --root ./ --version 2>&1};
     record_info('version', $podman_version);
     record_info('podman', $podman_output);
     record_info('exit', $podman_exit_code);

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -23,7 +23,9 @@ sub run {
     record_info('command', $podman_command);
     my $podman_output = qx{$command 2>&1};
     my $podman_exit_code = $? >> 8;
-    my $podman_version = qx{/usr/bin/podman --root ./ --version 2>&1};
+    my $pwd = qx{pwd};
+    record_info('pwd', $pwd);
+    my $podman_version = qx{/usr/bin/podman --root $pwd --version 2>&1};
     record_info('version', $podman_version);
     record_info('podman', $podman_output);
     record_info('exit', $podman_exit_code);

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -6,7 +6,7 @@
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
 use base Yam::Agama::patch_agama_base;
-use testapi qw(assert_script_run get_required_var select_console script_run record_info save_tmp_file);
+use testapi qw(assert_script_run get_required_var select_console script_run record_info save_tmp_file autoinst_url);
 
 sub run {
     select_console 'install-shell';

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -12,19 +12,20 @@ sub run {
     select_console 'install-shell';
     my $agama_test = get_required_var("AGAMA_TEST");
     my ($repo, $branch) = split /#/, get_required_var('YUPDATE_GIT');
+    my $tar_name = 'dist.tar.gz';
     my $destination = "/usr/share/agama/system-tests";
 
+    my $podman_output = `podman run --rm -v ./:/tmp/output ` .
+          `okynos/agama-integration-test-webpack-builder:latest ` .
+          get_required_var('YUPDATE_GIT');
+    record_info('podman', $podman_output);
 
-    my $output = `podman run --rm hello-world`;
-    record_info('podman', $output);
-    
-    #my $sha = script_output("curl -s https://api.github.com/repos/OWNER/REPO/commits/BRANCH | jq -r '.sha'");
-    #script_run("curl -L -o dist.tar.gz https://github.com/$repo/releases/download/tag-$branch/dist.tar.gz");
-    #script_run("curl -L -o dist.tar.gz https://github.com/$repo/releases/download/tag-$branch/dist.tar.gz");
-    #script_run("tar -xzf dist.tar.gz");
-    #script_run("mkdir -p $destination");
-    #script_run("cp dist/vendor.js $destination");
-    #script_run("cp dist/$agama_test* $destination");
+    my $tar_data = `cat $tar_name`;
+    save_tmp_file($tar_name, $tar_data);
+
+    my $tar_url = autoinst_url("/files/$tar_name");
+    script_run("curl -OL $tar_url");
+    script_run("tar -C '$destination' -xzf $tar_name");
 }
 
 1;

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -6,7 +6,7 @@
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
 use base Yam::Agama::patch_agama_base;
-use testapi qw(assert_script_run get_required_var select_console script_run);
+use testapi qw(assert_script_run get_required_var select_console script_run record_info);
 
 sub run {
     select_console 'install-shell';
@@ -15,7 +15,8 @@ sub run {
     my $destination = "/usr/share/agama/system-tests";
 
 
-    `podman run --rm hello-world`;
+    my $output = `podman run --rm hello-world`;
+    record_info('podman', $output);
     
     #my $sha = script_output("curl -s https://api.github.com/repos/OWNER/REPO/commits/BRANCH | jq -r '.sha'");
     #script_run("curl -L -o dist.tar.gz https://github.com/$repo/releases/download/tag-$branch/dist.tar.gz");

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -15,7 +15,7 @@ sub run {
     my $tar_name = 'dist.tar.gz';
     my $destination = "/usr/share/agama/system-tests";
     my $podman_command = "podman run --rm -v ./:/tmp/output " .
-          "okynos/agama-integration-test-webpack-builder:latest " .
+          "docker.io/okynos/agama-integration-test-webpack-builder:latest " .
           get_required_var('YUPDATE_GIT');
 
     my $podman_output = qx{$command};

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -18,8 +18,10 @@ sub run {
           "docker.io/okynos/agama-integration-test-webpack-builder:latest " .
           get_required_var('YUPDATE_GIT');
 
-    my $podman_output = qx{$command};
+    my $podman_output = qx{$command 2>&1};
+    my $podman_exit_code = $? >> 8;
     record_info('podman', $podman_output);
+    record_info('exit', $podman_exit_code);
 
     my $tar_data = `cat $tar_name`;
     save_tmp_file($tar_name, $tar_data);

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -23,7 +23,7 @@ sub run {
     record_info('command', $podman_command);
     my $podman_output = qx{$command 2>&1};
     my $podman_exit_code = $? >> 8;
-    my $podman_version = qx{which podman 2>&1};
+    my $podman_version = qx{/usr/bin/podman --version 2>&1};
     record_info('version', $podman_version);
     record_info('podman', $podman_output);
     record_info('exit', $podman_exit_code);

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -6,7 +6,7 @@
 # Maintainer: QE YaST and Migration (QE Yam) <qe-yam at suse de>
 
 use base Yam::Agama::patch_agama_base;
-use testapi qw(assert_script_run get_required_var select_console script_run record_info);
+use testapi qw(assert_script_run get_required_var select_console script_run record_info save_tmp_file);
 
 sub run {
     select_console 'install-shell';

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -12,7 +12,7 @@ sub run {
     select_console 'install-shell';
     my $tar_name = 'dist.tar.gz';
     my $destination = "/usr/share/agama/system-tests";
-    my $podman_command = "podman run --rm " .
+    my $podman_command = "/usr/bin/podman run --rm " .
           "--storage-opt ignore_chown_errors=true " .
           "--cgroup-manager=cgroupfs " .
           "--root ./ " .

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -23,7 +23,7 @@ sub run {
     record_info('command', $podman_command);
     my $podman_output = qx{$command 2>&1};
     my $podman_exit_code = $? >> 8;
-    my $pwd = qx{pwd};
+    my $pwd = chomp(qx{pwd});
     record_info('pwd', $pwd);
     my $podman_version = qx{/usr/bin/podman --root $pwd --version 2>&1};
     record_info('version', $podman_version);

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -14,11 +14,16 @@ sub run {
     my ($repo, $branch) = split /#/, get_required_var('YUPDATE_GIT');
     my $destination = "/usr/share/agama/system-tests";
 
-    script_run("curl -L -o dist.tar.gz https://github.com/$repo/releases/download/tag-$branch/dist.tar.gz");
-    script_run("tar -xzf dist.tar.gz");
-    script_run("mkdir -p $destination");
-    script_run("cp dist/vendor.js $destination");
-    script_run("cp dist/$agama_test* $destination");
+
+    `podman run --rm hello-world`;
+    
+    #my $sha = script_output("curl -s https://api.github.com/repos/OWNER/REPO/commits/BRANCH | jq -r '.sha'");
+    #script_run("curl -L -o dist.tar.gz https://github.com/$repo/releases/download/tag-$branch/dist.tar.gz");
+    #script_run("curl -L -o dist.tar.gz https://github.com/$repo/releases/download/tag-$branch/dist.tar.gz");
+    #script_run("tar -xzf dist.tar.gz");
+    #script_run("mkdir -p $destination");
+    #script_run("cp dist/vendor.js $destination");
+    #script_run("cp dist/$agama_test* $destination");
 }
 
 1;

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -23,6 +23,8 @@ sub run {
     record_info('command', $podman_command);
     my $podman_output = qx{$command 2>&1};
     my $podman_exit_code = $? >> 8;
+    my $podman_version = qx{podman --version};
+    record_info('version', $podman_version);
     record_info('podman', $podman_output);
     record_info('exit', $podman_exit_code);
 

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -23,7 +23,7 @@ sub run {
     record_info('command', $podman_command);
     my $podman_output = qx{$command 2>&1};
     my $podman_exit_code = $? >> 8;
-    my $podman_version = qx{whoami};
+    my $podman_version = qx{which podman 2>&1};
     record_info('version', $podman_version);
     record_info('podman', $podman_output);
     record_info('exit', $podman_exit_code);

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -23,7 +23,7 @@ sub run {
     record_info('command', $podman_command);
     my $podman_output = qx{$command 2>&1};
     my $podman_exit_code = $? >> 8;
-    my $podman_version = qx{podman --version};
+    my $podman_version = qx{whoami};
     record_info('version', $podman_version);
     record_info('podman', $podman_output);
     record_info('exit', $podman_exit_code);

--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -12,7 +12,11 @@ sub run {
     select_console 'install-shell';
     my $tar_name = 'dist.tar.gz';
     my $destination = "/usr/share/agama/system-tests";
-    my $podman_command = "podman run --rm -v ./:/tmp/output " .
+    my $podman_command = "podman run --rm " .
+          "--storage-opt ignore_chown_errors=true " .
+          "--cgroup-manager=cgroupfs " .
+          "--root ./ " .
+          "-v './:/tmp/output' " .
           "docker.io/okynos/agama-integration-test-webpack-builder:latest " .
           get_required_var('YUPDATE_GIT');
 


### PR DESCRIPTION
We have changed the Agama tests patch to use commands instead of Rake.

- Related ticket: https://progress.opensuse.org/issues/189948
- Related PR: https://github.com/qe-installation-and-migration/agama-integration-test-webpack/pull/194
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/20469474#
