### PR TITLE
Add the Erlang test

### DIFF
--- a/data/console/erlang_smoke_test.erl
+++ b/data/console/erlang_smoke_test.erl
@@ -1,0 +1,107 @@
+% erlang_smoke_test.erl
+-module(erlang_smoke_test).
+-export([run/0]).
+
+% Run all smoke tests for standard library and required modules
+run() ->
+    io:format("Running Erlang/Elixir smoke tests~n"),
+    standard_library_test(),
+    epmd_test(),
+    getopt_test(),
+    cf_test(),
+    erlware_commons_test(),
+    io:format("All tests passed successfully~n").
+
+% Standard Library Test (lists module example)
+standard_library_test() ->
+    io:format("Testing Standard Library~n"),
+    RevList = lists:reverse([1, 2, 3]),
+    case RevList of
+        [3, 2, 1] -> io:format("Standard Library test passed: lists:reverse/1~n");
+        _ -> io:format("Standard Library test failed: lists:reverse/1~n")
+    end.
+
+% Test for erlang-epmd (Erlang Port Mapper Daemon)
+epmd_test() ->
+    io:format("Testing Erlang EPMD with debug mode~n"),
+    os:cmd("epmd -d &"),
+    timer:sleep(1000),
+    case gen_tcp:connect({127,0,0,1}, 4369, []) of
+        {ok, Socket} ->
+            io:format("Erlang EPMD started successfully in debug mode~n"),
+            gen_tcp:close(Socket);
+        {error, _Reason} ->
+            io:format("Erlang EPMD test failed: Could not connect to EPMD~n")
+    end,
+    os:cmd("pkill epmd").
+
+% Test for erlang-getopt (Command-line options parser)
+getopt_test() ->
+    io:format("Testing Getopt Module with positional options and option terminator~n"),
+
+    OptSpecList = [
+        {xml, $x, "xml", undefined, "Output data as XML"},
+        {dbname, undefined, undefined, string, "Database name"},
+        {output_file, undefined, undefined, string, "File where the data will be saved to"}
+    ],
+
+    TestArgs = "-x mydb file.out -- --dbname mydb dummy",
+
+    case code:which(getopt) of
+        undefined ->
+            io:format("Getopt test failed: getopt module not found~n");
+        _ ->
+            case getopt:parse(OptSpecList, TestArgs) of
+                {ok, {Opts, NonOpts}} ->
+                    io:format("Parsed options: ~p~nNon-option arguments: ~p~n", [Opts, NonOpts]),
+                    if
+                        Opts == [xml, {dbname, "mydb"}, {output_file, "file.out"}] ->
+                            io:format("Getopt test passed: Parsed options correctly~n");
+                        true ->
+                            io:format("Getopt test failed: Unexpected positional options result~n")
+                    end,
+                    if
+                        NonOpts == ["--dbname", "mydb", "dummy"] ->
+                            io:format("Getopt test passed: Parsed non-option arguments correctly~n");
+                        true ->
+                            io:format("Getopt test failed: Non-option arguments not parsed as expected~n")
+                    end;
+                _ ->
+                    io:format("Getopt test failed: Parsing returned an error~n")
+            end
+    end.
+
+
+% Test for cf module (checking text output instead of colors)
+cf_test() ->
+    io:format("Testing CF Text Output~n"),
+    {ok, File} = file:open("/tmp/cf_test_output.txt", [write]),
+    OriginalGroupLeader = group_leader(),
+    erlang:group_leader(File, self()),
+    cf:print("Red text and blue background~n"),
+    cf:print("Green text reset to normal~n"),
+    erlang:group_leader(OriginalGroupLeader, self()),
+    file:close(File),
+    {ok, Output} = file:read_file("/tmp/cf_test_output.txt"),
+    OutputString = binary_to_list(Output),
+    case lists:all(fun(Text) -> string:find(OutputString, Text) =/= nomatch end,
+                   ["Red text", "blue background", "Green text"]) of
+        true -> io:format("CF test passed: Expected text was output~n");
+        false -> io:format("CF test failed: Expected text not found~n")
+    end.
+
+% Test for erlang-erlware_commons (Date formatting test)
+erlware_commons_test() ->
+    io:format("Testing Erlware Commons Date Formatting~n"),
+    
+    % Define a sample date and expected formatted output
+    SampleDate = {{2024, 10, 31}, {14, 30, 0}}, % October 31, 2024, 14:30:00
+    ExpectedOutput = "2024-10-31 14:30:00",
+
+    % Format the date using ec_date:format/2
+    case ec_date:format("{Y}-{m}-{d} {H}:{i}:{s}", SampleDate) of
+        ExpectedOutput ->
+            io:format("Erlware Commons test passed: Date formatted correctly~n");
+        ActualOutput ->
+            io:format("Erlware Commons test failed: Expected ~s but got ~s~n", [ExpectedOutput, ActualOutput])
+    end.

--- a/schedule/functional/extra_tests_misc.yaml
+++ b/schedule/functional/extra_tests_misc.yaml
@@ -12,6 +12,7 @@ conditional_schedule:
                 - console/supportutils
                 - console/rabbitmq
                 - console/redis
+                - console/erlang_smoke_test
                 - x11/ghostscript
 schedule:
     - installation/bootloader_start

--- a/schedule/qam/16/mau-extratests-phub.yaml
+++ b/schedule/qam/16/mau-extratests-phub.yaml
@@ -13,6 +13,7 @@ schedule:
   - console/systemd_rpm_macros
   - console/apache2_php_fpm
   - console/stalld
+  - console/erlang_smoke_test
   - console/coredump_collect
 conditional_schedule:
   sle15_x86_64:

--- a/tests/console/erlang_smoke_test.pm
+++ b/tests/console/erlang_smoke_test.pm
@@ -1,0 +1,94 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+#
+# Summary: Smoke test for erlang
+# Maintainer: QE-Core <qe-core@suse.de>
+
+use Mojo::Base 'consoletest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use version_utils;
+use registration qw(runtime_registration add_suseconnect_product);
+use package_utils 'install_package';
+
+
+my $requires_scc_registration = is_sle_micro || is_sle;
+
+sub install_pkgs {
+    my @to_install = (
+        "git",
+        "erlang",
+        "erlang-epmd",
+        "erlang-getopt",
+        "erlang-cf",
+        "elixir",
+        "erlang-providers",
+        "erlang-erlware_commons",
+        "elixir-hex",
+        "erlang-rebar3"
+    );
+
+    my $pkg_list = join ' ', @to_install;
+    record_info("Installing packages");
+    install_package("$pkg_list", trup_reboot => 1);
+}
+
+sub run_smoke_test {
+    record_info('Run Smoke Test', 'Running Erlang smoke test');
+    assert_script_run('erl -noshell -pa ~/ -s erlang_smoke_test run -s init stop');
+}
+
+sub test_elixir_hex {
+    record_info('Hex Test', 'Testing Elixir Hex availability');
+    assert_script_run("mix archive.install github hexpm/hex branch latest --force");
+    my $hex_result = script_output("mix hex.info", proceed_on_failure => 1);
+    die 'Hex installation test failed' unless ($hex_result =~ /Hex\:/);
+}
+
+sub test_rebar3 {
+    record_info('Rebar3 Test', 'Testing Rebar3 functionality');
+    assert_script_run('git config --global user.name "Test"');
+    assert_script_run('git config --global user.email "geekotest@suse.com"');
+    assert_script_run("mkdir -p ~/.config/rebar3/");
+    assert_script_run("cp -r /usr/lib64/erlang/lib/rebar3-*/priv/templates ~/.config/rebar3/");
+    my $rebar_install = script_run('DIAGNOSTIC=1 rebar3 local install');
+    if ($rebar_install != 0) {
+        my $msg = "Rebar3: rebar3 local install fails";
+        record_soft_failure "bsc#1232721 - $msg";
+        return;
+    }
+    my $rebar_result = script_run("DIAGNOSTIC=1 rebar3 new app sample_app");
+    if ($rebar_result == 0 && script_run("test -d sample_app") == 0) {
+        record_info('Rebar3 Test Passed', 'Rebar3 created the app directory successfully');
+        script_run("rm -rf sample_app");    # Clean up after the test
+    } else {
+        my $msg = "Rebar3 :App directory not created";
+        record_soft_failure "bsc#1232721 - $msg";
+    }
+}
+
+sub run {
+    select_serial_terminal;
+
+    # Step 1: Install Erlang and Elixir packages
+    install_pkgs();
+
+    # Step 2: Verify installation
+    record_info('Verify', 'Checking if Erlang and Elixir are installed');
+    assert_script_run('erl -eval "erlang:display(erlang:system_info(otp_release)), halt()." -noshell');
+    assert_script_run('elixir -v');
+
+    # Step 3: Download and compile smoke test
+    assert_script_run("curl -v -o ~/erlang_smoke_test.erl " . data_url("console/erlang_smoke_test.erl"));
+    assert_script_run("erlc -o ~/ ~/erlang_smoke_test.erl");
+
+    # Step 4: Compile and run the smoke test script
+    run_smoke_test();
+
+    # Step 5: Smoke test HEX and ReBAR 3
+    test_elixir_hex();
+    test_rebar3();
+}
+
+1;

--- a/tests/console/erlang_smoke_test.pm
+++ b/tests/console/erlang_smoke_test.pm
@@ -1,0 +1,87 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+#
+# Summary: Smoke test for erlang
+# Maintainer: QE-Core <qe-core@suse.de>
+
+use Mojo::Base 'consoletest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use version_utils;
+use registration qw(runtime_registration add_suseconnect_product);
+use package_utils 'install_package';
+
+sub install_pkgs {
+    my @to_install = (
+        "git",
+        "erlang",
+        "erlang-epmd",
+        "erlang-getopt",
+        "erlang-cf",
+        "elixir",
+        "erlang-providers",
+        "erlang-erlware_commons",
+        "elixir-hex",
+        "erlang-rebar3"
+    );
+
+    my $pkg_list = join ' ', @to_install;
+    record_info("Installing packages");
+    install_package("$pkg_list", trup_reboot => 1);
+}
+
+sub run_smoke_test {
+    record_info('Run Smoke Test', 'Running Erlang smoke test');
+    assert_script_run('erl -noshell -pa ~/ -s erlang_smoke_test run -s init stop');
+}
+
+sub test_elixir_hex {
+    record_info('Hex Test', 'Testing Elixir Hex availability');
+    assert_script_run("mix archive.install github hexpm/hex branch latest --force");
+    validate_script_output("mix hex.info", qr/Hex\:/);
+}
+
+sub test_rebar3 {
+    record_info('Rebar3 Test', 'Testing Rebar3 functionality');
+    assert_script_run('git config --global user.name "Test"');
+    assert_script_run('git config --global user.email "geekotest@suse.com"');
+    assert_script_run("mkdir -p ~/.config/rebar3/");
+    assert_script_run("cp -r /usr/lib64/erlang/lib/rebar3-*/priv/templates ~/.config/rebar3/");
+    my $rebar_install = script_run('DIAGNOSTIC=1 rebar3 local install');
+    if ($rebar_install != 0) {
+        my $msg = "Rebar3: rebar3 local install fails";
+        record_soft_failure "bsc#1232721 - $msg";
+        return;
+    }
+    my $rebar_result = script_run("DIAGNOSTIC=1 rebar3 new app sample_app");
+    if ($rebar_result == 0 && script_run("test -d sample_app") == 0) {
+        record_info('Rebar3 Test Passed', 'Rebar3 created the app directory successfully');
+        script_run("rm -rf sample_app");    # Clean up after the test
+    }
+}
+
+sub run {
+    select_serial_terminal;
+
+    # Step 1: Install Erlang and Elixir packages
+    install_pkgs();
+
+    # Step 2: Verify installation
+    record_info('Verify', 'Checking if Erlang and Elixir are installed');
+    assert_script_run('erl -eval "erlang:display(erlang:system_info(otp_release)), halt()." -noshell');
+    assert_script_run('elixir -v');
+
+    # Step 3: Download and compile smoke test
+    assert_script_run("curl -v -o ~/erlang_smoke_test.erl " . data_url("console/erlang_smoke_test.erl"));
+    assert_script_run("erlc -o ~/ ~/erlang_smoke_test.erl");
+
+    # Step 4: Compile and run the smoke test script
+    run_smoke_test();
+
+    # Step 5: Smoke test HEX and ReBAR 3
+    test_elixir_hex();
+    test_rebar3();
+}
+
+1;


### PR DESCRIPTION
Added Softfailure to the existing bug: rebar3 local install fail, https://bugzilla.suse.com/show_bug.cgi?id=1232721

- Related ticket: https://progress.opensuse.org/issues/155392
- Needles: NO
- Verification run:  https://openqa.suse.de/tests/overview?distri=sle&build=DeepthiYV%2Fos-autoinst-distri-opensuse%2324916&version=16.0
- Tumbleweed: https://openqa.opensuse.org/tests/6168336#step/erlang_smoke_test/1