### PR TITLE
Add @DeepthiYV and @chubykalo to CODEOWNERS for QE Security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,12 +57,12 @@ tests/ha/ @a-kpappas @alvarocarvajald @Amrysliu @BillAnastasiadis @emiura @janko
 tests/sles4sap/ @a-kpappas @alvarocarvajald @Amrysliu @BillAnastasiadis @emiura @jankohoutek @lilyeyes @lpalovsky @mpagot @badboywj
 
 # Security
-data/security/ @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi
-lib/security/ @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi
-lib/main_security.pm @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi
-lib/eal4_test.pm @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi
-lib/selinuxtest.pm @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi
-schedule/security/ @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi
-test_data/security/ @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi
-tests/security/ @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi
-tests/fips/ @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi
+data/security/ @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi @DeepthiYV @chubykalo
+lib/security/ @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi @DeepthiYV @chubykalo
+lib/main_security.pm @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi @DeepthiYV @chubykalo
+lib/eal4_test.pm @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi @DeepthiYV @chubykalo
+lib/selinuxtest.pm @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi @DeepthiYV @chubykalo
+schedule/security/ @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi @DeepthiYV @chubykalo
+test_data/security/ @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi @DeepthiYV @chubykalo
+tests/security/ @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi @DeepthiYV @chubykalo
+tests/fips/ @feri @ilmanzo @paolostivanin @realcharmer @tjyrinki @fsimorda @mmisi @DeepthiYV @chubykalo


### PR DESCRIPTION
Adding new squad rotators to the QE Security group in CODEOWNERS.