### PR TITLE
Add run0 tests to extra_tests_utils

### DIFF
--- a/schedule/opensuse/textmode_extra_tests_utils.yaml
+++ b/schedule/opensuse/textmode_extra_tests_utils.yaml
@@ -39,6 +39,7 @@ schedule:
     - console/snapper_zypp
     - console/zypper_extend
     - console/pam
+    - console/run0
     - console/shar
     - console/update_alternatives
     - console/rpm


### PR DESCRIPTION
openqa: clone https://openqa.opensuse.org/tests/5853449


#### Results from cloned jobs:
- [![https://openqa.opensuse.org/tests/5775782](https://openqa.opensuse.org/tests/5775782/badge)](https://openqa.opensuse.org/tests/5775782)

<sub>The above list is generated with a script with information from the "clone_mentioned_job" workflow.</sub>
