### PR TITLE
Remove workaround for target 16.1

### DIFF
--- a/tests/yam/migration/migration_unattended.pm
+++ b/tests/yam/migration/migration_unattended.pm
@@ -32,8 +32,6 @@ sub run {
 
     if ((get_var('SCC_URL', "") =~ /proxy/)) {
         zypper_call("rr Migration");
-        record_soft_failure 'bsc#1254800 - Migrate SLES15SP7 -> SLES16.1 needs a migration tools variant for 16.1';
-        assert_script_run('echo migration_product: SLES/' . get_var('VERSION') . '/' . get_var('ARCH') . ' > /etc/sle-migration-service.yml');
     }
 
     # deacivate unwanted/unsupported extensions before doing migration


### PR DESCRIPTION
As https://bugzilla.suse.com/show_bug.cgi?id=1254800#c6, we should remove the workaround to set 16.1 as migration target.

- Related ticket: quick PR.
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/21796481#step/migration_unattended/24
