### PR TITLE
kernel: Extend validation flavors with SLE 15 maintenance QR flavors

### DIFF
--- a/lib/kernel.pm
+++ b/lib/kernel.pm
@@ -119,7 +119,7 @@ sub check_kernel_package {
 
 # Check if flavor is validation
 sub is_kernel_validation_flavor {
-    return get_var('FLAVOR', '') =~ /(Online|Online-Kernel-(RT|Base|Azure|Baremetal|(RT|64kb)-Baremetal))$/;
+    return get_var('FLAVOR', '') =~ /(Full-QR|Online-QR|Online|Online-Kernel-(RT|Base|Azure|Baremetal|(RT|64kb)-Baremetal))$/;
 }
 
 1;


### PR DESCRIPTION
Add Full-QR and Online-QR flavors to the list of validation flavors, which are SLE 15 maintenance QR flavors.

Fail: https://openqa.suse.de/tests/21761845#step/update_kernel/28

- Related ticket: none
- Needles: none
- Verification run: 
15-SP7 QR: https://openqa.suse.de/tests/overview?version=15-SP7&build=czerw%2Fos-autoinst-distri-opensuse%2325293&distri=sle
SLE 16.1 Online: https://openqa.suse.de/tests/21817490
SLE 15-SP6 inc: https://openqa.suse.de/tests/21817498
