### PR TITLE
fix: Partially revert 4f22465829070330d1aefdfb108d2057e8877776

### DIFF
--- a/tests/kernel/ulp_openposix.pm
+++ b/tests/kernel/ulp_openposix.pm
@@ -6,9 +6,7 @@
 # Summary: Install glibc livepatch and run openposix testsuite
 # Maintainer: Martin Doucha <mdoucha@suse.cz>
 
-## no os-autoinst style
-
-use base 'opensusebasetest';
+use Mojo::Base 'opensusebasetest';
 use testapi;
 use utils;
 use serial_terminal;
@@ -20,6 +18,7 @@ use version_utils;
 use package_utils;
 
 sub parse_incident_repo {
+    my $incident_id = get_required_var('INCIDENT_ID');
     my $repo = get_required_var('INCIDENT_REPO');
     my @repos = split(",", $repo);
     my @repo_names;


### PR DESCRIPTION
Error under strict:

    Global symbol "$incident_id" requires explicit package name (did you forget to declare "my $incident_id"?) at ./tests/kernel/ulp_openposix.pm line 42.
    Global symbol "$incident_id" requires explicit package name (did you forget to declare "my $incident_id"?) at ./tests/kernel/ulp_openposix.pm line 46.
    Global symbol "$incident_id" requires explicit package name (did you forget to declare "my $incident_id"?) at ./tests/kernel/ulp_openposix.pm line 48.
    Global symbol "$incident_id" requires explicit package name (did you forget to declare "my $incident_id"?) at ./tests/kernel/ulp_openposix.pm line 60.

Issue: https://progress.opensuse.org/issues/194002
