### PR TITLE
Increase VM memory to ensure normal behavior after dompmsuspend/wakeup 

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_kvm_hvm_uefi_with_power_management_x86_64_qcow2_nvram.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_kvm_hvm_uefi_with_power_management_x86_64_qcow2_nvram.xml
@@ -13,7 +13,7 @@
     <guest_arch>x86_64</guest_arch>
     <guest_name/>
     <guest_domain_name/>
-    <guest_memory>2048,maxmemory=4096</guest_memory>
+    <guest_memory>4096,maxmemory=8192</guest_memory>
     <guest_vcpus>2,maxvcpus=4</guest_vcpus>
     <guest_cpumodel/>
     <guest_metadata/>


### PR DESCRIPTION
* **Increase** VM memory to ensure it can be waken up successfully after being suspended.

* **Less** memory may lead to system hang after being waken up, for example, [this one](https://openqa.suse.de/tests/22054200#step/uefi_guest_verification/71).

* **Verification Runs:**
  * [a verification run](https://openqa.suse.de/tests/22090554)