### PR TITLE
fix: Import function and remove warning

### DIFF
--- a/tests/console/run0.pm
+++ b/tests/console/run0.pm
@@ -5,10 +5,9 @@
 # Maintainer: QE Security <none@suse.de>
 # Tags: poo#160322, poo#194417
 
-## no os-autoinst style
-
-use base 'consoletest';
+use Mojo::Base 'consoletest';
 use testapi;
+use serial_terminal qw(select_serial_terminal);
 use utils qw(systemctl zypper_call);
 
 sub run {
@@ -28,7 +27,7 @@ sub run {
     my $uid = script_output('run0 id -u');
     die "run0 did not run as root (uid=$uid)" unless $uid eq '0';
     # User change
-    my $uid = script_output("id -u $testapi::username");
+    $uid = script_output("id -u $testapi::username");
     my $run0uid = script_output("run0 --user=$testapi::username id -u");
     die "run0 did not run as $testapi::username (exptected_uid=$uid, actual_uid=$run0uid)" unless $run0uid eq $uid;
     # Exit and error handling


### PR DESCRIPTION
There was one strict error:

    Bareword "select_serial_terminal" not allowed while "strict subs" in use at
    ././tests/console/run0.pm line 15.

and one warning:

    "my" variable $uid masks earlier declaration in same scope at
    ././tests/console/run0.pm line 31.

- Related ticket: https://progress.opensuse.org/issues/194002