### PR TITLE
toolbox: Skip on SLEM 5.2 that will be EOL on Apr30 due to poo#199412

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -413,7 +413,7 @@ sub load_container_tests {
             }
         } else {
             # Container Host tests
-            loadtest 'microos/toolbox' if (/podman/i && !is_staging && (is_sle_micro || is_microos || is_leap_micro));
+            loadtest 'microos/toolbox' if (/podman/i && !is_staging && (is_sle_micro(">=5.3") || is_microos || is_leap_micro));
             loadtest 'console/enable_mac' if get_var("SECURITY_MAC");
             load_host_tests_podman($run_args) if (/podman/i);
             load_host_tests_docker($run_args) if (/docker/i);


### PR DESCRIPTION
SLEM 5.2 will be EOL in 2 weeks and it makes no sense to spend a lot of time on this.

Failed job: https://openqa.suse.de/tests/21809839#step/toolbox/20
Related ticket: https://progress.opensuse.org/issues/199412
