### PR TITLE
fix(ci): restrict permission of pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: ci
 # yamllint disable-line rule:truthy
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   static:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/os-autoinst/os-autoinst-distri-opensuse/security/code-scanning/3](https://github.com/os-autoinst/os-autoinst-distri-opensuse/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/ci.yml` at the workflow root so it applies to all jobs (including `static`).  
Best minimal fix without changing functionality is:

- Add:
  ```yaml
  permissions:
    contents: read
  ```
- Place it after the `on:` block and before `jobs:`.

This grants only the read access needed for checkout and prevents inheriting broader defaults.