### PR TITLE
pc: img_proof: Prepare the instance in separate test module

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -107,30 +107,15 @@ sub load_publiccloud_consoletests {
     loadtest 'console/libgcrypt' unless check_var('BETA', '1') && !get_var('PUBLIC_CLOUD_QAM');
 }
 
-my $should_use_runargs = sub {
-    my @public_cloud_variables = qw(
-      PUBLIC_CLOUD_BTRFS
-      PUBLIC_CLOUD_CONSOLE_TESTS
-      PUBLIC_CLOUD_CONTAINERS
-      PUBLIC_CLOUD_SMOKETEST
-      PUBLIC_CLOUD_EXTRATESTS
-      PUBLIC_CLOUD_AZURE_NFS_TEST
-      PUBLIC_CLOUD_NVIDIA
-      PUBLIC_CLOUD_FUNCTIONAL
-      PUBLIC_CLOUD_AHB
-      PUBLIC_CLOUD_NEW_INSTANCE_TYPE);
-    return grep { exists $bmwqemu::vars{$_} } @public_cloud_variables;
-};
-
 sub load_latest_publiccloud_tests {
     my $args = OpenQA::Test::RunArgs->new();
+
     if (get_var('PUBLIC_CLOUD_UPLOAD_IMG')) {
         loadtest "publiccloud/upload_image", run_args => $args;
         return;    # Do not continue as there is no instance to destroy
-    } elsif (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
-        loadtest "publiccloud/img_proof", run_args => $args;
     }
-    elsif (get_var('PUBLIC_CLOUD_LTP')) {
+
+    if (get_var('PUBLIC_CLOUD_LTP')) {
         loadtest 'publiccloud/run_ltp', run_args => $args;
     }
     elsif (get_var('PUBLIC_CLOUD_ACCNET')) {
@@ -141,52 +126,55 @@ sub load_latest_publiccloud_tests {
     }
     elsif (get_var('PUBLIC_CLOUD_AZURE_AITL')) {
         loadtest "publiccloud/azure_aitl", run_args => $args;
-    }
-    elsif (&$should_use_runargs()) {
+    } else {    # All test cases below require prepare_instance
         loadtest "publiccloud/prepare_instance", run_args => $args;
-        loadtest("publiccloud/registration", run_args => $args);
-        if (get_var('PUBLIC_CLOUD_FUNCTIONAL')) {
-            loadtest('publiccloud/cloud_netconfig', run_args => $args);
-            loadtest('publiccloud/suspending', run_args => $args) if (is_sle('15-SP6+'));
-        } elsif (check_var('PUBLIC_CLOUD_AHB', 1)) {
-            loadtest('publiccloud/ahb', run_args => $args);
-        } elsif (get_var('PUBLIC_CLOUD_NEW_INSTANCE_TYPE')) {
-            loadtest("publiccloud/bsc_1205002", run_args => $args);
-        } else {
-            loadtest("publiccloud/check_services", run_args => $args) if (get_var('PUBLIC_CLOUD_SMOKETEST'));
-            loadtest "publiccloud/ssh_interactive_start", run_args => $args;
-            loadtest "publiccloud/instance_overview", run_args => $args;
-            if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
-                load_publiccloud_consoletests($args);
-            } elsif (get_var('PUBLIC_CLOUD_BTRFS')) {
-                loadtest 'publiccloud/btrfs', run_args => $args;
-                loadtest 'publiccloud/snapper', run_args => $args;
-            }
-            elsif (check_var('PUBLIC_CLOUD_NVIDIA', 1)) {
-                die "ConfigError: The provider is not supported\n" unless (check_var('PUBLIC_CLOUD_PROVIDER', 'GCE') && is_sle('15-SP4+'));
-                loadtest "publiccloud/nvidia", run_args => $args;
-            }
-            elsif (get_var('PUBLIC_CLOUD_CONTAINERS')) {
-                load_container_tests();
-            } elsif (get_var('PUBLIC_CLOUD_SMOKETEST')) {
-                loadtest "publiccloud/smoketest", run_args => $args;
-                # flavor_check is concentrated on checking things which make sense only for image which is registered
-                # against internal Public Cloud infra, so whenever we using SUSEConnect whole module does not make much sense
-                loadtest "publiccloud/flavor_check", run_args => $args if (is_ec2() && !check_var('PUBLIC_CLOUD_SCC_ENDPOINT', 'SUSEConnect'));
-                loadtest "publiccloud/systemd_detect_virt", run_args => $args;
-                loadtest "publiccloud/sev", run_args => $args if (get_var('PUBLIC_CLOUD_CONFIDENTIAL_VM'));
-                loadtest "publiccloud/xen", run_args => $args if (get_var('PUBLIC_CLOUD_XEN'));
-            } elsif (get_var('PUBLIC_CLOUD_XFS')) {
-                loadtest "publiccloud/xfsprepare", run_args => $args;
-            } elsif (get_var('PUBLIC_CLOUD_AZURE_NFS_TEST')) {
-                loadtest("publiccloud/azure_nfs", run_args => $args);
-            } elsif (get_var('PUBLIC_CLOUD_EXTRATESTS')) {
-                loadtest "publiccloud/selinux" if (is_sle("16.0+"));
-                loadtest "publiccloud/gcp_google_guest_agent" if (is_gce() && is_sle("16.0+"));
+        if (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
+            loadtest "publiccloud/img_proof", run_args => $args;
+        } else {    # All test cases below require registration
+            loadtest("publiccloud/registration", run_args => $args);
+            if (get_var('PUBLIC_CLOUD_FUNCTIONAL')) {
+                loadtest('publiccloud/cloud_netconfig', run_args => $args);
+                loadtest('publiccloud/suspending', run_args => $args) if (is_sle('15-SP6+'));
+            } elsif (check_var('PUBLIC_CLOUD_AHB', 1)) {
+                loadtest('publiccloud/ahb', run_args => $args);
+            } elsif (get_var('PUBLIC_CLOUD_NEW_INSTANCE_TYPE')) {
+                loadtest("publiccloud/bsc_1205002", run_args => $args);
+            } else {    # All test cases below excluding check_service require tunelled environment
+                loadtest("publiccloud/check_services", run_args => $args) if (get_var('PUBLIC_CLOUD_SMOKETEST'));
+                loadtest "publiccloud/ssh_interactive_start", run_args => $args;
+                loadtest "publiccloud/instance_overview", run_args => $args;
+                if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
+                    load_publiccloud_consoletests($args);
+                } elsif (get_var('PUBLIC_CLOUD_BTRFS')) {
+                    loadtest 'publiccloud/btrfs', run_args => $args;
+                    loadtest 'publiccloud/snapper', run_args => $args;
+                }
+                elsif (check_var('PUBLIC_CLOUD_NVIDIA', 1)) {
+                    die "ConfigError: The provider is not supported\n" unless (check_var('PUBLIC_CLOUD_PROVIDER', 'GCE') && is_sle('15-SP4+'));
+                    loadtest "publiccloud/nvidia", run_args => $args;
+                }
+                elsif (get_var('PUBLIC_CLOUD_CONTAINERS')) {
+                    load_container_tests();
+                } elsif (get_var('PUBLIC_CLOUD_SMOKETEST')) {
+                    loadtest "publiccloud/smoketest", run_args => $args;
+                    # flavor_check is concentrated on checking things which make sense only for image which is registered
+                    # against internal Public Cloud infra, so whenever we using SUSEConnect whole module does not make much sense
+                    loadtest "publiccloud/flavor_check", run_args => $args if (is_ec2() && !check_var('PUBLIC_CLOUD_SCC_ENDPOINT', 'SUSEConnect'));
+                    loadtest "publiccloud/systemd_detect_virt", run_args => $args;
+                    loadtest "publiccloud/sev", run_args => $args if (get_var('PUBLIC_CLOUD_CONFIDENTIAL_VM'));
+                    loadtest "publiccloud/xen", run_args => $args if (get_var('PUBLIC_CLOUD_XEN'));
+                } elsif (get_var('PUBLIC_CLOUD_XFS')) {
+                    loadtest "publiccloud/xfsprepare", run_args => $args;
+                } elsif (get_var('PUBLIC_CLOUD_AZURE_NFS_TEST')) {
+                    loadtest("publiccloud/azure_nfs", run_args => $args);
+                } elsif (get_var('PUBLIC_CLOUD_EXTRATESTS')) {
+                    loadtest "publiccloud/selinux" if (is_sle("16.0+"));
+                    loadtest "publiccloud/gcp_google_guest_agent" if (is_gce() && is_sle("16.0+"));
+                } else {
+                    die "*publiccloud - Latest* expects PUBLIC_CLOUD_* job variable. None is matched from the expected ones.";
+                }
             }
         }
-    } else {
-        die "*publiccloud - Latest* expects PUBLIC_CLOUD_* job variable. None is matched from the expected ones.";
     }
     loadtest('publiccloud/destroy', run_args => $args);
 }

--- a/tests/publiccloud/destroy.pm
+++ b/tests/publiccloud/destroy.pm
@@ -19,9 +19,18 @@ sub run {
     my $instance = $args->{my_instance};
     select_host_console(force => 1);
 
-    upload_final_logs($instance);
-    $provider->upload_boot_diagnostics();
-    $provider->teardown();
+    if ($instance) {
+        upload_final_logs($instance);
+    } else {
+        record_info('The $instance object is not available. The upload_final_logs() will not be executed.');
+    }
+
+    if ($provider) {
+        $provider->upload_boot_diagnostics();
+        $provider->teardown();
+    } else {
+        die('The $provider object is not available. We are not able to destroy the testing infrastructure.');
+    }
 }
 
 sub upload_final_logs {

--- a/tests/publiccloud/destroy.pm
+++ b/tests/publiccloud/destroy.pm
@@ -22,7 +22,7 @@ sub run {
     if ($instance) {
         upload_final_logs($instance);
     } else {
-        record_info('The $instance object is not available. The upload_final_logs() will not be executed.');
+        record_info('Undef instance', 'The $instance object is not available. The logs will not be uploaded.');
     }
 
     if ($provider) {

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -40,7 +40,7 @@ sub run {
     $args->{my_provider} = $self->provider_factory();
     $args->{my_instance} = $args->{my_provider}->create_instance(%instance_args);
     $args->{my_instance}->wait_for_guestregister() if (is_ondemand);
-    my $provider = $args->{my_provider};
+    my $provider = $self->{my_provider} = $args->{my_provider};
     my $instance = $args->{my_instance};
 
     $instance->network_speed_test();
@@ -64,7 +64,8 @@ sub run {
 sub test_flags {
     return {
         fatal => 1,
-        milestone => 1
+        milestone => 1,
+        no_rollback => 1
     };
 }
 


### PR DESCRIPTION
- Related ticket: [poo#198929](https://progress.opensuse.org/issues/198929)
- Verification run:
[Builddestroy](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=destroy&distri=sle&version=15-SP7) of sle-15-SP7-Azure-Basic-Updates.x86_64	[publiccloud_consoletests@64bit](https://pdostal-workbench.qe.prg2.suse.org/tests/384)
[Builddestroy](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=destroy&distri=sle&version=15-SP7) of sle-15-SP7-Server-DVD-Updates.x86_64	[publiccloud_tools_cli_ec2@64bit](https://pdostal-workbench.qe.prg2.suse.org/tests/387)
[Builddestroy](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=destroy&distri=sle-micro&version=6.1) of sle-micro-6.1-EC2-BYOS-Updates.x86_64	[publiccloud_download_testrepos@64bit](https://pdostal-workbench.qe.prg2.suse.org/tests/380)
[Builddestroy](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=destroy&distri=sle&version=16.0) of sle-16.0-EC2.x86_64	[publiccloud_img_proof@ec2_m5d.large](https://pdostal-workbench.qe.prg2.suse.org/tests/389)
[Builddestroy](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=destroy&distri=sle&version=16.0) of sle-16.0-EC2.x86_64	[publiccloud_smoketests@ec2_i3.large](https://pdostal-workbench.qe.prg2.suse.org/tests/388)
[Builddestroy](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=destroy&distri=sle-micro&version=6.1) of sle-micro-6.1-EC2-BYOS-Updates.x86_64	[slem_basic@ec2_t3a.small](https://pdostal-workbench.qe.prg2.suse.org/tests/379)
[Builddestroy](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=destroy&distri=sle&version=15-SP7) of sle-15-SP7-Server-DVD-Updates.x86_64	[azure_himmelblau@64bit](https://pdostal-workbench.qe.prg2.suse.org/tests/386)
[Builddestroy](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=destroy&distri=sle&version=15-SP7) of sle-15-SP7-Azure-BYOS-Updates.aarch64	[publiccloud_cloud_functional@64bit](https://pdostal-workbench.qe.prg2.suse.org/tests/382)
[Builddestroy](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=destroy&distri=sle&version=16.0) of sle-16.0-EC2.x86_64	[publiccloud_btrfstests@ec2_t3a.large](https://pdostal-workbench.qe.prg2.suse.org/tests/385)
[Builddestroy](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=destroy&distri=sle-micro&version=6.1) of sle-micro-6.1-EC2-BYOS-Updates.aarch64	[publiccloud_slem_containers@ec2_c6g.large](https://pdostal-workbench.qe.prg2.suse.org/tests/383)
[Builddestroy](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=destroy&distri=sle-micro&version=6.1) of sle-micro-6.1-EC2-BYOS-Updates.aarch64	[publiccloud_ltp@ec2_c6g.large](https://pdostal-workbench.qe.prg2.suse.org/tests/381)
[Builddestroy](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=destroy&distri=sle&version=16.0) of sle-16.0-GCE-Maintenance-Images.x86_64	[publiccloud_img_proof@gce_n1_standard_2](https://pdostal-workbench.qe.prg2.suse.org/tests/378)