### PR TITLE
Remove rpm test module from extra_tests_textmode_immutable

### DIFF
--- a/schedule/functional/sle16/extra_tests_textmode_immutable.yaml
+++ b/schedule/functional/sle16/extra_tests_textmode_immutable.yaml
@@ -56,7 +56,6 @@ schedule:
     - console/shar
     - console/sshd
     - console/update_alternatives
-    - console/rpm
     - console/slp
     - console/pkcon
     - console/command_not_found


### PR DESCRIPTION
Remove rpm test module from extra_tests_textmode_immutable

- Related ticket: https://progress.opensuse.org/issues/198968

