### PR TITLE
fix: Declare variable so module compiles with strict

### DIFF
--- a/tests/console/timezone.pm
+++ b/tests/console/timezone.pm
@@ -15,9 +15,7 @@
 # - Revert timezone changes
 # Maintainer: Paolo Stivanin <pstivanin@suse.com>
 
-## no os-autoinst style
-
-use base 'opensusebasetest';
+use Mojo::Base 'opensusebasetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
@@ -49,7 +47,7 @@ sub run {
     assert_script_run("rpm -q timezone");
 
     validate_script_output("zdump Europe/London", sub { m/Europe\/London\s+\w{3} \w{3}\s+\d+ (\d{2}|:){5} \d{4} (GMT|BST)/ });
-    $dateformat = is_sle ? "+'%a %b %e %r %Z %Y'" : "";
+    my $dateformat = is_sle ? "+'%a %b %e %r %Z %Y'" : "";
     validate_script_output("LC_TIME=\$(localectl status | head -n1 | cut -d= -f2) date $dateformat", sub { m/\w{3} \w{3}\s+\d+ (\d{2}|:){5} (AM|PM) \w+ \d{4}/ });
 
     my $zdump_cmd = "zdump -v Europe/Rome | grep -E 'Sun Mar 25 [0-9]{2}:[0:9]{2}:[0-9]{2} 2018'";


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/194002
