### PR TITLE
Add mergify to enforce LSG QE suggested rule of two-reviewer-principle+checks

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,7 @@
+pull_request_rules:
+  - name: ask to resolve conflict
+    conditions:
+      - conflict
+    actions:
+      comment:
+        message: This pull request is now in conflicts. Could you fix it? 🙏

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,9 @@
 pull_request_rules:
+  - name: remove outdated reviews
+    conditions:
+      - base=master
+    actions:
+      dismiss_reviews:
   - name: ask to resolve conflict
     conditions:
       - conflict

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,6 +4,25 @@ pull_request_rules:
       - base=master
     actions:
       dismiss_reviews:
+  - name: additional checks
+    conditions:
+      - and: &base_checks
+        - base=master
+        - -label~=^acceptance-tests-needed|notready|WIP
+        - -body~=PLACEHOLDER
+        - "status-success~=static tests.*"
+        - "status-success~=unit tests.*"
+        - "status-success~=compile.*"
+        - "#check-failure=0"
+        - "#check-pending=0"
+        - linear-history
+      - and:
+        - "#approved-reviews-by>=2"
+        - "#changes-requested-reviews-by=0"
+        - "#review-requested=0"
+    actions:
+      review:
+        type: APPROVE
   - name: ask to resolve conflict
     conditions:
       - conflict


### PR DESCRIPTION
* mergify: Add additional checks
* mergify: Remove outdated reviews
* Add mergify with hint to resolve conflicts

This is a rebased updated version of #13455 motivated by the LSG QE suggested rule of two-reviewer-principle and automated checks.

Related issues:
* https://progress.opensuse.org/issues/138542
* https://progress.opensuse.org/issues/168448
* https://progress.opensuse.org/issues/101355