### PR TITLE
Add  some more Aeon tests

### DIFF
--- a/products/aeon/main.pm
+++ b/products/aeon/main.pm
@@ -32,5 +32,6 @@ return 1 if load_yaml_schedule;
 loadtest 'aeon/tik';
 loadtest 'aeon/firstboot';
 loadtest 'aeon/reboot';
+loadtest 'aeon/distrobox';
 
 1;

--- a/products/aeon/main.pm
+++ b/products/aeon/main.pm
@@ -31,5 +31,6 @@ return 1 if load_yaml_schedule;
 
 loadtest 'aeon/tik';
 loadtest 'aeon/firstboot';
+loadtest 'aeon/reboot';
 
 1;

--- a/tests/aeon/distrobox.pm
+++ b/tests/aeon/distrobox.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC and contributors
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Test Aeon distrobox
+
+# Maintainer: Jan-Willem Harmannij <jwharmannij at gmail com>
+
+use Mojo::Base 'basetest';
+use testapi;
+use utils;
+
+sub run {
+    # Open GNOME Shell overview
+    unless (check_screen 'gnome-shell-overview') {
+        send_key 'super';
+        assert_screen 'gnome-shell-overview';
+    }
+
+    # Start GNOME Console
+    type_string 'console';
+    assert_screen 'gnome-console-icon';
+    send_key 'ret';
+    assert_screen 'gnome-console-open';
+
+    # Create and enter distrobox
+    type_string('distrobox create', lf => 1);
+    assert_screen 'distrobox-created', 600;
+
+    type_string('distrobox enter', lf => 1);
+    assert_screen 'distrobox-successful', 600;
+
+    # Exit distrobox and Console
+    type_string('exit', lf => 1);
+    type_string('exit', lf => 1);
+}
+
+1;

--- a/tests/aeon/reboot.pm
+++ b/tests/aeon/reboot.pm
@@ -20,7 +20,7 @@ sub run {
     type_string 'reboot';
     assert_and_click 'gnome-shell-confirm-reboot-1';
     assert_and_click 'gnome-shell-confirm-reboot-2';
-    
+
     # Input the encryption passphrase
     assert_screen 'aeon-boot-enter-passphrase', 600;
     type_string $testapi::password;

--- a/tests/aeon/reboot.pm
+++ b/tests/aeon/reboot.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC and contributors
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Test Aeon reboot and login
+
+# Maintainer: Jan-Willem Harmannij <jwharmannij at gmail com>
+
+use Mojo::Base 'basetest';
+use testapi;
+use utils;
+
+sub run {
+    # Open GNOME Shell overview
+    send_key 'super' unless (check_screen 'gnome-shell-overview');
+    assert_screen 'gnome-shell-overview';
+
+    # Initiate reboot
+    type_string 'reboot';
+    assert_and_click 'gnome-shell-confirm-reboot-1';
+    assert_and_click 'gnome-shell-confirm-reboot-2';
+    
+    # Input the encryption passphrase
+    assert_screen 'aeon-boot-enter-passphrase', 600;
+    type_string $testapi::password;
+    send_key 'ret';
+
+    # Aeon will boot and show the login screen
+    assert_screen 'login-1', 600;
+    assert_and_click 'login-1';
+    assert_screen 'login-2';
+    type_string $testapi::password;
+    send_key 'ret';
+
+    # Wait until the GNOME Shell overview is visible again
+    assert_screen 'gnome-shell-overview';
+}
+
+1;

--- a/tests/aeon/reboot.pm
+++ b/tests/aeon/reboot.pm
@@ -19,7 +19,7 @@ sub run {
     # Initiate reboot
     type_string 'reboot';
     assert_and_click 'gnome-shell-confirm-reboot-1';
-    assert_and_click 'gnome-shell-confirm-reboot-2';
+    assert_and_click('gnome-shell-confirm-reboot-2', timeout => 60);
 
     # Input the encryption passphrase
     assert_screen 'aeon-boot-enter-passphrase', 600;


### PR DESCRIPTION
This expands the initial, minimal Aeon testcase with two new scripts:
- Reboot and login after installation
- Create and enter the default (Tumbleweed) Distrobox

- Related ticket: n/a
- Needles: https://github.com/aeonDesktop/os-autoinst-needles-aeon
- Verification run: https://openqa.opensuse.org/tests/5973555
