### PR TITLE
Fix empty browser automation logs when retrieved in root console

### DIFF
--- a/tests/yam/validate/validate_self_update.pm
+++ b/tests/yam/validate/validate_self_update.pm
@@ -12,8 +12,6 @@ use utils qw(systemctl);
 use scheduler qw(get_test_suite_data);
 
 sub run {
-    select_console 'root-console';
-
     my $self_update_enabled = get_test_suite_data()->{self_update_enabled};
     if ($self_update_enabled) {
         my $retcode = script_output('cat /run/live-self-update/result');


### PR DESCRIPTION
Just removing the console select, not needed for self_update validation.

- Related ticket: https://progress.opensuse.org/issues/198923
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/21700626
