### PR TITLE
fix: Correct variable name

### DIFF
--- a/tests/console/openssl_nodejs.pm
+++ b/tests/console/openssl_nodejs.pm
@@ -11,9 +11,7 @@
 #          - List eventually skipped and failed test
 # Maintainer: QE Core <qe-core@suse.de>
 
-## no os-autoinst style
-
-use base 'consoletest';
+use Mojo::Base 'consoletest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
@@ -41,7 +39,7 @@ sub run {
     }
     if (check_var('FLAVOR', 'Online-Increments')) {
         my $increment_repo = get_var('INCREMENT_REPO');
-        chop $increment_repo if $incident_repo =~ /\/$/;
+        chop $increment_repo if $increment_repo =~ /\/$/;
         zypper_call("ar -f $increment_repo/repo/SLES-16.0-" . get_var('ARCH') . "-Source TEST_0_Source");
     }
     assert_script_run 'wget --quiet ' . data_url('qam/crypto_rsa_dsa.patch') unless get_var('FLAVOR') =~ /TERADATA/ || is_sle('=12-sp5') || is_sle('=15-sp4');


### PR DESCRIPTION
This error is shown when strict is enabled:

    Global symbol "$incident_repo" requires explicit package name (did you
    forget to declare "my $incident_repo"?) at
    ./tests/console/openssl_nodejs.pm line 44.

Since in that branch the variable `$incident_repo` was never defined, this can never have been working as expected.

Also it might be easier to just do:

    $increment_repo =~ s{/$}{};


- Related ticket: https://progress.opensuse.org/issues/194002