### PR TITLE
Upload configfile and template generated by the sap install role

### DIFF
--- a/lib/sles4sap/qesap/qesapdeployment.pm
+++ b/lib/sles4sap/qesap/qesapdeployment.pm
@@ -1443,6 +1443,18 @@ sub qesap_cluster_log_cmds {
         {
             Cmd => 'rpm -qa',
             Output => 'rpm-qa.txt',
+        },
+        {
+            Cmd => 'cat /tmp/hdblcm_before_jinja.cfg',
+            Output => 'hdblcm_before_jinja.cfg.txt'
+        },
+        {
+            Cmd => 'cat /tmp/hdblcm_template.j2',
+            Output => 'hdblcm_template.j2.txt'
+        },
+        {
+            Cmd => 'cat /tmp/hdblcm_processed_configfile.cfg',
+            Output => 'hdblcm_processed_configfile.cfg.txt'
         }
     );
     if ($args{provider} eq 'EC2') {


### PR DESCRIPTION
HANA Installation in qe-sap-deployment is performed via the configuration file configfile. That file is not available at the end of the execution, or at least not uploaded by openQA, which makes it difficult to figure out any details about how the HANA installation has been configured.

This retrieves the config files,  that were saved after each step of templating them into the final configuration.

To be merged after  https://github.com/SUSE/qe-sap-deployment/pull/459

Related Ticket: TEAM-10054
Verification Runs: 
https://openqaworker15.qe.prg2.suse.org/tests/363108#settings (without the new deployment, the code fails to get the logs, doesnt fail the test)
https://openqaworker15.qe.prg2.suse.org/tests/363001
https://openqaworker15.qe.prg2.suse.org/tests/363000 (configfile uploaded even after crash failure)