### PR TITLE
Fix: Fetch credentials only via IPv4

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -306,7 +306,8 @@ sub get_credentials {
     my $url = $base_url . '/' . $args{namespace} . '/' . $args{url_suffix};
 
     my $url_auth = Mojo::URL->new($url)->userinfo("$user:$pwd");
-    my $ua = Mojo::UserAgent->new;
+    # Force the usage of IPv4 because we use IP address whitelisting. For unknown reasons both Domain and LocalAddr are required.
+    my $ua = Mojo::UserAgent->new(socket_options => {Domain => AF_INET, LocalAddr => '0.0.0.0'});
     $ua->insecure(1);
     my $tx = $ua->get($url_auth);
     my $res = $tx->result;


### PR DESCRIPTION
Force the usage of PublicCloud test credentials over IPv4 because we use an IP address allow-list.

For IPv6 in our configuration there is no guarantee that the outgoing connection will not use a temporary IPv6 address, which makes IP address allowlisting a futile task.

- Related ticket: https://progress.opensuse.org/issues/199562
- Verification run: https://duck-norris.qe.suse.de/tests/15239#step/prepare_instance/1
