### PR TITLE
Enable migration SL Micro 6.2 to 16.1 immutable

### DIFF
--- a/schedule/yam/slmicro_migration.yaml
+++ b/schedule/yam/slmicro_migration.yaml
@@ -1,0 +1,19 @@
+---
+name: slmicro_migration
+description: >
+  Perform migration for SL Micro to SLES 16 immutable using transactional-upgrade.
+schedule:
+  - microos/disk_boot
+  - transactional/host_config
+  - console/suseconnect_scc
+  - transactional/install_updates
+  - migration/online_migration/zypper_migration
+  - yam/validate/validate_selinux
+  - yam/validate/validate_base_product
+  - yam/validate/validate_product
+  - yam/validate/validate_connectivity
+  - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
+  - yam/validate/validate_snapshots
+  - yam/validate/validate_registered_products
+  - console/validate_repos

--- a/schedule/yam/slmicro_migration_s390x.yaml
+++ b/schedule/yam/slmicro_migration_s390x.yaml
@@ -1,0 +1,19 @@
+---
+name: slmicro_migration_s390x
+description: >
+  Perform migration for SL Micro to SLES 16 immutable using transactional-upgrade.
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - transactional/host_config
+  - console/suseconnect_scc
+  - transactional/install_updates
+  - migration/online_migration/zypper_migration
+  - yam/validate/validate_selinux
+  - yam/validate/validate_base_product
+  - yam/validate/validate_product
+  - yam/validate/validate_connectivity
+  - yam/validate/validate_first_user
+  - yam/validate/validate_snapshots
+  - yam/validate/validate_registered_products
+  - console/validate_repos

--- a/tests/migration/online_migration/zypper_migration.pm
+++ b/tests/migration/online_migration/zypper_migration.pm
@@ -12,7 +12,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use power_action_utils 'power_action';
-use version_utils qw(is_desktop_installed is_sles4sap is_leap_migration is_sle_micro);
+use version_utils qw(is_desktop_installed is_sles4sap is_leap_migration is_sle_micro is_sle is_transactional);
 use Utils::Backends 'is_pvm';
 use Utils::Logging 'upload_solvertestcase_logs';
 use transactional;
@@ -40,7 +40,7 @@ sub run {
 
     my $zypper_migration_signing_key = qr/^Do you want to reject the key, trust temporarily, or trust always?[\s\S,]* \[r/m;
     # start migration
-    if (is_sle_micro) {
+    if (is_sle_micro || (is_sle('16.1+') && is_transactional)) {
         # We set DEBUG_TARGET_OS_TEST_ISSUES and DEBUG_TARGET_OS_TEST_REPOS
         # to add the target product's patch before migration.
         # This is for debug using, for more info please check out poo#161156.
@@ -63,6 +63,7 @@ sub run {
         if (script_run('systemctl is-active apparmor.service') == 0) {
             systemctl('disable --now apparmor.service');
         }
+        assert_script_run("echo 'url: " . get_required_var('SCC_URL') . "' > /etc/SUSEConnect") if is_sle('16.1+');
         script_run("(transactional-update migration; echo ZYPPER-DONE) | tee /dev/$serialdev", 0);
     } else {
         my $option = (is_leap_migration) || (get_var("SCC_ADDONS") =~ /phub/) || (get_var("SMT_URL") =~ /smt/) ? " --allow-vendor-change " : " ";


### PR DESCRIPTION
##
### Enable migration SL Micro 6.2 to 16.1 immutable
- Related ticket: 
  - https://progress.opensuse.org/issues/195812
- Related MR:
  - https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/766
- VR:
  - [__slmicro_migration__](https://openqa.suse.de/tests/overview?test=slem_migration_6.2_to_16.1_dev3&distri=sle&version=16.1&build=38.1&groupid=318)
  - [regression for slem_migration_6.1_to_6.2](https://openqa.suse.de/tests/21858646)
##