### PR TITLE
Replace 'package_version_cmp' with 'zypper_version_cmp' in console tests

### DIFF
--- a/tests/console/bind.pm
+++ b/tests/console/bind.pm
@@ -27,10 +27,9 @@
 use Mojo::Base 'consoletest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use utils 'zypper_call';
+use utils qw(zypper_call zypper_version_cmp);
 use version_utils 'is_sle';
 use registration qw(add_suseconnect_product get_addon_fullname);
-use version_utils qw(package_version_cmp);
 
 sub run {
     select_serial_terminal;
@@ -83,7 +82,7 @@ sub run {
     assert_script_run 'ip a';
     my $bind_cmd;
     my $worker_count = is_sle('<15-SP2') ? 2 : 8;
-    if (package_version_cmp($bind_version, '9.18.33') <= 0) {
+    if (zypper_version_cmp($bind_version, '9.18.33') <= 0) {
         $bind_cmd = "runuser -u bernhard -- sh runall.sh -n $worker_count";
     }
     else {
@@ -98,11 +97,11 @@ sub run {
         record_info 'Retry:', 'poo#71329';
         for (1 .. 3) {
             eval {
-                if (package_version_cmp($bind_version, '9.18.33') <= 0) {
+                if (zypper_version_cmp($bind_version, '9.18.33') <= 0) {
                     assert_script_run 'TFAIL=$(awk -F: -e \'/^R:.*:FAIL/ {print$2}\' /tmp/test-suite.txt); echo $TFAIL';
                     assert_script_run "for t in \$TFAIL; do runuser -u bernhard -- sh run.sh \$t; done", 2000;
                 }
-                elsif (package_version_cmp($bind_version, '9.20.9') < 0) {
+                elsif (zypper_version_cmp($bind_version, '9.20.9') < 0) {
                     assert_script_run 'TFAIL=$(awk \'/^FAIL:/ {print$2}\' /tmp/test-suite.txt); echo $TFAIL';
                     assert_script_run "for t in \$TFAIL; do runuser -u bernhard -- sh run.sh \$t; done", 2000;
                 }

--- a/tests/console/libjpeg_turbo.pm
+++ b/tests/console/libjpeg_turbo.pm
@@ -14,7 +14,7 @@ use Mojo::Base 'consoletest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use version_utils;
-use utils 'upload_y2logs';
+use utils qw(upload_y2logs zypper_version_cmp);
 use package_utils 'install_package';
 use registration qw(add_suseconnect_product get_addon_fullname);
 use registration qw(add_suseconnect_product is_phub_ready);
@@ -32,7 +32,7 @@ sub run {
     install_package("libjpeg-turbo ImageMagick", trup_reboot => 1);
     my $install_version = script_output('rpm -q libjpeg-turbo --qf %{version}');
     record_info("libjpeg-turbo version", $install_version);
-    die("libjpeg-turbo version was not updated") if (package_version_cmp($install_version, '2.1.1') <= 0);
+    die("libjpeg-turbo version was not updated") if (zypper_version_cmp($install_version, '2.1.1') <= 0);
 
     # Use jpegtran command to rotate image
     my $image = 'lizard.jpeg';

--- a/tests/console/pam.pm
+++ b/tests/console/pam.pm
@@ -55,7 +55,7 @@ sub run {
     my $ret = "";
     my $tap_results = "/tmp/results.tap";
     assert_script_run("sed -i 's/ROOT_PASSWORD/$testapi::password/g' $pamdir/*.sh");
-    if (package_version_cmp($pam_version, $limit_pam_version) >= 0) {
+    if (zypper_version_cmp($pam_version, $limit_pam_version) >= 0) {
         $ret = script_run("cd $pamdir; prove -v pam.sh >$tap_results", timeout => 200);
     } else {
         $ret = script_run("cd $pamdir; prove -v pam_deprecated.sh >$tap_results", timeout => 300);

--- a/tests/console/python3_new_version_check.pm
+++ b/tests/console/python3_new_version_check.pm
@@ -18,6 +18,7 @@ use version_utils;
 use package_utils 'install_package';
 use python_version_utils;
 use registration "add_suseconnect_product";
+use utils 'zypper_version_cmp';
 
 sub run {
     select_serial_terminal;
@@ -29,10 +30,10 @@ sub run {
     my $python3_spec_release = script_output("rpm -q $system_python_version | awk -F \'-\' \'{print \$2}\'");
     record_info("python_verison", $python3_spec_release);
     # Python313 is the default python version for sle16
-    die("Python default version differs from 3.13") if ((package_version_cmp($python3_spec_release, "3.13") < 0) && is_sle('>=16'));
+    die("Python default version differs from 3.13") if ((zypper_version_cmp($python3_spec_release, "3.13") < 0) && is_sle('>=16'));
     if (is_sle('>=15-SP4') && is_sle('<16')) {
-        if ((package_version_cmp($python3_spec_release, "3.6") < 0) ||
-            (package_version_cmp($python3_spec_release, "3.7") >= 0)) {
+        if ((zypper_version_cmp($python3_spec_release, "3.6") < 0) ||
+            (zypper_version_cmp($python3_spec_release, "3.7") >= 0)) {
             # Factory default Python3 version for SLE15-SP4+ should be 3.6
             die("Python default version differs from 3.6");
         }

--- a/tests/console/weechat.pm
+++ b/tests/console/weechat.pm
@@ -7,8 +7,7 @@
 
 use Mojo::Base 'consoletest';
 use testapi;
-use utils 'zypper_call';
-use version_utils 'package_version_cmp';
+use utils qw(zypper_call zypper_version_cmp);
 
 sub run {
     select_console('root-console');
@@ -16,7 +15,7 @@ sub run {
     select_console('user-console');
     my $weechat_version = script_output("rpm -q --qf '%{version}' weechat");
     record_info('weechat', "Weechat version $weechat_version detected");
-    my $ssl = package_version_cmp($weechat_version, '4') < 0 ? 'ssl' : 'tls';
+    my $ssl = zypper_version_cmp($weechat_version, '4') < 0 ? 'ssl' : 'tls';
 
     script_run("weechat; echo weechat-status-\$? > /dev/$serialdev", 0);
     assert_screen('weechat');


### PR DESCRIPTION
https://progress.opensuse.org/issues/197795

Use new function for console tests

- [Verification run](https://openqa.suse.de/tests/overview?distri=sle&build=rfan0415_vcmp) 