### PR TITLE
rebootmgr: Move check_reboot_strategy_and_reboot to transactional

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -29,6 +29,7 @@ our @EXPORT = qw(
   process_reboot
   check_reboot_changes
   check_target_version
+  check_reboot_strategy_and_reboot
   rpmver
   trup_call
   trup_install
@@ -74,6 +75,21 @@ sub handle_first_grub {
         wait_still_screen 60 if (check_var('MACHINE', 'ppc64le-emu') || check_var('MACHINE', 'svirt-vmware70'));
         save_screenshot;
     }
+}
+
+# Soft reboot only triggers a full reboot when installing a new kernel
+# update of the bootloader or any command like rollback, grub.cfg, bootloader, run or shell
+sub check_reboot_strategy_and_reboot {
+    my @reboot_args;
+    if (!is_sle_micro) {
+        my $regex = qr/Minimally required reboot level:\s(.*)[\r\n]/;
+        my $output = wait_serial($regex, timeout => 300) or die "Could not capture reboot type";
+        if ($output =~ $regex) {
+            @reboot_args = (expected_grub => 0) if $1 eq 'soft-reboot';
+            record_info("Reboot strategy: $1");
+        }
+    }
+    process_reboot(@reboot_args);
 }
 
 sub process_reboot {

--- a/tests/network/network_bonding_setup.pm
+++ b/tests/network/network_bonding_setup.pm
@@ -17,7 +17,7 @@ use lockapi;
 use utils;
 use version_utils;
 use registration qw(runtime_registration add_suseconnect_product);
-use transactional qw(trup_call process_reboot);
+use transactional qw(trup_call process_reboot check_reboot_strategy_and_reboot);
 
 my $server_ip = "10.0.2.101";
 my $subnet = "/24";
@@ -61,7 +61,7 @@ sub install_pkgs {
             assert_script_run "rebootmgrctl set-strategy instantly";
             record_info("Installing packages", "Using transactional-update, requires reboot: $pkg_list");
             trup_call "reboot pkg install $pkg_list";
-            process_reboot(expected_grub => 1);
+            check_reboot_strategy_and_reboot;
             select_serial_terminal;
         } else {
             record_info("Installing packages", "Using zypper for installation: $pkg_list");

--- a/tests/transactional/rebootmgr.pm
+++ b/tests/transactional/rebootmgr.pm
@@ -45,21 +45,6 @@ sub rbm_set_window {
     rbm_call "set-window \$(date -d $time +%T) $duration";
 }
 
-# Soft reboot only triggers a full reboot when installing a new kernel
-# update of the bootloader or any command like rollback, grub.cfg, bootloader, run or shell
-sub check_reboot_strategy_and_reboot {
-    my @reboot_args;
-    if (!is_sle_micro) {
-        my $regex = qr/Minimally required reboot level:\s(.*)[\r\n]/;
-        my $output = wait_serial($regex, timeout => 300) or die "Could not capture reboot type";
-        if ($output =~ $regex) {
-            @reboot_args = (expected_grub => 0) if $1 eq 'soft-reboot';
-            record_info("Reboot strategy: $1");
-        }
-    }
-    process_reboot(@reboot_args);
-}
-
 #1 Test instant reboot
 sub check_strategy_instantly {
     select_console('root-console');


### PR DESCRIPTION
This fixes a [test failure](https://openqa.opensuse.org/tests/5854247#step/network_bonding_setup/110) in the `network_bonding` testsuite where
installing packages via `reboot pkg install` could trigger a soft-reboot
and process_reboot has no way of knowing whether to expect grub or not.

openqa: clone https://openqa.opensuse.org/tests/5854247


#### Results from cloned jobs:
- [![https://openqa.opensuse.org/tests/5855128](https://openqa.opensuse.org/tests/5855128/badge)](https://openqa.opensuse.org/tests/5855128)
- [![https://openqa.opensuse.org/tests/5855127](https://openqa.opensuse.org/tests/5855127/badge)](https://openqa.opensuse.org/tests/5855127)

<sub>The above list is generated with a script with information from the "clone_mentioned_job" workflow.</sub>
