### PR TITLE
Remove publiccloud_multi_module=>1 from PC run_ltp

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -629,7 +629,7 @@ sub zypper_install_available_remote {
 }
 
 sub test_flags {
-    return {fatal => 1, publiccloud_multi_module => 1};
+    return {fatal => 1};
 }
 
 1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/194624
- VR: https://openqa.suse.de/tests/21311988
- https://openqa.suse.de/tests/21311994