### PR TITLE
refactor: Improve a few test modules to support strict and signatures

### DIFF
--- a/tests/console/python_liblouis.pm
+++ b/tests/console/python_liblouis.pm
@@ -10,6 +10,7 @@
 use base "x11test";
 use testapi;
 use version_utils;
+use serial_terminal;
 use utils "zypper_call";
 
 sub run {

--- a/tests/console/run0.pm
+++ b/tests/console/run0.pm
@@ -7,6 +7,7 @@
 
 use base 'consoletest';
 use testapi;
+use serial_terminal;
 use utils qw(systemctl zypper_call);
 
 sub run {

--- a/tests/console/timezone.pm
+++ b/tests/console/timezone.pm
@@ -47,7 +47,7 @@ sub run {
     assert_script_run("rpm -q timezone");
 
     validate_script_output("zdump Europe/London", sub { m/Europe\/London\s+\w{3} \w{3}\s+\d+ (\d{2}|:){5} \d{4} (GMT|BST)/ });
-    $dateformat = is_sle ? "+'%a %b %e %r %Z %Y'" : "";
+    my $dateformat = is_sle ? "+'%a %b %e %r %Z %Y'" : "";
     validate_script_output("LC_TIME=\$(localectl status | head -n1 | cut -d= -f2) date $dateformat", sub { m/\w{3} \w{3}\s+\d+ (\d{2}|:){5} (AM|PM) \w+ \d{4}/ });
 
     my $zdump_cmd = "zdump -v Europe/Rome | grep -E 'Sun Mar 25 [0-9]{2}:[0:9]{2}:[0-9]{2} 2018'";

--- a/tests/console/validate_dud_addon_repos.pm
+++ b/tests/console/validate_dud_addon_repos.pm
@@ -16,7 +16,7 @@ use repo_tools 'validate_repo_properties';
 use scheduler 'get_test_suite_data';
 
 sub run {
-    my $test_data = get_test_suite_data;
+    my $test_data = get_test_suite_data();
     select_console 'root-console';
 
     foreach my $repo (keys %{$test_data->{dud_repos}}) {

--- a/tests/console/validate_fstab.pm
+++ b/tests/console/validate_fstab.pm
@@ -40,7 +40,7 @@ sub validate_mounting_option {
 }
 
 sub run {
-    my $test_data = get_test_suite_data;
+    my $test_data = get_test_suite_data();
     select_console 'root-console';
 
     foreach my $disk (@{$test_data->{disks}}) {

--- a/tests/console/validate_subvolumes.pm
+++ b/tests/console/validate_subvolumes.pm
@@ -28,7 +28,7 @@ sub validate_subvolume {
 }
 
 sub run {
-    my $test_data = get_test_suite_data;
+    my $test_data = get_test_suite_data();
     select_console 'root-console';
 
     foreach my $subvolume (@{$test_data->{validate_subvolumes}}) {

--- a/tests/containers/multi_runtime.pm
+++ b/tests/containers/multi_runtime.pm
@@ -181,7 +181,7 @@ sub post_fail_hook {
     cleanup;
 }
 
-sub test_flags () {
+sub test_flags {
     return {always_rollback => 1};
 }
 

--- a/tests/elemental3/start_k8s.pm
+++ b/tests/elemental3/start_k8s.pm
@@ -27,7 +27,7 @@ Wait for kubectl command to be available.
 sub wait_kubectl_cmd {
     my (%args) = @_;
     $args{timeout} //= 120;
-    $timeout = bmwqemu::scale_timeout($args{timeout});
+    my $timeout = bmwqemu::scale_timeout($args{timeout});
     my $starttime = time;
     my $ret = undef;
 


### PR DESCRIPTION
I stopped here; probably many more test modules needed adjustment if we wanted to enable `ENABLE_MODERN_PERL_FEATURES=1` globally.

Related ticket: https://progress.opensuse.org/issues/192181