### PR TITLE
Skip python314-setuptools test

### DIFF
--- a/tests/console/python3_setuptools.pm
+++ b/tests/console/python3_setuptools.pm
@@ -43,9 +43,9 @@ sub run_tests ($python3_spec_release) {
         record_info("Skip python39", 'https://jira.suse.com/browse/PED-8196');
         return;
     }
-    if ($python3_spec_release eq 'python311' && is_sle('>=16.0')) {
+    if (($python3_spec_release eq 'python311' || $python3_spec_release eq 'python314') && is_sle('>=16.0')) {
         # python311-setuptools is not available on sle16
-        record_info("Skip python311", 'Skip python311-setuptools test on SLE 16.0');
+        record_info("Skip $python3_spec_release", 'Skip $python3_spec_release-setuptools test on SLE');
         return;
     }
 


### PR DESCRIPTION
python314-setuptools is not available in SCC for SLES 16.1

- Related ticket: https://progress.opensuse.org/issues/196634
- Needles:NO
- Verification run: 
 SLE16.1:  [x86_64](https://openqa.suse.de/tests/21178487#step/python3_setuptools/2) | [aarch64](https://openqa.suse.de/tests/21178468#step/python3_setuptools/2) | [s390x](https://openqa.suse.de/tests/21178481#step/python3_setuptools/2) | [ppc64le](https://openqa.suse.de/tests/21178471#step/python3_setuptools/2) 
SLE16.0:  [aarch64](https://openqa.suse.de/tests/21178546#step/python3_setuptools/2)  | [x86_64](https://openqa.suse.de/tests/21178543#step/python3_setuptools/2) 
SLE15-SP7:  [aarch64](https://openqa.suse.de/tests/21178548#step/python3_setuptools/2) | [s390x](https://openqa.suse.de/tests/21178552#step/python3_new_version_check/2) | [x86_64](https://openqa.suse.de/tests/21178553#step/python3_new_version_check/2)