### PR TITLE
Don't fail on expected BCI image version missmatch

### DIFF
--- a/tests/containers/bci_version_check.pm
+++ b/tests/containers/bci_version_check.pm
@@ -55,7 +55,7 @@ sub run {
         my $reference = script_output(qq($engine inspect --type image $image | jq -r '.[0].Config.Labels."org.opensuse.reference"'));
         # Note: Both lines are aligned, thus the additional space
         record_info('builds', "CONTAINER_IMAGE_BUILD:  $build\norg.opensuse.reference: $reference");
-        die('Missmatch in image build number. The image build number is different than the one triggered by the container bot!') if ($reference !~ /$buildrelease$/);
+        record_info('Missmatch in image build number', 'The image build number is different than the one triggered by the container bot!', result => "obsolete") if ($reference !~ /$buildrelease$/);
     }
 }
 


### PR DESCRIPTION
There is nothing to do. A new job will be scheduled.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1259075
- Needles: none
- Verification run: https://openqa.suse.de/tests/21180716