### PR TITLE
Kselftests: Small fixes

### DIFF
--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -48,7 +48,7 @@ sub build
 
     my $jobs = get_var('KSELFTEST_BUILD_JOBS', '$(getconf _NPROCESSORS_ONLN)');
     my $build_env = get_var('KSELFTEST_BUILD_ENV', '');
-    my $make_cmd = "make -j$jobs -C $source_dir/tools/testing/selftests install SKIP_TARGETS= TARGETS=$targets O=$build_dir $build_env";
+    my $make_cmd = "make -j$jobs -C $source_dir/tools/testing/selftests install O=$build_dir SKIP_TARGETS= TARGETS=$targets FORCE_TARGETS=1 $build_env";
     $make_cmd =~ s/\s+$//;
 
     assert_script_run($make_cmd, 7200);

--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -120,7 +120,7 @@ sub install_dependencies
         install_package('clang libcap-devel libnuma-devel libmnl-devel python3-PyYAML python3-jsonschema', trup_continue => 1);
 
         # install test deps
-        install_available_packages('ipvsadm conntrack-tools jq tcpdump iperf iproute2 net-tools net-tools-deprecated ipv6toolkit netsniff-ng ndisc6 socat smcroute dropwatch');
+        install_available_packages('iptables ipvsadm conntrack-tools jq tcpdump iperf iproute2 net-tools net-tools-deprecated ipv6toolkit netsniff-ng ndisc6 socat smcroute dropwatch');
 
         if (is_sle('>=16.0')) {
             # NetworkManager interferes with tests such as busy_poll_test.sh and rtnetlink.sh, due to automatically reacting to device creation

--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -120,7 +120,7 @@ sub install_dependencies
         install_package('clang libcap-devel libnuma-devel libmnl-devel python3-PyYAML python3-jsonschema', trup_continue => 1);
 
         # install test deps
-        install_available_packages('iptables ipvsadm conntrack-tools jq tcpdump iperf iproute2 net-tools net-tools-deprecated ipv6toolkit netsniff-ng ndisc6 socat smcroute dropwatch');
+        install_available_packages('wireshark iptables ipvsadm conntrack-tools jq tcpdump iperf iproute2 net-tools net-tools-deprecated ipv6toolkit netsniff-ng ndisc6 socat smcroute dropwatch');
 
         if (is_sle('>=16.0')) {
             # NetworkManager interferes with tests such as busy_poll_test.sh and rtnetlink.sh, due to automatically reacting to device creation

--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -46,8 +46,9 @@ sub build
     zypper_call('install -t pattern --recommends devel_kernel');    # no trup support for now
     zypper_call('rl kernel-source kernel-syms') if $lock_kernel_pkgs;
 
+    my $jobs = get_var('KSELFTEST_BUILD_JOBS', '$(getconf _NPROCESSORS_ONLN)');
     my $build_env = get_var('KSELFTEST_BUILD_ENV', '');
-    my $make_cmd = "make -j\$(getconf _NPROCESSORS_ONLN) -C $source_dir/tools/testing/selftests install SKIP_TARGETS= TARGETS=$targets O=$build_dir $build_env";
+    my $make_cmd = "make -j$jobs -C $source_dir/tools/testing/selftests install SKIP_TARGETS= TARGETS=$targets O=$build_dir $build_env";
     $make_cmd =~ s/\s+$//;
 
     assert_script_run($make_cmd, 7200);

--- a/tests/kernel/run_kselftests.pm
+++ b/tests/kernel/run_kselftests.pm
@@ -225,6 +225,18 @@ Example:
 
   KSELFTEST_BUILD_ENV="SKIP_DOCS=1"
 
+=head2 KSELFTEST_BUILD_JOBS
+
+Optional number of parallel jobs passed to C<make -j> when building
+kselftests from source (i.e. when C<KSELFTEST_FROM_GIT> or
+C<KSELFTEST_FROM_SRC> is set). Defaults to the number of online CPUs
+(C<getconf _NPROCESSORS_ONLN>). Has no effect when installing from a
+pre-built RPM package.
+
+Example:
+
+  KSELFTEST_BUILD_JOBS=4
+
 =head1 Example openQA Settings
 
   KSELFTEST_COLLECTION=cgroup


### PR DESCRIPTION
Add `iptables` and `wireshark` to net dependency list; introduce a new variable KSELFTEST_BUILD_JOBS for `-j` customization in build(); set FORCE_TARGETS=1 to make sure buid() actually built all tests.

Verification runs:
- https://rmarliere-openqa.qe.prg2.suse.org/tests/1928
- https://rmarliere-openqa.qe.prg2.suse.org/tests/1929