### PR TITLE
Run *_ppc64le saptune pattern only for ppc64le on 16+

### DIFF
--- a/tests/sles4sap/saptune/mr_test_run.pm
+++ b/tests/sles4sap/saptune/mr_test_run.pm
@@ -429,17 +429,19 @@ sub test_override {
     foreach my $override (@overrides) {
         $self->workaround_for_bsc1260865() if is_sle('>=16');
 
-        $self->wrap_script_run("mr_test verify Pattern/${SLE}/testpattern_baseline_Cust");
+        my $suffix = (is_ppc64le() && is_sle('>=16') && is_pvm_hmc()) ? '_ppc64le' : '';
+        $self->wrap_script_run("mr_test verify Pattern/${SLE}/testpattern_baseline_Cust$suffix");
         $self->wrap_script_run("mr_test dump Pattern/$SLE/testpattern_note_${override}_b > baseline_testpattern_note_${override}_b");
         $self->wrap_script_run("cp Pattern/$SLE/override/$override /etc/saptune/override/$note");
         $self->wrap_script_run("saptune note apply $note");
-        $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_note_${override}_a_override");
+        my $override_suffix = ($suffix && $override eq '3565382') ? $suffix : '';
+        $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_note_${override}_a_override${override_suffix}");
         $self->wrap_script_run("mr_test verify baseline_testpattern_note_${override}_b");
         tune_baseline("baseline_testpattern_note_${override}_b");
         $self->reboot_wait;
         $self->workaround_for_bsc1260865() if is_sle('>=16');
 
-        $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_note_${override}_a_override");
+        $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_note_${override}_a_override${override_suffix}");
         $self->wrap_script_run("mr_test verify baseline_testpattern_note_${override}_b");
         $self->wrap_script_run("saptune note revert $note");
         $self->wrap_script_run("rm -f /etc/saptune/override/$note");


### PR DESCRIPTION
only run *_ppc64le saptune pattern for pvm_hmc on 16+ to avoid the issue:
https://openqa.suse.de/tests/21500441#step/1_saptune_overrides/438

- Related ticket: https://jira.suse.com/browse/TEAM-10994
- Needles: None
- Verification run:
    https://openqa.suse.de/tests/21760354 (16.1/ppc64le hmc)
    https://openqa.suse.de/tests/21760356 (16.0/ppc64le-p10-virtio)
    http://openqaworker15.qe.prg2.suse.org/tests/362468 (15-SP7/az_Standard_E4s_v3)
    https://openqa.suse.de/tests/21760343 (16.0/uefi-sap)