### PR TITLE
Remove keyword 'state' from guest agama jsonnet

### DIFF
--- a/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_aarch64.jsonnet
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_aarch64.jsonnet
@@ -63,8 +63,7 @@
           "opensuse.org"
         ]
       }
-    ],
-    "state": {}
+    ]
   },
   scripts: {
     post: [

--- a/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet
@@ -64,8 +64,7 @@
           "opensuse.org"
         ]
       }
-    ],
-    "state": {}
+    ]
   },
   scripts: {
     post: [


### PR DESCRIPTION
* **Remove** keyword ```state``` in ```network``` section which is temporary workaround for guest agama installation.

* **The** keyword ```state``` was initially introduced in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/24523 to workaround [bsc#1257544](https://bugzilla.suse.com/show_bug.cgi?id=1257544).

* **Now** the keyword ```state``` causes many failures on OSD, for example, [this one](https://openqa.suse.de/tests/21996885#step/unified_guest_installation/337).  This keyword has no meaning at all, but just for workaround, so safe to remove.

* **Verification Runs:**
  * [sle-16.0-Online-x86_64-Build221.7-uefi-gi-full-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/21997866)
  * [sle-16.0-Online-x86_64-Build221.7-sev-es-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/21997867)
  * [sle-16.0-Online-x86_64-Build221.7-uefi-gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/21997870)
  * [sle-16.0-Online-aarch64-Build221.7-uefi-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/21998225)
  * [sle-16.0-Online-x86_64-Build221.7-sev-snp-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/21998227)
  * [sle-16.0-Online-x86_64-Build221.7-snapshot-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/21998228)
  * [sle-16.1-Online-x86_64-Build40.1-immutable-gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/21998241)
  * [sle-16.1-Online-x86_64-Build40.1-sev-snp-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/21998242)
  * [sle-16.1-Online-x86_64-Build40.1-uefi-gi-guest_developing-on-host_sles15sp7-kvm](https://openqa.suse.de/tests/21998243)
  * [sle-16.1-Online-x86_64-Build40.1-uefi-gi-guest_sles15sp7-on-host_developing-kvm](https://openqa.suse.de/tests/21998244)
  * [sle-16.1-Online-x86_64-Build40.1-uefi-gi-guest_sles16_0-online-on-host_developing-kvm](https://openqa.suse.de/tests/21998246)
  * [sle-16.1-Online-x86_64-Build40.1-default_svirt_sle16](https://openqa.suse.de/tests/21999279)
  * [sle-16.1-Online-aarch64-Build40.1-sles16_transactional_installation_virt](https://openqa.suse.de/tests/21999280)
  * [sle-16.1-Online-ppc64le-Build40.1-sles16_transactional_installation_virt](https://openqa.suse.de/tests/21999281)
  * [sle-16.1-Online-x86_64-Build40.1-sles16_transactional_installation_virt](https://openqa.suse.de/tests/21999282)
  * [sle-16.1-Online-s390x-Build40.1-sles16_transactional_installation_virt](https://openqa.suse.de/tests/21999283)
  * [sle-16.1-Transactional-Base-x86_64-Build7.5-sles16_transactional_virtualization](https://openqa.suse.de/tests/21999288)
  * [sle-16.1-Transactional-Base-SelfInstall-aarch64-Build7.5-sles16_transactional_installation_virt](https://openqa.suse.de/tests/21999290)
  * [sle-16.1-Transactional-Base-VMware-x86_64-Build7.5-sles16_transactional_open_vm_tools](https://openqa.suse.de/tests/21999291)
  * [sle-16.1-Transactional-Base-ppc-4096-ppc64le-Build7.5-sles16_transactional_virtualization](https://openqa.suse.de/tests/21999298)
  * [sle-16.1-Transactional-Base-qcow-aarch64-Build7.5-sles16_transactional_virtualization](https://openqa.suse.de/tests/21999299)
  * [sle-16.1-Base-SelfInstall-pxe-x86_64-Build7.5-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/21999362)
  * [sle-16.1-Online-aarch64-Build40.1-sles16_transactional_installation_virt](https://openqa.suse.de/tests/21999563)
  * [sle-16.1-Online-aarch64-Build40.1-uefi-gi-guest_postsles16-on-host_developing-kvm](https://openqa.suse.de/tests/21999564)