### PR TITLE
fix: Repair perlcritic test

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,15 +1,16 @@
 theme = freenode
 severity = 4
+exclude = OpenQA::RedundantStrictWarning
 
 # TODO: Remove once Perl::Critic::Freenode 0.028 is widely available
-[Freenode::DiscouragedModules]
+[Community::DiscouragedModules]
 severity = 3
 
 # Test modules have no package declaration
-[Freenode::PackageMatchesFilename]
+[Community::PackageMatchesFilename]
 severity = 1
 
-[Perl::Critic::Policy::HashKeyQuotes]
+[OpenQA::HashKeyQuotes]
 severity = 5
 
 [ControlStructures::ProhibitDeepNests]

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -2,10 +2,6 @@ theme = freenode
 severity = 4
 exclude = OpenQA::RedundantStrictWarning
 
-# TODO: Remove once Perl::Critic::Freenode 0.028 is widely available
-[Community::DiscouragedModules]
-severity = 3
-
 # Test modules have no package declaration
 [Community::PackageMatchesFilename]
 severity = 1

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,6 +1,8 @@
-theme = freenode
+theme = community
 severity = 4
-exclude = OpenQA::RedundantStrictWarning
+exclude = OpenQA::RedundantStrictWarning Community::DiscouragedModules
+
+verbose = ::warning file=%f,line=%l,col=%c,title=%m - severity %s::[%p] %e\n
 
 # Test modules have no package declaration
 [Community::PackageMatchesFilename]

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ tools/tidy: os-autoinst/
 	@test -e tools/tidy || ln -s ../os-autoinst/tools/tidy tools/
 
 tools/lib/: os-autoinst/
-	@test -e tools/lib || ln -s ../os-autoinst/tools/lib tools/
+	@test -e tools/lib || ln -s ../os-autoinst/external/os-autoinst-common/lib/ tools/
 
 .PHONY: check-links
 check-links: tools/tidy tools/lib/ os-autoinst/

--- a/Makefile
+++ b/Makefile
@@ -143,14 +143,13 @@ else
 test: unit-test test-static test-compile test-isotovideo perlcritic
 endif
 
-PERLCRITIC=PERL5LIB=tools/lib/perlcritic:$$PERL5LIB perlcritic --stern --include Perl::Critic::Policy::HashKeyQuote \
-  --verbose "::warning file=%f,line=%l,col=%c,title=%m - severity %s::%e\n" --quiet
+PERLCRITIC=PERL5LIB=tools/lib/perlcritic:$$PERL5LIB perlcritic --quiet
 
 .PHONY: perlcritic
 # strictures and warnings are already enforced by os-autoinst basetest.pm so
 # exclude here for test modules
 perlcritic: tools/lib/
-	${PERLCRITIC} --include=strict $$(git ls-files -- '*.p[ml]' ':!:data/' ':!:tests/')
+	${PERLCRITIC} $$(git ls-files -- '*.p[ml]' ':!:data/' ':!:tests/')
 	${PERLCRITIC} --exclude=strict $$(git ls-files -- ':tests/*.p[ml]')
 
 .PHONY: test-unused-modules-changed


### PR DESCRIPTION
A file in os-autoinst/lib/perlcritic was removed (and has been replaced with a file in os-autoinst/external/... a while ago).
Switching to that also enabled the other custom OpenQA perlcritic rules, so I ended up fixing the whole, slightly messed up perlcritic setup here.
We now specify everything in the .perlcriticrc file.
As a plus we are now getting the name of the perlcritic violation, if there is any, so one can lookup the module on CPAN with an explanation of the rule.

Note that you have to remove the `tools/lib` symlink locally before running `make test` again. The link has changed to a different target.