### PR TITLE
test: Add check for strictures in all test modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
             perl-version: 5.26
           - test: compile-os-autoinst
             perl-version: '5.40'
+          - test: check-strict
+            perl-version: '5.40'
     container:
       image: perldocker/perl-tester:${{ matrix.perl-version }}
     steps:
@@ -38,6 +40,7 @@ jobs:
         echo " requires 'Code::DRY';" >> cpanfile
         echo " requires 'Date::Parse';" >> cpanfile
         echo " requires 'Regexp::Common';" >> cpanfile
+        echo " requires 'Syntax::Keyword::Try';" >> cpanfile
         echo " requires 'Perl::Tidy', '== 20250616.0.0';" >> cpanfile
         . "$HOME/.cargo/env"
         make prepare

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,11 @@ test-compile-changed: os-autoinst/
 test-compile-os-autoinst: os-autoinst/
 	prove tools/check_os_autoinst_compile
 
+.PHONY: test-check-strict
+test-check-strict: os-autoinst/
+	perl ./os-autoinst/script/os-autoinst-testmodules-strict tests/**/*.pm -v --write
+	git diff --exit-code tests
+
 .PHONY: test_pod_whitespace_rule
 test_pod_whitespace_rule:
 	tools/check_pod_whitespace_rule
@@ -126,6 +131,8 @@ else ifeq ($(TESTS),compile-changed)
 test: test-compile-changed
 else ifeq ($(TESTS),compile-os-autoinst)
 test: test-compile-os-autoinst
+else ifeq ($(TESTS),check-strict)
+test: test-check-strict
 else ifeq ($(TESTS),static)
 test: test-static
 else ifeq ($(TESTS),unit)


### PR DESCRIPTION
Ensure that all modules use Mojo::Base for strict and warnings (unless explicitly requested to be ignored with '## no os-autoinst style')

- Ticket: https://progress.opensuse.org/issues/194002

