### PR TITLE
Add '--terse' option for 'zypper_version_cmp'

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -829,26 +829,19 @@ sub zypper_ar {
 Compare the versions supplied as arguments and tell whether version1 is
 older or newer than version2 or the two version strings match.
 
-Example:
-# zypper vcmp 2.1 3.1
- 2.1 is older than 3.1
-# zypper vcmp 3.1 2.1
- 3.1 is newer than 2.1
-# zypper vcmp 3.1 3.1
- 3.1 matches 3.1
+The default output is in human-friendly form. If --terse global option is used,
+the result is an integer number, negative/positive if version1 is older/newer
+than version2, zero if they match.
 
 =cut
 
 sub zypper_version_cmp {
     my ($ver1, $ver2) = @_;
-    my ($ret, $output) = cmd_run("zypper vcmp $ver1 $ver2");
+    my ($ret, $output) = cmd_run("zypper --terse vcmp $ver1 $ver2");
     die "Zypper cannot compare $ver1 and $ver2" unless defined($ret) && grep { $_ == $ret } (0, 11, 12);
-
     chomp($output);
-
-    return -1 if ($output =~ /older/);
-    return 1 if ($output =~ /newer/);
-    return 0;
+    die "Invalid zypper output: $output" unless $output =~ m/^-?[01]$/;
+    return $output;
 }
 
 =head2 fully_patch_system


### PR DESCRIPTION
Adapt the code based on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25130#issuecomment-4181331671


- Related ticket: https://progress.opensuse.org/issues/197795
- [Verification run](https://openqa.suse.de/tests/overview?distri=sle&build=rfan0414_vcmp)