### PR TITLE
Increase timeout for zypper ref in Azure

### DIFF
--- a/tests/sles4sap/publiccloud/cluster_add_repos.pm
+++ b/tests/sles4sap/publiccloud/cluster_add_repos.pm
@@ -35,7 +35,7 @@ QE-SAP <qe-sap@suse.de>
 
 use Mojo::Base 'sles4sap::publiccloud_basetest';
 use sles4sap::publiccloud;
-use publiccloud::utils qw(zypper_call_remote);
+use publiccloud::utils qw(zypper_call_remote is_azure);
 use qam;
 use testapi;
 
@@ -61,9 +61,10 @@ sub run {
         }
         $repo_index++;
     }
+    my $ref_timeout = is_azure ? 900 : 240;
     foreach my $instance (@{$self->{instances}}) {
         next if ($instance->{'instance_id'} !~ m/vmhana/);
-        zypper_call_remote($instance, cmd => " --gpg-auto-import-keys ref", timeout => 240, retry => 6, delay => 60);
+        zypper_call_remote($instance, cmd => " --gpg-auto-import-keys ref", timeout => $ref_timeout, retry => 6, delay => 60);
     }
 }
 


### PR DESCRIPTION
According to https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/sles4sap/publiccloud/general_patch_and_reboot.pm#L65 , set the same timeout for Azure here

Related: https://jira.suse.com/browse/TEAM-11118

VR: http://openqa.suse.de/tests/21839335

