### PR TITLE
Reset network configuration before upgrade

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -111,6 +111,7 @@ our @EXPORT = qw(
   check_kvm_modules
   install_product_software
   collect_guests_supportconfig_and_logs
+  reset_network_config
 );
 
 my %log_cursors;
@@ -2172,6 +2173,32 @@ sub collect_guests_supportconfig_and_logs {
         # Pull the archive to the host and upload to openQA
         script_run("scp root\@$guest:$var_log_archive $var_log_archive");
         upload_logs("$var_log_archive", log_name => "var_logs_${guest}.tar.gz");
+    }
+}
+
+=head2 reset_network_config
+
+  reset_network_config(config => absolute path to config file);
+
+Reset network config, for example, restore auto dns policy to enable automatic
+dns migration to higher version
+
+=cut
+
+sub reset_network_config {
+    my (%args) = @_;
+    $args{config} //= '';
+
+    if (!is_networkmanager) {
+        $args{config} = '/etc/sysconfig/network/config';
+        return if (script_run("ls $args{config}") != 0);
+        assert_script_run("sed -i -r \'/^NETCONFIG_DNS_POLICY.*\$/d\' $args{config}");
+        if (script_run("grep -E \"^NETCONFIG_DNS_POLICY.*\$\" $args{config}") == 0) {
+            assert_script_run("sed -i -r \'s/^NETCONFIG_DNS_POLICY.*\$/NETCONFIG_DNS_POLICY=\"auto\"/g\' $args{config}");
+        }
+        else {
+            assert_script_run("echo -e \"NETCONFIG_DNS_POLICY=\"auto\"\" >> $args{config}");
+        }
     }
 }
 

--- a/schedule/virt_autotest/sles_host_upgrade.yaml
+++ b/schedule/virt_autotest/sles_host_upgrade.yaml
@@ -5,6 +5,7 @@ schedule:
   - '{{prepare_host_installation}}'
   - '{{prepare_virtualization}}'
   - yam/migration/restore_upgrade_env
+  - virt_autotest/restore_upgrade_system
   - console/system_prepare
   - '{{network_prepare}}'
   - yam/migration/migration_unattended

--- a/tests/virt_autotest/restore_upgrade_system.pm
+++ b/tests/virt_autotest/restore_upgrade_system.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Restore system for automatic upgrade which avoids missing features
+# after upgrade, for example, non-auto dns policy leads to no dns config after
+# upgrade.
+#
+# Maintainer: Wayne Chen <wchen@suse.com>, qe-virt@suse.de
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use virt_autotest::utils qw(select_backend_console reset_network_config);
+
+sub run {
+    # Login as root
+    select_backend_console(init => 0) if (!check_screen('text-logged-in-root'));
+    # Ensure automatic network configuration migration
+    reset_network_config;
+}
+
+1;


### PR DESCRIPTION
* **New** subroutine ```reset_network_config``` in ```lib/virt_autotest/utils.pm``` to ensure automatic network configuration migration, for example, automatic dns policy migration.

* **Call** ```reset_network_config``` in new test module ```tests/virt_autotest/restore_upgrade_system.pm```.

* **Load** new test module ```tests/virt_autotest/restore_upgrade_system.pm``` in schedule file ```schedule/virt_autotest/sles_host_upgrade.yaml```.

* **Without** auto dns policy, NetworkManager will not generate dns configuration which leads to dns query failure, for example, [this one](https://openqa.suse.de/tests/21705388#step/verify_virtualization/110). 

* **Verification Runs:**
  * [Modify NETCONFIG_DNS_POLICY to auto if it exists](https://openqa.suse.de/tests/21940668)
  * [Add auto NETCONFIG_DNS_POLICY if it does not exist](https://openqa.suse.de/tests/21981530)
  * [sle-16.1-Online-x86_64-Build38.1-sles_migration_160](https://openqa.suse.de/tests/21940670)
  * [sle-16.1-Online-aarch64-Build38.1-sles_migration_15sp4_textmode](https://openqa.suse.de/tests/21940671)
  * [sle-16.1-Online-ppc64le-Build38.1-sles_migration_15sp4_textmode_all_modules_and_extensions](https://openqa.suse.de/tests/21940674)
  * [sle-16.1-Online-s390x-Build38.1-sles_migration_15sp5_textmode](https://openqa.suse.de/tests/21940676)
  * [sle-16.1-Online-x86_64-Build38.1-sles_migration_15sp5_textmode](https://openqa.suse.de/tests/21940677)
  * [sle-16.1-Online-aarch64-Build38.1-sles_migration_15sp5_textmode_all_modules_and_extensions](https://openqa.suse.de/tests/21940678)
  * [sle-16.1-Online-ppc64le-Build38.1-sles_migration_15sp5_textmode_all_modules_and_extensions](https://openqa.suse.de/tests/21940679)
  * [sle-16.1-Online-s390x-Build38.1-sles_migration_15sp5_textmode_all_modules_and_extensions](https://openqa.suse.de/tests/21940681)
  * [sle-16.1-Online-x86_64-Build38.1-sles_migration_15sp5_textmode_all_modules_and_extensions](https://openqa.suse.de/tests/21940685)
  * [sle-16.1-Online-aarch64-Build38.1-sles_migration_15sp6_textmode_all_modules_and_extensions](https://openqa.suse.de/tests/21940686)
  * [sle-16.1-Online-ppc64le-Build38.1-sles_migration_15sp7_textmode](https://openqa.suse.de/tests/21940687)
  * [sle-16.1-Online-s390x-Build38.1-sles_migration_15sp7_textmode](https://openqa.suse.de/tests/21940688)
  * [sle-16.1-Online-x86_64-Build38.1-sles_migration_15sp7_ha](https://openqa.suse.de/tests/21940689)
  * [sle-16.1-Online-aarch64-Build38.1-sles_migration_160](https://openqa.suse.de/tests/21940690)
  * [sle-16.1-Online-ppc64le-Build38.1-sles_migration_160](https://openqa.suse.de/tests/21940691)
  * [sle-16.1-Online-s390x-Build38.1-sles_migration_160](https://openqa.suse.de/tests/21940692)
