### PR TITLE
Get sshpass from QA:Head

### DIFF
--- a/tests/console/sssd_389ds_functional.pm
+++ b/tests/console/sssd_389ds_functional.pm
@@ -108,7 +108,9 @@ sub run ($self) {
         is_sle('<15') ? add_suseconnect_product("sle-module-containers", 12) : add_suseconnect_product("sle-module-containers");
     }
     # on SLE we need packagehub for sshpass, let's enable it
-    add_suseconnect_product(get_addon_fullname('phub')) if is_sle();
+    add_suseconnect_product(get_addon_fullname('phub')) if is_sle('<16.1');
+    # SLE16.1 not yet has a Package Hub workarond
+    zypper_ar(get_required_var('QA_HEAD_REPO'), name => 'qa_head', no_gpg_check => 1) if is_sle('>16.0');
 
     install_dependencies($container_engine);
     setup_389ds_container($container_engine);


### PR DESCRIPTION
PHub workaround for SLE16.1

- Related ticket: https://progress.opensuse.org/issues/196865
- Verification runs: 
  - 15-SP4: https://openqa.suse.de/tests/21287599
  - 16.0: https://openqa.suse.de/tests/21288093
  - 16.1: https://openqa.suse.de/tests/21287597 