### PR TITLE
Support systemd-boot in append_kernel_options

### DIFF
--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -78,6 +78,19 @@ sub handle_installer_medium_bootup {
 sub append_kernel_options {
     my ($options) = @_;
 
+    if (is_bootloader_sdboot()) {
+        send_key "e";
+        assert_screen "systemd-boot-edit-cmdline";
+        send_key "end";
+
+        type_string " " . $options;
+
+        save_screenshot;
+        send_key "ret";    # Boot
+        return;
+    }
+
+    # Code for grub2 and grub2-bls
     send_key 'e';
     check_screen "linux-line-selected", 2;
     # Move to end of kernel boot parameters line
@@ -88,8 +101,7 @@ sub append_kernel_options {
     type_string " " . $options;
 
     save_screenshot;
-    my $execute_command = (is_bootloader_sdboot()) ? 'ret' : 'ctrl-x';
-    send_key $execute_command;
+    send_key 'ctrl-x';
 }
 
 1;

--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -45,7 +45,7 @@ sub grub_test {
     send_key_until_needlematch("bootmenu-xen-kernel", 'down', 11, 5) if get_var('XEN');
     if (get_var('GRUB_KERNEL_OPTION_APPEND'))
     {
-        append_kernel_options() unless get_var("BOOT_TO_SNAPSHOT");
+        append_kernel_options(get_var('GRUB_KERNEL_OPTION_APPEND')) unless get_var("BOOT_TO_SNAPSHOT");
     }
     else {
         # avoid timeout for booting to HDD
@@ -76,6 +76,8 @@ sub handle_installer_medium_bootup {
 }
 
 sub append_kernel_options {
+    my ($options) = @_;
+
     send_key 'e';
     check_screen "linux-line-selected", 2;
     # Move to end of kernel boot parameters line
@@ -83,7 +85,7 @@ sub append_kernel_options {
     send_key "end";
 
     assert_screen "linux-line-matched";
-    type_string " " . get_var('GRUB_KERNEL_OPTION_APPEND') if get_var('GRUB_KERNEL_OPTION_APPEND');
+    type_string " " . $options;
 
     save_screenshot;
     my $execute_command = (is_bootloader_sdboot()) ? 'ret' : 'ctrl-x';

--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -25,8 +25,7 @@ Handle grub menu after reboot
     - Handle grub2 to boot from hard disk (opposed to installation)
     - Handle passphrase for encrypted disks
     - Handle booting of snapshot or XEN, acconding to BOOT_TO_SNAPSHOT or XEN
-    - Enable plymouth debug if product if GRUB_KERNEL_OPTION_APPEND is set,
-      or product is sle, aarch64 and PLYMOUTH_DEBUG is set
+    - Append kernel options if set with GRUB_KERNEL_OPTION_APPEND
 =cut
 
 sub grub_test {
@@ -44,8 +43,7 @@ sub grub_test {
     stop_grub_timeout;
     boot_into_snapshot if get_var("BOOT_TO_SNAPSHOT");
     send_key_until_needlematch("bootmenu-xen-kernel", 'down', 11, 5) if get_var('XEN');
-    if ((is_aarch64 && is_sle && get_var('PLYMOUTH_DEBUG'))
-        || get_var('GRUB_KERNEL_OPTION_APPEND'))
+    if (get_var('GRUB_KERNEL_OPTION_APPEND'))
     {
         append_kernel_options() unless get_var("BOOT_TO_SNAPSHOT");
     }
@@ -85,12 +83,6 @@ sub append_kernel_options {
     send_key "end";
 
     assert_screen "linux-line-matched";
-    if (get_var('PLYMOUTH_DEBUG')) {
-        record_soft_failure "Running with plymouth:debug to catch bsc#1005313";
-        # remove "splash=silent quiet showopts"
-        for (1 .. 28) { send_key "backspace" }
-        type_string 'plymouth:debug';
-    }
     type_string " " . get_var('GRUB_KERNEL_OPTION_APPEND') if get_var('GRUB_KERNEL_OPTION_APPEND');
 
     save_screenshot;

--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -8,8 +8,7 @@
 # - Handle grub2 to boot from hard disk (opposed to installation)
 # - Handle passphrase for encrypted disks
 # - Handle booting of snapshot or XEN, acconding to BOOT_TO_SNAPSHOT or XEN
-# - Enable plymouth debug if product if GRUB_KERNEL_OPTION_APPEND is set,
-# or product is sle, aarch64 and PLYMOUTH_DEBUG is set
+# - Append kernel options if set with GRUB_KERNEL_OPTION_APPEND
 # Tags: poo#9716, poo#10286, poo#10164
 # Maintainer: Martin Kravec <mkravec@suse.com>
 


### PR DESCRIPTION
Drop obsolete PLYMOUTH_DEBUG, refactor a bit and add explicit systemd-boot handling.

- Related ticket: https://progress.opensuse.org/issues/199193
- Needles: Created on o3 with the VR
- Verification run: https://openqa.opensuse.org/tests/5851148
