### PR TITLE
PC LTP kernel devel package to match kernel

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -51,14 +51,28 @@ sub should_partially_build_ltp_from_git_modules_install {
 sub install_build_deps {
     my ($self, $instance) = @_;
 
+    my @deps = get_required_build_dependencies();
+
+    # Remove kernel-default-devel from the list of dependencies since matching kernel version kernel-<flavor>-devel-<ver> package will be added.
+    @deps = grep { $_ ne 'kernel-default-devel' } @deps;
+
+    # Sample value: kernel-default-devel-6.12.0-160000.27.1
+    my $kernel_devel_pkg = $instance->ssh_script_output(cmd => q{
+        rpm -qf /boot/config-$(uname -r) \
+        | sed -e "s/\.$(arch)//" \
+              -e "s/^kernel-\([^-]\+\)-/kernel-\1-devel-/"
+    });
+
+    push @deps, $kernel_devel_pkg;
+
     if (is_transactional) {
         $instance->ssh_assert_script_run(
-            cmd => sprintf('sudo transactional-update -n pkg in --no-recommends %s', join(' ', get_required_build_dependencies())),
+            cmd => sprintf('sudo transactional-update -n pkg in --no-recommends %s', join(' ', @deps)),
             timeout => 300
         );
         $instance->softreboot();
     } else {
-        zypper_call_remote($instance, cmd => "install --no-recommends " . join(' ', get_required_build_dependencies()));
+        zypper_call_remote($instance, cmd => "install --no-recommends " . join(' ', @deps));
     }
     zypper_install_available_remote($instance);
 }


### PR DESCRIPTION
Ensure that devel package matches the kernel version before building LTP modules for the targeted kernel

- Related ticket: https://progress.opensuse.org/issues/198164
- Verification run:
  - SLEM (irrelevant because we don't have `PUBLIC_CLOUD_LTP_BUILD_MODULES=1`):
    - 6.1:
      - Azure:
        - [aarch64](https://openqa.suse.de/tests/21618742)
      - EC2:
        - [aarch64](https://openqa.suse.de/tests/21618744)
  - 15-SP6:
    - Azure:
      - BYOS:
        - [aarch64](https://openqa.suse.de/tests/21627224) 
        - [x86_64](https://openqa.suse.de/tests/21627207)
    - EC2:
      - BYOS:
        - [aarch64](https://openqa.suse.de/tests/21627244)
        - [x86_64](https://openqa.suse.de/tests/21627246)
    - GCE:
      - BYOS:
        - [aarch64](https://openqa.suse.de/tests/21627252)
        - [x86_64](https://openqa.suse.de/tests/21627255)
  - 15-SP7:
    - Azure:
      - BYOS:
        - [aarch64](https://openqa.suse.de/tests/21627266) 
        - [x86_64](https://openqa.suse.de/tests/21627267)
    - EC2:
      - BYOS:
        - [aarch64](https://openqa.suse.de/tests/21627268)
        - [x86_64](https://openqa.suse.de/tests/21627269)
    - GCE:
      - BYOS:
        - [aarch64](https://openqa.suse.de/tests/21627270)
        - [x86_64](https://openqa.suse.de/tests/21627271)     
  - 16.0:
    - Azure:
      - Basic:
        - [x86_64](https://openqa.suse.de/tests/21617102)  
      - BYOS: 
        - [aarch64](https://openqa.suse.de/tests/21615953#step/run_ltp/264)
        - [x86_64](https://openqa.suse.de/tests/21617071)   
      - Standard:
        - [aarch64](https://openqa.suse.de/tests/21617080)
        - [x86_64](https://openqa.suse.de/tests/21617095)  
    - EC2:
      - EC2:
        - [aarch64](https://openqa.suse.de/tests/21627791)
        - [x86_64](https://openqa.suse.de/tests/21627792)
      - EC2-BYOS:
        - [aarch64](https://openqa.suse.de/tests/21627793)
        - [x86_64](https://openqa.suse.de/tests/21627794)
      - EC2-Hardened:
        - [aarch64](https://openqa.suse.de/tests/21628481)
        - [x86_64](https://openqa.suse.de/tests/21628482)  
    - GCE:
      - GCE:
        - [aarch64](https://openqa.suse.de/tests/21627718)
        - [x86_64](https://openqa.suse.de/tests/21627719)
      - GCE-BYOS:
        - [aarch64](https://openqa.suse.de/tests/21627720)
        - [x86_64](https://openqa.suse.de/tests/21627721)    

[VR after code change](https://openqa.suse.de/tests/21630832)