### PR TITLE
test fails in perf - no supported events

### DIFF
--- a/tests/console/perf.pm
+++ b/tests/console/perf.pm
@@ -13,6 +13,35 @@ use serial_terminal 'select_serial_terminal';
 use utils 'zypper_call';
 use Utils::Architectures;
 
+# Auxiliar function to filter and group events
+sub run_perf_stat_grouped {
+    my $raw_list = script_output("perf list --raw-dump");
+
+    # Define groups of events
+    my %groups = (
+        "CPU_Usage" => [qw(cycles cpu-clock task-clock)],
+        "Execution" => [qw(instructions branches branch-misses)],
+        "Cache_Memory" => [qw(cache-references cache-misses page-faults)],
+        "System_Load" => [qw(bus-cycles context-switches cpu-migrations)]
+    );
+
+    foreach my $group_name (sort keys %groups) {
+        my @supported;
+        foreach my $event (@{$groups{$group_name}}) {
+            # Check if event exists in 'perf list'
+            push(@supported, $event) if ($raw_list =~ /\b$event\b/);
+        }
+
+        if (@supported) {
+            my $list = join(',', @supported);
+            record_info($group_name, "Testing: $list");
+            assert_script_run("perf stat -e $list -a sleep 2");
+        } else {
+            record_info($group_name, "No events supported for this category");
+        }
+    }
+}
+
 sub run {
     select_serial_terminal;
 
@@ -48,7 +77,9 @@ sub run {
     # Counting Events ( stat command)
     assert_script_run('perf stat ls');
     assert_script_run('perf stat -a sleep 5');
-    assert_script_run('perf stat -e cycles,instructions,cache-references,cache-misses,bus-cycles -a sleep 5');
+
+    run_perf_stat_grouped();
+
     assert_script_run("perf stat -e 'syscalls:sys_enter_*' -a sleep 5");
     assert_script_run("perf stat -e 'block:*' -a sleep 10");
     # test6


### PR DESCRIPTION
`perf stat -e cycles,instructions,cache-references,cache-misses,bus-cycles -a sleep 5` fails because the list of supported events is incorrect for XEN HVM guests. In this particular case we need to go through perf list select events that make sense for HVM and execute the above commands with the new list of events.

I grouped all the `perf` possible events in categories to have it sorted and prevent future failures for an unexistent event.

- Related ticket: https://progress.opensuse.org/issues/198473
- Verification run: https://openqa.suse.de/tests/21838424#step/perf/36
