### PR TITLE
LTP: Allow to test with strace

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -605,6 +605,10 @@ sub init_debug {
         install_package('supportutils', trup_reboot => 1);
     }
 
+    if (check_var_array('LTP_DEBUG', 'strace')) {
+        install_package('strace', trup_reboot => 1);
+    }
+
     # Initialize VNC console now to avoid login attempts on frozen system
     select_console('root-console');
 

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -380,6 +380,11 @@ sub run {
     my $test_result_export = $tinfo->test_result_export;
     my $test = $tinfo->test;
     my %env = %{$test_result_export->{environment}};
+    my $strace_log = "/tmp/$test->{name}.strace.txt";
+
+    if (check_var_array('LTP_DEBUG', 'strace')) {
+        $test->{command} = "strace -o $strace_log -f $test->{command}";
+    }
 
     $env{retval} = 'undefined';
     $self->{ltp_env} = \%env;
@@ -433,6 +438,7 @@ sub run {
         die "Timed out waiting for LTP test case which may still be running or the OS may have crashed!";
     }
 
+    upload_logs($strace_log) if (check_var_array('LTP_DEBUG', 'strace'));
     script_run('vmstat -w');
 
     # reboot unless TCONF or last test
@@ -540,6 +546,7 @@ Comma separated list of debug features to enable during test run.
 - C<tasktrace>: Print backtrace of all processes and show blocked tasks
 - C<tcpdump>: Capture all packets sent or received during each test.
 - C<supportconfig>: Run supportconfig after boot and before shutdown.
+- C<strace>: Run tests with strace and upload log of each test.
 
 =head2 LTP_MIN_UPTIME
 


### PR DESCRIPTION
Add LTP_DEBUG=strace to allow to test with strace.

Verification run:
- http://quasar.suse.cz/tests/949#step/clone10/6 (`LTP_DEBUG=strace`, http://quasar.suse.cz/tests/949/logfile?filename=clone10-clone10.strace.txt) 
- https://openqa.suse.de/tests/overview?build=clone10
- https://openqa.opensuse.org/tests/overview?build=clone10
- http://quasar.suse.cz/tests/950#step/clone10/8 (run without it)