### PR TITLE
Pass ssh key from openQA parameter and keep fake public key

### DIFF
--- a/data/yam/agama/auto/lib/base.libsonnet
+++ b/data/yam/agama/auto/lib/base.libsonnet
@@ -20,9 +20,9 @@
     hashedPassword: true,
     userName: 'bernhard'
   },
-  root(password):: {
-    [if password then 'password']: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
-    [if password then 'hashedPassword']: true,
-    sshPublicKey: 'fake public key to enable sshd and open firewall',
+  root(params):: {
+    [if params.password && params.worker then 'password']: std.get(params, "password", default='$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/'),
+    [if params.password then 'hashedPassword']: true,
+    sshPublicKey: std.get(params, "ssh_key", default="fake public key to enable sshd and open firewall"),
   },
 }

--- a/data/yam/agama/auto/lib/base.libsonnet
+++ b/data/yam/agama/auto/lib/base.libsonnet
@@ -20,9 +20,9 @@
     hashedPassword: true,
     userName: 'bernhard'
   },
-  root(password):: {
-    [if password then 'password']: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
-    [if password then 'hashedPassword']: true,
-    sshPublicKey: 'fake public key to enable sshd and open firewall',
+  root(params):: {
+    [if params.worker then 'password']: std.get(params, "password", default='$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/'),
+    [if params.password == '' then 'hashedPassword']: true,
+    sshPublicKey: std.get(params, "ssh_key", default="fake public key to enable sshd and open firewall"),
   },
 }

--- a/data/yam/agama/auto/template.libsonnet
+++ b/data/yam/agama/auto/template.libsonnet
@@ -29,15 +29,20 @@ function(bootloader=true,
          registration_code_ha='',
          registration_packagehub=false,
          registration_url='',
+         remote_worker=false,
          root_password=true,
          scripts_pre='',
          scripts_post_partitioning='',
          scripts_post='',
          software_only_required=false,
+         ssh_pub_key='',
          ssl_certificates=false,
          storage='',
          decrypt_password='',
          user=true) (
+        local rp = root_password;
+        local sk = ssh_pub_key;
+        local rw = remote_worker;
         base_lib.bootloader(bootloader, bootloader_timeout, bootloader_extra_kernel_params) +
         {
           [if dasd == true then 'dasd']: dasd_lib.dasd(),
@@ -64,7 +69,12 @@ function(bootloader=true,
             [if registration_code != '' then 'registrationCode']: registration_code,
             [if registration_url != '' then 'registrationUrl']: registration_url,
           },
-          root: base_lib.root(root_password),
+         // root: base_lib.root(root_password, ssh_pub_key, remote_worker),
+          root: base_lib.root({
+            password: rp,
+            ssh_key: sk,
+            worker: rw
+          }),
           [if ssl_certificates == true then 'security']: security_lib.sslCertificates(),
           [if scripts_pre != '' || scripts_post != '' || scripts_post_partitioning != '' then 'scripts']: {
             [if scripts_post != '' then 'post']: [ scripts_post_lib[x] for x in std.split(scripts_post, ',') ],

--- a/data/yam/agama/auto/template.libsonnet
+++ b/data/yam/agama/auto/template.libsonnet
@@ -30,15 +30,21 @@ function(bootloader=true,
          registration_code_ha='',
          registration_packagehub=false,
          registration_url='',
+         remote_worker=false,
          root_password=true,
+         root_password_hash='',
          scripts_pre='',
          scripts_post_partitioning='',
          scripts_post='',
          software_only_required=false,
+         ssh_pub_key='',
          ssl_certificates=false,
          storage='',
          decrypt_password='',
          user=true) (
+        local rp = root_password_hash;
+        local sk = ssh_pub_key;
+        local rw = remote_worker;
         base_lib.bootloader(bootloader, bootloader_timeout, bootloader_extra_kernel_params) +
         {
           [if dasd == true then 'dasd']: dasd_lib.dasd(),
@@ -65,7 +71,12 @@ function(bootloader=true,
             [if registration_code != '' then 'registrationCode']: registration_code,
             [if registration_url != '' then 'registrationUrl']: registration_url,
           },
-          root: base_lib.root(root_password),
+         // root: base_lib.root(root_password, ssh_pub_key, remote_worker),
+          root: base_lib.root({
+            password: rp,
+            ssh_key: sk,
+            worker: rw
+          }),
           [if ssl_certificates == true then 'security']: security_lib.sslCertificates(),
           [if scripts_pre != '' || scripts_post != '' || scripts_post_partitioning != '' then 'scripts']: {
             [if scripts_post != '' then 'post']: [ scripts_post_lib[x] for x in std.split(scripts_post, ',') ],

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -808,7 +808,8 @@ sub generate_json_profile {
     my $profile_path = get_required_var('CASEDIR') . "/data/" . $profile;
 
     my @profile_options = map { "--tla-" . (/true|false/ ? "code" : "str") . " $_ " }
-      split(' ', trim(get_var('AGAMA_PROFILE_OPTIONS')));
+      # Split on whitespace, but only if followed by "something="
+      split(/\s+(?=\w+=)/, trim(get_var('AGAMA_PROFILE_OPTIONS')));
     diag "jsonnet @profile_options $profile_path";
     record_info("JSONNET Command", "jsonnet @profile_options $profile_path");
     my $profile_content = `jsonnet @profile_options $profile_path`;

--- a/tests/yam/agama/agama_cli.pm
+++ b/tests/yam/agama/agama_cli.pm
@@ -30,10 +30,12 @@ sub run {
     assert_script_run('agama config show | jq -C');
 
     my $workaround = is_sle('16.1+') ? " > /dev/null" : "";
+    assert_script_run("agama config show");
     record_soft_failure("bsc#1265431 - Agama config load blocks in BUSY state") if (is_sle('16.1+'));
     assert_script_run("jq -n '.root.password = \"$testapi::password\"' | agama config load $workaround");
 
     assert_script_run("agama config show | grep $testapi::password");
+    assert_script_run("agama config show");
 
     my $product_id = get_var('AGAMA_PRODUCT_ID');
     assert_script_run("jq -n '.product.id = \"$product_id\"' | agama config load $workaround");


### PR DESCRIPTION


- Related ticket: https://progress.opensuse.org/issues/197990
- Needles: N/A
- Verification run: 
  https://openqa.suse.de/tests/21706017#details  without ssh_pub_key set
  https://openqa.suse.de/tests/21706018#details  with ssh_pub_key='real ssh key'.
