### PR TITLE
t: Add check script to ensure test modules compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
             perl-version: 5.26
           - test: compile
             perl-version: 5.26
+          - test: compile-os-autoinst
+            perl-version: '5.40'
     container:
       image: perldocker/perl-tester:${{ matrix.perl-version }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ test-compile: check-links
 test-compile-changed: os-autoinst/
 	export PERL5LIB=${PERL5LIB_}:$(shell ./tools/wheel --verify) ; for f in `git diff --name-only | grep '.pm'` ; do perl -c $$f 2>&1 | grep -v " OK$$" && exit 2; done ; true
 
+.PHONY: test-compile-os-autoinst
+test-compile-os-autoinst: os-autoinst/
+	prove tools/check_os_autoinst_compile
+
 .PHONY: test_pod_whitespace_rule
 test_pod_whitespace_rule:
 	tools/check_pod_whitespace_rule
@@ -120,6 +124,8 @@ ifeq ($(TESTS),compile)
 test: test-compile
 else ifeq ($(TESTS),compile-changed)
 test: test-compile-changed
+else ifeq ($(TESTS),compile-os-autoinst)
+test: test-compile-os-autoinst
 else ifeq ($(TESTS),static)
 test: test-static
 else ifeq ($(TESTS),unit)

--- a/lib/virt_autotest/domain_management_utils.pm
+++ b/lib/virt_autotest/domain_management_utils.pm
@@ -10,6 +10,7 @@
 # Maintainer: Wayne Chen <wchen@suse.com>, qe-virt <qe-virt@suse.de>
 package virt_autotest::domain_management_utils;
 
+use base 'Exporter';
 use strict;
 use warnings;
 use testapi;

--- a/tests/cpu_bugs/kvm_guest_mitigations.pm
+++ b/tests/cpu_bugs/kvm_guest_mitigations.pm
@@ -5,6 +5,9 @@
 
 # Summary: CPU BUGS on Linux kernel check
 # Maintainer: Qi Wang <qwang@suse.com>
+
+## no os-autoinst compile-check
+
 package kvm_guest_mitigations;
 use base "consoletest";
 use bootloader_setup;

--- a/tests/cpu_bugs/mds_taa.pm
+++ b/tests/cpu_bugs/mds_taa.pm
@@ -6,6 +6,8 @@
 # Summary: CPU BUGS on Linux kernel check
 # Maintainer: James Wang <jnwang@suse.com>
 
+## no os-autoinst compile-check
+
 
 use base "consoletest";
 use bootloader_setup;

--- a/tests/cpu_bugs/mitigations.pm
+++ b/tests/cpu_bugs/mitigations.pm
@@ -6,6 +6,8 @@
 # Summary: CPU BUGS on Linux kernel check
 # Maintainer: James Wang <jnwang@suse.com>
 
+## no os-autoinst compile-check
+
 use base "consoletest";
 use bootloader_setup;
 use testapi;

--- a/tests/cpu_bugs/spectre_v2.pm
+++ b/tests/cpu_bugs/spectre_v2.pm
@@ -5,6 +5,9 @@
 
 # Summary: CPU BUGS on Linux kernel check
 # Maintainer: James Wang <jnwang@suse.com>
+
+## no os-autoinst compile-check
+
 package spectre_v2;
 
 use base "consoletest";

--- a/tests/cpu_bugs/spectre_v4.pm
+++ b/tests/cpu_bugs/spectre_v4.pm
@@ -5,6 +5,9 @@
 
 # Summary: CPU BUGS on Linux kernel check
 # Maintainer: James Wang <jnwang@suse.com>
+
+## no os-autoinst compile-check
+
 package spectre_v4;
 
 use base "consoletest";

--- a/tests/cpu_bugs/xen_domu_mitigation_test.pm
+++ b/tests/cpu_bugs/xen_domu_mitigation_test.pm
@@ -62,6 +62,8 @@
 # one by one execution checking.
 #
 
+## no os-autoinst compile-check
+
 package xen_domu_mitigation_test;
 use base "consoletest";
 use bootloader_setup;

--- a/tests/virt_autotest/esxi_open_vm_tools.pm
+++ b/tests/virt_autotest/esxi_open_vm_tools.pm
@@ -6,6 +6,8 @@
 # Summary: Run open-vm-tools testing against VMware ESXi
 # Maintainer: Nan Zhang <nan.zhang@suse.com>
 
+## no os-autoinst compile-check
+
 use base 'consoletest';
 use testapi;
 use transactional;

--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -16,6 +16,8 @@
 # - Make sure machine is back to original system
 # Maintainer: Dumitru Gutu <dgutu@suse.com>
 
+## no os-autoinst compile-check
+
 use base "x11test";
 use testapi;
 use utils;

--- a/tests/xfstests/run_subtest.pm
+++ b/tests/xfstests/run_subtest.pm
@@ -7,6 +7,8 @@
 # Summary: Run single xfstests subtest
 # Maintainer: Yong Sun <yosun@suse.com>, An Long <lan@suse.com>
 
+## no os-autoinst compile-check
+
 use 5.018;
 use base 'opensusebasetest';
 use File::Basename;

--- a/tools/check_os_autoinst_compile
+++ b/tools/check_os_autoinst_compile
@@ -1,0 +1,83 @@
+#!/usr/bin/perl
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Call as:
+# prove tools/check_os_autoinst_compile
+# perl tools/check_os_autoinst_compile tests/some/specifictest.pm
+use Test::Most;
+use FindBin '$Bin';
+use lib "$Bin/../os-autoinst";
+use lib "$Bin/../lib";
+
+use Test::MockModule;
+use File::Find;
+use Mojo::File qw(path);
+
+use autotest ();
+use testapi ();
+
+my $tests_dir = "$Bin/..";
+
+testapi::set_var('ENABLE_MODERN_PERL_FEATURES', 1) if $ENV{ENABLE_MODERN_PERL_FEATURES};
+
+# make compilation still work despite code like
+#   my @category = split(/,/, # get_required_var('CATEGORY'));
+# at compile time (outside of run())
+my $testapi_mock = Test::MockModule->new('testapi');
+$testapi_mock->redefine(get_required_var => sub { testapi::get_var(@_) // '?' });
+
+# Set some dummy variables to avoid errors (some modules die on missing variables
+# already at compile time)
+$bmwqemu::vars{VERSION} = 1;
+$bmwqemu::vars{FLAVOR} = 'dev';
+# Set CASEDIR needed by _make_test_code_to_eval
+$bmwqemu::vars{CASEDIR} = $tests_dir;
+
+my @tests;
+sub wanted {
+    push @tests, $File::Find::name if -f $_ and m/\.pm$/;
+}
+
+if (@ARGV) {
+    @tests = @ARGV;
+}
+else {
+    find(\&wanted, "tests");
+}
+
+@tests = sort @tests;
+for my $num (0 .. $#tests) {
+    my $test = $tests[$num];
+
+    my $module_code = path($test)->slurp;
+    if ($module_code =~ m/^ *## no os-autoinst compile-check/m) {
+        local $TODO = "skipping $test because of special comment";
+        fail "$test";
+        next;
+    }
+    my $header = '';
+
+    # lib/y2_base.pm uses Carp::Always, which makes every warning output the
+    # whole module code because it prints a stacktrace, and the code is used
+    # via a string eval. So we disable it again before every new test to reduce
+    # the noise
+    $header .= "no Carp::Always;\n";
+    # Set test name to n$num to avoid loading the same package name from
+    # different directories
+    $module_code = autotest::_make_test_code_to_eval("./$test", $test, "n$num", 0);
+
+    my $code = $header . $module_code;
+    my @warnings;
+    {
+        local $SIG{__WARN__} = sub { push @warnings, @_ };
+        eval $code;
+    }
+    my $err = $@;
+    if ($err) {
+        diag "########### ERROR: $err";
+    }
+    ok !$err, "$test - compiles";
+    is_deeply \@warnings, [], "$test - no warnings";
+}
+
+done_testing;


### PR DESCRIPTION
This script will load all test modules under tests/.

You can use it to check all modules by doing

    prove tools/check_strict

or check specific files with

    perl tools/check_strict tests/category/one.pm tests/category/two.pm

- Related ticket: https://progress.opensuse.org/issues/194002

As an excepttion, I added

    ## no os-autoinst compile-check

to modules which currently have warnings.

Still, this will fail right now, as there are a few warnings left. I will prepare a PR for them. It would require to skip too many modules.
```
Attempt to call undefined import method with arguments ("construct_uri" ...) via package
 "virt_autotest::domain_management_utils" (Perhaps you forgot to load the package?) at
 /home/tina/openqadev.leap/openqa/share/tests/opensuse/tools/../lib/parallel_guest_migration_base.pm line 55.
```
The problem is
```
use virt_autotest::domain_management_utils qw(construct_uri);
```
while `virt_autotest::domain_management_utils` actually does not inherit from `Exporter`, so it doesn't export anything.

As a next step I will create a PR with a tool that adds `Mojo::Base` lines to test modules automatically.

Based on:
* #25083