### PR TITLE
sles4sap: Use SPN secret from vault server instead of openQA variables

### DIFF
--- a/tests/sles4sap/publiccloud/azure_fence_agents_test.pm
+++ b/tests/sles4sap/publiccloud/azure_fence_agents_test.pm
@@ -42,6 +42,7 @@ QE-SAP <qe-sap@suse.de>
 use Mojo::Base 'sles4sap::publiccloud_basetest';
 use serial_terminal 'select_serial_terminal';
 use testapi;
+use publiccloud::utils 'get_credentials';
 use sles4sap::publiccloud;
 use sles4sap::qesap::qesapdeployment;
 use sles4sap::qesap::azure;
@@ -81,8 +82,9 @@ sub run {
     my @bashrc_vars = ("export SUBSCRIPTION_ID=$subscription_id");
 
     if ($fence_agent_configuration eq 'spn') {
-        my $spn_application_id = get_var('AZURE_SPN_APPLICATION_ID', get_required_var('_SECRET_AZURE_SPN_APPLICATION_ID'));
-        my $spn_application_password = get_var('AZURE_SPN_APP_PASSWORD', get_required_var('_SECRET_AZURE_SPN_APP_PASSWORD'));
+        my $data = get_credentials(url_suffix => 'azure.json');
+        my $spn_application_id = $data->{fencing_client_id};
+        my $spn_application_password = $data->{fencing_client_secret};
 
         push @bashrc_vars, "export SPN_APPLICATION_ID=$spn_application_id";
         push @bashrc_vars, "export SPN_APP_PASSWORD=$spn_application_password";

--- a/tests/sles4sap/publiccloud/qesap_configure.pm
+++ b/tests/sles4sap/publiccloud/qesap_configure.pm
@@ -129,14 +129,6 @@ Storage key name for PTFs.
 
 Azure fencing type (e.g., 'spn', 'msi').
 
-=item B<AZURE_SPN_APPLICATION_ID>
-
-SPN ID for Azure fencing.
-
-=item B<AZURE_SPN_APP_PASSWORD>
-
-SPN password for Azure fencing.
-
 =item B<SCC_REGCODE_SLES4SAP>
 
 SCC registration code for SLES for SAP.
@@ -158,7 +150,7 @@ package qesap_configure;
 use Mojo::Base 'sles4sap::publiccloud_basetest';
 use testapi;
 use publiccloud::ssh_interactive 'select_host_console';
-use publiccloud::utils qw(is_azure is_gce is_ec2 get_ssh_private_key_path is_byos detect_worker_ip);
+use publiccloud::utils qw(is_azure is_gce is_ec2 get_ssh_private_key_path is_byos detect_worker_ip get_credentials);
 use sles4sap::publiccloud;
 use sles4sap::qesap::qesapdeployment;
 use sles4sap::qesap::azure;
@@ -325,8 +317,9 @@ sub run {
     if ($playbook_configs{fencing} eq 'native' and is_azure()) {
         $playbook_configs{fence_type} = get_required_var('AZURE_FENCE_AGENT_CONFIGURATION');
         if ($playbook_configs{fence_type} eq 'spn') {
-            $playbook_configs{spn_application_id} = get_var('AZURE_SPN_APPLICATION_ID', get_required_var('_SECRET_AZURE_SPN_APPLICATION_ID'));
-            $playbook_configs{spn_application_password} = get_var('AZURE_SPN_APP_PASSWORD', get_required_var('_SECRET_AZURE_SPN_APP_PASSWORD'));
+            my $data = get_credentials(url_suffix => 'azure.json');
+            $playbook_configs{spn_application_id} = $data->{fencing_client_id};
+            $playbook_configs{spn_application_password} = $data->{fencing_client_secret};
         }
     }
 

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -132,14 +132,6 @@ The fencing mechanism to use (e.g., 'sbd', 'native'). Defaults to 'sbd'.
 
 (Azure-specific) The configuration for the native fence agent ('msi' or 'spn').
 
-=item B<QESAPDEPLOY_AZURE_SPN_APPLICATION_ID> or B<_SECRET_AZURE_SPN_APPLICATION_ID>
-
-(Azure-specific) The application ID for the Service Principal Name used for fencing.
-
-=item B<QESAPDEPLOY_AZURE_SPN_APP_PASSWORD> or B<_SECRET_AZURE_SPN_APP_PASSWORD>
-
-(Azure-specific) The password for the Service Principal Name used for fencing.
-
 =item B<QESAPDEPLOY_HANA_INSTALL_MODE>
 
 The installation mode for HANA. Defaults to 'standard'.
@@ -174,7 +166,7 @@ QE-SAP <qe-sap@suse.de>
 
 use Mojo::Base 'publiccloud::basetest';
 use publiccloud::azure_client;
-use publiccloud::utils qw(get_ssh_private_key_path detect_worker_ip);
+use publiccloud::utils qw(get_ssh_private_key_path detect_worker_ip get_credentials);
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use registration qw(get_addon_fullname scc_version %ADDONS_REGCODE);
@@ -278,9 +270,8 @@ sub run {
         if ($variables{FENCING} eq 'native') {
             $variables{AZURE_NATIVE_FENCING_AIM} = get_var('QESAPDEPLOY_AZURE_FENCE_AGENT_CONFIGURATION', 'msi');
             if ($variables{AZURE_NATIVE_FENCING_AIM} eq 'spn') {
-                $variables{AZURE_NATIVE_FENCING_APP_ID} = get_var('QESAPDEPLOY_AZURE_SPN_APPLICATION_ID', get_required_var('_SECRET_AZURE_SPN_APPLICATION_ID'));
-                $variables{AZURE_NATIVE_FENCING_APP_PASSWORD} = get_var('QESAPDEPLOY_AZURE_SPN_APP_PASSWORD', get_required_var('_SECRET_AZURE_SPN_APP_PASSWORD'));
-                save_tmp_file('spn_secret.yaml', "spn_application_id: $variables{AZURE_NATIVE_FENCING_APP_ID}\nspn_application_password: $variables{AZURE_NATIVE_FENCING_APP_PASSWORD}");
+                my $data = get_credentials(url_suffix => 'azure.json');
+                save_tmp_file('spn_secret.yaml', "spn_application_id: $data->{fencing_client_id}\nspn_application_password: $data->{fencing_client_secret}");
                 assert_script_run('curl ' . autoinst_url . '/files/spn_secret.yaml -o ~/spn_secret.yaml');
             }
         }


### PR DESCRIPTION
I use `get_credentials` instead of `get_var` to get SPN secrets from larry (
`PUBLIC_CLOUD_CREDENTIALS_URL`).

The secret is newly generated, the test runs pass show that the new secret is working properly.

- Related ticket: https://jira.suse.com/browse/TEAM-10928
- Needles: none
- Verification run: 
hanasr: https://openqa.suse.de/tests/21899836
qesap deployment: https://openqaworker15.qe.prg2.suse.org/tests/363260