### PR TITLE
Fix missing whitespace in rebuild_initrd test module for s390x

### DIFF
--- a/tests/microos/rebuild_initrd.pm
+++ b/tests/microos/rebuild_initrd.pm
@@ -17,7 +17,7 @@ sub run {
     my ($self) = @_;
     select_console 'root-console';
 
-    assert_script_run(q|echo 'omit_dracutmodules+="ignition ignition-microos combustion"' > /etc/dracut.conf.d/20-disable_ignition.conf|);
+    assert_script_run(q|echo 'omit_dracutmodules+=" ignition ignition-microos combustion "' > /etc/dracut.conf.d/20-disable_ignition.conf|);
     trup_call('initrd');
     check_reboot_changes;
 }


### PR DESCRIPTION
As per dev comments, it should contain whitespace before and after the quotation marks of the line <omit_dracutmodules+="ignition ignition-microos combustion">  in rebuild_initrd test module. Refer to https://bugzilla.suse.com/show_bug.cgi?id=1259124

- Related ticket: https://progress.opensuse.org/issues/199430
- Verification run: https://openqa.suse.de/tests/21763559
