### PR TITLE
Add agnostic test for go-1.24+ PQ key exchange

### DIFF
--- a/data/security/openqa_agnostic/goPostQuantum/go.mod
+++ b/data/security/openqa_agnostic/goPostQuantum/go.mod
@@ -1,0 +1,3 @@
+module postquantum
+
+go 1.24.0

--- a/data/security/openqa_agnostic/goPostQuantum/main.go
+++ b/data/security/openqa_agnostic/goPostQuantum/main.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log"
+	"os"
+	"time"
+)
+
+func main() {
+	cert, err := tls.LoadX509KeyPair("cert.pem", "key.pem")
+	if err != nil {
+		log.Fatalf("LoadX509KeyPair: %v", err)
+	}
+
+	ca, err := os.ReadFile("cert.pem")
+	if err != nil {
+		log.Fatalf("ReadFile: %v", err)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(ca)
+
+	serverConfig := &tls.Config{
+		Certificates:     []tls.Certificate{cert},
+		ClientCAs:        pool,
+		MinVersion:       tls.VersionTLS13,
+		CurvePreferences: []tls.CurveID{tls.X25519MLKEM768},
+	}
+
+	clientConfig := &tls.Config{
+		RootCAs:            pool,
+		ServerName:         "localhost",
+		MinVersion:         tls.VersionTLS13,
+		MaxVersion:         tls.VersionTLS13,
+		InsecureSkipVerify: true,
+		CurvePreferences:   []tls.CurveID{tls.X25519MLKEM768},
+	}
+
+	done := make(chan bool)
+
+	go func() {
+		listener, err := tls.Listen("tcp", "localhost:8443", serverConfig)
+		if err != nil {
+			log.Fatalf("Server Listen: %v", err)
+		}
+		defer listener.Close()
+
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Fatalf("Server Accept: %v", err)
+		}
+		defer conn.Close()
+
+		buf := make([]byte, 1024)
+		n, err := conn.Read(buf)
+		if err != nil {
+			log.Fatalf("Server Read: %v", err)
+		}
+
+		fmt.Printf("Server: received %q\n", string(buf[:n]))
+
+		err = conn.(*tls.Conn).Handshake()
+		if err != nil {
+			log.Fatalf("Server Handshake: %v", err)
+		}
+
+		cs := conn.(*tls.Conn).ConnectionState()
+		fmt.Printf("Server: TLS ver=0x%x, cipher=0x%x\n", cs.Version, cs.CipherSuite)
+		done <- true
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	go func() {
+		conn, err := tls.Dial("tcp", "localhost:8443", clientConfig)
+		if err != nil {
+			log.Fatalf("Client Dial: %v", err)
+		}
+		defer conn.Close()
+
+		_, err = conn.Write([]byte("Hello, post-quantum world!"))
+		if err != nil {
+			log.Fatalf("Client Write: %v", err)
+		}
+
+		err = conn.Handshake()
+		if err != nil {
+			log.Fatalf("Client Handshake: %v", err)
+		}
+
+		cs := conn.ConnectionState()
+		fmt.Printf("Client: TLS ver=0x%x, cipher=0x%x\n", cs.Version, cs.CipherSuite)
+		done <- true
+	}()
+
+	<-done
+	<-done
+}

--- a/data/security/openqa_agnostic/goPostQuantum/runtest
+++ b/data/security/openqa_agnostic/goPostQuantum/runtest
@@ -1,0 +1,35 @@
+#!/bin/bash
+# METADATA_START
+# ---
+# test: post-quantum TLS
+# desc: Verifies post-quantum TLS 1.3 connection using X25519MLKEM768
+# steps:
+#   - generate self-signed certificate
+#   - start TLS server and client with post-quantum cipher suite
+#   - verify server receives message from client
+#   - verify TLS 1.3 connection established with post-quantum cipher
+# author: <emil.miler@suse.com>
+# maintainer: QE Security <none@suse.de>
+# expected: no errors raised, connection succeed
+# platform: Tumbleweed
+# tags: security tls post-quantum pq
+# ---
+# METADATA_END
+
+set -e
+
+case "${1:-}" in
+clean)
+    rm -f cert.pem key.pem
+    ;;
+"")
+    openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:secp384r1 \
+        -keyout key.pem -out cert.pem -days 365 -nodes \
+        -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" 2>/dev/null || true
+    go run .
+    ;;
+*)
+    echo "Usage: $0 [clean]"
+    exit 1
+    ;;
+esac

--- a/schedule/security/fips/fips_env_mode_textmode_extra.yaml
+++ b/schedule/security/fips/fips_env_mode_textmode_extra.yaml
@@ -36,6 +36,7 @@ schedule:
     - security/vsftpd/vsftpd_setup
     - security/vsftpd/vsftpd
     - security/vsftpd/lftp
+    - security/oqa_agnostic/go_post_quantum
     - console/ca_certificates_mozilla
     - console/unzip
     - console/rsync

--- a/schedule/security/fips/fips_ker_mode_textmode_extra.yaml
+++ b/schedule/security/fips/fips_ker_mode_textmode_extra.yaml
@@ -36,6 +36,7 @@ schedule:
     - security/vsftpd/vsftpd_setup
     - security/vsftpd/vsftpd
     - security/vsftpd/lftp
+    - security/oqa_agnostic/go_post_quantum
     - console/ca_certificates_mozilla
     - console/unzip
     - console/rsync

--- a/schedule/security/fips/sle16/fips_ker_mode_textmode_extra.yaml
+++ b/schedule/security/fips/sle16/fips_ker_mode_textmode_extra.yaml
@@ -42,3 +42,4 @@ schedule:
     - console/gdb
     - console/sysctl
     - console/clamav
+    - security/oqa_agnostic/go_post_quantum

--- a/tests/security/oqa_agnostic/go_post_quantum.pm
+++ b/tests/security/oqa_agnostic/go_post_quantum.pm
@@ -1,0 +1,53 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Run test for post-quantum cyphers in go >=2.14
+# Maintainer: QE Security <none@suse.de>
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils 'zypper_call';
+
+sub run {
+    select_serial_terminal;
+
+    # Install Go
+    record_info('Installing Go', 'Installing Go');
+    zypper_call 'in go';
+    my $go_version = script_output('go version');
+    die "Unable to parse Go version: $go_version" if ($go_version !~ /go(\d+)\.(\d+)/);
+    my ($major, $minor) = ($1, $2);
+    if ($major < 1 || ($major == 1 && $minor < 24)) {
+        record_soft_failure("Go >= 1.24.0 required (available $go_version); poo#182489");
+        return;
+    }
+    record_info('Go Version', $go_version);
+
+    # Prepare Test
+    record_info('Preparing', 'Downloading test files');
+    my $data_url = data_url('security/openqa_agnostic/goPostQuantum');
+    my $test_dir = '~/go_post_quantum';
+    assert_script_run "mkdir -p $test_dir";
+    my @files = ('main.go', 'go.mod', 'runtest');
+    for my $file (@files) {
+        assert_script_run "curl -s -o $test_dir/$file $data_url/$file";
+    }
+
+    # Run Test
+    record_info('Running', 'Executing the test binary');
+    assert_script_run "cd $test_dir && chmod +x runtest";
+    validate_script_output("./runtest", sub { m/Hello, post-quantum world!/ }, proceed_on_failure => 1);
+
+    # Cleanup
+    record_info('Cleaning', 'Cleaning');
+    assert_script_run "cd .. && rm -rf $test_dir";
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/182489
- Verification runs:
  - TW: https://openqa.opensuse.org/tests/5855113
  - 16.0 FIPS: https://openqa.suse.de/tests/21861908
  - 15.7 FIPS: https://openqa.suse.de/tests/21861909
  - 15.4 FIPS: https://openqa.suse.de/tests/21862265 (Softfail expected due to old Go version)
