### PR TITLE
pc: Ignore other arches when downloading repos

### DIFF
--- a/tests/publiccloud/download_repos.pm
+++ b/tests/publiccloud/download_repos.pm
@@ -56,7 +56,9 @@ sub run {
     die "No test repositories" if ($check_empty_repos && $count == 0);
     my $ret = 0;
     my $reject = "'robots.txt,*.ico,*.png,*.gif,*.css,*.js,*.htm*,*.mirrorlist'";
-    my $regex = "'s390x\\/|ppc64le\\/|kernel*debuginfo*.rpm|src\\/'";
+    # If running on x86_64, also ignore aarch64 and viceversa
+    my $other = check_var("ARCH", "x86_64") ? "aarch64" : "x86_64";
+    my $regex = "'s390x\\/|ppc64le\\/|$other\\/|kernel*debuginfo*.rpm|src\\/'";
 
     set_var("PUBLIC_CLOUD_EMBARGOED_UPDATES_DETECTED", 0);
 


### PR DESCRIPTION
When downloading repos we're ignoring ppc64le & s390x as they're not available on PC.  Also ignore aarch64 when running on x86_64 and viceversa to reduce the amount of data transferred.

Note: We'll only get a size reduction on repos that are not suffixed by `_$arch` like `https://dist.suse.de/ibs/QA:/Head/SLE-15-SP6/`.  The incident repos are suffixed so we'll see this size reduction on tests using the QA:/Head repo like the xfstests.