### PR TITLE
Change supportconfig timeout in ipaddr2

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -2394,7 +2394,7 @@ sub ipaddr2_logs_collect_cmds {
         {
             name => 'supportconfig',
             remote_log => 1,
-            timeout => 1200,
+            timeout => 2400,
             f_log => sub {
                 my $id = shift;
                 my $file = "supportconfig_$id";


### PR DESCRIPTION
Problem is on 12sp5 where duration can be as longer as 1700sec

- Related ticket: https://jira.suse.com/browse/TEAM-11162?filter=-2

# Verification run:

sle-12-SP5-Azure-SAP-PAYG-Incidents-x86_64-ipaddr2
- http://openqaworker15.qe.prg2.suse.org/tests/363004
- http://openqaworker15.qe.prg2.suse.org/tests/363005