### PR TITLE
Extend SDAF modules to handle all MU update repos

### DIFF
--- a/schedule/sles4sap/sap_deployment_automation_framework/sdaf_deployment.yml
+++ b/schedule/sles4sap/sap_deployment_automation_framework/sdaf_deployment.yml
@@ -6,6 +6,7 @@ vars:
   TEST_CONTEXT: 'OpenQA::Test::RunArgs'
 schedule:
   - boot/boot_to_desktop
+  - '{{validate_repo}}'
   - sles4sap/sap_deployment_automation_framework/create_deployer_vm
   - sles4sap/sap_deployment_automation_framework/connect_to_deployer
   - sles4sap/sap_deployment_automation_framework/configure_deployer
@@ -20,6 +21,10 @@ schedule:
   - sles4sap/redirection_tests/check_netweaver
 
 conditional_schedule:
+  validate_repo:
+    IS_MAINTENANCE:
+      1:
+        - publiccloud/validate_repos
   maintenance_update:
     IS_MAINTENANCE:
       1:

--- a/tests/sles4sap/sap_deployment_automation_framework/patch_and_reboot.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/patch_and_reboot.pm
@@ -42,7 +42,7 @@ B<The key tasks performed by this module include:>
 
 =over
 
-=item * B<INCIDENT_REPO> : Incident repository URL
+=item * B<REPOS> : Repository URL(s)
 
 =item * B<IS_MAINTENANCE> : Define if test scenario includes applying maintenance updates
 
@@ -93,7 +93,7 @@ sub run {
     my $project_root_dir = "/tmp/$project_name";
     my $log_dir = "$project_root_dir/logs";
     my $test_dir = "$project_root_dir/tests";
-    my $sut_ssh_key_path = '/home/azureadm/.ssh/sut_id_rsa';
+    my $sut_ssh_key_path = '/home/azureadm/.ssh/sut_sid_id_rsa';
 
     git_clone(get_required_var('HLQR_GIT_REPO'),
         branch => $project_branch,
@@ -106,7 +106,7 @@ sub run {
     # Prepare test argument files
     my @arg_files;
     my $arg_index = 1;
-    my $repo_mirror = get_required_var('INCIDENT_REPO');
+    my $repos = join(',', get_test_repos());
     my $repo_mirror_host = get_required_var('REPO_MIRROR_HOST');
     for my $hostname (keys %update_hosts) {
         my $file_content = <<"file_content";
@@ -120,7 +120,7 @@ KEYFILE:$sut_ssh_key_path
 --variable
 REPO_MIRROR_HOST:$repo_mirror_host
 --variable
-INCIDENT_REPO:$repo_mirror
+REPOS:$repos
 --variable
 LOG_DIR:$log_dir
 file_content
@@ -154,7 +154,7 @@ file_content
     # Fetch SUT SSH key from keyvault
     my $workload_rg = get_workload_resource_group(deployment_id => find_deployment_id());
     my $workload_key_vault = ${az_keyvault_list(resource_group => $workload_rg)}[0];
-    sdaf_ssh_key_from_keyvault(key_vault => $workload_key_vault, target_file => $sut_ssh_key_path);
+    sdaf_ssh_key_from_keyvault(query => 'sid-sshkey', key_vault => $workload_key_vault, target_file => $sut_ssh_key_path);
 
     my $pabot_cmd = join(' ', 'pabot',
         '--name "Patch and reboot all hosts"',


### PR DESCRIPTION
Extend SDAF MU modules to handle an array of maintenance update repositories 

Related ticket:
[TEAM-10935](https://sd.suse.com/browse/SD-10935) - [SDAF] Extend MU modules to handle an array of maintenance update repositories

Related MR:
https://gitlab.suse.de/qa-css/hlqr/-/merge_requests/5
  
VRs:
15-SP7 SDAF_PRD_deploy_ENSA2_sbd, `aggregate` job multiple *_TEST_ISSUES, **38** repos in total:
https://openqaworker15.qe.prg2.suse.org/tests/360224#step/app_deployment/210 (patch_and_reboot passed, it failed on an MS known issue)
15-SP7 SDAF_PRD_deploy_HanaSR, `single incident` job with **4** repos:
https://openqaworker15.qe.prg2.suse.org/tests/360080#step/patch_and_reboot/1 (patch_and_reboot passed)
15-SP7 SDAF_PRD_deploy_HanaSR, `single incident` job with **1** repo:
https://openqaworker15.qe.prg2.suse.org/tests/359867#step/patch_and_reboot/1 (patch_and_reboot passed)
