### PR TITLE
Revert "Kselftests: Fix per-test log path for sub-collections"

### DIFF
--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -155,7 +155,7 @@ sub install_kselftests
 sub get_sanitized_test_name
 {
     my $test = shift;
-    my $test_name = $test =~ s/^[^:]+://r;    # Remove the collection from it (including sub-paths like net/forwarding), sub . with _
+    my $test_name = $test =~ s/^\w+://r;    # Remove the collection from it, sub . with _
     my $sanitized_test_name = $test_name =~ s/\.|-/_/gr;    # Dots and hyphens should be underscore for better handling in Perl and YAML files
     return ($test_name, $sanitized_test_name);
 }


### PR DESCRIPTION
This reverts commit a928563e392ccd0961a4a036d4f389ce0c9a631f.

Seems recently we introduced the regression in the kselftest openqa runner, so the test results for cgroup aren't rendered correctly.
I'm trying to see what is the root cause and how to get this fixed.

- Related ticket: tbd
- Verification run: tbd
