### PR TITLE
Bump openTOFU EC2 Provider version to latest in Public Cloud

### DIFF
--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "= 5.98.0"
+      version = "= 6.38.0"
       source  = "hashicorp/aws"
     }
     random = {


### PR DESCRIPTION
- Verification run: https://openqa.suse.de/tests/21538262#step/prepare_instance/83