### PR TITLE
mdadm: Sync after all mdadm --stop

### DIFF
--- a/data/qam/mdadm.sh
+++ b/data/qam/mdadm.sh
@@ -318,6 +318,7 @@ done
 run umount $MD_DEVICE
 run mdadm --detail --scan |& tee /var/tmp/mdadm.conf
 run mdadm --stop $MD_DEVICE
+run sync
 run mdadm --assemble --scan --config=/var/tmp/mdadm.conf
 run mount $MD_DEVICE $tempmnt
 mount | grep -F -q $tempmnt || exit 1
@@ -428,6 +429,7 @@ done
 run umount $MD_DEVICE
 run mdadm --detail --scan |& tee /var/tmp/mdadm.conf
 run mdadm --stop $MD_DEVICE
+run sync
 run mdadm --assemble --scan --config=/var/tmp/mdadm.conf
 run mount $MD_DEVICE $tempmnt
 mount | grep -F -q $tempmnt || exit 1


### PR DESCRIPTION
RAID5 is failing occasionally

- Related ticket: https://progress.opensuse.org/issues/198059
https://openqa.suse.de/tests/21773195#step/mdadm/18
https://openqa.suse.de/tests/21729385#step/mdadm/18
https://openqa.suse.de/tests/21727894#step/mdadm/18
