### PR TITLE
Keep grub's timeout for vmware

### DIFF
--- a/lib/jeos.pm
+++ b/lib/jeos.pm
@@ -8,10 +8,16 @@ use serial_terminal 'select_serial_terminal';
 use utils qw(ensure_serialdev_permissions);
 use power_action_utils qw(power_action);
 use Utils::Backends qw(is_hyperv);
-use version_utils qw(is_sle is_community_jeos is_tumbleweed is_wsl);
+use version_utils qw(is_sle is_community_jeos is_tumbleweed is_wsl is_vmware);
 use bootloader_setup qw(change_grub_config grep_grub_settings grub_mkconfig set_framebuffer_resolution set_extrabootparams_grub_conf);
 
-our @EXPORT = qw(expect_mount_by_uuid set_grub_gfxmode reboot_image is_translations_preinstalled);
+our @EXPORT = qw(
+  expect_mount_by_uuid
+  set_grub_gfxmode
+  reboot_image
+  is_translations_preinstalled
+  disable_grub_timeout
+);
 
 sub expect_mount_by_uuid {
     return !(!is_hyperv && is_sle('<15-sp2'));
@@ -30,10 +36,20 @@ sub reboot_image {
 sub set_grub_gfxmode {
     change_grub_config('=.*', '=1024x768', 'GRUB_GFXMODE=');
     change_grub_config('^#', '', 'GRUB_GFXMODE');
-    change_grub_config('=.*', '=-1', 'GRUB_TIMEOUT') unless check_var('VIRSH_VMM_TYPE', 'linux');
     grep_grub_settings('^GRUB_GFXMODE=1024x768$');
     set_framebuffer_resolution;
     set_extrabootparams_grub_conf;
+    grub_mkconfig;
+}
+
+sub disable_grub_timeout {
+    if (get_var('KEEP_GRUB_TIMEOUT') || is_vmware) {
+        # KEEP_GRUB_TIMEOUT=1 in order to skip bootloader needles
+        set_var('KEEP_GRUB_TIMEOUT', 1);
+        return;
+    }
+
+    change_grub_config('=.*', '=-1', 'GRUB_TIMEOUT') unless check_var('VIRSH_VMM_TYPE', 'linux');
     grub_mkconfig;
 }
 

--- a/tests/jeos/host_config.pm
+++ b/tests/jeos/host_config.pm
@@ -13,7 +13,7 @@
 use Mojo::Base 'opensusebasetest';
 use testapi;
 use serial_terminal;
-use jeos qw(set_grub_gfxmode);
+use jeos qw(set_grub_gfxmode disable_grub_timeout);
 use utils qw(ensure_serialdev_permissions);
 use Utils::Architectures qw(is_s390x);
 use version_utils qw(is_sle);
@@ -22,6 +22,7 @@ sub run {
     select_console('root-console');
 
     set_grub_gfxmode;
+    disable_grub_timeout;
     ensure_serialdev_permissions;
     prepare_serial_console;
     if (is_s390x && is_sle('16.0+')) {


### PR DESCRIPTION
Matching grub2 menu in vmware is prone to [failures](https://openqa.suse.de/tests/21805174#step/glibc_locale/61) as the backend
is not using VNC. From the test module perspective, it can skip grub2
and keep the default timeout.

- Verification run: https://openqa.suse.de/tests/21907296#step/glibc_locale/1
