### PR TITLE
Update hawk image path to load the container built by Leap16.0

### DIFF
--- a/tests/ha/hawk_gui.pm
+++ b/tests/ha/hawk_gui.pm
@@ -42,9 +42,9 @@ sub run {
     # TODO: Use another namespace using team group name
     # Docker image source in https://github.com/ricardobranco777/hawk_test
     # It will be eventually moved to https://github.com/ClusterLabs/hawk/e2e_test
-    my $image = "registry.opensuse.org/devel/openqa/ci/tooling/containers_15_4/hawk_test:latest";
-
-    assert_script_run("podman pull $image", 240);
+    my $image = get_var('HAWK_E2E_TEST_IMAGE', 'registry.opensuse.org/devel/openqa/ci/tooling/containers_16_0/hawk_test:latest');
+    my $docker_content_trust = get_var('DOCKER_CONTENT_TRUST') ? 'env DOCKER_CONTENT_TRUST=1 ' : '';
+    assert_script_run($docker_content_trust . 'podman pull ' . $image, 240);
 
     # Rest of the test needs to be performed on the x11 console, but with the
     # HA_CLUSTER setting that console is not yet activated; newer versions of gdm
@@ -80,7 +80,8 @@ sub run {
     # and then cd to the user's home directory.
     become_root;
     assert_script_run("cd /home/$testapi::username");
-    my $test_cmd = "podman run --rm --name test --ipc=host -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=\$DISPLAY -v \$PWD/$path:/$path ";
+    record_info('podman images', script_output('podman images'));
+    my $test_cmd = "${docker_content_trust}podman run --rm --name test --ipc=host -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=\$DISPLAY -v \$PWD/$path:/$path ";
     $test_cmd .= "$image -b $browser -H $node1 -S $node2 -s $testapi::password -r /$results --virtual-ip $virtual_ip";
     enter_cmd "$test_cmd 2>&1 | tee $logs; echo $pyscr-\$PIPESTATUS > $retcode; echo HAWK_TEST_DONE; sleep 30;";
     assert_screen "hawk-$browser", 60;


### PR DESCRIPTION
Please allow me to use this merge request to implement:
1. Update default hawk image path to load the container built by Leap16.0
2. Add the followed two parameters:
    - DOCKER_CONTENT_TRUST:  set DOCKER_CONTENT_TRUST=1 this is env variable to enable Docker content trust by default it is in disable mode
     - HAWK_E2E_TEST_IMAGE: Load customized container instead of default path

- Related ticket: https://jira.suse.com/browse/TEAM-11085
- Needles: N/A
- Verification run: 
Leap15 image:
16.0 https://openqa.suse.de/tests/21718933
15.7 https://openqa.suse.de/tests/21718893
15.6 https://openqa.suse.de/tests/21718900
15.5 https://openqa.suse.de/tests/21718909
15.4 https://openqa.suse.de/tests/21718919
12.5 https://openqa.suse.de/tests/21718926
Leap16 image:
16.0 https://openqa.suse.de/tests/21718929
15.7 https://openqa.suse.de/tests/21718888
15.6 https://openqa.suse.de/tests/21718898
15.5 https://openqa.suse.de/tests/21718906
15.4 https://openqa.suse.de/tests/21718919
12.5 https://openqa.suse.de/tests/21718923


