### PR TITLE
IPMI qe-sec - change boot handling

### DIFF
--- a/schedule/security/fips/ipmi/prepare_baremetal_fips.yaml
+++ b/schedule/security/fips/ipmi/prepare_baremetal_fips.yaml
@@ -23,7 +23,7 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/handle_reboot
-  - installation/first_boot
+  - security/boot_disk
   - console/hostname
   - console/system_prepare
   - console/consoletest_setup


### PR DESCRIPTION
IPMI qe-sec installation - change boot handling

- Related ticket: https://progress.opensuse.org/issues/195278
- Verification run: https://openqa.suse.de/tests/21385206