### PR TITLE
PC: Run wait_for_ssh separately

### DIFF
--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -35,10 +35,11 @@ sub run {
 
     # Create public cloud instance
     my %instance_args;
-    $instance_args{check_connectivity} = 1;
+    $instance_args{check_connectivity} = 0;    # Don't run wait_for_ssh() inside create_instance()
     $instance_args{use_extra_disk} = {size => $additional_disk_size, type => $additional_disk_type} if ($additional_disk_size > 0);
     $args->{my_provider} = $self->provider_factory();
     $args->{my_instance} = $args->{my_provider}->create_instance(%instance_args);
+    $args->{my_instance}->wait_for_ssh(scan_ssh_host_key => 1);
     $args->{my_instance}->wait_for_guestregister() if (is_ondemand);
     my $provider = $self->{my_provider} = $args->{my_provider};
     my $instance = $args->{my_instance};


### PR DESCRIPTION
Run `wait_for_ssh()` separately instead of inside `create_instances()`.

This solves the problem when `wait_for_ssh()` fails the system readiness check we still have the `$instance` property.

We need the `$instance` property for the `destroy.pm` to run `upload_final_logs()`.

* Verification run: [pdostal-workbench.qe.prg2.suse.org/t391](https://pdostal-workbench.qe.prg2.suse.org/tests/391) - The failure is unrelated.