### PR TITLE
Enable scheduling AITL on Maintenance Images Public Cloud

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -50,6 +50,8 @@ sub load_maintenance_publiccloud_tests {
         loadtest('publiccloud/ahb', run_args => $args);
     } elsif (get_var('PUBLIC_CLOUD_NEW_INSTANCE_TYPE')) {
         loadtest("publiccloud/bsc_1205002", run_args => $args);
+    } elsif (get_var('PUBLIC_CLOUD_AZURE_AITL')) {
+        loadtest "publiccloud/azure_aitl", run_args => $args;
     } elsif (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
         loadtest("publiccloud/registercloudguest", run_args => $args, name => "re-registration");
     } else {

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -55,6 +55,8 @@ sub load_maintenance_publiccloud_tests {
         loadtest('publiccloud/ahb', run_args => $args);
     } elsif (get_var('PUBLIC_CLOUD_NEW_INSTANCE_TYPE')) {
         loadtest("publiccloud/bsc_1205002", run_args => $args);
+    } elsif (get_var('PUBLIC_CLOUD_AZURE_AITL')) {
+        loadtest "publiccloud/azure_aitl", run_args => $args;
     } elsif (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
         loadtest("publiccloud/registercloudguest", run_args => $args, name => "re-registration");
         loadtest("publiccloud/ssh_interactive_end", run_args => $args);

--- a/tests/publiccloud/azure_aitl.pm
+++ b/tests/publiccloud/azure_aitl.pm
@@ -34,6 +34,11 @@ sub run {
 
     my $aitl_image_gallery = "test_image_gallery";
     my $aitl_image_version = "latest";
+    if (get_var("FLAVOR") =~ /Maintenance/) {
+        $aitl_image_version = $provider->get_image_version();
+        $aitl_image_version =~ s/.*\/versions\///;
+        record_info("AITL image version:", $aitl_image_version);
+    }
     my $aitl_job_name = "openqa-aitl-$job_id";
     my $aitl_manifest = "custom.json";
     my $aitl_image_name = $provider->generate_azure_image_definition();

--- a/tests/publiccloud/azure_aitl.pm
+++ b/tests/publiccloud/azure_aitl.pm
@@ -47,6 +47,11 @@ sub run {
 
     my $aitl_image_gallery = "test_image_gallery";
     my $aitl_image_version = "latest";
+    if (get_var("FLAVOR") =~ /Maintenance/) {
+        $aitl_image_version = $provider->get_image_version();
+        $aitl_image_version =~ s/.*\/versions\///;
+        record_info("AITL image version:", $aitl_image_version);
+    }
     my $aitl_job_name = "openqa-aitl-$job_id";
     my $aitl_manifest = "custom.json";
     my $aitl_image_name = $provider->generate_azure_image_definition();


### PR DESCRIPTION
As part of AITL resurrection in Public Cloud, we need an ability to schedule AITL tests for Maintenance Images. This PR addresses it by adding `PUBLIC_CLOUD_AZURE_AITL` branch into `load_maintenance_publiccloud_tests`.

- Related ticket: https://progress.opensuse.org/issues/193564
- Verification run: 
  + [15-SP6 Basic](https://openqa.suse.de/tests/21523868)
  + [15-SP7 Basic](https://openqa.suse.de/tests/21520771#step/azure_aitl/99)

Related PR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2780
