### PR TITLE
fix: Import 'is_upgrade'

### DIFF
--- a/tests/installation/configure_bls.pm
+++ b/tests/installation/configure_bls.pm
@@ -6,12 +6,10 @@
 # Summary: Select systemd-boot in the installer
 # Maintainer: Fabian Vogt <fvogt@suse.com>
 
-## no os-autoinst style
-
-use base 'y2_installbase';
+use Mojo::Base 'y2_installbase';
 use testapi;
 use utils;
-use version_utils qw(is_bootloader_sdboot is_bootloader_grub2_bls is_bootloader_grub2 is_sle is_leap is_staging);
+use version_utils qw(is_bootloader_sdboot is_bootloader_grub2_bls is_bootloader_grub2 is_sle is_leap is_staging is_upgrade);
 
 sub run {
     my ($self) = shift;


### PR DESCRIPTION
Under strict:

    Bareword "is_upgrade" not allowed while "strict subs" in use at
    ./tests/installation/configure_bls.pm line 34.

Issue: https://progress.opensuse.org/issues/194002

