### PR TITLE
Add --no-pager for outputting perf events

### DIFF
--- a/tests/console/perf.pm
+++ b/tests/console/perf.pm
@@ -15,7 +15,7 @@ use Utils::Architectures;
 
 # Auxiliar function to filter and group events
 sub run_perf_stat_grouped {
-    my $raw_list = script_output("perf list --raw-dump");
+    my $raw_list = script_output("perf --no-pager list --raw-dump");
 
     # Define groups of events
     my %groups = (


### PR DESCRIPTION
Fix for #25298 

- Related ticket: https://progress.opensuse.org/issues/198473
- Verification run: https://openqa.suse.de/tests/21905229#step/perf/52
