### PR TITLE
Revert workaround for qemu-guest-agent in bsc1257492

### DIFF
--- a/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet
@@ -24,12 +24,6 @@
     "hashedPassword": true,
     "sshPublicKey": "##Authorized-Keys##"
   },
-  // Workaround for bsc#1257492
-  "software": {
-      "packages": [
-        'qemu-guest-agent'
-      ]
-  },
   "storage": {
     "drives": [
       {

--- a/tests/virt_autotest/uefi_guest_verification.pm
+++ b/tests/virt_autotest/uefi_guest_verification.pm
@@ -104,10 +104,8 @@ sub regen_efi_secret_key {
 
 sub check_guest_pmsuspend_enabled {
     my $self = shift;
-    foreach (keys %virt_autotest::common::guests) {
-        record_soft_failure("Bug bsc#1257492: qemu-guest-agent is not installed by default. We have workaround to install it in jsonnet.") if ($_ =~ /sles-16-1/i);
-        $self->do_guest_pmsuspend($_, 'mem');
-    }
+
+    $self->do_guest_pmsuspend($_, 'mem') foreach (keys %virt_autotest::common::guests);
     if (is_kvm_host) {
         foreach (keys %virt_autotest::common::guests) {
             if (is_sle('>=15') and ($_ =~ /12-sp5/img)) {


### PR DESCRIPTION
This reverts commit 6a126d1260d0ffcbd315d70454d97e9cd5e8ba3f. The [bug ](https://bugzilla.suse.com/show_bug.cgi?id=1257492) is fixed now, so remove the workaround.


- Related ticket: https://progress.opensuse.org/issues/195734
- Verification run: https://openqa.suse.de/tests/21900611#
