### PR TITLE
Make himmelblau bsc#1260384 softfail stricter

### DIFF
--- a/tests/publiccloud/himmelblau.pm
+++ b/tests/publiccloud/himmelblau.pm
@@ -65,7 +65,7 @@ sub run {
     zypper_call("update");
     zypper_call("lr -U");
     if (zypper_call("install himmelblau", exitcode => [0, 104]) == 104) {
-        if (is_sle("<16")) {
+        if (is_sle("<=15-SP6")) {
             record_soft_failure('bsc#1260384');
             return;
         }


### PR DESCRIPTION
Make version check stricter in soft failure for package not found in himmelblau.pm to cover only 15-SP6 and lower
Continuation of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25080
- Related ticket: https://progress.opensuse.org/issues/198338
- Verification run: https://openqa.suse.de/tests/21515292