### PR TITLE
Enhance uefi guest power management verification

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -34,6 +34,7 @@ our @EXPORT = qw(
   is_fv_guest
   is_pv_guest
   is_sev_es_guest
+  is_transactional_guest
   guest_is_sle
   is_guest_ballooned
   is_xen_host
@@ -2200,6 +2201,32 @@ sub reset_network_config {
             assert_script_run("echo -e \"NETCONFIG_DNS_POLICY=\"auto\"\" >> $args{config}");
         }
     }
+}
+
+=head2 is_transactional_guest
+
+  is_transactional_guest(address => ip or domain name or fqdn);
+
+Check whether guest is in immutable mode by leveraging the two most reliable methods
+, namely transactional-update shell exists or root partition is mounted read only if
+its domain name does not have 'immutable' or 'transactional'. Need ssh connection to
+perform the check, so argument address is needed which can be guest ip address, domain
+name or FQDN as long as it can be used for ssh connection.
+
+=cut
+
+sub is_transactional_guest {
+    my (%args) = @_;
+    $args{address} //= '';
+    croak('Guest ip address, domain name or FQDN must be given') if (!$args{address});
+
+    return 1 if ($args{address} =~ /immutable|transactional/i);
+    return 0 if ($args{address} =~ /standard|traditional/i);
+    my $ret = 1;
+    my $ssh_command_prefix = "ssh -vvv -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no";
+    $ret &= script_retry("$ssh_command_prefix root\@$args{address} transactional-update --help || mount | grep \'on / \' | grep ro", die => 0);
+    save_screenshot;
+    $ret == 0 ? return 1 : return 0;
 }
 
 1;

--- a/tests/virt_autotest/uefi_guest_verification.pm
+++ b/tests/virt_autotest/uefi_guest_verification.pm
@@ -108,16 +108,8 @@ sub check_guest_pmsuspend_enabled {
     $self->do_guest_pmsuspend($_, 'mem') foreach (keys %virt_autotest::common::guests);
     if (is_kvm_host) {
         foreach (keys %virt_autotest::common::guests) {
-            if (is_sle('>=15') and ($_ =~ /12-sp5/img)) {
-                record_info("PMSUSPEND to hyrbrid is not supported here", "Guest $_ on kvm sles 15+ host");
-                next;
-            }
-            $self->regen_efi_secret_key($_) if (is_sle('>=15') or ($_ =~ /sles-15|sles15/img));
-            $self->do_guest_pmsuspend($_, 'hybrid');
-        }
-        foreach (keys %virt_autotest::common::guests) {
-            if (is_sle('>=15') and ($_ =~ /12-sp5/img)) {
-                record_info("PMSUSPEND to disk is not supported here", "Guest $_ on kvm sles 15+ host");
+            if ((is_sle('>=15') and $_ =~ /12-sp5/img) or is_transactional_guest(address => $_)) {
+                record_info("bsc#1260076 PMSUSPEND to disk is not supported here", "Guest $_ is sles 15- on kvm sles 15+ host or transactional");
                 next;
             }
             $self->regen_efi_secret_key($_) if (is_sle('>=15') or ($_ =~ /sles-15|sles15/img));
@@ -136,7 +128,7 @@ sub do_guest_pmsuspend {
     $suspend_target //= 'mem';
     $suspend_duration //= 0;
 
-    record_info("PM suspend to $suspend_target on $suspend_domain test", "Xen only supports suspend to memory, kvm also supports suspend to disk and hybrid modes");
+    record_info("PM suspend to $suspend_target on $suspend_domain test", "Xen only supports suspend to memory, kvm also supports disk/hybrid but only suspend to memory/disk is officially supported.");
     my $guest_state_after_suspend = 'pmsuspended';
     $guest_state_after_suspend = 'shut off' if ($suspend_target eq 'disk');
     assert_script_run("virsh dompmsuspend --domain $suspend_domain --target $suspend_target");


### PR DESCRIPTION
* **Remove** ```dompmsuspend to hybrid``` which is not officially supported for all scenarios.

* **Do** not do ```dompmsuspend to disk``` for transactional guest which does not have swap partition.

* **New** subroutine ```is_transactional_guest``` in module ```lib/virt_autotest/utils.pm```. 

* **Remove** record_soft_failure for bsc#1257492 which is already fixed.

* **Verification Runs:**
  * [traditional guest on traditional host(guest names has traditional)](http://vh012.qa2.suse.asia/tests/704)
  * [traditional guest on traditional host(guest names has standard)](http://vh012.qa2.suse.asia/tests/707)
  * [traditional guest on traditional host(check traditional system for sure)](http://vh012.qa2.suse.asia/tests/704)
  * [immuable guest on immutable host(guest name has immutable)](http://vh012.qa2.suse.asia/tests/692)
  * [immutable guest on immutable host(guest name has transactional)](http://vh012.qa2.suse.asia/tests/698)
  * [immutable guest on immutable host(check immutable system for sure)](http://vh012.qa2.suse.asia/tests/705)
  * [sle-16.1-Online-x86_64-Build40.1-immutable-gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/21977768)
  * [sle-16.1-Online-x86_64-Build40.1-uefi-gi-full-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/21939860)
  * [sle-16.1-Online-x86_64-Build40.1-uefi-gi-guest_developing-on-host_sles15sp7-kvm](https://openqa.suse.de/tests/21978667)
  * [sle-16.1-Online-x86_64-Build40.1-uefi-gi-guest_developing-on-host_sles16_0-kvm](https://openqa.suse.de/tests/21978668)
  * [sle-16.1-Online-x86_64-Build40.1-uefi-gi-guest_sles15sp7-on-host_developing-kvm](https://openqa.suse.de/tests/21978669)
  * [sle-16.1-Online-x86_64-Build40.1-uefi-gi-guest_sles16_0-online-on-host_developing-kvm](https://openqa.suse.de/tests/21978670)
  * [sle-16.1-Online-x86_64-Build40.1-uefi-gi-guest_win2025-on-host_developing-kvm](https://openqa.suse.de/tests/21978671)
  * [sle-16.1-Online-x86_64-Build40.1-uefi-gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/21978672)
  * [sle-16.1-Online-x86_64-Build40.1-snapshot-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/21978673)
  * [sle-16.1-Online-x86_64-Build40.1-snapshot-gi-guest_developing-on-host_sles15sp7-kvm](https://openqa.suse.de/tests/21978674)
  * [sle-16.1-Online-x86_64-Build40.1-snapshot-gi-guest_developing-online-on-host_sles16_0-kvm](https://openqa.suse.de/tests/21978675)
  * [sle-16.1-Online-x86_64-Build40.1-snapshot-gi-guest_sles15sp7-on-host_developing-kvm](https://openqa.suse.de/tests/21978678)
  * [sle-16.1-Online-x86_64-Build40.1-snapshot-gi-guest_sles16_0-online-on-host_developing-kvm](https://openqa.suse.de/tests/21978679)