### PR TITLE
Add migration for Leap16.1 to SLES16.1

### DIFF
--- a/data/yam/agama/auto/leap.jsonnet
+++ b/data/yam/agama/auto/leap.jsonnet
@@ -1,0 +1,18 @@
+{
+  product: {
+    id: 'openSUSE_Leap'
+  },
+  bootloader: {
+    stopOnBootMenu: true,
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard'
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+  },
+}

--- a/schedule/yam/agama_migration_leap.yaml
+++ b/schedule/yam/agama_migration_leap.yaml
@@ -1,0 +1,14 @@
+---
+name: agama_migration_leap
+description: >
+  Migration from openSUSE Leap using zypper migration
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - yam/migration/zypper_migration
+  - yam/validate/validate_migration_logs
+  - yam/validate/validate_product
+  - console/validate_repos

--- a/tests/yam/migration/zypper_migration.pm
+++ b/tests/yam/migration/zypper_migration.pm
@@ -25,6 +25,10 @@ sub run {
     };
 
     select_console 'root-console';
+
+    # Register openSUSE Leap against SCC; Leap can not be registered against ProxySCC, it is not available on ProxySCC.
+    assert_script_run("SUSEConnect -r " . get_var("SCC_REGCODE"), timeout => 60) if (get_var("ISO") =~ /Leap/);
+
     assert_script_run("echo 'url: " . get_required_var('SCC_URL') . "' > /etc/SUSEConnect");
 
     script_run("(zypper migration; echo $zypper_done) |& tee /dev/$serialdev", 0);


### PR DESCRIPTION
Add migration for Leap16.1 to SLES16.1 by zypper migration.

- Related ticket: https://progress.opensuse.org/issues/198935
- Verification run: https://openqa.suse.de/tests/21861595#details
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/765
