### PR TITLE
publiccloud: route migration.pm zypper calls through zypper_call_remote

### DIFF
--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -13,7 +13,7 @@ use testapi;
 use Time::Piece;
 use version_utils 'is_sle';
 use publiccloud::ssh_interactive "select_host_console";
-use publiccloud::utils qw(is_ec2 is_gce is_azure registercloudguest);
+use publiccloud::utils qw(is_ec2 is_gce is_azure registercloudguest zypper_call_remote);
 
 
 sub run {
@@ -28,32 +28,32 @@ sub run {
     if (is_sle('=12-SP5')) {
         # https://bugzilla.suse.com/show_bug.cgi?id=1230009
         # aws-cli and azure-cli break the migration. This is known issue.
-        $instance->ssh_script_run("sudo zypper -n rm aws-cli", timeout => 900) if (is_ec2());
-        $instance->ssh_script_run("sudo zypper -n rm azure-cli python3-azure-devops python3-azure-nspkg", timeout => 900) if (is_azure());
+        zypper_call_remote($instance, cmd => "rm aws-cli", exitcode => [0, 104], timeout => 900) if (is_ec2());
+        zypper_call_remote($instance, cmd => "rm azure-cli python3-azure-devops python3-azure-nspkg", exitcode => [0, 104], timeout => 900) if (is_azure());
 
         # LTSS should be disabled before the migration
         $instance->ssh_assert_script_run("sudo SUSEConnect -d -p SLES-LTSS/12.5/x86_64", timeout => 180);
 
-        $instance->ssh_assert_script_run("sudo zypper -n ar -Gef -p90 " . get_required_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_12_SP5 Migration");
-        $instance->ssh_script_run("sudo zypper -n ref", timeout => 1800) if (is_ec2());
-        $instance->ssh_assert_script_run("sudo zypper -n in suse-migration-sle15-activation", timeout => 1800);
-        $instance->ssh_assert_script_run("sudo zypper -n rr Migration", timeout => 900);
-        $instance->ssh_assert_script_run("sudo zypper refresh-services --force", timeout => 180);
+        zypper_call_remote($instance, cmd => "ar -Gef -p90 " . get_required_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_12_SP5 Migration");
+        zypper_call_remote($instance, cmd => "ref", timeout => 1800, proceed_on_failure => 1) if (is_ec2());
+        zypper_call_remote($instance, cmd => "in suse-migration-sle15-activation", timeout => 1800);
+        zypper_call_remote($instance, cmd => "rr Migration", timeout => 900);
+        zypper_call_remote($instance, cmd => "refresh-services --force", timeout => 180);
 
         # Disable maintenance updates for the migration as directory is not available during it
-        $instance->ssh_script_run("sudo sudo sed -i 's/^enabled=1/enabled=0/' /etc/zypp/repos.d/SUSE_Maintenance_*");
+        $instance->ssh_script_run("sudo sed -i 's/^enabled=1/enabled=0/' /etc/zypp/repos.d/SUSE_Maintenance_*");
 
         # Reboot to run the migration
         $instance->softreboot(timeout => 3600);
         validate_version($instance);
 
         # Re-enable maintenance updates for the migration
-        $instance->ssh_script_run("sudo sudo sed -i 's/^enabled=0/enabled=1/' /etc/zypp/repos.d/SUSE_Maintenance_*");
+        $instance->ssh_script_run("sudo sed -i 's/^enabled=0/enabled=1/' /etc/zypp/repos.d/SUSE_Maintenance_*");
 
         # Try to install aws-cli and azure-cli as they were removed for the migration
-        $instance->ssh_script_run("sudo zypper -n ref", timeout => 1800) if (is_ec2());
-        $instance->ssh_assert_script_run("sudo zypper -n in aws-cli", timeout => 1800) if (is_ec2());
-        $instance->ssh_assert_script_run("sudo zypper -n in azure-cli", timeout => 1800) if (is_azure());
+        zypper_call_remote($instance, cmd => "ref", timeout => 1800, proceed_on_failure => 1) if (is_ec2());
+        zypper_call_remote($instance, cmd => "in aws-cli", timeout => 1800) if (is_ec2());
+        zypper_call_remote($instance, cmd => "in azure-cli", timeout => 1800) if (is_azure());
     }
 
     if (is_sle('=15-SP7')) {
@@ -64,14 +64,14 @@ sub run {
             $instance->ssh_assert_script_run(qq(echo -e "network:\\n    wicked2nm-continue-migration: true\\n" | sudo tee -a /etc/sle-migration-service.yml));
         }
 
-        $instance->ssh_assert_script_run("sudo zypper -n ar -Gef -p90 " . get_required_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_15_SP7 Migration");
-        $instance->ssh_script_run("sudo zypper -n ref", timeout => 1800) if (is_ec2());
-        $instance->ssh_assert_script_run("sudo zypper -n in SLES16-Migration suse-migration-sle16-activation", timeout => 1800);
-        $instance->ssh_assert_script_run("sudo zypper -n rr Migration", timeout => 900);
-        $instance->ssh_assert_script_run("sudo zypper refresh-services --force", timeout => 180);
+        zypper_call_remote($instance, cmd => "ar -Gef -p90 " . get_required_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_15_SP7 Migration");
+        zypper_call_remote($instance, cmd => "ref", timeout => 1800, proceed_on_failure => 1) if (is_ec2());
+        zypper_call_remote($instance, cmd => "in SLES16-Migration suse-migration-sle16-activation", timeout => 1800);
+        zypper_call_remote($instance, cmd => "rr Migration", timeout => 900);
+        zypper_call_remote($instance, cmd => "refresh-services --force", timeout => 180);
 
         # Disable maintenance updates for the migration as directory is not available during it
-        $instance->ssh_script_run("sudo sudo sed -i 's/^enabled=1/enabled=0/' /etc/zypp/repos.d/SUSE_Maintenance_*");
+        $instance->ssh_script_run("sudo sed -i 's/^enabled=1/enabled=0/' /etc/zypp/repos.d/SUSE_Maintenance_*");
 
         my $arch = get_required_var('ARCH');
         $instance->ssh_script_run("echo 'migration_product: SLES/16.0/$arch\\n' | sudo tee -a /etc/sle-migration-service.yml");


### PR DESCRIPTION
## Summary

- Convert 15 direct SSH zypper calls in `tests/publiccloud/migration.pm` to use `zypper_call_remote()` wrapper
- Fix 3 `sudo sudo` typos in `sed` calls

## Motivation

`migration.pm` was the largest file bypassing `zypper_call_remote`, with 14 direct SSH zypper calls that missed the wrapper's benefits:

- **No lock-wait guard** — `wait_quit_zypper_pc()` prevents ZYPP_LOCKED (exit 7) race conditions with background packagekit/zypper processes
- **No automatic retry** on transient errors (exit codes 4/7)
- **No zypper log upload/parsing** on failure — solver conflicts, capability-not-found, and RPM scriptlet failures go undiagnosed

## What changed

All zypper calls (`rm`, `ar`, `ref`, `in`, `rr`, `refresh-services`) now go through `zypper_call_remote()`:

- `rm` calls use `exitcode => [0, 104]` to accept "package not found" as success (matching original non-fatal intent)
- `ref` calls use `proceed_on_failure => 1` (matching original fire-and-forget intent via `ssh_script_run`)
- Fatal calls (`ar`, `in`, `rr`, `refresh-services`) use default behavior (die on failure, same as previous `ssh_assert_script_run`)
- `zypper lr` in `print_os_version` stays as `ssh_script_output` — it needs stdout capture which `zypper_call_remote` doesn't provide

Also fixed `sudo sudo sed` → `sudo sed` on 3 lines.

## Verification

### Current status

9 `publiccloud_migration` jobs in **Public Cloud Maintenance Updates** (group 427) cover this code:

| Version | Provider | Arch | Latest Job |
|---|---|---|---|
| 12-SP5 | EC2 | x86_64 | [21753441](https://openqa.suse.de/tests/21753441) |
| 12-SP5 | Azure | x86_64 | [21753442](https://openqa.suse.de/tests/21753442) |
| 12-SP5 | GCE | x86_64 | [21753477](https://openqa.suse.de/tests/21753477) |
| 15-SP7 | EC2 | x86_64 | [21753725](https://openqa.suse.de/tests/21753725) |
| 15-SP7 | EC2 | aarch64 | [21753727](https://openqa.suse.de/tests/21753727) |
| 15-SP7 | Azure | x86_64 | [21757591](https://openqa.suse.de/tests/21757591) |
| 15-SP7 | Azure | aarch64 | [21757593](https://openqa.suse.de/tests/21757593) |
| 15-SP7 | GCE | x86_64 | [21757599](https://openqa.suse.de/tests/21757599) |
| 15-SP7 | GCE | aarch64 | [21753741](https://openqa.suse.de/tests/21753741) |

All currently `softfailed` (baseline). EC2 jobs are the most critical as they exercise the `ref` + `rm`/reinstall code paths unique to EC2.

### VR runs: TBD