### PR TITLE
fix: Declare variable @new_binaries

### DIFF
--- a/tests/qam-updinstall/SLFO_update_install.pm
+++ b/tests/qam-updinstall/SLFO_update_install.pm
@@ -20,9 +20,7 @@
 #
 # Maintainer: QE Core <qe-core@suse.com>
 
-## no os-autoinst style
-
-use base "opensusebasetest";
+use Mojo::Base 'opensusebasetest';
 
 use utils;
 use power_action_utils qw(prepare_system_shutdown power_action);
@@ -178,6 +176,7 @@ sub run {
         zypper_call("in -l -t patch $patch", exitcode => [0, 102, 103], log => "zypper_$patch.log", timeout => 1500);
 
         # Install binaries newly added by the incident
+        my @new_binaries;
         if (scalar @new_binaries) {
             record_info 'New packages', "New packages: @new_binaries";
             zypper_call("in -l @new_binaries", exitcode => [0, 102, 103], log => "new_$patch.log", timeout => 1500);


### PR DESCRIPTION
This is very likely the wrong fix, as the array has no entries, but I couldn't figure out where this should come from, and with this wrong PR I hope to get some attention :)

    Global symbol "@new_binaries" requires explicit package name (did you
    forget to declare "my @new_binaries"?) at
    ./tests/qam-updinstall/SLFO_update_install.pm line 181.  Global symbol
    "@new_binaries" requires explicit package name (did you forget to declare
    "my @new_binaries"?) at ./tests/qam-updinstall/SLFO_update_install.pm line
    182.
    Global symbol "@new_binaries" requires explicit package name (did you
    forget to declare "my @new_binaries"?) at
    ./tests/qam-updinstall/SLFO_update_install.pm line 183.

Issue: https://progress.opensuse.org/issues/194002
