### PR TITLE
Change to use default ovmf binaries for sle15sp7 guest on sle16.1 host

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_kvm_hvm_uefi_with_power_management_x86_64.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_15_sp7_64_kvm_hvm_uefi_with_power_management_x86_64.xml
@@ -26,7 +26,7 @@
     <guest_installation_wait/>
     <guest_installation_method_others/>
     <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP7-Full-x86_64-GM-Media1/</guest_installation_media>
-    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-ms-code.bin,loader.readonly=yes,loader.type=pflash,hd,network</guest_boot_settings>
+    <guest_boot_settings>uefi,loader.readonly=yes,loader.type=pflash,hd,network</guest_boot_settings>
     <guest_secure_boot>true</guest_secure_boot>
     <guest_os_variant/>
     <guest_storage_path/>


### PR DESCRIPTION
`ovmf-x86_64-ms-code.bin` is specified in virt-install currently, but this file is not present on the latest build any more, so change to use the default OVMF binaries,  `ovmf-x86_64-smm-ms*`.

- Related ticket: https://progress.opensuse.org/issues/199361

- Verification run: 
https://openqa.suse.de/tests/21741707
https://openqa.suse.de/tests/21741706