### PR TITLE
Use openssh-server-config-rootlogin instead of post-script to permit root login

### DIFF
--- a/data/yam/agama/auto/autoyast_supported.xml
+++ b/data/yam/agama/auto/autoyast_supported.xml
@@ -76,6 +76,10 @@ systemLog:
     </drive>
   </partitioning>
   <software>
+    <packages t="list">
+      <package>openssh</package>
+      <package>openssh-server-config-rootlogin</package>
+    </packages>
     <patterns config:type="list">
       <pattern>base</pattern>
       <pattern>minimal_base</pattern>
@@ -110,15 +114,5 @@ agama questions mode non-interactive
 ]]></source>
       </script>
     </pre-scripts>
-    <chroot-scripts config:type="list">
-      <script>
-        <file_name>post.sh</file_name>
-        <chrooted config:type="boolean">true</chrooted>
-        <source><![CDATA[
-#!/usr/bin/env bash
-echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
-]]></source>
-      </script>
-    </chroot-scripts>
   </scripts>
 </profile>

--- a/data/yam/agama/auto/autoyast_unsupported.xml
+++ b/data/yam/agama/auto/autoyast_unsupported.xml
@@ -79,6 +79,7 @@
   <software>
     <packages t="list">
       <package>openssh</package>
+      <package>openssh-server-config-rootlogin</package>
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>
@@ -104,18 +105,6 @@
       </authorized_keys>
     </user>
   </users>
-  <scripts>
-    <chroot-scripts config:type="list">
-      <script>
-        <file_name>post.sh</file_name>
-        <chrooted config:type="boolean">true</chrooted>
-        <source><![CDATA[
-#!/usr/bin/env bash
-echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
-]]></source>
-      </script>
-    </chroot-scripts>
-  </scripts>
   <audit-laf>
     <auditd>
       <flush>INCREMENTAL</flush>

--- a/data/yam/agama/auto/lib/scripts_post.libsonnet
+++ b/data/yam/agama/auto/lib/scripts_post.libsonnet
@@ -1,12 +1,4 @@
 {
-  enable_root_login: {
-    name: 'enable root login',
-    chroot: true,
-    content: |||
-      #!/usr/bin/env bash
-      echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
-    |||
-  },
   add_serial_console_hvc1: {
     name: 'add serial console hvc1 for ppc64le',
     chroot: true,


### PR DESCRIPTION


- Related ticket: https://progress.opensuse.org/issues/199079
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/768
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&build=lemon-suse%2Fos-autoinst-distri-opensuse%23use-openssh-server-config-rootlogin-instead-rootpermit&version=16.1
