### PR TITLE
transactional: Rework conditions under which soft-reboot is enabled

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -81,7 +81,13 @@ sub handle_first_grub {
 # update of the bootloader or any command like rollback, grub.cfg, bootloader, run or shell
 sub check_reboot_strategy_and_reboot {
     my @reboot_args;
-    if (!is_sle_micro) {
+
+    # as this will likely grow, it is better to have single line checks to give room to more
+    # complex expressions
+    my $has_soft_reboot = 1;
+    $has_soft_reboot = 0 if (is_sle_micro || is_sle);
+
+    if ($has_soft_reboot) {
         my $regex = qr/Minimally required reboot level:\s(.*)[\r\n]/;
         my $output = wait_serial($regex, timeout => 300) or die "Could not capture reboot type";
         if ($output =~ $regex) {


### PR DESCRIPTION
Making the checks separate allows for easier reading of the different
conditions (which will grow in the future) where the softreboot can
be expected by process_reboot.

openqa: clone https://openqa.opensuse.org/tests/5856108

Verification run: https://openqa.suse.de/tests/21902844

openSUSE vr fails due to https://bugzilla.opensuse.org/show_bug.cgi?id=1262275

#### Results from cloned jobs:
- [![https://openqa.opensuse.org/tests/5857408](https://openqa.opensuse.org/tests/5857408/badge)](https://openqa.opensuse.org/tests/5857408)

<sub>The above list is generated with a script with information from the "clone_mentioned_job" workflow.</sub>
