### PR TITLE
Fix systemd_detect_virt on PC xen

### DIFF
--- a/tests/publiccloud/systemd_detect_virt.pm
+++ b/tests/publiccloud/systemd_detect_virt.pm
@@ -17,6 +17,7 @@ use Utils::Architectures qw(is_aarch64);
 sub systemd_detect_virt_expected_output_virtual {
     my ($self) = @_;
 
+    return "xen" if get_var("TEST") =~ /_xen$/;
     return "google" if is_gce;
     return "amazon" if is_ec2;
     return "microsoft" if is_azure;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/194624
Because of https://openqa.suse.de/tests/21364782. Independent of which CSP, xen is reported as xen and that's expected behavior.
- Verification run:
  - https://openqa.suse.de/tests/21368028