### PR TITLE
Ignore TMPFS fail in mr_test on Azure

### DIFF
--- a/tests/sles4sap/saptune/mr_test_run.pm
+++ b/tests/sles4sap/saptune/mr_test_run.pm
@@ -19,6 +19,7 @@ use version_utils qw(is_sle is_public_cloud);
 use Utils::Architectures;
 use Mojo::JSON 'encode_json';
 use publiccloud::instances;
+use publiccloud::utils qw(is_azure);
 use mr_test_lib qw(get_notes get_solutions);
 
 =head1 NAME
@@ -766,6 +767,10 @@ sub wrap_script_run {
                 # SP6 is shipped with saptune v3.1.2. The ASE solution in this version contains the Notes: 941735 1680803 1771258 2578899 2993054 1656250.
                 # The test still assumes, that 1410736 is part of the solution, which sets (among others) net.ipv4.tcp_keepalive_time.
                 push @ignore_issue, $line;
+            }
+            elsif ($output =~ /TMPFS.*?\[FAIL\].*?33% > 5%/ && is_azure()) {
+                # With saptune 3.2.3 TMPFS is left alone on Azure because it cannot be set reliably anymore
+                record_soft_failure('Issue can be ignored, see c1 in bsc#1261666');
             }
             else {
                 push @real_failures, $line;


### PR DESCRIPTION
With saptune 3.2.3 TMPFS is left alone on Azure because it cannot be set reliably anymore[1], it only impact Azure, so I only updated openQA code to ignore the related issue on Azure rather than to update all the test case in mr_test code.
[1] - https://bugzilla.suse.com/show_bug.cgi?id=1261666#c1

- Related ticket: https://jira.suse.com/browse/TEAM-11137
- Needles: None
- Verification run:
    https://openqa.suse.de/tests/21905515 (15-SP7/notes)
    https://openqa.suse.de/tests/21905514 (15-SP7/solutions)
    https://openqa.suse.de/tests/21900161 (15-SP6/notes)
    https://openqa.suse.de/tests/21902900 (15-SP5/notes)
    https://openqa.suse.de/tests/21905276 (15-SP5/solutions)
    https://openqa.suse.de/tests/21905516 (12-SP5/notes)
    https://openqa.suse.de/tests/21905517 (12-SP5/solutions)
    https://openqa.suse.de/tests/21924362#step/1_saptune_notes/1112 (mark softfail)
    https://openqa.suse.de/tests/21936822#step/1_saptune_notes/1112 (mark softfail)