### PR TITLE
fix: Import is_transactional function

### DIFF
--- a/tests/microos/image_checks.pm
+++ b/tests/microos/image_checks.pm
@@ -6,11 +6,9 @@
 # Summary: Run simple image specific checks
 # Maintainer: Fabian Vogt <fvogt@suse.de>
 
-## no os-autoinst style
-
-use base "consoletest";
+use Mojo::Base 'consoletest';
 use testapi;
-use version_utils qw(is_microos is_sle_micro is_jeos is_leap_micro);
+use version_utils qw(is_microos is_sle_micro is_jeos is_leap_micro is_transactional);
 use Utils::Backends 'is_pvm';
 use Utils::Architectures qw(is_aarch64 is_ppc64le);
 


### PR DESCRIPTION
    Bareword "is_transactional" not allowed while "strict subs" in use at
    ./tests/microos/image_checks.pm line 39.

Issue: https://progress.opensuse.org/issues/194002

