### PR TITLE
Use crm cluster copy instead of csync2 in cluster in 16+

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -38,6 +38,8 @@ our @EXPORT = qw(
   $sbd_watchdog_timeout
   $sbd_delay_start
   $pcmk_delay_max
+  sync_file
+  sync_path
   exec_csync
   add_file_in_csync
   get_cluster_info
@@ -162,6 +164,42 @@ sub _test_var_defined {
 }
 
 # Public functions
+
+=head2 sync_file
+
+ sync_file('/path/to/file');
+
+Wrapper function to synchronize a specific file to all nodes in the cluster based
+on the OS version. It will call C<crm cluster copy> in SLES 16 or newer, and
+C<add_file_in_csync> which internally calls C<exec_csync> in versions older than 16.
+
+=cut
+
+sub sync_file {
+    my $file = shift;
+    is_sle('>=16') ? assert_script_run("crm cluster copy $file") : add_file_in_csync(value => $file);
+}
+
+=head2 sync_path
+
+ sync_path('/path/to/dir');
+ sync_path('/path/to/files*');
+
+Function to syncronize a list of files or a directory to all nodes in the cluster based
+on the OS version. It will use C<add_file_in_csync> which internally calls C<exec_csync> when
+the OS is older than 16.0; on newer, it will call C<crm cluster copy> for all files matching the
+given path after expanding any shell wildcards and recursing into any directories.
+
+=cut
+
+sub sync_path {
+    my $path = shift;
+    # In OS older than 16, use add_file_in_csync and let csync2 handle it
+    return (add_file_in_csync(value => $path)) if is_sle('<16');
+    # On 16 or newer, expand any wildcard and pass the path to find to get all files
+    # Loop will abort with retval 1 in case any of the crm cluster copy commands fail
+    assert_script_run qq@for p in $path; do find "\$p" -type f -print; done | while read f; do crm cluster copy "\$f" || exit 1; done@;
+}
 
 =head2 exec_csync
 

--- a/t/11_hacluster.t
+++ b/t/11_hacluster.t
@@ -953,4 +953,66 @@ subtest '[generate_lun_list]' => sub {
     foreach my $i (0 .. 2) { ok($results[$i] =~ /.+$tgt_ip_port.+$iqn-lun\-$i/, "Correct LUN path [$i]"); }
 };
 
+subtest '[sync_file] crm cluster copy' => sub {
+    my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
+    my @results = ();
+    $hacluster->redefine(assert_script_run => sub { push @results, $_[0]; });
+    my $test_file = 'MEGATRON';
+    set_var('VERSION', '16.0');
+    set_var('DISTRI', 'sle');
+    sync_file($test_file);
+    set_var('VERSION', undef);
+    set_var('DISTRI', undef);
+    note("\n --> " . join("\n --> ", @results));
+    ok($results[0] eq "crm cluster copy $test_file", 'Using "crm cluster copy"');
+};
+
+subtest '[sync_file] csync2' => sub {
+    my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
+    my @results = ();
+    $hacluster->redefine(assert_script_run => sub { push @results, $_[0]; });
+    my $test_file = 'UNICRON';
+    set_var('VERSION', '14');
+    set_var('DISTRI', 'sle');
+    sync_file($test_file);
+    set_var('VERSION', undef);
+    set_var('DISTRI', undef);
+    note("\n --> " . join("\n --> ", @results));
+    ok($results[0] =~ m|w./etc/csync2/csync2.cfg|, 'Checking csync2.cfg is writable');
+    ok($results[1] =~ /grep.+$test_file.+sed.+$test_file/, 'Checking file in csyn2.cfg and adding it');
+    ok($results[1] =~ m|/etc/csync2/csync2.cfg|, 'Adding file to csync2.cfg');
+    ok($results[2] eq 'csync2 -vxF ; sleep 2 ; csync2 -vxF', 'Using csyn2');
+};
+
+subtest '[sync_path] crm cluster copy' => sub {
+    my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
+    my @results = ();
+    $hacluster->redefine(assert_script_run => sub { push @results, $_[0]; });
+    my $test_path = 'STARSCREAM/*';
+    set_var('VERSION', '16.0');
+    set_var('DISTRI', 'sle');
+    sync_path($test_path);
+    set_var('VERSION', undef);
+    set_var('DISTRI', undef);
+    note("\n --> " . join("\n --> ", @results));
+    ok($results[0] =~ m|for p in $test_path.+crm cluster copy|, 'Using "crm cluster copy"');
+};
+
+subtest '[sync_path] csync2' => sub {
+    my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
+    my @results = ();
+    $hacluster->redefine(assert_script_run => sub { push @results, $_[0]; });
+    my $test_path = 'SOUNDWAVE/*';
+    set_var('VERSION', '14');
+    set_var('DISTRI', 'sle');
+    sync_path($test_path);
+    set_var('VERSION', undef);
+    set_var('DISTRI', undef);
+    note("\n --> " . join("\n --> ", @results));
+    ok($results[0] =~ m|w./etc/csync2/csync2.cfg|, 'Checking csync2.cfg is writable');
+    ok($results[1] =~ /grep.+$test_path.+sed.+$test_path/, 'Checking file in csyn2.cfg and adding it');
+    ok($results[1] =~ m|/etc/csync2/csync2.cfg|, 'Adding file to csync2.cfg');
+    ok($results[2] eq 'csync2 -vxF ; sleep 2 ; csync2 -vxF', 'Using csyn2');
+};
+
 done_testing;

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -235,7 +235,7 @@ sub run {
             # Apply workaround in node 1, sync with rest of the cluster and cleanup cluster_md resource
             if (is_node(1)) {
                 file_content_replace($mdadm_conf, 'UUID=[a-z0-9:]+' => "UUID=$uuid");
-                exec_csync;
+                sync_file($mdadm_conf);
                 rsc_cleanup 'cluster_md';
             }
         }

--- a/tests/ha/cluster_md.pm
+++ b/tests/ha/cluster_md.pm
@@ -46,8 +46,9 @@ sub run {
         assert_script_run "echo DEVICE $clustermd_lun_01 $clustermd_lun_02 > $mdadm_conf", $default_timeout;
         assert_script_run "mdadm --detail --scan >> $mdadm_conf", $default_timeout;
 
-        # We need to add the configuration in csync2.conf
-        add_file_in_csync(value => "$mdadm_conf");
+        # Sync mdadm configuration to all nodes
+        sync_file($mdadm_conf);
+        sync_file('/etc/lvm/lvm.conf');
     }
     else {
         diag 'Wait until cluster-md device is created...';

--- a/tests/ha/drbd_passive.pm
+++ b/tests/ha/drbd_passive.pm
@@ -57,6 +57,8 @@ B<The key tasks performed by this module include:>
 
 =item * Add drbd files in C</etc/csync2/csync2.conf> and run csync2 from node 1 to synchronize configuration files in all nodes.
 
+=item * Alternatively, use C<crm cluster copy> instead of C<csync2> on 16 or newer.
+
 =item * Create and enable a drbd block device in both nodes with C<drbdadm>
 
 =item * While waiting in node 2, configure the drbd device in node 1 as the master and wait for both devices to sync.
@@ -192,8 +194,8 @@ sub run {
         # Show the result
         enter_cmd "cat $drbd_rsc_file";
 
-        # We need to add the configuration in csync2.conf
-        add_file_in_csync(value => '/etc/drbd*');
+        # Synchronize drbd configuration in both nodes
+        sync_path('/etc/drbd*');
     }
     else {
         diag 'Wait until DRBD configuration is created...';

--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -92,8 +92,8 @@ sub run {
         file_content_replace("$sbd_cfg", "SBD_DELAY_START=.*" => "SBD_DELAY_START=yes");
     }
 
-    # Execute csync2 to synchronise the sysconfig sbd file
-    exec_csync;
+    # Synchronize the sysconfig sbd file
+    sync_file($sbd_cfg);
 
     # Set wait_for_all option to 0 if we are in a two nodes cluster situation
     # We need to set it for reproducing the same behaviour we had with no-quorum-policy=ignore
@@ -114,8 +114,8 @@ sub run {
     diag 'Waiting for other nodes to join...';
     barrier_wait("NODE_JOINED_$cluster_name");
 
-    # Execute csync2 to synchronise the configuration files
-    exec_csync;
+    # Synchronize the configuration files
+    sync_file($corosync_conf);
 
     # State of SBD if shared storage SBD is used
     if (!get_var('USE_DISKLESS_SBD')) {


### PR DESCRIPTION
Debugging done while researching bug https://bugzilla.suse.com/show_bug.cgi?id=1258400#c1 suggests to use `crm cluster copy` instead of `csync2` in clusters created using the SLES 16 code stream. This commit introduces 2 new functions into `lib/hacluster.pm`:

* sync_file: a wrapper around `crm cluster copy` and `add_file_to_csync` and `exec_csync` to decide which to use depending on the version of the SUT.
* sync_path: similar to `sync_file`, it uses `add_file_to_csync` and `exec_csync` when run on SLES versions older than 16.0, and will use `crm cluster copy` on a list of files when running on 16 or newer.

Commit also replaces calls to `exec_csync` and `add_file_to_csync` in some of the test modules in `tests/ha/`, in particular those used on the 2 nodes and 3 nodes test scenarios. Further changes could be required in other modules in `tests/ha/` and in `tests/sles4sap/`.

- Related ticket: https://jira.suse.com/browse/TEAM-11012
- Needles: N/A

Verification runs:

* 16.1: http://mango.qe.nue2.suse.org/tests/overview?build=31.1&distri=sle&version=16.1 :red_circle:
             http://mango.qe.nue2.suse.org/tests/overview?build=32.2&distri=sle&version=16.1 :red_circle: 
* 16.0: http://mango.qe.nue2.suse.org/tests/overview?build=204.8&distri=sle&version=16.0 :green_circle: 
* 15-SP7: https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR24944&distri=sle&version=15-SP7 :green_circle: 
* 12-SP5: https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR24944&distri=sle&version=12-SP5 :green_circle: 

Failures in 16.1 are caused by https://bugzilla.suse.com/show_bug.cgi?id=1260027 and are unrelated to the PR.