### PR TITLE
Public Cloud tag openqa-secondary-nic in Azure

### DIFF
--- a/data/publiccloud/terraform/azure_cloud-netconfig.tf
+++ b/data/publiccloud/terraform/azure_cloud-netconfig.tf
@@ -174,6 +174,12 @@ resource "azurerm_network_interface" "openqa-secondary-nic" {
     private_ip_address_version  = "IPv4"
     private_ip_address_allocation = "Dynamic"
   }
+
+  tags = merge({
+    openqa_created_by   = var.name
+    openqa_created_date = timestamp()
+    openqa_created_id   = element(random_id.service.*.hex, 0)
+  }, var.tags)
 }
 
 resource "azurerm_image" "image" {


### PR DESCRIPTION
As of now, tags are incomplete for secondary-nic in cloud-netconfig.

I didn't see `default_tags` in azurerm provider like in aws provider. Open to better options.
VR: https://openqa.suse.de/tests/21652153/logfile?filename=serial_terminal.txt#line-4833