### PR TITLE
Update cleanup_known_coredumps and skip it on Tumbleweed

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -173,7 +173,8 @@ sub cleanup_known_coredumps {
     my %known_coredumps = (
         # don't add ", it will get lost in compared string
         'poo#198596' => q(openssl3-conf\/base_only.cnf -p \$'hello'),
-        'bsc#1129403' => q(unzip-mem  v files.zip)
+        'bsc#1129403' => q(unzip-mem  v files.zip),
+        'bsc#1261358' => q(gvfs-udisks2-volume-monitor),
     );
 
     for my $pid (split(/\n/, script_output(q(coredumpctl -q --no-pager --no-legend | awk '$9 == "present" { print $5 }'), proceed_on_failure => 1))) {

--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -175,6 +175,7 @@ sub cleanup_known_coredumps {
         'poo#198596' => q(openssl3-conf\/base_only.cnf -p \$'hello'),
         'bsc#1129403' => q(unzip-mem  v files.zip),
         'bsc#1261358' => q(gvfs-udisks2-volume-monitor),
+        'bsc#1261625' => q(ovs-vswitchd unix:),
     );
 
     for my $pid (split(/\n/, script_output(q(coredumpctl -q --no-pager --no-legend | awk '$9 == "present" { print $5 }'), proceed_on_failure => 1))) {

--- a/tests/console/coredump_collect.pm
+++ b/tests/console/coredump_collect.pm
@@ -11,12 +11,13 @@ use Mojo::Base 'consoletest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use Utils::Logging qw(upload_coredumps cleanup_known_coredumps);
+use version_utils qw(is_tumbleweed);
 
 sub run {
     my $self = shift;
     select_serial_terminal;
 
-    cleanup_known_coredumps;
+    cleanup_known_coredumps unless is_tumbleweed;
     upload_coredumps;
 }
 


### PR DESCRIPTION
- Add entry for https://bugzilla.suse.com/show_bug.cgi?id=1261358 affecting [ovs-switch](https://openqa.suse.de/tests/21851597/file/core.ovs-vswitchd.472.e04e37f5e5b647ec84012ed5262e6aef.9018.1776303423000000.zst.txt)
- Add entry for https://bugzilla.suse.com/show_bug.cgi?id=1261625 affecting [gvfs-udisks2-volume-monitor](https://openqa.suse.de/tests/21850676/file/core.gvfs-udisks2-vo.1000.ebe8300f06cf43e291e0fbe8f64b7738.2378.1776315094000000.zst.txt)
- Skip `cleanup_known_coredumps` on Tumbleweed.  We want to be aware of those in Tumbleweed when new packages arrive.

Related ticket: https://progress.opensuse.org/issues/197969
