### PR TITLE
Implement BCI_SKIP_ENVS

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -138,6 +138,7 @@ sub run {
     record_info('Run', "Starting the tests for the following environments:\n$test_envs");
     assert_script_run("cd /root/BCI-tests && git fetch && git reset --hard $bci_tests_branch");
     assert_script_run("export TOX_PARALLEL_NO_SPINNER=1");
+    assert_script_run("export TOX_SKIP_ENV=" . get_var('BCI_SKIP_ENVS', ''));
     assert_script_run("export CONTAINER_RUNTIME=$engine");
     if ($os_version) {
         script_run("export OS_VERSION=$os_version");

--- a/variables.md
+++ b/variables.md
@@ -30,6 +30,7 @@ BASE_VERSION | string | | |
 BATS_* | string | | Used for [BATS tests](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/containers/bats/README.md) |
 BETA | boolean | false | Enables checks and processing of beta warnings. Defines current stage of the product under test.
 BCI_DEVEL_REPO | string | | This parameter is given to the bci-tests to inject a different SLE_BCI repository url to the container image instead of the default one. Used by `bci_test.pm`.
+BCI_SKIP_ENVS | string | | This tells tox to skip any env whose name matches that pattern.
 BCI_TEST_ENVS | string | | The list of environments to be tested, e.g. `base,init,dotnet,python,node,go,multistage`. Used by `bci_test.pm`. Use `-` to not schedule any BCI test runs.
 BCI_TESTS_REPO | string | https://github.com/SUSE/BCI-tests.git | If set, use this instead of the standart BCI-Test repo (see default). Uses the same syntax as CASE_DIR, so to use branch `branch123` on that repo use e.g. https://github.com/SUSE/BCI-tests#branch123
 BCI_TIMEOUT | string | | Timeout given to the command to test each environment. Used by `bci_test.pm`.


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/194969 (https://openqa.opensuse.org/tests/5608403#step/_root_BCI-tests_all_/366)
- Verification run: [no python:3.12 due to BCI_SKIP_ENVS=^py312](https://openqa.opensuse.org/tests/5610811)
