### PR TITLE
fix: Import select_serial_terminal function

### DIFF
--- a/tests/console/python_liblouis.pm
+++ b/tests/console/python_liblouis.pm
@@ -7,9 +7,8 @@
 # Summary: New tests for the braille translation library
 # Maintainer: QE Core <qe-core@suse.com>
 
-## no os-autoinst style
-
-use base "x11test";
+use Mojo::Base 'x11test';
+use serial_terminal qw(select_serial_terminal);
 use testapi;
 use version_utils;
 use utils "zypper_call";


### PR DESCRIPTION
    Bareword "select_serial_terminal" not allowed while "strict subs" in use at
    ././tests/console/python_liblouis.pm line 19.

- Related ticket: https://progress.opensuse.org/issues/194002