### PR TITLE
pc: Download and transfer repo for xfstests

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -65,7 +65,9 @@ sub load_maintenance_publiccloud_tests {
         } elsif (get_var('PUBLIC_CLOUD_CONTAINERS')) {
             load_container_tests();
         } elsif (get_var('PUBLIC_CLOUD_XFS')) {
+            # xfstests call destroy internally
             loadtest "publiccloud/xfsprepare", run_args => $args;
+            return;
         } elsif (get_var('PUBLIC_CLOUD_SMOKETEST')) {
             loadtest "publiccloud/smoketest";
             # flavor_check is concentrated on checking things which make sense only for image which is registered
@@ -164,7 +166,9 @@ sub load_latest_publiccloud_tests {
                     loadtest "publiccloud/sev", run_args => $args if (get_var('PUBLIC_CLOUD_CONFIDENTIAL_VM'));
                     loadtest "publiccloud/xen", run_args => $args if (get_var('PUBLIC_CLOUD_XEN'));
                 } elsif (get_var('PUBLIC_CLOUD_XFS')) {
+                    # xfstests call destroy internally
                     loadtest "publiccloud/xfsprepare", run_args => $args;
+                    return;
                 } elsif (get_var('PUBLIC_CLOUD_AZURE_NFS_TEST')) {
                     loadtest("publiccloud/azure_nfs", run_args => $args);
                 } elsif (get_var('PUBLIC_CLOUD_EXTRATESTS')) {

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -32,6 +32,7 @@ use maintenance_smelt qw(is_embargo_update);
 my $openqa_port_allowed = 0;
 
 our @EXPORT = qw(
+  additional_repos
   deregister_addon
   define_secret_variable
   get_credentials
@@ -704,6 +705,31 @@ sub get_available_packages_remote {
 
     my @result = grep { $available{$_} } @not_installed;
     return join(' ', @result);
+}
+
+=head2 additional_repos
+
+additional_repos();
+
+This function returns a list of additional repos
+relevant to the Public Cloud job
+
+=cut
+
+sub additional_repos {
+    my @repos = ();
+
+    # Add repo for xfstests
+    if (get_var("PUBLIC_CLOUD_XFS")) {
+        my $version = get_required_var("VERSION");
+        my $prefix = "";
+        $prefix = "SLE" if is_sle;
+        $prefix = "SLES" if is_sle(">=16.0");
+        $prefix = "SL-Micro" if is_sle_micro(">=6.0");
+        die "Unsupported product for QA:Head" unless $prefix;
+        push @repos, "https://dist.suse.de/ibs/QA:/Head/$prefix-$version/";
+    }
+    return @repos;
 }
 
 =head2 zypper_add_repo_remote

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -257,7 +257,7 @@ sub register_addons_in_pc {
 # Validation for update repos
 sub validate_repo {
     my ($maintrepo) = @_;
-    if (is_sle_micro('>=6.0') || is_sle('>=16')) {
+    if (is_sle_micro('>=6.0') || is_sle('>=16') || get_var("PUBLIC_CLOUD_XFS")) {
         record_info("Product Increments", "Can't validate repository");
         return 1;
     }

--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -13,7 +13,7 @@ use testapi;
 use utils;
 use version_utils 'is_sle_micro';
 use publiccloud::ssh_interactive "select_host_console";
-use publiccloud::utils "validate_repo";
+use publiccloud::utils qw(additional_repos validate_repo);
 
 
 # Get the status of the update repos
@@ -59,6 +59,8 @@ sub run {
     my $regex = "'s390x\\/|ppc64le\\/|kernel*debuginfo*.rpm|src\\/'";
 
     set_var("PUBLIC_CLOUD_EMBARGOED_UPDATES_DETECTED", 0);
+
+    push @repos, additional_repos();
 
     for my $maintrepo (@repos) {
         unless (validate_repo($maintrepo)) {

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -15,7 +15,7 @@ use utils;
 use publiccloud::ssh_interactive "select_host_console";
 use maintenance_smelt qw(is_embargo_update);
 use version_utils qw(is_sle_micro is_sle);
-use publiccloud::utils qw(zypper_call_remote);
+use publiccloud::utils qw(additional_repos zypper_call_remote);
 
 sub run {
     my ($self, $args) = @_;
@@ -50,6 +50,8 @@ sub run {
             ($incident, $type) = ($2, $1) if ($maintrepo =~ /\/(PTF|Maintenance):\/(\d+)/g);
             push(@repos, $maintrepo) unless (is_embargo_update($incident, $type)); }
     }
+
+    push @repos, additional_repos();
 
     s/https?:\/\/.*\/ibs\/// for @repos;
 

--- a/tests/publiccloud/xfsprepare.pm
+++ b/tests/publiccloud/xfsprepare.pm
@@ -22,23 +22,6 @@ use utils;
 my $INST_DIR = '/opt/xfstests';
 my $CONFIG_FILE = "$INST_DIR/local.config";
 
-# The filesystems repo has different links for different versions now
-sub get_filesystem_repo {
-    my $version = get_required_var('VERSION');
-    # The naming scheme of the filesystems repo depens on the version. See https://download.opensuse.org/repositories/filesystems/
-    # For SLE<15-SP4 -     e.g. https://download.opensuse.org/repositories/filesystems/SLE_15_SP3
-    # From 15-SP4 onwards: e.g. https://download.opensuse.org/repositories/filesystems/15.4
-    if (is_sle("<15-SP5")) {
-        $version =~ s/-/_/g;    # Version in repo-path needs an underscore instead of a dash
-        return "https://download.opensuse.org/repositories/filesystems/SLE_${version}/";
-    } elsif (is_sle(">=15-SP5")) {
-        $version =~ s/-SP/./g;    # Unified versions with dot (e.g. 15.3)
-        return "https://download.opensuse.org/repositories/filesystems/${version}/";
-    } else {
-        die "Unsupported version: $version for the filesystems repo";
-    }
-}
-
 # Check if the given user exists, and if not, add it to the system
 sub ensure_user_exists {
     my ($user, $uid) = @_;
@@ -47,8 +30,6 @@ sub ensure_user_exists {
 
 # Install requirements
 sub install_xfstests {
-    my ($repo) = @_;
-    zypper_ar($repo, name => "filesystems");    # Add filesystem repository, which contains the xfstests
     if (is_sle) {
         # packagehub is required for dbench (required for e.g. generic/241)
         if (is_azure) {
@@ -59,15 +40,15 @@ sub install_xfstests {
     }
     my $packages = "xfsprogs xfsdump btrfsprogs kernel-default xfstests fio";
     $packages .= " dbench" unless (is_sle("<15"));    # dbench is not available on <SLE15
-    zypper_call("in $packages");
+    zypper_call("in --allow-vendor-change $packages");
     assert_script_run('ln -s /usr/lib/xfstests/ /opt/xfstests');    # xfstests/run expects the tests to be in /opt/xfstests
     record_info("xfstests", script_output("rpm -q xfstests"));
     # Ensure users 'nobody' and 'daemon' exists
     ensure_user_exists("nobody", 65534);
     ensure_user_exists("daemon", 2);
     # Create test users (See https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git/tree/README)
-    assert_script_run("useradd -mU fsgqa");    # Create home directory (-m) and 'fsgqa' group for the user (-U) as well
-    assert_script_run("useradd fsgqa2");
+    script_run("useradd -mU fsgqa");    # Create home directory (-m) and 'fsgqa' group for the user (-U) as well
+    script_run("useradd fsgqa2");
 
     # The following is only required by few tests and there is a chance that users starting with digits won't work
     my $fsgqa_123456 = script_run("useradd 123456-fsgqa") == 0;
@@ -176,7 +157,9 @@ sub run {
         die "'$device' size does not match PUBLIC_CLOUD_HDD2_SIZE" unless $hdd2_size == $dev_size;
     }
 
-    install_xfstests(get_filesystem_repo());
+    # We assume that the repo was downloaded and transferred to
+    # the SUT in the download_repos & transfer_repos modules.
+    install_xfstests();
     partition_disk($device, $mnt_xfs, $mnt_scratch);
     create_config($device, $mnt_xfs, $mnt_scratch);
     script_run("source $CONFIG_FILE");


### PR DESCRIPTION
- Introduce `additional_repos` function to inject repos that will be downloaded and transferred to the SUT.
- For now use the above function to inject the QA:/Head repo for the xfstests.
- Fix the xfstests not running because the instance was destroyed first with the job passing: 
https://openqa.suse.de/tests/21741101

Related ticket: https://progress.opensuse.org/issues/199394
Verification runs:
- 12-SP5: https://openqa.suse.de/tests/21807128
- 15-SP7: https://openqa.suse.de/tests/21807129

Notes
- The above tests fail because the xfstests package is newer and they must be sorted out.
- Some assertions removed due to https://openqa.suse.de/tests/21800541#step/xfsprepare/80
