### PR TITLE
console/snapper_zypp.pm: Use proper is_jeos

### DIFF
--- a/tests/console/snapper_zypp.pm
+++ b/tests/console/snapper_zypp.pm
@@ -14,7 +14,7 @@ use Mojo::Base 'consoletest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use version_utils qw(is_community_jeos is_sle);
+use version_utils qw(is_jeos is_sle);
 use Test::Assert 'assert_equals';
 
 sub get_snapshot_id {
@@ -38,7 +38,7 @@ sub run_zypper_cmd {
 
 sub run {
     select_serial_terminal;
-    my $package = (is_community_jeos() ? 'vim-small' : 'vim');
+    my $package = (is_jeos() ? 'vim-small' : 'vim');
 
     assert_script_run("rpm -q snapper-zypp-plugin");
     run_zypper_cmd("rm $package", $package);


### PR DESCRIPTION
It's not just community JeOS, but also Minimal-VM that uses vim-small.

- Related failure: https://openqa.opensuse.org/tests/5852796
- Verification run: https://openqa.opensuse.org/tests/5852903
