### PR TITLE
Support sle15+/16+ efi guests to disable secure boot for kernel update

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -40,6 +40,8 @@ our @EXPORT = qw(
   is_kvm_host
   is_sles_mu_virt_test
   is_sles16_mu_virt_test
+  host_os_version_prefix
+  is_guest_of_host_version
   is_monolithic_libvirtd
   turn_on_libvirt_debugging_log
   restart_libvirtd
@@ -205,6 +207,64 @@ sub is_sles_mu_virt_test {
 sub is_sles16_mu_virt_test {
     return is_sle('>=16') && get_var('REGRESSION', '') =~ /xen|kvm|qemu|hyperv|vmware/ && !get_var("VIRT_AUTOTEST");
     # Note: Xen will be tested from SLES16.2
+}
+
+# Convert openQA VERSION variable to the guest name prefix used in %virt_autotest::common::guests.
+# This normalizes the different versioning schemes:
+#   "15-SP7"  -> "sles15sp7"   (dash-based, SLES15 and older)
+#   "16.0"    -> "sles16"      (dot-based, SLES16+ base release)
+#   "16.1"    -> "sles16sp1"   (dot-based, SLES16+ service pack)
+#   "12.5"    -> "sles12sp5"   (dot-based service pack)
+# Returns: e.g. "sles16", "sles15sp7"
+sub host_os_version_prefix {
+    my $distri = get_var('DISTRI', 'sle');
+    my $version = get_var('VERSION', '');
+    return "${distri}s" . _normalize_version($version);
+}
+
+# Normalize VERSION string to guest name component:
+#   "15-SP7"  -> "15sp7"
+#   "16.0"    -> "16"       (x.0 means base release, no SP suffix)
+#   "16.1"    -> "16sp1"
+sub _normalize_version {
+    my $version = shift;
+    if ($version =~ /^(\d+)\.(\d+)$/) {
+        return $2 == 0 ? $1 : "${1}sp${2}";
+    }
+    # Dash-based: "15-SP7" -> "15SP7" -> "15sp7"
+    return lc($version =~ s/-//r);
+}
+
+# Check if a guest name corresponds to the host OS version.
+# Handles all naming conventions across backends:
+#   KVM/Xen:      sles16efi_online, sles16sp2efi_online, sles15sp7PV, sles15sp7-efi-sev-es
+#   VMware/HyperV: sles16.0, sles16.2, sles15sp7, sles15sp7TD
+# Args: $guest_name - the guest name key from %virt_autotest::common::guests
+# Returns: 1 if guest matches host version, 0 otherwise
+sub is_guest_of_host_version {
+    my $guest = shift;
+    my $distri = get_var('DISTRI', 'sle');
+    my $version = get_var('VERSION', '');
+    my $base = "${distri}s";
+    my $prefix;
+
+    if ($version =~ /^(\d+)\.(\d+)$/) {
+        my ($major, $minor) = ($1, $2);
+        if ($minor == 0) {
+            # 16.0: KVM="sles16...", VMware/HyperV="sles16.0..."
+            $prefix = "${base}${major}(?:\\.0)?";
+        } else {
+            # 16.2: KVM="sles16sp2...", VMware/HyperV="sles16.2..."
+            $prefix = "(?:${base}${major}sp${minor}|${base}${major}\\.${minor})";
+        }
+    } else {
+        # Dash-based: "15-SP7" -> "sles15sp7"
+        $prefix = $base . lc($version =~ s/-//r);
+    }
+
+    # Negative lookahead: reject if followed by "sp\d" or bare digit,
+    # which would indicate a different version (e.g. sles16sp1 != sles16).
+    return $guest =~ /^${prefix}(?!sp\d|\d)/;
 }
 
 #return 1 if it is a fv guest judging by name

--- a/tests/virt_autotest/esxi_open_vm_tools.pm
+++ b/tests/virt_autotest/esxi_open_vm_tools.pm
@@ -14,6 +14,7 @@ use transactional;
 use utils;
 use virt_autotest::common;
 use virt_autotest::esxi_utils;
+use virt_autotest::utils;
 use Time::Local;
 use Utils::Backends qw(is_qemu is_svirt);
 use version_utils qw(is_sle is_transactional);
@@ -30,9 +31,8 @@ sub run {
         run_tests($vm_name);
     }
     elsif (is_qemu) {
-        my $host_os_ver = get_var('DISTRI') . "s" . lc(get_var('VERSION') =~ s/-//r);
         foreach my $guest (keys %virt_autotest::common::guests) {
-            run_tests($guest) if ($guest eq $host_os_ver || $guest eq "${host_os_ver}TD" || $guest eq "${host_os_ver}PV" || $guest eq "${host_os_ver}HVM" || $guest eq "${host_os_ver}ES");
+            run_tests($guest) if (is_guest_of_host_version($guest));
         }
     }
 }

--- a/tests/virtualization/universal/kernel.pm
+++ b/tests/virtualization/universal/kernel.pm
@@ -10,6 +10,7 @@
 use Mojo::Base 'consoletest';
 use virt_autotest::common;
 use virt_autotest::kernel;
+use virt_autotest::utils;
 use testapi;
 use utils;
 use qam;
@@ -24,10 +25,9 @@ sub run {
 
     # For kernel updates, verify MU pkg is installed on compatible guests
     my @guests = keys %virt_autotest::common::guests;
-    my $host_os_version = get_var('DISTRI') . "s" . lc(get_var('VERSION') =~ s/-//r);
 
     foreach my $guest (@guests) {
-        if ($pkg eq "kernel-default" && $guest =~ /^${host_os_version}(?:TD|PV|HVM|ES|efi|_online|_full|$)/) {
+        if ($pkg eq "kernel-default" && is_guest_of_host_version($guest)) {
             validate_script_output("ssh root\@$guest zypper if $pkg", sub { m/(?=.*TEST_\d+)(?=.*up-to-date)/s });
             record_info("Package Validated on $guest", "$pkg validated on $guest: from TEST repository and up-to-date");
         }

--- a/tests/virtualization/universal/patch_guests.pm
+++ b/tests/virtualization/universal/patch_guests.pm
@@ -35,10 +35,8 @@ sub run {
     select_console('root-console');
     my @guests = keys %virt_autotest::common::guests;
     set_var('MAINT_TEST_REPO', get_var('INCIDENT_REPO'));
-    my $host_os_version = get_var('DISTRI') . "s" . lc(get_var('VERSION') =~ s/-//r);
     foreach my $guest (@guests) {
-        # Match guests by prefix to handle various suffixes (efi, TD, PV, HVM, ES, _online, _full, etc.)
-        if ($guest =~ /^${host_os_version}(?:TD|PV|HVM|ES|efi|_online|_full|$)/) {
+        if (is_guest_of_host_version($guest)) {
             if (check_var('PATCH_WITH_ZYPPER', '1') || check_var('PATCH_ON_GUEST', '1')) {
                 assert_script_run("ssh root\@$guest dmesg --level=emerg,crit,alert,err -tx|sort -o /tmp/${guest}_dmesg_err_before.txt");
                 record_info("Patching $guest");

--- a/tests/virtualization/universal/prepare_guests.pm
+++ b/tests/virtualization/universal/prepare_guests.pm
@@ -109,7 +109,7 @@ sub create_autoyast_profile {
         record_info("UEFI Config", "Modified autoyast profile for $vm_name to use grub2-efi for UEFI boot");
     }
 
-    my $host_os_version = get_var('DISTRI') . "s" . lc(get_var('VERSION') =~ s/-//r);
+    my $host_os_version = host_os_version_prefix();
     my $incident_repos = "";
     $incident_repos = get_var('INCIDENT_REPO', '') if ($vm_name eq $host_os_version || $vm_name eq "${host_os_version}PV" || $vm_name eq "${host_os_version}HVM");
     my $vars = {
@@ -209,12 +209,12 @@ sub run {
             record_info("$guest->{autoyast}");
             $guest->{osinfo} = gen_osinfo($guest->{name});
 
-            # For SLES16 VMs with kernel update, disable secure boot
-            if ($guest->{name} =~ /sles16/i && get_var("UPDATE_PACKAGE", "") =~ /kernel/) {
-                if ($guest->{boot_firmware} && $guest->{boot_firmware} =~ /^efi/) {
-                    $guest->{boot_firmware_disable_secure} = 1;
-                    record_info("Secure Boot", "Disabling secure boot for $guest->{name} due to kernel update");
-                }
+            # For EFI VMs with kernel update, disable secure boot to prevent boot failure
+            # (kernel MU packages are unsigned and will be rejected by secure boot)
+            if (get_var("UPDATE_PACKAGE", "") =~ /kernel/
+                && $guest->{boot_firmware} && $guest->{boot_firmware} =~ /^efi/) {
+                $guest->{boot_firmware_disable_secure} = 1;
+                record_info("Secure Boot", "Disabling secure boot for $guest->{name} due to kernel update");
             }
 
             create_guest($guest, $method);


### PR DESCRIPTION
Support sle15+/16+ efi guests to disable secure boot for kernel update

Remove the sles16-only name check so that all EFI guests (including
sles15sp7efi) get secure boot disabled during kernel MU testing.
Kernel MU packages are unsigned and will be rejected by secure boot.


- Related ticket: https://progress.opensuse.org/issues/193270
- Needles: na
- Verification run:
https://openqa.suse.de/tests/21800023
https://openqa.suse.de/tests/21800023
https://openqa.suse.de/tests/21798916#step/patch_guests/29

