### PR TITLE
Log collection handles timeouts and failures

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -1302,6 +1302,7 @@ using the assert_script_run API
 
 =item B<no_assert> - If specified internally use 'script_run' in place of
                      'assert_script_run' and return the exit code.
+                     Also suppresses timeout exceptions (returns undef).
 
 =item B<retry> - Number of retries in case of failure. Default 1 (no retry)
 
@@ -1320,13 +1321,20 @@ sub ipaddr2_ssh_internal(%args) {
         bastion_ip => $args{bastion_ip},
         cmd => $args{cmd});
 
-    my $ret = 0;
+    my $ret;
     for (1 .. $args{retry}) {
-        $ret = script_run($command, timeout => $args{timeout});
-        return $ret if ($ret == 0);
-        record_info("Failed $_ time", "Command $command failed with exit code $ret");
+        eval { $ret = script_run($command, timeout => $args{timeout}); };
+        if ($@) {
+            die $@ unless $args{no_assert};
+            record_info('SSH timeout', "cmd: $command\nerr: $@", result => 'fail');
+            return undef;
+        }
+        return $ret if (defined $ret && $ret == 0);
+        record_info("Failed $_ time",
+            "Command $command failed with exit code " . ($ret // 'undef'),
+            result => 'fail');
     }
-    die "Command $command failed with exit code $ret" if (!defined $args{no_assert});
+    die "Command $command failed with exit code " . ($ret // 'undef') unless $args{no_assert};
     return $ret;
 }
 

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -1215,22 +1215,21 @@ subtest '[ipaddr2_cleanup] ipaddr2_deployment_logs' => sub {
 
 subtest '[ipaddr2_logs_collect]' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
-    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
-    my @ssh_calls;
-    $ipaddr2->redefine(ipaddr2_ssh_internal => sub {
-            my (%args) = @_;
-            push @ssh_calls, "VM$args{id}: $args{cmd}";
-            return;
-    });
     my @upload_calls;
     $ipaddr2->redefine(upload_logs => sub {
             push @upload_calls, $_[0];
             return;
     });
     $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    my @ssh_calls;
     my @calls;
-    $ipaddr2->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $ipaddr2->redefine(script_run => sub {
+            push @ssh_calls, $_[0] if $_[0] =~ /^ssh /;
+            push @calls, $_[0];
+            return 0;
+    });
     $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
 
     ipaddr2_logs_collect();
 
@@ -1239,7 +1238,7 @@ subtest '[ipaddr2_logs_collect]' => sub {
     note("\n  -->  " . join("\n  -->  ", @calls));
 
     is(scalar @ssh_calls, 8, "ipaddr2_ssh_internal called " . (scalar @ssh_calls) . " and expected 8 times (4 log files * 2 VM)");
-    is(scalar @upload_calls, 10, "upload_logs called 8 times (4 log files * 2 VM + 2 ssh local logs)");
+    is(scalar @upload_calls, 10, "upload_logs called 10 times (4 log files * 2 VM + 2 ssh local logs)");
 
     ok((any { /crm report/ } @ssh_calls), "crm report command called");
     ok((any { /save_y2logs/ } @ssh_calls), "YaST2 logs collected");
@@ -1249,6 +1248,48 @@ subtest '[ipaddr2_logs_collect]' => sub {
     ok((any { /crm_report_.*gz/ } @upload_calls), "crm_report.tar.gz uploaded");
     ok((any { /y2logs/ } @upload_calls), "y2logs uploaded");
     ok((any { /supportconfig.*/ } @upload_calls), "supportconfig uploaded");
+};
+
+subtest '[ipaddr2_logs_collect] fail' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    my @upload_calls;
+    $ipaddr2->redefine(upload_logs => sub {
+            push @upload_calls, $_[0];
+            return;
+    });
+    my @records;
+    $ipaddr2->redefine(record_info => sub { push @records, \@_; note(join(' ', 'RECORD_INFO -->', @_)); });
+    $ipaddr2->redefine(script_run => sub {
+            return 1 if $_[0] =~ /^ssh /;
+            return 0;
+    });
+    $ipaddr2->redefine(assert_script_run => sub { return; });
+
+    lives_ok { ipaddr2_logs_collect(bastion_ip => '1.2.3.4') } 'survives failing script_run';
+
+    is(scalar @upload_calls, 10, "upload_logs called 10 times even if commands fail");
+    ok((any { $_->[0] =~ /Failed.*time/ } @records), "failure was recorded");
+};
+
+subtest '[ipaddr2_logs_collect] timeout' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    my @upload_calls;
+    $ipaddr2->redefine(upload_logs => sub {
+            push @upload_calls, $_[0];
+            return;
+    });
+    my @records;
+    $ipaddr2->redefine(record_info => sub { push @records, \@_; note(join(' ', 'RECORD_INFO -->', @_)); });
+    $ipaddr2->redefine(script_run => sub {
+            die "command '$_[0]' timed out" if $_[0] =~ /^ssh /;
+            return 0;
+    });
+    $ipaddr2->redefine(assert_script_run => sub { return; });
+
+    lives_ok { ipaddr2_logs_collect(bastion_ip => '1.2.3.4') } 'survives timeout from script_run';
+
+    is(scalar @upload_calls, 10, "upload_logs called 10 times even if commands timeout");
+    ok((any { $_->[0] =~ /SSH timeout/ } @records), "timeout was recorded");
 };
 
 subtest '[ipaddr2_ssh_intrusion_detection]' => sub {


### PR DESCRIPTION
Update `ipaddr2_ssh_internal` to catch and handle exceptions (e.g., timeouts) from `script_run` when `no_assert` is enabled.
Instead of dying, it now records the timeout and returns `undef`, allowing the caller to continue.
This ensures that log collection tasks can proceed even if a single command fails or times out, improving the completeness of diagnostic data.

- Related ticket: https://jira.suse.com/browse/TEAM-11162

# Verification run:

## With code to simulate command failure and timeout
sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-ipaddr2_azure_test
 - http://openqaworker15.qe.prg2.suse.org/tests/363270

## Normal code
sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-ipaddr2_azure_test az_Standard_B1s
 - http://openqaworker15.qe.prg2.suse.org/tests/363269
 - http://openqaworker15.qe.prg2.suse.org/tests/363272