### PR TITLE
shutdown_ltp: Detect serial errors outside install jobs

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -26,6 +26,7 @@ use package_utils;
 
 our @EXPORT = qw(
   check_kernel_taint
+  unmask_serial_failures
   export_ltp_env
   get_ltproot
   get_ltp_openposix_test_list_file
@@ -256,6 +257,23 @@ sub check_kernel_taint {
             result => 'fail');
         $testmod->{result} = 'fail';
     }
+}
+
+sub unmask_serial_failures {
+    my ($pattern_list) = @_;
+    my @ret;
+    my $expect_warn = get_var('LTP_WARN_EXPECTED');
+
+    for my $pattern (@$pattern_list) {
+        my %tmp = %$pattern;
+
+        # don't switch to hard fail when test is expected to produce kernel warning
+        $tmp{type} = $tmp{post_boot_type} if defined($tmp{post_boot_type}) && !($tmp{soft_on_expect_warn} && $expect_warn);
+
+        push @ret, \%tmp;
+    }
+
+    return \@ret;
 }
 
 sub init_ltp_tests {

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -19,7 +19,7 @@ use Utils::Backends qw(is_backend_s390x is_pvm);
 use serial_terminal;
 use Mojo::File 'path';
 use Mojo::JSON;
-use LTP::utils 'prepare_ltp_env';
+use LTP::utils qw(prepare_ltp_env unmask_serial_failures);
 use LTP::WhiteList;
 require bmwqemu;
 
@@ -363,21 +363,11 @@ sub upload_oprofile {
 
 sub pre_run_hook {
     my ($self) = @_;
-    my @pattern_list;
 
     # Kernel error messages should be treated as soft-fail in boot_ltp,
     # install_ltp and shutdown_ltp so that at least some testing can be done.
-    # But change them to hard fail in this test module.
-    for my $pattern (@{$self->{serial_failures}}) {
-        my %tmp = %$pattern;
-
-        # don't switch to hard fail when test is expected to produce kernel warning
-        $tmp{type} = $tmp{post_boot_type} if defined($tmp{post_boot_type}) && !($tmp{soft_on_expect_warn} && get_var('LTP_WARN_EXPECTED'));
-
-        push @pattern_list, \%tmp;
-    }
-
-    $self->{serial_failures} = \@pattern_list;
+    # But change them to hard fail in this module.
+    $self->{serial_failures} = unmask_serial_failures($self->{serial_failures});
     $self->SUPER::pre_run_hook;
 }
 

--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -26,6 +26,17 @@ sub export_to_json {
     bmwqemu::save_json_file($test_result_export, $export_file);
 }
 
+sub pre_run_hook {
+    my ($self) = @_;
+
+    # Kernel error messages should be treated as soft-fail in boot_ltp
+    # and install jobs so that at least some testing can be done.
+    # But change them to hard fail here if errors will not impact other jobs.
+    $self->{serial_failures} = unmask_serial_failures($self->{serial_failures})
+      unless has_published_assets();
+    $self->SUPER::pre_run_hook;
+}
+
 sub run {
     my ($self, $tinfo) = @_;
 

--- a/variables.md
+++ b/variables.md
@@ -151,6 +151,7 @@ LTP_RUN_NG_REPO | string | https://github.com/linux-test-project/kirk.git | Defi
 LTP_PC_RUNLTP_ENV | string | empty | Contains eventual internal environment new parameters for `runltp-ng`, defined with the `--env` option, initialized in a column-separated string format: "PAR1=xxx:PAR2=yyy:...". By default it is empty, undefined.
 LTP_SUITE_TIMEOUT | integer | 9600 |Used to define --suite-timeout value passed to kirk
 LTP_TAINT_EXPECTED | integer | 0x80019801 | Bitmask of expected kernel taint flags.
+LTP_WARN_EXPECTED | boolean | false | If set, some kernel warnings and backtraces will be treated as softfails instead of errors.
 LVM | boolean | false | Use lvm for partitioning.
 LVM_THIN_LV | boolean | false | Use thin provisioning logical volumes for partitioning,
 MACHINE | string | | Define machine name which defines worker specific configuration, including WORKER_CLASS.


### PR DESCRIPTION
Kernel error messages are whitelisted by default to allow full testing even if the kernel has issues on boot. Only the run_ltp test module will currently treat them as errors. Expand the same error checks to the shutdown_ltp module but only if it's not part of an install job where it would prevent further tests from running.

- Related ticket: https://progress.opensuse.org/issues/198461
- Needles: N/A
- Verification runs:
  - https://openqa.suse.de/tests/21807118#step/cve-2023-0461/10
  - https://openqa.suse.de/tests/21808189#step/shutdown_ltp/87
