### PR TITLE
Softfail know bug untit it's resolved

### DIFF
--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -58,6 +58,11 @@ sub run {
     if (is_sle('>=15-SP3') && ($current_ver < 0.101)) {
         record_soft_failure("jsc#SLE-16780: upgrade Clamav SLE feature is not yet released");
     }
+    # Softfail until BSC1258122 resolved
+    elsif (get_var('FIPS_ENABLED') && (is_sle('=15-SP5') || is_sle('=15-SP4'))) {
+        record_soft_failure("Softfail clamav on SLE 15.4 and 15.5 due to bsc#1258122");
+        return;
+    }
 
     # Initialize and download ClamAV database
     # First from local mirror, it's much faster, then from official clamav db


### PR DESCRIPTION
Record a softfail for clamav on 15-SP4/15-SP5 (when FIPS is enabled)

- Related ticket: https://progress.opensuse.org/issues/197522
- Verification runs:
  - 15-SP4: https://openqa.suse.de/tests/21233498
  - 15-SP5: https://openqa.suse.de/tests/21233500
  - 15-SP6: https://openqa.suse.de/tests/21233499 