### PR TITLE
Kselftests: Sync kernel version with its sources

### DIFF
--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -38,7 +38,14 @@ sub build
     $source_dir //= "/lib/modules/$version/source";
     my $build_dir = "/lib/modules/$version/build";
 
+    # Lock kernel-source/syms to their already-installed versions if present (e.g. pre-installed
+    # by install_kotd at the same version as the running kernel), so the devel_kernel pattern
+    # cannot upgrade them to a mismatched version pulled from a rolling repo like KOTD.
+    my $lock_kernel_pkgs = !script_run('rpm -q kernel-source kernel-syms');
+    zypper_call('al kernel-source kernel-syms') if $lock_kernel_pkgs;
     zypper_call('install -t pattern --recommends devel_kernel');    # no trup support for now
+    zypper_call('rl kernel-source kernel-syms') if $lock_kernel_pkgs;
+
     my $build_env = get_var('KSELFTEST_BUILD_ENV', '');
     my $make_cmd = "make -j\$(getconf _NPROCESSORS_ONLN) -C $source_dir/tools/testing/selftests install SKIP_TARGETS= TARGETS=$targets O=$build_dir $build_env";
     $make_cmd =~ s/\s+$//;

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -415,10 +415,13 @@ sub install_kotd {
     my $repo = shift;
     my $kernel_flavor = get_kernel_flavor;
     my $devel_flavor = get_kernel_devel_flavor;
+    my $src_flavor = get_kernel_source_flavor;
     fully_patch_system;
     remove_kernel_packages;
     zypper_ar($repo, name => 'KOTD', priority => 90, no_gpg_check => 1);
     install_package("-r KOTD $kernel_flavor", trup_continue => 1);
+    my $kver = script_output("rpm -q --qf '%{VERSION}-%{RELEASE}' $kernel_flavor");
+    install_package("$src_flavor=$kver kernel-syms=$kver", trup_continue => 1);
     install_package("--recommends $devel_flavor", trup_continue => 1);
 }
 


### PR DESCRIPTION
Currently, if there's a new KOTD version published between the time of creation of the qcow2 test medium and the Kselftests test run, [it will fail](https://openqa.suse.de/tests/21814773#step/run_kselftests/69) because it will install the new `kernel-source` package. Fix by also installing kernel-source and kernel-syms from the image build job and locking them when installing the `devel_kernel` pattern at test runtime.

Verification runs:
- Install kernel-source and kernel-syms in update_kernel: https://rmarliere-openqa.qe.prg2.suse.org/tests/1923#step/update_kernel/62
- Add lock to kernel-source and kernel-syms in build: https://rmarliere-openqa.qe.prg2.suse.org/tests/1924#step/run_kselftests/68
- There is no lock added in non-KOTD code paths: https://rmarliere-openqa.qe.prg2.suse.org/tests/1925#step/run_kselftests/45