### PR TITLE
xfstests: Create the dir before write local.config

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -134,6 +134,7 @@ sub do_partition_for_xfstests {
     # Create mount points
     script_run("mkdir $TEST_FOLDER $SCRATCH_FOLDER");
     # Setup configure file xfstests/local.config
+    script_run("mkdir -p \$(dirname $CONFIG_FILE)");
     script_run("echo 'export FSTYP=$para{fstype}' >> $CONFIG_FILE") if ($para{fstype} !~ /overlay/);
     script_run("echo 'export TEST_DEV=$test_dev' >> $CONFIG_FILE");
     set_var('XFSTESTS_TEST_DEV', $test_dev);


### PR DESCRIPTION
For some reason, the xfstests installer may not create the folder containing local.config(by default it would be /opt/xfstests), it will cause fail when write to it directly
And it would be safe if the dir already exist for `mkdir -p`.

- Related ticket: https://progress.opensuse.org/issues/199373
- Verification run: https://openqa.suse.de/tests/21760700