### PR TITLE
Fix kernel devel build dependency in PC LTP

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -55,8 +55,9 @@ sub install_build_deps {
     # Sample value: kernel-default-devel-6.12.0-160000.27.1
     my $kernel_devel_pkg = $instance->ssh_script_output(cmd => q{
         rpm -qf /boot/config-$(uname -r) \
-        | sed -e "s/\.$(arch)//" \
-              -e "s/^kernel-\([^-]\+\)-/kernel-\1-devel-/"
+        | sed -r 's/\.[^.]*$//' \
+        | cut -d- -f2- \
+        | awk -F- '{print "kernel-" $1 "-devel-" substr($0, index($0,$2))}'
     });
 
     push @deps, $kernel_devel_pkg;


### PR DESCRIPTION
Continuation of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25166

Adapt to changes introduced by
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25234

When using $'...', \1 is interpreted as an ANSI C escape (octal),
resulting in a control character instead of a backreference.
Switch to combination of sed, cut and awk to resolve the issue.

- Related ticket: https://progress.opensuse.org/issues/199364
- Verification run: https://openqa.suse.de/tests/21745325#step/run_ltp/38