### PR TITLE
Adapt automation regarding new bootloader features

### DIFF
--- a/lib/Distribution/Opensuse/AgamaDevel.pm
+++ b/lib/Distribution/Opensuse/AgamaDevel.pm
@@ -8,12 +8,15 @@
 # Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
 
 package Distribution::Opensuse::AgamaDevel;
+use utils;
 use strict;
 use warnings FATAL => 'all';
 use parent 'susedistribution';
 
 use Yam::Agama::Pom::GrubMenuBasePage;
 use Yam::Agama::Pom::GrubMenuAgamaPage;
+use Yam::Agama::Pom::GrubMenuAgamaBasePage;
+use Yam::Agama::Pom::GrubMenuAgamaPageWithBootFromHD;
 use Yam::Agama::Pom::GrubMenuTumbleweedPage;
 use Yam::Agama::Pom::GrubEntryEditionPage;
 use Yam::Agama::Pom::AgamaUpAndRunningPage;
@@ -26,8 +29,10 @@ use Yam::Agama::Pom::EnterPassphraseForHomePage;
 use Utils::Architectures;
 
 sub get_grub_menu_agama {
-    return Yam::Agama::Pom::GrubMenuAgamaPage->new({
-            grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()});
+    my $args = {grub_menu_base => Yam::Agama::Pom::GrubMenuAgamaBasePage->new()};
+    return (is_x86_64() && !is_uefi_boot)
+      ? Yam::Agama::Pom::GrubMenuAgamaPageWithBootFromHD->new($args)
+      : Yam::Agama::Pom::GrubMenuAgamaPage->new($args);
 }
 
 sub get_grub_menu_base {

--- a/lib/Distribution/Opensuse/Leap/160.pm
+++ b/lib/Distribution/Opensuse/Leap/160.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The class represents Leap 16.0 distribution and
+# provides access to its features.
+#
+# Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
+
+package Distribution::Opensuse::Leap::160;
+use parent Distribution::Opensuse::Leap::16Latest;
+use strict;
+use warnings FATAL => 'all';
+
+use Yam::Agama::Pom::GrubMenuLeapPage;
+
+sub get_grub_menu_agama {
+    return Yam::Agama::Pom::GrubMenuAgamaPageWithBootFromHD->new({
+            grub_menu_base => Yam::Agama::Pom::GrubMenuAgamaBasePage->new()});
+}
+
+1;

--- a/lib/Distribution/Sle/160.pm
+++ b/lib/Distribution/Sle/160.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: The class represents SLE 16.0 distribution and
+# provides access to its features.
+
+# Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
+
+package Distribution::Sle::160;
+use parent Distribution::Sle::16Latest;
+use strict;
+use warnings FATAL => 'all';
+
+use Yam::Agama::Pom::GrubMenuSlesPage;
+
+sub get_grub_menu_agama {
+    return Yam::Agama::Pom::GrubMenuAgamaPageWithBootFromHD->new({
+            grub_menu_base => Yam::Agama::Pom::GrubMenuAgamaBasePage->new()});
+}
+
+1;

--- a/lib/Distribution/Sle/AgamaDevel.pm
+++ b/lib/Distribution/Sle/AgamaDevel.pm
@@ -12,17 +12,12 @@ use strict;
 use warnings FATAL => 'all';
 use parent 'Distribution::Opensuse::Leap::16Latest';
 
-use Yam::Agama::Pom::GrubMenuBasePage;
+use Yam::Agama::Pom::GrubMenuAgamaBasePage;
 use Yam::Agama::Pom::GrubMenuSlesPage;
 
 sub get_grub_menu_installed_system {
     return Yam::Agama::Pom::GrubMenuSlesPage->new({
-            grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()});
-}
-
-sub get_grub_menu_agama {
-    return Yam::Agama::Pom::GrubMenuAgamaPage->new({
-            grub_menu_base => Yam::Agama::Pom::GrubMenuBasePage->new()});
+            grub_menu_base => Yam::Agama::Pom::GrubMenuAgamaBasePage->new()});
 }
 
 1;

--- a/lib/DistributionProvider.pm
+++ b/lib/DistributionProvider.pm
@@ -15,6 +15,7 @@ use version_utils;
 
 use Distribution::Sle::AgamaDevel;
 use Distribution::Sle::16Latest;
+use Distribution::Sle::160;
 use Distribution::Sle::15sp0;
 use Distribution::Sle::15sp2;
 use Distribution::Sle::15_current;
@@ -40,14 +41,16 @@ If there is no matched version, then returns Tumbleweed as the default one.
 =cut
 
 sub provide {
-    return Distribution::Sle::AgamaDevel->new() if is_sle('16+') && get_var('FLAVOR', '') =~ /agama-installer/;
-    return Distribution::Sle::16Latest->new() if is_sle('16+');
+    return Distribution::Sle::AgamaDevel->new() if is_sle('16.1+') && get_var('FLAVOR', '') =~ /agama-installer/;
+    return Distribution::Sle::16Latest->new() if is_sle('16.1+');
+    return Distribution::Sle::160->new() if is_sle('=16.0');
     return Distribution::Sle::15_current->new() if (is_sle('>=15-sp3') || is_sle_micro);
     return Distribution::Sle::15sp2->new() if is_sle('>15');
     return Distribution::Sle::15sp0->new() if is_sle('=15');
     return Distribution::Sle::12->new() if is_sle('12+');
     return Distribution::Aeon::RC3->new() if is_aeon();
-    return Distribution::Opensuse::Leap::16Latest->new() if is_leap('16.0+');
+    return Distribution::Opensuse::Leap::16Latest->new() if is_leap('16.1+');
+    return Distribution::Opensuse::Leap::160->new() if is_leap('=16.0');
     return Distribution::Opensuse::Leap::15->new() if is_leap('15.0+');
     return Distribution::Opensuse::Leap::42->new() if is_leap('42.0+');
     return Distribution::Opensuse::AgamaDevel->new() if is_opensuse() && get_var('VERSION', '') =~ /agama/;

--- a/lib/Yam/Agama/Pom/GrubMenuAgamaBasePage.pm
+++ b/lib/Yam/Agama/Pom/GrubMenuAgamaBasePage.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Handles common grub Agama screen actions.
+# Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
+
+package Yam::Agama::Pom::GrubMenuAgamaBasePage;
+use strict;
+use warnings;
+use testapi;
+
+sub new {
+    my ($class, $args) = @_;
+    return bless {
+        key_edit_entry => 'e'
+    }, $class;
+}
+
+sub boot_from_hd {
+    send_key_until_needlematch 'inst-bootmenu-boot-harddisk', 'down';
+    send_key 'ret';
+}
+
+sub select_check_installation_medium_entry {
+    my ($self) = @_;
+    send_key_until_needlematch('grub-menu-agama-mediacheck-highlighted', 'down');
+}
+
+sub edit_current_entry {
+    my ($self) = @_;
+    wait_screen_change { send_key($self->{key_edit_entry}) };
+}
+
+sub select_first_entry {
+    send_key("ret");
+}
+
+sub select_rescue_system_entry {
+    send_key_until_needlematch('grub-menu-agama-rescue-system-highlighted', 'down');
+}
+
+1;

--- a/lib/Yam/Agama/Pom/GrubMenuAgamaPageWithBootFromHD.pm
+++ b/lib/Yam/Agama/Pom/GrubMenuAgamaPageWithBootFromHD.pm
@@ -1,12 +1,12 @@
 # SUSE's openQA tests
 #
-# Copyright 2024 SUSE LLC
+# Copyright 2026 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: Handles GRUB screen.
+# Summary: Handles GRUB screen with boot from hard disk option.
 # Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
 
-package Yam::Agama::Pom::GrubMenuAgamaPage;
+package Yam::Agama::Pom::GrubMenuAgamaPageWithBootFromHD;
 use strict;
 use warnings;
 use testapi;
@@ -15,7 +15,8 @@ sub new {
     my ($class, $args) = @_;
     return bless {
         grub_menu_base => $args->{grub_menu_base},
-        tag_first_entry_highlighted => 'grub-menu-install-highlighted',
+        tag_first_entry_highlighted => 'grub-menu-first-entry-highlighted',
+        tag_install_product => 'grub-menu-install-product',
     }, $class;
 }
 
@@ -24,7 +25,11 @@ sub expect_is_shown {
     assert_screen($self->{tag_first_entry_highlighted}, 60);
 }
 
-sub select_install_product { }
+sub select_install_product {
+    my ($self) = @_;
+    send_key_until_needlematch($self->{tag_install_product}, 'down');
+}
+
 sub boot_from_hd { shift->{grub_menu_base}->boot_from_hd() }
 sub select_check_installation_medium_entry { shift->{grub_menu_base}->select_check_installation_medium_entry() }
 sub edit_current_entry { shift->{grub_menu_base}->edit_current_entry() }

--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -96,6 +96,7 @@ sub run {
     my @params = prepare_boot_params();
 
     $grub_menu->expect_is_shown();
+    # PED-13766: Boot from HD menu dropped in 16.1 except x86 legacy BIOS
     $grub_menu->select_install_product();
     $grub_menu->select_check_installation_medium_entry() if check_var('AGAMA_GRUB_SELECTION', 'check_medium');
     $grub_menu->select_rescue_system_entry() if check_var('AGAMA_GRUB_SELECTION', 'rescue_system');


### PR DESCRIPTION
We talked about different options to manage the bootloader change.
From 16.1 the option `Boot from hard disk` is no longer available for s390x/ppc64le/aarch64/x86_64_uefi but it still available in x86_64 legacy BIOS.
So we created different classes and modify the distribution pattern (This also affects Leap and TW).
We decided to create Leap/160.pm and SLE/160.pm to manage 16.0 case and left Latest and Devel for the new scenario.
The target is to not modify test steps avoiding conditionals and modifications so, the test remains the same but the function to `select_install_product` is performing different on each case, when 16.1+ it doesn't modify the setup letting the test to select the first entry. When 16.0 the test  will push down until the expected screen matches.
We select each case based on architecture only x86_64 and firmware UEFI or not if x86_64 and not UEFI we have to use 16.0 steps if not 16.1+ steps.

- Related ticket: https://progress.opensuse.org/issues/196988
- Needles: `grub-menu-install-highlighted`
- Verification run:
  - TW:
    - x86_64: https://openqa.opensuse.org/tests/5709245
    - x86_64 UEFI: https://openqa.opensuse.org/tests/5709246
  - Leap:
    - 16.0: 
      - x86_64: 
      - x86_64 UEFI: 
      - aarch64:  
    - 16.1: 
      - x86_64: 
      - x86_64 UEFI: 
      - aarch64:  
  - SLES:
    - Prod: 
      - 16.0:
        - x86_64: 
        - x86_64 UEFI: 
        - aarch64:  
      - 16.1:
        - x86_64: 
        - x86_64 UEFI: 
        - aarch64:  
    - Devel: 
      - 16.0:
        - x86_64: 
        - x86_64 UEFI: 
        - aarch64:  
        - ppc64le: 
        - ppc64le-hmc: 
        - s390x-kvm: 
        - s390x-zvm: 
      - 16.1:
        - x86_64: 
        - x86_64 UEFI: 
        - aarch64:  
        - ppc64le: 
        - ppc64le-hmc: 
        - s390x-kvm: 
        - s390x-zvm: 
    - Maintenance:
      - 16.0-QU1:
        - x86_64: 
        - x86_64 UEFI: 
        - aarch64:  
