### PR TITLE
Fix waitfor_guestson  15Sp7 host SEV test

### DIFF
--- a/tests/virtualization/universal/waitfor_guests.pm
+++ b/tests/virtualization/universal/waitfor_guests.pm
@@ -50,7 +50,7 @@ sub run {
 
     # When SEV_ES guests are rebooted by AutoYast installation in the end of stage 1
     # they will stay in shutdown state, we have to start the guest to continue with stage 2
-    if (check_var('ENABLE_SEV_ES', '1')) {
+    if (check_var('ENABLE_SEV_ES', '1') && is_sle('>=16')) {
         record_info("Installation Stage 1", "Waiting for SEV-ES guests to finish AutoYast stage 1.");
 
         while (@wait_stage_1_install && $count++ < $retry) {


### PR DESCRIPTION
Fix "waitfor_guestson"  to 15Sp7 host  SEV test
If host is 16 or 16+ , guests are left in shutdown stage after installation
If host is 15SP7 , guests are left reboot stage after installation
 
- Related ticket: https://progress.opensuse.org/issues/199535

- Verification run:
  -SLES15-SP7 ->  https://openqa.suse.de/tests/21837444
  -SLES16 -> https://openqa.suse.de/tests/21861950