### PR TITLE
Fix xen-based EC2 instances assertion in systemd_detect_virt

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -40,6 +40,7 @@ our @EXPORT = qw(
   is_byos
   is_ondemand
   is_ec2
+  is_ec2_xen
   is_azure
   is_gce
   is_container_host
@@ -83,6 +84,11 @@ sub is_ondemand() {
 # Check if we are on an AWS test run
 sub is_ec2() {
     return is_public_cloud && check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
+}
+
+sub is_ec2_xen {
+    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html -> Xen-based instances
+    return is_public_cloud && is_ec2 && get_var("PUBLIC_CLOUD_INSTANCE_TYPE") =~ /^(m1|m2|m3|m4|t1|t2|c1|c3|c4|r3|r4|x1|x1e|d2|h1|i2|i3|f1|g3|p2|p3)\..+/;
 }
 
 # Check if we are on an Azure test run

--- a/tests/publiccloud/systemd_detect_virt.pm
+++ b/tests/publiccloud/systemd_detect_virt.pm
@@ -17,7 +17,7 @@ use Utils::Architectures qw(is_aarch64);
 sub systemd_detect_virt_expected_output_virtual {
     my ($self) = @_;
 
-    return "xen" if get_var("TEST") =~ /_xen$/;
+    return "xen" if (get_var("TEST") =~ /_xen$/) || is_ec2_xen();
     return "google" if is_gce;
     return "amazon" if is_ec2;
     return "microsoft" if is_azure;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/194624
Because of https://openqa.suse.de/tests/21402868#step/systemd_detect_virt/23. There are some xen instances in EC2 that report as `xen` not `amazon`. To be precise as per https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html :
Xen-based instances
- General purpose: M1 | M2 | M3 | M4 | T1 | T2
- Compute optimized: C1 | C3 | C4
- Memory optimized: R3 | R4 | X1 | X1e
- Storage optimized: D2 | H1 | I2 | I3
- Accelerated computing: F1 | G3 | P2 | P3

- Verification run:
- https://openqa.suse.de/tests/21407112

