### PR TITLE
Disable application_starts_on_login for SLE16 or above

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2015,11 +2015,13 @@ sub load_x11_gnome {
         loadtest "x11/gdm_session_switch";
         loadtest "x11/gnomecase/gnome_classic_switch";
     }
-    loadtest "x11/gnomecase/gnome_default_applications" if (is_sle('<16') || is_tumbleweed);
+    if (is_sle('<16') || is_tumbleweed) {
+        loadtest "x11/gnomecase/gnome_default_applications";
+        loadtest "x11/gnomecase/application_starts_on_login";
+    }
     loadtest "x11/gnomecase/nautilus_cut_file";
     loadtest "x11/gnomecase/nautilus_permission";
     loadtest "x11/gnomecase/nautilus_open_ftp";
-    loadtest "x11/gnomecase/application_starts_on_login";
     loadtest "x11/gnomecase/login_test";
     loadtest "x11/gnomecase/gnome_window_switcher";
     loadtest "x11/gnomecase/change_password";


### PR DESCRIPTION
application_starts_on_login needs gnome-tweaks.
We don't have gnome-tweaks on SLE16 and SLE16.1, so we need to disable application_starts_on_login for SLE16 or above

- Related ticket: https://progress.opensuse.org/issues/199211
- Needles: N/A
- Verification run: 

> SLE16.1 https://openqa.suse.de/tests/21758822#
> 15SP7 https://openqa.suse.de/tests/21759678#
