### PR TITLE
publiccloud: add timeout notification in jobs Details page

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -475,6 +475,7 @@ sub wait_for_ssh {
             }    # end loop
         }    # endif
         $exit_timeout = 1 if ($duration >= $args{timeout});
+        record_info('TIMEOUT', "System services still starting/waiting, while timeout expired: boot incomplete", result => 'fail') if $exit_timeout;
 
         if ($args{scan_ssh_host_key}) {
             record_info('RESCAN', 'Rescanning SSH host key');


### PR DESCRIPTION
Add clear debug notification on `timeout`, in openqa job _Details_ page, when the just-created cloud instance has incomplete boot still after a given time.
Improve the timeout-case identification.

Example of execution without this notification is [this test](https://openqa.suse.de/tests/21756059#step/img_proof/121), where the timeout was triggered, but other post-checks and notifications  were going on, before the status summary.