### PR TITLE
saltbase: Refactor error parsing when collecting logs

### DIFF
--- a/lib/saltbase.pm
+++ b/lib/saltbase.pm
@@ -105,7 +105,7 @@ sub logs_from_salt {
             record_soft_failure('bsc#1211591');
             $softfail_flag = 1;
         }
-        if (script_run('grep "Encountered StreamClosedException" /var/log/salt/master') == 0) {
+        if (is_master_node && script_run('grep "Encountered StreamClosedException" /var/log/salt/master') == 0) {
             record_soft_failure('bsc#1213635');
             $softfail_flag = 1;
         }

--- a/lib/saltbase.pm
+++ b/lib/saltbase.pm
@@ -12,6 +12,10 @@ use known_bugs;
 
 use utils qw(zypper_call systemctl remount_tmp_if_ro);
 
+sub is_master_node {
+    return check_var('HOSTNAME', 'master');
+}
+
 sub master_prepare {
     # Install the salt master
     zypper_call("in salt-master");
@@ -38,7 +42,7 @@ sub minion_prepare {
 
     # Set the right address of the salt master
     assert_script_run "echo `hostname` > /etc/salt/minion_id";
-    if (check_var('HOSTNAME', 'master')) {
+    if (is_master_node) {
         assert_script_run("sed -i -e 's/#master:.*/master: localhost/' /etc/salt/minion");
     } else {
         assert_script_run("sed -i -e 's/#master:.*/master: 10.0.2.101/' /etc/salt/minion");
@@ -65,7 +69,7 @@ sub minion_prepare {
 }
 
 sub stop {
-    if (check_var('HOSTNAME', 'master')) {
+    if (is_master_node) {
         systemctl 'stop salt-master';
     }
     systemctl 'stop salt-minion';
@@ -80,7 +84,7 @@ Method fetching Salt specific logs.
 sub logs_from_salt {
     assert_script_run "ls /var/log/salt";
 
-    if (check_var('HOSTNAME', 'master')) {
+    if (is_master_node) {
         upload_logs '/var/log/salt/master', log_name => 'salt-master.txt';
         upload_logs '/var/log/salt/event', log_name => 'salt-event.txt';
     }
@@ -93,7 +97,7 @@ sub logs_from_salt {
     $error .= "| grep -vi 'Error while bringing up minion for multi-master'";
     if (script_run("$error") != 1) {
         my $softfail_flag = 0;
-        if (check_var('HOSTNAME', 'master') && script_run('grep "self.pusher.connect(timeout=timeout)" /var/log/salt/master') == 0) {
+        if (is_master_node && script_run('grep "self.pusher.connect(timeout=timeout)" /var/log/salt/master') == 0) {
             record_soft_failure('bsc#1209248');
             $softfail_flag = 1;
         }

--- a/lib/saltbase.pm
+++ b/lib/saltbase.pm
@@ -91,11 +91,27 @@ sub logs_from_salt {
 
     upload_logs '/var/log/salt/minion', log_name => 'salt-minion.txt';
 
-    my $error = "cat /var/log/salt/* | grep -i '\\[.*CRITICAL.*\\]\\|\\[.*ERROR.*\\]\\|Traceback' ";
-    $error .= "| grep -vi 'Error while parsing IPv\\|Error loading module\\|Unable to resolve address\\|SaltReqTimeoutError' ";
-    $error .= "| grep -vi 'has cached the public key for this node\\|Minion unable to successfully connect to a Salt Master'";
-    $error .= "| grep -vi 'Error while bringing up minion for multi-master'";
-    if (script_run("$error") != 1) {
+    my @patterns = (
+        "grep -i '\\[.*CRITICAL.*\\]\\|\\[.*ERROR.*\\]\\|Traceback'",
+        "grep -vi 'Error while parsing IPv\\|Error loading module\\|Unable to resolve address\\|SaltReqTimeoutError'",
+        "grep -vi 'has cached the public key for this node\\|Minion unable to successfully connect to a Salt Master'",
+        "grep -vi 'Error while bringing up minion for multi-master'"
+    );
+    my $error_cmd = join(' | ', @patterns);
+
+    my $log_files = script_output('find /var/log/salt -type f');
+    my $has_errors = 0;
+
+    for my $file (split(/\n/, $log_files)) {
+        next unless $file;
+        if (script_run("cat $file | $error_cmd") == 0) {
+            my $matched_output = script_output("cat $file | $error_cmd");
+            record_info("$file has errors", "File: $file\n\nMatched output:\n$matched_output", result => 'fail');
+            $has_errors = 1;
+        }
+    }
+
+    if ($has_errors) {
         my $softfail_flag = 0;
         if (is_master_node && script_run('grep "self.pusher.connect(timeout=timeout)" /var/log/salt/master') == 0) {
             record_soft_failure('bsc#1209248');


### PR DESCRIPTION
In the current state the test just greps for some patterns and fails
without much explanation of which file contains the error or what
the pattern matched, making it harder to debug.

Additionally rework how the test checks for the master node.

Failing [VRs is expected](https://openqa.opensuse.org/tests/5852923#step/salt_minion/100)

openqa: clone https://openqa.opensuse.org/tests/5851825
#### Results from cloned jobs:
- [![https://openqa.opensuse.org/tests/5852922](https://openqa.opensuse.org/tests/5852922/badge)](https://openqa.opensuse.org/tests/5852922)
- [![https://openqa.opensuse.org/tests/5852923](https://openqa.opensuse.org/tests/5852923/badge)](https://openqa.opensuse.org/tests/5852923)

<sub>The above list is generated with a script with information from the "clone_mentioned_job" workflow.</sub>
