### PR TITLE
PC: xfstests Make sure we always run destroy.pm

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -67,6 +67,7 @@ sub load_maintenance_publiccloud_tests {
         } elsif (get_var('PUBLIC_CLOUD_XFS')) {
             # xfstests call destroy internally
             loadtest "publiccloud/xfsprepare", run_args => $args;
+            loadtest "xfstests/run", run_args => $args;
             return;
         } elsif (get_var('PUBLIC_CLOUD_SMOKETEST')) {
             loadtest "publiccloud/smoketest";
@@ -168,6 +169,7 @@ sub load_latest_publiccloud_tests {
                 } elsif (get_var('PUBLIC_CLOUD_XFS')) {
                     # xfstests call destroy internally
                     loadtest "publiccloud/xfsprepare", run_args => $args;
+                    loadtest "xfstests/run", run_args => $args;
                     return;
                 } elsif (get_var('PUBLIC_CLOUD_AZURE_NFS_TEST')) {
                     loadtest("publiccloud/azure_nfs", run_args => $args);

--- a/tests/publiccloud/xfsprepare.pm
+++ b/tests/publiccloud/xfsprepare.pm
@@ -167,4 +167,16 @@ sub run {
     autotest::loadtest("tests/xfstests/run.pm", run_args => $args);
 }
 
+sub post_fail_hook {
+    my ($self) = @_;
+    my $args = $self->{run_args};
+    # In case this test module fails and xfstests/run where the
+    # publiccloud/destroy isn't loaded we load it here.
+    autotest::loadtest('tests/publiccloud/destroy.pm', run_args => $args);
+}
+
+sub test_flags {
+    return {fatal => 1, always_run => 1};
+}
+
 1;

--- a/tests/publiccloud/xfsprepare.pm
+++ b/tests/publiccloud/xfsprepare.pm
@@ -163,20 +163,10 @@ sub run {
     partition_disk($device, $mnt_xfs, $mnt_scratch);
     create_config($device, $mnt_xfs, $mnt_scratch);
     script_run("source $CONFIG_FILE");
-
-    autotest::loadtest("tests/xfstests/run.pm", run_args => $args);
-}
-
-sub post_fail_hook {
-    my ($self) = @_;
-    my $args = $self->{run_args};
-    # In case this test module fails and xfstests/run where the
-    # publiccloud/destroy isn't loaded we load it here.
-    autotest::loadtest('tests/publiccloud/destroy.pm', run_args => $args);
 }
 
 sub test_flags {
-    return {fatal => 1, always_run => 1};
+    return {fatal => 1};
 }
 
 1;

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -153,7 +153,6 @@ sub run {
             autotest::loadtest("tests/xfstests/run_subtest.pm", name => $test, run_args => $targs);
             mutex_lock 'last_subtest_run_finish';
             autotest::loadtest 'tests/xfstests/generate_report.pm';
-            autotest::loadtest("tests/publiccloud/destroy.pm", run_args => $args) if is_public_cloud();
         } else {
             autotest::loadtest("tests/xfstests/run_subtest.pm", name => $test, run_args => $targs);
         }
@@ -163,15 +162,26 @@ sub run {
 sub test_flags {
     return {
         fatal => 1,
-        milestone => 1
+        milestone => 1,
+        # We need to run this always on PC because of post_fail_hook()
+        always_run => (is_public_cloud()) ? 1 : 0
     };
+}
+
+sub post_run_hook {
+    my ($self) = @_;
+    cleanup($self->{run_args});
 }
 
 sub post_fail_hook {
     my ($self) = @_;
-    my $args = $self->{run_args};
-    autotest::loadtest('tests/publiccloud/destroy.pm', run_args => $args) if is_public_cloud();
+    cleanup($self->{run_args});
     return;
+}
+
+sub cleanup {
+    my ($args) = @_;
+    autotest::loadtest('tests/publiccloud/destroy.pm', run_args => $args) if is_public_cloud();
 }
 
 1;

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -154,8 +154,7 @@ sub run {
             mutex_lock 'last_subtest_run_finish';
             autotest::loadtest 'tests/xfstests/generate_report.pm';
             autotest::loadtest("tests/publiccloud/destroy.pm", run_args => $args) if is_public_cloud();
-        }
-        else {
+        } else {
             autotest::loadtest("tests/xfstests/run_subtest.pm", name => $test, run_args => $targs);
         }
     }
@@ -164,11 +163,14 @@ sub run {
 sub test_flags {
     return {
         fatal => 1,
-        milestone => 1,
+        milestone => 1
     };
 }
 
 sub post_fail_hook {
+    my ($self) = @_;
+    my $args = $self->{run_args};
+    autotest::loadtest('tests/publiccloud/destroy.pm', run_args => $args) if is_public_cloud();
     return;
 }
 


### PR DESCRIPTION
As `xfstests` are loaded dynamically in `tests/xfstests/run.pm` and that's loaded from `tests/publiccloud/xfsprepare.pm` and we need to make sure that we always load `tests/publiccloud/destroy.pm` at the very end.
But the test run might fail before `xfsprepare.pm` or `run.pm` and in that case our `destroy.pm` would not be loaded at all. That's what this ugly pull request tries to fix.

- Related ticket: [poo#199394](https://progress.opensuse.org/issues/199394)
- Related pull request: #25286
- Verification run: [Failing](https://pdostal-workbench.qe.prg2.suse.org/tests/409#step/destroy/222), [Passing](https://pdostal-workbench.qe.prg2.suse.org/tests/410#step/destroy/1)
