### PR TITLE
feat(pubcloud): exclude die in destroy when provider missing

### DIFF
--- a/tests/publiccloud/destroy.pm
+++ b/tests/publiccloud/destroy.pm
@@ -29,7 +29,7 @@ sub run {
         $provider->upload_boot_diagnostics();
         $provider->teardown();
     } else {
-        die('The $provider object is not available. We are not able to destroy the testing infrastructure.');
+        record_info('Undef provider', 'The $provider object is not available. We are not able to destroy the testing infrastructure, eventually present.', result => 'fail');
     }
 }
 


### PR DESCRIPTION
Change provider-missing case in `destroy` module for publicloud, to simply do record_info.
Remove `die` that created another fatal error overwriting the root cause, when test job was in destroying phase, for a previous main fault.
