### PR TITLE
Adapt repo setting for leap autoyast profile

### DIFF
--- a/data/autoyast_opensuse/opensuse_leap.xml.ep
+++ b/data/autoyast_opensuse/opensuse_leap.xml.ep
@@ -46,23 +46,9 @@
         <product_dir/>
       </listentry>
       <listentry t="map">
-        <alias>repo-debug</alias>
-        <media_url>http://download.opensuse.org/debug/distribution/leap/<%= $get_var->('VERSION') %>/repo/oss/</media_url>
-        <name>Debug Repository</name>
-        <priority t="integer">99</priority>
-        <product_dir/>
-      </listentry>
-      <listentry t="map">
-        <alias>repo-debug-update</alias>
-        <media_url>http://download.opensuse.org/debug/update/leap/<%= $get_var->('VERSION') %>/oss/</media_url>
-        <name>Update Repository (Debug)</name>
-        <priority t="integer">99</priority>
-        <product_dir/>
-      </listentry>
-      <listentry t="map">
-        <alias>repo-sle-debug-update</alias>
-        <media_url>http://download.opensuse.org/debug/update/leap/<%= $get_var->('VERSION') %>/sle/</media_url>
-        <name>Update repository with debuginfo for updates from SUSE Linux Enterprise 15</name>
+        <alias>repo-openh264</alias>
+        <media_url>http://codecs.opensuse.org/openh264/openSUSE_Leap/</media_url>
+        <name>Open H.264 Codec (openSUSE Leap)</name>
         <priority t="integer">99</priority>
         <product_dir/>
       </listentry>


### PR DESCRIPTION
1. added 'openh264'
2. removed 'debug' repos

https://progress.opensuse.org/issues/198977

- Verification run:

[autoyast](https://openqa.opensuse.org/tests/overview?build=rfan0414_new&version=15.6&distri=opensuse)