### PR TITLE
snapper_zypp: make use of is_community_jeos()

### DIFF
--- a/tests/console/snapper_zypp.pm
+++ b/tests/console/snapper_zypp.pm
@@ -14,7 +14,7 @@ use Mojo::Base 'consoletest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_community_jeos is_sle);
 use Test::Assert 'assert_equals';
 
 sub get_snapshot_id {
@@ -38,7 +38,7 @@ sub run_zypper_cmd {
 
 sub run {
     select_serial_terminal;
-    my $package = (get_var('FLAVOR', '') =~ /^JeOS/ ? 'vim-small' : 'vim');
+    my $package = (is_community_jeos() ? 'vim-small' : 'vim');
 
     assert_script_run("rpm -q snapper-zypp-plugin");
     run_zypper_cmd("rm $package", $package);


### PR DESCRIPTION
This will fix the test on Armv9 where the flavor is `Armv9JeOS-for-AArch64` and does not start with `JeOS`.

- Verification run: https://openqa.opensuse.org/tests/5840208#step/snapper_zypp/85
