### PR TITLE
publiccloud: remove dead zypper_remove_repo_remote and unused import

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -60,7 +60,6 @@ our @EXPORT = qw(
   venv_activate
   get_python_exec
   zypper_add_repo_remote
-  zypper_remove_repo_remote
   wait_quit_zypper_pc
   detect_worker_ip
   zypper_call_remote
@@ -720,23 +719,6 @@ sub zypper_add_repo_remote {
     my ($instance, $repo_name, $repo_url) = @_;
     $instance->ssh_assert_script_run(
         cmd => "sudo zypper -n addrepo -fG $repo_url $repo_name",
-        timeout => 600
-    );
-}
-
-=head2 zypper_remove_repo_remote
-
-zypper_remove_repo_remote($instance, $repo_name)
-
-This function removes a repository from the remote instance using zypper.
-It uses the `-n` option to run the command non-interactively.
-
-=cut
-
-sub zypper_remove_repo_remote {
-    my ($instance, $repo_name) = @_;
-    $instance->ssh_assert_script_run(
-        cmd => "sudo zypper -n removerepo $repo_name",
         timeout => 600
     );
 }

--- a/t/13_publiccloud.t
+++ b/t/13_publiccloud.t
@@ -334,20 +334,6 @@ subtest '[zypper_add_repo_remote] passes correct cmd and timeout' => sub {
       'correct addrepo command';
 };
 
-subtest '[zypper_remove_repo_remote] passes correct cmd and timeout' => sub {
-    my $inst = Test::MockObject->new;
-    my @seen;
-    $inst->mock('ssh_assert_script_run', sub { push @seen, \@_; return 0 });
-
-    publiccloud::utils::zypper_remove_repo_remote($inst, 'repo-name');
-
-    is scalar(@seen), 1, 'one SSH call';
-    my %args = @{$seen[0]}[1 .. $#{$seen[0]}];
-    is $args{timeout}, 600, 'timeout 600';
-    is $args{cmd}, 'sudo zypper -n removerepo repo-name',
-      'correct removerepo command';
-};
-
 subtest '[wait_quit_zypper_pc] uses defaults and expected command' => sub {
     my $inst = Test::MockObject->new;
     my @calls;

--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -12,7 +12,7 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use version_utils 'is_sle';
 use publiccloud::ssh_interactive "select_host_console";
-use publiccloud::utils qw(is_ec2 is_gce is_azure registercloudguest register_addons_in_pc);
+use publiccloud::utils qw(is_ec2 is_gce is_azure registercloudguest);
 
 
 sub run {


### PR DESCRIPTION
## Summary
- Remove `zypper_remove_repo_remote` (sub definition, POD, `@EXPORT` entry, and unit test) — it was exported and tested but had zero production callers
- Remove unused `register_addons_in_pc` import from `tests/publiccloud/migration.pm`

Found during an audit of zypper usage across the public cloud test codebase. Eliminates dead code that adds confusion during code reviews and makes the zypper remote API surface appear larger than it actually is.