### PR TITLE
Fix parsing metal in PUBLIC_CLOUD_INSTANCE_TYPE for EC2 systemd-detec…

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -88,7 +88,7 @@ sub is_ec2() {
 
 sub is_ec2_xen {
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html -> Xen-based instances
-    return is_public_cloud && is_ec2 && get_var("PUBLIC_CLOUD_INSTANCE_TYPE") =~ /^(m1|m2|m3|m4|t1|t2|c1|c3|c4|r3|r4|x1|x1e|d2|h1|i2|i3|f1|g3|p2|p3)\..+/;
+    return is_public_cloud && is_ec2 && get_var("PUBLIC_CLOUD_INSTANCE_TYPE") =~ /^(m1|m2|m3|m4|t1|t2|c1|c3|c4|r3|r4|x1|x1e|d2|h1|i2|i3|f1|g3|p2|p3)/;
 }
 
 # Check if we are on an Azure test run

--- a/tests/publiccloud/systemd_detect_virt.pm
+++ b/tests/publiccloud/systemd_detect_virt.pm
@@ -99,7 +99,7 @@ sub assert_systemd_detect_virt {
 
     record_info('systemd version', $systemd_version);
 
-    if (get_var('PUBLIC_CLOUD_INSTANCE_TYPE') =~ /-metal$/) {
+    if (get_var('PUBLIC_CLOUD_INSTANCE_TYPE') =~ /metal$/) {
         $self->assert_systemd_detect_virt_metal($rc, $output);
     } else {
         $self->assert_systemd_detect_virt_virtual($rc, $output);


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/194624
Because of https://openqa.suse.de/tests/21402893#step/systemd_detect_virt/12. For EC2 we define metal instances with .metal, not -metal. This PR is intended to fix parsing not as metal.
- VR: https://openqa.suse.de/tests/21407261