### PR TITLE
refactor(publiccloud): introduce publiccloud::zypper module with pc_ API

### DIFF
--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -14,6 +14,7 @@ use testapi;
 use version_utils qw(is_transactional is_sle);
 use Utils::Architectures qw(is_aarch64);
 use publiccloud::utils qw(is_byos pc_data_url);
+use publiccloud::zypper qw(pc_zypper_call);
 use publiccloud::aws_client;
 use publiccloud::ssh_interactive 'select_host_console';
 
@@ -464,7 +465,7 @@ sub _install_ec2_cloudwatch_agent
         $instance->softreboot();
     } else {
         if (is_sle(">12-SP5")) {
-            $instance->zypper_call_remote(cmd => "install --no-recommends --allow-unsigned-rpm $download_directory/$rpm_file");
+            pc_zypper_call($instance, "install --no-recommends --allow-unsigned-rpm $download_directory/$rpm_file");
         } else {
             $instance->ssh_assert_script_run("sudo rpm -Uvh $download_directory/$rpm_file");
         }

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -24,9 +24,10 @@ use warnings;
 use testapi;
 use utils;
 use version_utils qw(is_sle is_public_cloud get_version_id is_transactional is_sle_micro check_version);
-use transactional qw(reboot_on_changes trup_call process_reboot);
+use transactional qw(process_reboot);
 use registration qw(get_addon_fullname add_suseconnect_product %ADDONS_REGCODE);
 use maintenance_smelt qw(is_embargo_update);
+use publiccloud::zypper ();
 
 # Indicating if the openQA port has been already allowed via SELinux policies
 my $openqa_port_allowed = 0;
@@ -59,9 +60,7 @@ our @EXPORT = qw(
   install_in_venv
   venv_activate
   get_python_exec
-  wait_quit_zypper_pc
   detect_worker_ip
-  zypper_call_remote
   calculate_custodian_ttl
   pc_data_url
 );
@@ -241,14 +240,21 @@ sub register_addons_in_pc {
     my $timeout = $args{timeout} // 90;
     my @addons = split(/,/, get_var('SCC_ADDONS', ''));
     my $remote = $instance->username . '@' . $instance->public_ip;
-    # Using zypper_call_remote here appends `transactional-update -n pkg` and it
-    # fails with invalid syntax and causes registration failures.
-    #
-    # TODO: this is a hotfix. We need to fix the `zypper_call_remote` itself
-    # as transactional-update does not support repo actions => poo#195920)
-    my $ret = $instance->ssh_script_retry(cmd => "sudo zypper -n --gpg-auto-import-keys ref", timeout => $timeout, retry => 3, delay => 60, die => 0);
-    die 'No enabled repos defined: bsc#1245651' if $ret == 6;    # from zypper man page: ZYPPER_EXIT_NO_REPOS
-    die 'System management is locked by the application with pid xxx (/usr/bin/zypper)' if $ret == 7;    # from zypper man page: ZYPPER_EXIT_ZYPP_LOCKED
+    # Refresh repos. publiccloud::zypper::pc_refresh always uses plain zypper
+    # (never transactional-update, which does not support repo actions, see
+    # poo#195920). Accept all exit codes and inspect the result here so we
+    # can give the historical bsc references.
+    my $ret = publiccloud::zypper::pc_refresh(
+        $instance,
+        timeout => $timeout,
+        exitcode => [
+            publiccloud::zypper::EXIT_OK,
+            publiccloud::zypper::EXIT_NO_REPOS,
+            publiccloud::zypper::EXIT_LOCKED,
+        ],
+    );
+    die 'No enabled repos defined: bsc#1245651' if $ret == publiccloud::zypper::EXIT_NO_REPOS;
+    die 'System management is locked by the application with pid xxx (/usr/bin/zypper)' if $ret == publiccloud::zypper::EXIT_LOCKED;
     for my $addon (@addons) {
         next if ($addon =~ /^\s+$/);
         register_addon($remote, $addon);
@@ -351,7 +357,7 @@ sub gcloud_install {
     push @pkgs, 'python' . $py_pkg_version;
     add_suseconnect_product(get_addon_fullname('python3')) if (is_sle('15-SP6+') && is_sle("<16.0"));
 
-    zypper_call("in @pkgs", $timeout);
+    publiccloud::zypper::pc_install_packages_local(\@pkgs, timeout => $timeout);
 
     assert_script_run("export CLOUDSDK_PYTHON=/usr/bin/python$py_version");
     assert_script_run("export CLOUDSDK_CORE_DISABLE_PROMPTS=1");
@@ -423,13 +429,7 @@ sub allow_openqa_port_selinux {
     return if ($openqa_port_allowed);
 
     # Additional packages required for semanage
-    my $pkgs = 'policycoreutils-python-utils';
-    if (is_transactional) {
-        trup_call("pkg install $pkgs");
-        reboot_on_changes;
-    } else {
-        zypper_call("in $pkgs");
-    }
+    publiccloud::zypper::pc_install_packages_local(['policycoreutils-python-utils']);
     # allow ssh tunnel port (to openQA)
     my $upload_port = get_required_var('QEMUPORT') + 1;
     assert_script_run("semanage port -a -t ssh_port_t -p tcp $upload_port");
@@ -451,20 +451,19 @@ Transactional systems like SLE micro used C<transactional_update up> and reboot.
 
 sub ssh_update_transactional_system {
     my ($instance) = @_;
-    my $cmd_time = time();
-    my $cmd = "sudo transactional-update -n up";
-    my $cmd_name = "transactional update";
-    # first run, possible update of packager
-    my $ret = $instance->ssh_script_run(cmd => $cmd, timeout => 1500);
-    $instance->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));
-    record_info($cmd_name, 'The command ' . $cmd_name . ' took ' . (time() - $cmd_time) . ' seconds.');
-    die "$cmd_name failed with $ret" if ($ret != 0 && $ret != 102 && $ret != 103);
-    # second run, full system update
-    $cmd_time = time();
-    $ret = $instance->ssh_script_run(cmd => $cmd, timeout => 6000);
-    $instance->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));
-    record_info($cmd_name, 'The second command ' . $cmd_name . ' took ' . (time() - $cmd_time) . ' seconds.');
-    die "$cmd_name failed with $ret" if ($ret != 0 && $ret != 102);
+    my $cmd_name = 'transactional update';
+
+    # First run: may update the packager itself.
+    my $t0 = time();
+    publiccloud::zypper::pc_transactional_call($instance, 'up', timeout => 1500);
+    record_info($cmd_name, "The command $cmd_name took " . (time() - $t0) . ' seconds.');
+
+    # Second run: full system update. Treat reboot-needed (102) and the
+    # extra "reboot scheduled" (103) as success; transactional_call already
+    # accepts these by default.
+    $t0 = time();
+    publiccloud::zypper::pc_transactional_call($instance, 'up', timeout => 6000);
+    record_info($cmd_name, "The second command $cmd_name took " . (time() - $t0) . ' seconds.');
 }
 
 
@@ -649,39 +648,6 @@ exit \$exit_code
 EOT
 }
 
-=head2 wait_quit_zypper_pc
-
-    wait_quit_zypper_pc($instance
-        [, timeout => 20 ]   # per-attempt SSH timeout (s)
-        [, delay   => 10 ]   # delay between attempts (s)
-        [, retry   => 60 ]   # number of attempts
-    );
-
-Wait until no background zypper-related processes are running on the remote
-instance. Uses C<retry_ssh_command> for polling. Returns on success; dies
-after retries are exhausted.
-
-=cut
-
-sub wait_quit_zypper_pc {
-    my ($instance, %args) = @_;
-
-    my $timeout = $args{timeout} // 20;    # per-attempt SSH timeout
-    my $delay = $args{delay} // 10;    # seconds between polls
-    my $retry = $args{retry} // 120;    # total attempts (~10 min ceiling)
-
-    # Succeeds (RC 0) only when NO matching processes exist.
-    # Using '!' avoids explicit 'exit' and works cleanly with ssh_script_retry.
-    my $cmd = q{! pgrep -a "zypper|packagekit|purge-kernels|rpm"};
-
-    $instance->ssh_script_retry(
-        cmd => $cmd,
-        timeout => $timeout,
-        delay => $delay,
-        retry => $retry,
-    );
-}
-
 =head2 detect_worker_ip
 
     detect_worker_ip($proceed_on_failure)
@@ -711,143 +677,6 @@ sub detect_worker_ip {
     return undef if $args{proceed_on_failure};
     die "Worker IP could not be determined - return was $ip";
 }
-
-=head2 zypper_call_remote
-
-    zypper_call_remote($instance, cmd => $cmd, [%args]);
-
-Executes a C<zypper> or C<transactional-update> command on a remote C<$instance> via SSH.
-The function automatically handles command prefixing (adding sudo and non-interactive flags),
-retries on specific network/solver failures, and parses logs for detailed error reporting.
-
-=over 4
-
-=item B<cmd> => $string
-
-The zypper subcommand and arguments (e.g., C<'install -y vim'>). Do not include C<sudo> 
-or C<-n>, as these are added automatically. B<Note:> Piping to C<grep> is forbidden 
-to ensure exit codes are captured correctly.
-
-=item B<timeout> => $int
-
-Command timeout in seconds. Defaults to B<900> for transactional systems and 
-B<700> for standard systems. Must be greater than 0.
-
-=item B<exitcode> => $arrayref
-
-A list of exit codes to be treated as success. Defaults to C<[0]>.
-
-=item B<retry> => $int
-
-Number of times to attempt the command if it fails. Defaults to C<1>.
-
-=item B<delay> => $int
-
-Seconds to wait between retries. Defaults to C<5>.
-
-=item B<proceed_on_failure> => $boolean
-
-If set to C<1>, the function will record a failure in the test results but will
-not C<die>. Defaults to C<0>.
-
-=item B<wait_quit_zypper> => $boolean
-
-If set to C<1> (default), it calls C<wait_quit_zypper_pc> to wait for any 
-running zypper processes to terminate before starting. This effectively 
-eliminates the need for manual handling of B<exit code 7> (ZYPPER_EXIT_INTERFACE_LOCKED), 
-which occurs when zypper cannot acquire the execution lock because it is 
-held by another process.
-
-=back
-
-=head3 Transactional Systems
-If C<is_transactional()> is true, the command is prefixed with C<transactional-update -n pkg>.
-Additionally, a C<softreboot()> is triggered automatically upon success to apply changes.
-
-=head3 Error Handling
-On failure, the function:
-1. Uploads C</var/log/zypper.log> to the test results.
-2. Specifically checks for known issues like B<bsc#1070851> (502 errors).
-3. Parses logs for Solver Conflicts (Exit 4), Missing Capabilities (Exit 104), or
-   RPM scriptlet failures (Exit 107) and reports them via C<record_info>.
-
-=cut
-
-sub zypper_call_remote {
-    my $instance = shift;
-    my %args = testapi::compat_args({cmd => undef}, ['cmd'], @_);
-    $args{rc_only} = 1;
-    $args{timeout} //= is_transactional() ? 900 : 700;
-    die "Invalid value 'timeout' = 0" unless ($args{timeout});
-    die "Empty 'cmd' argument in zypper call" unless ($args{cmd});
-    die "Exit code is from PIPESTATUS[0], not grep" if $args{cmd} =~ /^((?!`).)*\| ?grep/;
-    my $log = "/var/log/zypper.log";
-    my $exit_codes = $args{exitcode} || [0];
-    my $retry = $args{retry} // 1;
-    my $delay = $args{delay} // 5;
-    my $proceed = $args{proceed_on_failure} // 0;
-    my $cmd = "sudo zypper -n " . $args{cmd};
-    my $wait_quit_zypper = $args{wait_quit_zypper} // 1;
-    delete $args{cmd};
-    delete $args{exitcode};
-    delete $args{retry};
-    delete $args{delay};
-    # retry loop
-    my $ret;
-    wait_quit_zypper_pc($instance) if $wait_quit_zypper;
-    for (1 .. $retry) {
-        # pause on next
-        sleep($delay) if (defined($ret));
-        # remote execution
-        $ret = $instance->ssh_script_run(cmd => $cmd, %args);
-        last if ($ret == 0);
-        # check exit codes
-        if ($ret == 4) {
-            if ($instance->ssh_script_run(qq[sudo grep "Error code.*502" $log]) == 0) {
-                die 'According to bsc#1070851 zypper should automatically retry internally. Bugfix missing for current product?';
-            }
-            elsif ($instance->ssh_script_run(qq[sudo grep "Solverrun finished with an ERROR" $log]) == 0) {
-                my $search_conflicts = q[sudo awk '/Solverrun finished with an ERROR/,/statistics/{ print group"|", $0; if ($0 ~ /statistics/ ){ print "EOL"; group++ } }' ] . $log;
-                my $conflicts = $instance->ssh_script_output($search_conflicts);
-                record_info("Conflicts", $conflicts, result => 'fail');
-                diag "Package conflicts found, not retrying anymore" if $conflicts;
-                last;
-            }
-            next;
-        }
-        elsif ($ret == 7) {
-            record_info("Retry $retry as system management is locked");
-            next;
-        }
-        last;
-    }
-    unless (grep { $_ == $ret } @$exit_codes) {
-        $instance->ssh_script_run(qq[sudo chmod o+r $log]);
-        $instance->upload_log($log);
-        my $msg = qq[$cmd failed with code: $ret];
-        if ($ret == 104) {
-            $msg .= " (ZYPPER_EXIT_INF_CAP_NOT_FOUND)\n\nRelated zypper logs:\n";
-            $instance->ssh_script_run(qq[sudo tac $log | grep -F -m1 -B100000 "Hi, me zypper" | tac | grep -E '(SolverRequester.cc|THROW|CAUGHT)' > /tmp/z104.txt]);
-            $msg .= $instance->ssh_script_output('cat /tmp/z104.txt');
-        }
-        elsif ($ret == 107) {
-            $msg .= " (ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED)\n\nRelated zypper logs:\n";
-            $instance->ssh_script_run(qq[sudo tac $log | grep -F -m1 -B100000 "Hi, me zypper" | tac | grep -E 'RpmPostTransCollector.cc(executeScripts):.* scriptlet failed, exit status' > /tmp/z107.txt]);
-            $msg .= $instance->ssh_script_output('cat /tmp/z107.txt') . "\n\n";
-        }
-        else {
-            $instance->ssh_script_run(qq[sudo tac $log | grep -F -m1 -B100000 "Hi, me zypper" | tac | grep 'Exception.cc' > /tmp/zlog.txt]);
-            $msg .= "\n\nRelated zypper logs:\n";
-            $msg .= $instance->ssh_script_output('cat /tmp/zlog.txt');
-        }
-        die $msg unless ($proceed);
-        record_info("zypper error", $msg, result => 'fail');
-    }
-    record_info("zypper remote call", "Command: $cmd \nResult: $ret");
-    $instance->softreboot() if is_transactional();
-    return $ret;
-}
-
 
 =head2 calculate_custodian_ttl
 

--- a/lib/publiccloud/zypper.pm
+++ b/lib/publiccloud/zypper.pm
@@ -1,0 +1,632 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+#
+# Summary: Zypper / transactional-update plumbing for public cloud tests
+# Maintainer: QE-C team <qa-c@suse.de>
+
+package publiccloud::zypper;
+
+=encoding UTF-8
+
+=head1 NAME
+
+publiccloud::zypper - Zypper / transactional-update plumbing for public cloud tests
+
+=head1 SYNOPSIS
+
+    use publiccloud::zypper qw(pc_pkg_call pc_refresh pc_add_repo);
+
+    pc_refresh($instance);
+    pc_add_repo($instance, 'my-repo', 'http://example.com/repo');
+    pc_pkg_call($instance, 'in some-package');
+
+=head1 DESCRIPTION
+
+Centralises all package-management interactions with remote public cloud
+instances (and a small helper for local installations). On transactional
+systems, package-changing operations are transparently routed through
+C<transactional-update>; refresh and repository management always go
+through plain C<zypper>.
+
+=head1 PUBLIC API
+
+=over 4
+
+=item L</pc_zypper_call>           - plain C<sudo zypper -n ...>
+
+=item L</pc_transactional_call>    - plain C<sudo transactional-update -n ...>
+
+=item L</pc_pkg_call>              - smart dispatch based on C<is_transactional()>
+
+=item L</pc_refresh>               - C<zypper ref> (always plain; poo#195920)
+
+=item L</pc_add_repo>              - add a GPG-checked repository
+
+=item L</pc_wait_quit>             - wait for zypper/rpm/etc. to finish
+
+=item L</pc_installed_packages>    - filter list to installed packages
+
+=item L</pc_available_packages>    - filter list to available-but-not-installed
+
+=item L</pc_install_packages_local> - local-SUT install helper
+
+=back
+
+See the per-function sections below for full signatures and options.
+
+=cut
+
+use strict;
+use warnings;
+use Exporter qw(import);
+
+use testapi;
+use utils ();
+use transactional ();
+use version_utils qw(is_transactional);
+
+# Zypper exit codes (see man zypper, EXIT CODES section)
+use constant {
+    EXIT_OK => 0,
+    EXIT_SOLVER => 4,    # generic solver problem
+    EXIT_NO_REPOS => 6,    # ZYPPER_EXIT_NO_REPOS
+    EXIT_LOCKED => 7,    # ZYPPER_EXIT_ZYPP_LOCKED
+    EXIT_REBOOT_NEEDED => 102,
+    EXIT_REBOOT_SCHED => 103,
+    EXIT_CAP_NOT_FOUND => 104,    # ZYPPER_EXIT_INF_CAP_NOT_FOUND
+    EXIT_RPM_SCRIPT_FAIL => 107,    # ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED
+                                    # Tunable defaults
+    DEFAULT_TIMEOUT_ZYPPER => 700,
+    DEFAULT_TIMEOUT_TRANSACTIONAL => 900,
+    DEFAULT_RETRY => 1,
+    DEFAULT_DELAY => 5,
+    ZYPPER_LOG => '/var/log/zypper.log',
+};
+
+our @EXPORT_OK = qw(
+  pc_zypper_call
+  pc_transactional_call
+  pc_pkg_call
+  pc_refresh
+  pc_add_repo
+  pc_wait_quit
+  pc_installed_packages
+  pc_available_packages
+  pc_install_packages_local
+  EXIT_OK
+  EXIT_SOLVER
+  EXIT_NO_REPOS
+  EXIT_LOCKED
+  EXIT_REBOOT_NEEDED
+  EXIT_REBOOT_SCHED
+  EXIT_CAP_NOT_FOUND
+  EXIT_RPM_SCRIPT_FAIL
+);
+
+our %EXPORT_TAGS = (
+    all => [@EXPORT_OK],
+    codes => [grep { /^EXIT_/ } @EXPORT_OK],
+);
+
+
+# Strict allow-list of zypper verbs that transactional-update can wrap.
+# See https://kubic.opensuse.org/documentation/man-pages/transactional-update.8.html
+#
+# Top-level transactional-update commands (no `pkg` prefix). Note `up`/`update`
+# at the toplevel updates the whole system; `pkg update <pkgs>` updates a
+# selection.
+my %TOPLEVEL_VERB = (
+    up => 'up',
+    update => 'up',
+    dup => 'dup',
+    'dist-upgrade' => 'dup',
+    patch => 'patch',
+);
+
+# Verbs that require the `pkg <verb>` wrapper.
+my %PKG_VERB = (
+    in => 'install',
+    install => 'install',
+    rm => 'remove',
+    remove => 'remove',
+);
+
+# The *only* options transactional-update accepts in its global slot, i.e.
+# before the general/package command (see OPTIONS in transactional-update.8).
+# Any other dash-prefixed token is a zypper *command* option and must travel
+# with the verb, never be hoisted here -- otherwise e.g. `zypper in -y curl`
+# would become `transactional-update -y pkg install curl`, and `-y` is not a
+# valid transactional-update global option.
+my %TU_GLOBAL_OPT = map { $_ => 1 } qw(
+  -i --interactive
+  -n --non-interactive
+  -c --continue
+  -d --drop-if-no-change
+  --quiet
+  --no-selfupdate
+  --no-allow-vendor-change
+);
+
+# Failure-classification table. Maps zypper exit codes to a label and a
+# regex used to scrape the relevant lines from the last zypper session in
+# /var/log/zypper.log.
+my %FAILURE_CLASSIFIERS = (
+    EXIT_CAP_NOT_FOUND() => {
+        label => 'ZYPPER_EXIT_INF_CAP_NOT_FOUND',
+        regex => '(SolverRequester.cc|THROW|CAUGHT)',
+    },
+    EXIT_RPM_SCRIPT_FAIL() => {
+        label => 'ZYPPER_EXIT_INF_RPM_SCRIPT_FAILED',
+        regex => 'RpmPostTransCollector\.cc\(executeScripts\):.* scriptlet failed, exit status',
+    },
+);
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+=head2 pc_zypper_call
+
+    pc_zypper_call($instance, $cmd, %opts);
+    pc_zypper_call($instance, cmd => $cmd, %opts);
+
+Runs C<sudo zypper -n $cmd> on a remote instance. Never wraps the command in
+C<transactional-update>; use this for repo/refresh/info operations even on
+transactional systems.
+
+Options (all optional):
+
+=over 4
+
+=item B<timeout>           => seconds, default 700
+
+=item B<retry>             => number of attempts, default 1
+
+=item B<delay>             => seconds between retries, default 5
+
+=item B<exitcode>          => arrayref of accepted exit codes, default [0]
+
+=item B<proceed_on_failure> => if true, record the failure but don't die
+
+=item B<wait_quit>          => if true (default), wait for any running
+                                zypper-related processes to finish before
+                                running the command
+
+=back
+
+=cut
+
+sub pc_zypper_call {
+    my ($instance, $cmd, %opts) = _normalize_call_args(@_);
+    _validate_args($cmd, \%opts);
+    return _run($instance, "sudo zypper -n $cmd", %opts, _kind => 'zypper');
+}
+
+=head2 pc_transactional_call
+
+    pc_transactional_call($instance, $cmd, %opts);
+
+Runs C<sudo transactional-update -n $cmd> on a remote instance and triggers
+a soft reboot on success (unless C<no_reboot => 1> is passed). The default
+accepted exit codes are 0, 102, 103.
+
+=cut
+
+sub pc_transactional_call {
+    my ($instance, $cmd, %opts) = _normalize_call_args(@_);
+    _validate_args($cmd, \%opts);
+
+    $opts{timeout} //= DEFAULT_TIMEOUT_TRANSACTIONAL;
+    $opts{exitcode} //= [EXIT_OK, EXIT_REBOOT_NEEDED, EXIT_REBOOT_SCHED];
+    my $no_reboot = delete $opts{no_reboot};
+
+    my $ret = _run($instance, "sudo transactional-update -n $cmd", %opts, _kind => 'transactional');
+
+    if (!$no_reboot && grep { $_ == $ret } @{$opts{exitcode}}) {
+        $instance->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));
+    }
+    return $ret;
+}
+
+=head2 pc_pkg_call
+
+    pc_pkg_call($instance, $cmd, %opts);
+
+Smart dispatch: on transactional systems, translates C<$cmd> into the
+equivalent C<transactional-update> invocation when possible (for install /
+remove / update / dup / patch). Anything that C<transactional-update> does
+not support (refresh, repo management, queries, ...) falls through to plain
+C<pc_zypper_call>. On non-transactional systems this is identical to
+C<pc_zypper_call>.
+
+=cut
+
+sub pc_pkg_call {
+    my ($instance, $cmd, %opts) = _normalize_call_args(@_);
+
+    return pc_transactional_call($instance, _zypper_to_transactional($cmd), %opts)
+      if (is_transactional() && _is_translatable_to_transactional($cmd));
+
+    return pc_zypper_call($instance, $cmd, %opts);
+}
+
+=head2 pc_refresh
+
+    pc_refresh($instance, %opts);
+
+Refreshes repositories on the remote instance. Always uses plain zypper,
+even on transactional systems, because C<transactional-update> does not
+support repo refresh actions (poo#195920).
+
+=cut
+
+sub pc_refresh {
+    my ($instance, %opts) = @_;
+    $opts{retry} //= 3;
+    $opts{delay} //= 60;
+    $opts{timeout} //= 90;
+    return pc_zypper_call($instance, '--gpg-auto-import-keys ref', %opts);
+}
+
+=head2 pc_add_repo
+
+    pc_add_repo($instance, $name, $url, [timeout => 600]);
+
+Adds a GPG-checked repository to the remote instance. Uses
+C<ssh_assert_script_run> directly (i.e. dies on non-zero exit) rather than
+the full C<pc_zypper_call> retry pipeline, since adding a single repository is
+a one-shot operation.
+
+=cut
+
+sub pc_add_repo {
+    my ($instance, $name, $url, %opts) = @_;
+    my $timeout = $opts{timeout} // 600;
+    $instance->ssh_assert_script_run(
+        cmd => "sudo zypper -n addrepo -fG $url $name",
+        timeout => $timeout,
+    );
+}
+
+=head2 pc_wait_quit
+
+    pc_wait_quit($instance, [timeout => 20], [delay => 10], [retry => 120]);
+
+Waits until no zypper / packagekit / purge-kernels / rpm processes are
+running on the remote instance. Defaults give a ~20 minute ceiling.
+
+=cut
+
+sub pc_wait_quit {
+    my ($instance, %opts) = @_;
+    my $timeout = $opts{timeout} // 20;
+    my $delay = $opts{delay} // 10;
+    my $retry = $opts{retry} // 120;
+
+    # RC 0 (success) only when no matching processes exist.
+    my $cmd = q{! pgrep -a "zypper|packagekit|purge-kernels|rpm"};
+
+    $instance->ssh_script_retry(
+        cmd => $cmd,
+        timeout => $timeout,
+        delay => $delay,
+        retry => $retry,
+    );
+}
+
+=head2 pc_installed_packages
+
+    pc_installed_packages($instance, \@pkgs);
+
+Returns an arrayref of those packages from C<\@pkgs> that are installed on
+the remote instance, preserving the order from the input list.
+
+=cut
+
+sub pc_installed_packages {
+    my ($instance, $pkgs_ref) = @_;
+    die "Expected arrayref" unless ref($pkgs_ref) eq 'ARRAY';
+    return [] unless @$pkgs_ref;
+
+    my $pkg_list = join(' ', @$pkgs_ref);
+    my $output = $instance->ssh_script_output(
+        cmd => qq{rpm -q --qf '%{NAME}|' $pkg_list 2>/dev/null},
+        proceed_on_failure => 1,
+    );
+    my @seen = grep { length && $_ !~ /is not installed/i } split(/\|/, $output);
+    return \@seen;
+}
+
+=head2 pc_available_packages
+
+    pc_available_packages($instance, \@pkgs);
+
+Returns an arrayref of packages from C<\@pkgs> that are not yet installed
+but are available for installation. Uses C<zypper -x info> to query
+availability.
+
+=cut
+
+sub pc_available_packages {
+    my ($instance, $pkgs_ref) = @_;
+    die "Expected arrayref" unless ref($pkgs_ref) eq 'ARRAY';
+
+    my %installed = map { $_ => 1 } @{pc_installed_packages($instance, $pkgs_ref)};
+    my @missing = grep { !$installed{$_} } @$pkgs_ref;
+    return [] unless @missing;
+
+    my $output = $instance->ssh_script_output(
+        cmd => 'zypper -x info ' . join(' ', @missing) . ' 2>/dev/null',
+        proceed_on_failure => 1,
+    );
+    my @available = ($output =~ /^Name\s*:\s*(\S+)/mg);
+    return \@available;
+}
+
+=head2 pc_install_packages_local
+
+    pc_install_packages_local(\@pkgs, [timeout => $seconds]);
+
+Installs packages on the local SUT. On transactional systems uses
+C<trup_call("pkg install ...")> followed by C<reboot_on_changes>; otherwise
+uses the standard C<utils::zypper_call("in ...")>.
+
+=cut
+
+sub pc_install_packages_local {
+    my ($pkgs_ref, %opts) = @_;
+    die "Expected arrayref" unless ref($pkgs_ref) eq 'ARRAY';
+    return unless @$pkgs_ref;
+
+    my $list = join(' ', @$pkgs_ref);
+    if (is_transactional()) {
+        transactional::trup_call("pkg install $list");
+        transactional::reboot_on_changes();
+        return;
+    }
+    utils::zypper_call("in $list", timeout => $opts{timeout} // $bmwqemu::default_timeout);    # avoid "package not found" errors due to stale cache
+    return;
+}
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+# Accept any of:
+#   func($instance, "cmd", retry => 3)             positional cmd
+#   func($instance, cmd => "cmd", retry => 3)      named cmd
+#   $instance->func("cmd", retry => 3)             method-style positional
+#   $instance->func(cmd => "cmd")                  method-style named
+sub _normalize_call_args {
+    my $instance = shift;
+    my $cmd;
+    if (@_ && @_ % 2 == 1) {
+        # odd number of remaining args -> first must be the positional cmd
+        $cmd = shift;
+    } elsif (@_ && (@_ % 2 == 0)) {
+        # even -> could be (cmd => "...", ...) or (key => val, key => val)
+        # without a leading positional.
+        my %tmp = @_;
+        if (exists $tmp{cmd}) {
+            $cmd = delete $tmp{cmd};
+            @_ = %tmp;
+        } else {
+            # No cmd provided; let _validate_args complain.
+            $cmd = undef;
+        }
+    }
+    return ($instance, $cmd, @_);
+}
+
+sub _validate_args {
+    my ($cmd, $opts) = @_;
+    die "Empty 'cmd' argument in zypper call" unless defined $cmd && length $cmd;
+    die "Invalid value 'timeout' = 0" if exists $opts->{timeout} && defined $opts->{timeout} && !$opts->{timeout};
+    die "Exit code is from PIPESTATUS[0], not grep" if $cmd =~ /^((?!`).)*\| ?grep/;
+}
+
+# Orchestrator. Owns argument cleanup, transient-failure handling,
+# log uploads and reporting.
+sub _run {
+    my ($instance, $full_cmd, %opts) = @_;
+
+    # Copy and consume our own options; everything else is passed through
+    # to ssh_script_run.
+    my %args = %opts;
+    my $kind = delete $args{_kind};
+    my $exit_codes = delete $args{exitcode} // [EXIT_OK];
+    my $retry = delete $args{retry} // DEFAULT_RETRY;
+    my $delay = delete $args{delay} // DEFAULT_DELAY;
+    my $proceed = delete $args{proceed_on_failure} // 0;
+    my $wait_quit = delete $args{wait_quit} // 1;
+    $args{timeout} //= ($kind eq 'transactional')
+      ? DEFAULT_TIMEOUT_TRANSACTIONAL
+      : DEFAULT_TIMEOUT_ZYPPER;
+    $args{rc_only} = 1;
+
+    pc_wait_quit($instance) if $wait_quit;
+
+    my $ret = _retry_loop($instance, $full_cmd, $retry, $delay, \%args);
+
+    unless (grep { $_ == $ret } @$exit_codes) {
+        _report_failure($instance, $full_cmd, $ret, $proceed);
+    }
+    record_info('zypper remote call', "Command: $full_cmd\nResult: $ret");
+    return $ret;
+}
+
+sub _retry_loop {
+    my ($instance, $cmd, $retry, $delay, $ssh_args) = @_;
+    my $ret;
+    for my $attempt (1 .. $retry) {
+        $ret = $instance->ssh_script_run(cmd => $cmd, %$ssh_args);
+        return $ret if $ret == EXIT_OK;
+        sleep($delay) if defined $ret;
+
+        my $action = _handle_transient_failure($instance, $ret, $attempt, $retry);
+        return $ret if $action eq 'stop';
+        next if $action eq 'retry';
+        last;    # 'fail'
+    }
+    return $ret;
+}
+
+# Returns 'retry' (try again), 'stop' (give up but don't drop into the
+# generic failure path), or 'fail' (let _run handle it).
+sub _handle_transient_failure {
+    my ($instance, $ret, $attempt, $max) = @_;
+
+    if ($ret == EXIT_SOLVER) {
+        # bsc#1070851 -- transient 502 from server; zypper should retry
+        # internally. If we still see this, the bug-fix is missing.
+        if (_log_grep($instance, 'Error code.*502') == 0) {
+            die 'According to bsc#1070851 zypper should automatically retry internally. Bugfix missing for current product?';
+        }
+        if (_log_grep($instance, 'Solverrun finished with an ERROR') == 0) {
+            my $awk = q{awk '/Solverrun finished with an ERROR/,/statistics/{ print group"|", $0; if ($0 ~ /statistics/ ){ print "EOL"; group++ } }' } . ZYPPER_LOG;
+            my $conflicts = $instance->ssh_script_output("sudo $awk");
+            record_info('Conflicts', $conflicts, result => 'fail');
+            diag 'Package conflicts found, not retrying anymore' if $conflicts;
+            return 'stop';
+        }
+        return 'retry';
+    }
+    if ($ret == EXIT_LOCKED) {
+        record_info("Retry $attempt/$max as system management is locked");
+        return 'retry';
+    }
+    return 'fail';
+}
+
+sub _report_failure {
+    my ($instance, $cmd, $ret, $proceed) = @_;
+
+    $instance->ssh_script_run('sudo chmod o+r ' . ZYPPER_LOG);
+    $instance->upload_log(ZYPPER_LOG);
+
+    my $info = _classify_failure($instance, $ret);
+    my $msg = "$cmd failed with code: $ret";
+    if (defined $info->{label}) {
+        $msg .= " ($info->{label})";
+    }
+    $msg .= "\n\nRelated zypper logs:\n" . ($info->{excerpt} // '');
+
+    die $msg unless $proceed;
+    record_info('zypper error', $msg, result => 'fail');
+}
+
+sub _classify_failure {
+    my ($instance, $ret) = @_;
+    my $cls = $FAILURE_CLASSIFIERS{$ret} // {label => undef, regex => 'Exception\.cc'};
+    my $excerpt = _last_zypper_session($instance, $cls->{regex});
+    return {label => $cls->{label}, excerpt => $excerpt};
+}
+
+# Extract the lines from the last "Hi, me zypper" session that match
+# $regex. Replaces three near-identical inline pipelines.
+sub _last_zypper_session {
+    my ($instance, $regex) = @_;
+    my $tmp = '/tmp/zlog_' . int(rand(1 << 31)) . '.txt';
+    my $log = ZYPPER_LOG;
+    $instance->ssh_script_run(
+        sprintf(
+            q{sudo tac %s | grep -F -m1 -B100000 "Hi, me zypper" | tac | grep -E %s > %s},
+            $log, _shell_quote($regex), $tmp
+        )
+    );
+    return $instance->ssh_script_output("cat $tmp");
+}
+
+sub _log_grep {
+    my ($instance, $pattern) = @_;
+    return $instance->ssh_script_run(
+        sprintf('sudo grep %s %s', _shell_quote($pattern), ZYPPER_LOG)
+    );
+}
+
+sub _shell_quote {
+    my ($s) = @_;
+    $s =~ s/'/'\\''/g;
+    return "'$s'";
+}
+
+# Returns true if $cmd's verb is something transactional-update can wrap.
+# Only the verb decides translatability; option placement does not. Any zypper
+# command option (whether before or after the verb) is carried with the verb by
+# _zypper_to_transactional, so leading options never affect this check.
+sub _is_translatable_to_transactional {
+    my ($cmd) = @_;
+    my $verb = _verb_of($cmd);
+    return 0 unless defined $verb;
+    return exists $TOPLEVEL_VERB{$verb} || exists $PKG_VERB{$verb};
+}
+
+# Translate a zypper-style $cmd into the equivalent transactional-update
+# invocation. Dies if the verb is not supported.
+#
+# Token routing (per transactional-update.8):
+#   - Only options in %TU_GLOBAL_OPT that appear *before* the verb are hoisted
+#     into transactional-update's global slot (@globals).
+#   - The verb and *everything from the verb onward* (its own flags and the
+#     package arguments) stay together, verbatim and in order (@args). The man
+#     page states `pkg <command> <arguments>` forwards any zypper option for
+#     that command, so command flags must not be reordered or hoisted.
+#   - A dash-prefixed token that precedes the verb but is *not* a recognised
+#     global option is a zypper command flag in an unusual position; it is kept
+#     with the verb's arguments (never silently dropped, never hoisted).
+sub _zypper_to_transactional {
+    my ($cmd) = @_;
+
+    my @parts = grep { length } split(/\s+/, $cmd);
+    my @globals;
+    # Consume leading tokens until the verb. Recognised globals go to @globals;
+    # any other leading flag is held back to be re-attached after the verb.
+    my @pre_verb_flags;
+    while (@parts && $parts[0] =~ /^-/) {
+        my $tok = shift @parts;
+        if ($TU_GLOBAL_OPT{$tok}) {
+            push @globals, $tok;
+        }
+        else {
+            push @pre_verb_flags, $tok;
+        }
+    }
+    my $verb = shift @parts;
+    # verb's arguments = any misplaced pre-verb command flags, then the rest.
+    my @args = (@pre_verb_flags, @parts);
+
+    die 'Cannot translate empty zypper command to transactional-update' unless defined $verb;
+
+    if (exists $TOPLEVEL_VERB{$verb}) {
+        # bare "up" / "dup" / "patch" -> top-level command
+        return join(' ', @globals, $TOPLEVEL_VERB{$verb}) unless @args;
+
+        # "up <pkgs>" -> "pkg update <pkgs>".  dup/patch don't accept package
+        # arguments at the top level, so route them through `pkg` only when
+        # supported (only `update` is, per the man page).
+        if ($verb eq 'up' || $verb eq 'update') {
+            return join(' ', @globals, 'pkg', 'update', @args);
+        }
+        die "transactional-update does not support '$verb' with package arguments";
+    }
+    if (exists $PKG_VERB{$verb}) {
+        return join(' ', @globals, 'pkg', $PKG_VERB{$verb}, @args);
+    }
+
+    die "Cannot translate zypper command '$cmd' to transactional-update: "
+      . "verb '$verb' is not supported by transactional-update. "
+      . 'Use pc_zypper_call() explicitly if this command is intended to bypass '
+      . 'transactional-update.';
+}
+
+sub _verb_of {
+    my ($cmd) = @_;
+    my @parts = split(/\s+/, $cmd);
+    shift @parts while @parts && $parts[0] =~ /^-/;
+    return $parts[0];
+}
+
+1;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -917,7 +917,10 @@ sub _ssh_fully_patch_system_run_patch {
 
     if ($instance) {
         $cmd = "patch --with-interactive -l";
-        $ret = $instance->publiccloud::utils::zypper_call_remote($cmd, exitcode => $accept_codes, timeout => $timeout);
+        # Lazy require to avoid a circular `use` loop at compile time
+        # (publiccloud::zypper -> transactional -> utils).
+        require publiccloud::zypper;
+        $ret = publiccloud::zypper::pc_pkg_call($instance, $cmd, exitcode => $accept_codes, timeout => $timeout);
     }
     else {
         $cmd = "ssh $remote 'sudo zypper -n patch --with-interactive -l'";

--- a/t/13_publiccloud.t
+++ b/t/13_publiccloud.t
@@ -9,6 +9,7 @@ use testapi 'set_var';
 
 use publiccloud::azure;
 use publiccloud::utils;
+use publiccloud::zypper qw(pc_wait_quit pc_pkg_call);
 
 sub _unset { for my $k (@_) { set_var($k, undef) } }
 
@@ -249,7 +250,7 @@ subtest '[find_img] - image version not found' => sub {
     is $res, 0, 'The image version has not been found.';
 };
 
-subtest '[wait_quit_zypper_pc] uses defaults and expected command' => sub {
+subtest '[pc_wait_quit] uses defaults and expected command' => sub {
     my $inst = Test::MockObject->new;
     my @calls;
 
@@ -259,7 +260,7 @@ subtest '[wait_quit_zypper_pc] uses defaults and expected command' => sub {
             return 1;
     });
 
-    publiccloud::utils::wait_quit_zypper_pc($inst);
+    pc_wait_quit($inst);
 
     is scalar(@calls), 1, 'one call to ssh_script_retry';
     is $calls[0]->{cmd},
@@ -270,7 +271,7 @@ subtest '[wait_quit_zypper_pc] uses defaults and expected command' => sub {
     is $calls[0]->{retry}, 120, 'default retry=120';
 };
 
-subtest '[wait_quit_zypper_pc] honors custom timeout/delay/retry' => sub {
+subtest '[pc_wait_quit] honors custom timeout/delay/retry' => sub {
     my $inst = Test::MockObject->new;
     my $seen;
 
@@ -280,7 +281,7 @@ subtest '[wait_quit_zypper_pc] honors custom timeout/delay/retry' => sub {
             return 1;
     });
 
-    publiccloud::utils::wait_quit_zypper_pc($inst,
+    pc_wait_quit($inst,
         timeout => 5, delay => 2, retry => 3);
 
     is $seen->{cmd},
@@ -291,7 +292,7 @@ subtest '[wait_quit_zypper_pc] honors custom timeout/delay/retry' => sub {
     is $seen->{retry}, 3, 'custom retry applied';
 };
 
-subtest '[wait_quit_zypper_pc] succeeds on 5th attempt (4 fail + 1 success)' => sub {
+subtest '[pc_wait_quit] succeeds on 5th attempt (4 fail + 1 success)' => sub {
     my $expected_cmd = q{! pgrep -a "zypper|packagekit|purge-kernels|rpm"};
 
     my $inst = Test::MockObject->new;
@@ -309,7 +310,7 @@ subtest '[wait_quit_zypper_pc] succeeds on 5th attempt (4 fail + 1 success)' => 
             return 1;
     });
 
-    my $rc = publiccloud::utils::wait_quit_zypper_pc($inst, retry => 5, delay => 0, timeout => 1);
+    my $rc = pc_wait_quit($inst, retry => 5, delay => 0, timeout => 1);
 
     ok($rc, 'returned success');
     is($calls, 5, 'performed 5 attempts (4 fail + 1 success)');
@@ -319,7 +320,7 @@ subtest '[wait_quit_zypper_pc] succeeds on 5th attempt (4 fail + 1 success)' => 
     is($seen{timeout}, 1, 'timeout=1 passed');
 };
 
-subtest '[wait_quit_zypper_pc] times out after 5 failures' => sub {
+subtest '[pc_wait_quit] times out after 5 failures' => sub {
     my $expected_cmd = q{! pgrep -a "zypper|packagekit|purge-kernels|rpm"};
 
     my $inst = Test::MockObject->new;
@@ -338,7 +339,7 @@ subtest '[wait_quit_zypper_pc] times out after 5 failures' => sub {
 
     my $err;
     eval {
-        publiccloud::utils::wait_quit_zypper_pc($inst, retry => 5, delay => 0, timeout => 1);
+        pc_wait_quit($inst, retry => 5, delay => 0, timeout => 1);
         1;
     } or $err = $@;
 
@@ -464,6 +465,107 @@ subtest '[is_cloudinit_supported] via set_var only' => sub {
       'not public cloud => NOT supported';
 
     _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER DISTRI/);
+};
+
+# --- pc_pkg_call -> transactional-update translation ---------------------------
+#
+# These assert that zypper *command* options stay attached to the verb and are
+# never hoisted into transactional-update's global slot. Regression guard for
+# the case where `zypper in -y curl` became `transactional-update -y pkg ...`,
+# with -y being an invalid transactional-update global option.
+
+# Run pc_pkg_call with is_transactional() forced to $transactional and capture
+# the command string handed to the transactional / plain-zypper layer.
+sub _capture_pkg_call {
+    my ($transactional, $cmd, %opts) = @_;
+    my $mod = Test::MockModule->new('publiccloud::zypper');
+    $mod->redefine(is_transactional => sub { $transactional });
+
+    my %captured;
+    $mod->redefine(pc_transactional_call => sub {
+            my ($instance, $c, %o) = @_;
+            $captured{transactional} = $c;
+            return 0;
+    });
+    $mod->redefine(pc_zypper_call => sub {
+            my ($instance, $c, %o) = @_;
+            $captured{zypper} = $c;
+            return 0;
+    });
+
+    my $inst = Test::MockObject->new;
+    pc_pkg_call($inst, $cmd, %opts);
+    return \%captured;
+}
+
+subtest '[pc_pkg_call] command flags stay with verb, not hoisted to global' => sub {
+    my %cases = (
+        'in -y docker' => 'pkg install -y docker',
+        'in --force-resolution -y curl' => 'pkg install --force-resolution -y curl',
+        'in -r net_perf iperf' => 'pkg install -r net_perf iperf',
+        'install --no-recommends foo bar' => 'pkg install --no-recommends foo bar',
+        'update -y' => 'pkg update -y',
+        'in libcontainers-common' => 'pkg install libcontainers-common',
+        'rm -u oldpkg' => 'pkg remove -u oldpkg',
+    );
+    for my $input (sort keys %cases) {
+        my $cap = _capture_pkg_call(1, $input);
+        is $cap->{transactional}, $cases{$input},
+          "[$input] -> transactional-update $cases{$input}";
+        ok !defined $cap->{zypper}, "[$input] did not fall through to plain zypper";
+    }
+};
+
+# The core regression guard: a zypper *command* flag placed BEFORE the verb must
+# NOT be hoisted into transactional-update's global slot (where it is invalid).
+# The old loop swept every leading dash-token into @flags; these cases prove the
+# command flag now travels with the verb instead.
+subtest '[pc_pkg_call] pre-verb command flag is kept with the verb' => sub {
+    my %cases = (
+        '-y in docker' => 'pkg install -y docker',
+        '--force-resolution in curl' => 'pkg install --force-resolution curl',
+        '--no-recommends install foo' => 'pkg install --no-recommends foo',
+        # only the genuine global (-n) stays global; -y moves to the verb
+        '-n -y in curl' => '-n pkg install -y curl',
+    );
+    for my $input (sort keys %cases) {
+        my $cap = _capture_pkg_call(1, $input);
+        is $cap->{transactional}, $cases{$input},
+          "[$input] -> transactional-update $cases{$input}";
+    }
+};
+
+subtest '[pc_pkg_call] bare top-level verbs translate without pkg wrapper' => sub {
+    my %cases = (
+        'up' => 'up',
+        'dup' => 'dup',
+        'dist-upgrade' => 'dup',
+        'patch' => 'patch',
+    );
+    for my $input (sort keys %cases) {
+        my $cap = _capture_pkg_call(1, $input);
+        is $cap->{transactional}, $cases{$input},
+          "[$input] -> transactional-update $cases{$input}";
+    }
+};
+
+subtest '[pc_pkg_call] real transactional-update global opt is hoisted' => sub {
+    # A genuine global option placed before the verb belongs in the global slot.
+    my $cap = _capture_pkg_call(1, '-n in -y curl');
+    is $cap->{transactional}, '-n pkg install -y curl',
+      'global -n stays global; command -y stays with verb';
+};
+
+subtest '[pc_pkg_call] non-translatable verb falls through to plain zypper' => sub {
+    my $cap = _capture_pkg_call(1, 'info foo');
+    is $cap->{zypper}, 'info foo', 'info passed verbatim to pc_zypper_call';
+    ok !defined $cap->{transactional}, 'info not routed through transactional-update';
+};
+
+subtest '[pc_pkg_call] non-transactional system always uses plain zypper' => sub {
+    my $cap = _capture_pkg_call(0, 'in -y docker');
+    is $cap->{zypper}, 'in -y docker', 'verbatim zypper on non-transactional host';
+    ok !defined $cap->{transactional}, 'no transactional-update translation';
 };
 
 done_testing;

--- a/tests/publiccloud/az_accelerated_net.pm
+++ b/tests/publiccloud/az_accelerated_net.pm
@@ -12,7 +12,8 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use publiccloud::utils qw(zypper_call_remote is_container_host);
+use publiccloud::utils qw(is_container_host);
+use publiccloud::zypper qw(pc_zypper_call pc_pkg_call);
 
 =head2 prepare_vm
 
@@ -27,8 +28,8 @@ sub prepare_vms {
     foreach my $instance (@instances) {
         record_info('Instance', 'Instance ' . $instance->instance_id . ' created');
         record_info('Iperf', 'Install IPerf binaries in VM');
-        zypper_call_remote($instance, cmd => "ar --no-gpgcheck $repo net_perf");
-        zypper_call_remote($instance, cmd => "in -r net_perf iperf");
+        pc_zypper_call($instance, "ar --no-gpgcheck $repo net_perf");
+        pc_pkg_call($instance, "in -r net_perf iperf");
     }
 
     return \@instances;
@@ -87,7 +88,7 @@ sub check_sriov {
     my ($self, $instance) = @_;
     record_info('sr-iov', 'Checking SRIOV feature for instance ' . $instance->instance_id);
     my $lspci_output = $instance->ssh_script_output(cmd => "sudo lspci");
-    zypper_call_remote($instance, cmd => 'in ethtool') if is_container_host();
+    pc_pkg_call($instance, 'in ethtool') if is_container_host();
     my $ethtool_output = $instance->ssh_script_output(cmd => "sudo ethtool -S eth0 | grep vf_");
     record_info('lspci', $lspci_output);
     record_info('ethtool', $ethtool_output);

--- a/tests/publiccloud/registercloudguest.pm
+++ b/tests/publiccloud/registercloudguest.pm
@@ -16,6 +16,7 @@ use registration;
 use testapi;
 use utils;
 use publiccloud::utils;
+use publiccloud::zypper qw(pc_pkg_call);
 use publiccloud::ssh_interactive 'select_host_console';
 use 5.018;
 
@@ -192,7 +193,7 @@ sub test_container_runtimes {
 
     record_info('Test docker');
     $instance->ssh_assert_script_run("sudo rm -f /root/.docker/config.json");    # workaround for https://bugzilla.suse.com/show_bug.cgi?id=1231185
-    $instance->zypper_call_remote("in -y docker", timeout => 600);
+    pc_pkg_call($instance, "in -y docker", timeout => 600);
     $instance->ssh_assert_script_run("sudo systemctl start docker.service");
     record_info("systemctl status docker.service", $instance->ssh_script_output("systemctl status docker.service"));
     $instance->ssh_script_retry("sudo docker pull $image", retry => 3, delay => 60, timeout => 600);
@@ -208,7 +209,7 @@ sub test_container_runtimes {
             record_info('permissions #1', 'permissions when libcontainers-common is missing');
             $instance->ssh_script_run('sudo stat /etc/containers/registries.conf');
             $instance->ssh_script_run('sudo rm -rf /etc/containers/registries.conf');
-            $instance->zypper_call_remote("in libcontainers-common");
+            pc_pkg_call($instance, "in libcontainers-common");
             record_info('permissions #2', 'The previous registries.conf has been removed, then libcontainers-common was installed');
             $instance->ssh_script_run('sudo stat /etc/containers/registries.conf');
             cleanup_instance($instance);
@@ -218,7 +219,7 @@ sub test_container_runtimes {
         }
         $instance->ssh_script_run('sudo chmod 644 /etc/containers/registries.conf');
     }
-    $instance->zypper_call_remote("in -y podman", timeout => 240);
+    pc_pkg_call($instance, "in -y podman", timeout => 240);
     $instance->ssh_script_retry("podman --debug pull $image", retry => 3, delay => 60, timeout => 600);
     return 0;
 }

--- a/tests/publiccloud/registration.pm
+++ b/tests/publiccloud/registration.pm
@@ -15,6 +15,7 @@ use registration;
 use testapi;
 use utils;
 use publiccloud::utils;
+use publiccloud::zypper qw(pc_pkg_call pc_wait_quit);
 use publiccloud::ssh_interactive "select_host_console";
 use File::Basename 'basename';
 
@@ -23,19 +24,19 @@ sub run {
 
     select_host_console();    # select console on the host, not the PC instance
 
-    wait_quit_zypper_pc($args->{my_instance});
+    pc_wait_quit($args->{my_instance});
 
     registercloudguest($args->{my_instance}) if (is_byos() || get_var('PUBLIC_CLOUD_FORCE_REGISTRATION'));
 
     # https://progress.opensuse.org/issues/196370 workaround for a known issue on 15-SP5
     if (is_sle('=15-SP5')) {
-        $args->{my_instance}->zypper_call_remote("update -y", retry => 10, delay => 60, timeout => 1800);
+        pc_pkg_call($args->{my_instance}, "update -y", retry => 10, delay => 60, timeout => 1800);
         $args->{my_instance}->softreboot(timeout => 3600);
     }
 
-    wait_quit_zypper_pc($args->{my_instance});
+    pc_wait_quit($args->{my_instance});
     register_addons_in_pc($args->{my_instance}, timeout => 240);
-    wait_quit_zypper_pc($args->{my_instance});
+    pc_wait_quit($args->{my_instance});
     # Double confirm system is correctly registered, and quit earlier if anything wrong
     # see bsc#1253777, we may need have to rerun the failed job in this case
     record_info('Check registration status');
@@ -45,7 +46,7 @@ sub run {
     die "System is not correctly registered" if ($reg_status =~ /Not Registered/m);
     # Since SLE 15 SP6 CHOST images don't have curl and we need it for testing
     if (is_sle('>15-SP5') && is_container_host()) {
-        $args->{my_instance}->zypper_call_remote("in --force-resolution -y curl");
+        pc_pkg_call($args->{my_instance}, "in --force-resolution -y curl");
     }
 }
 

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -19,6 +19,7 @@ use LTP::utils qw(get_ltproot prepare_whitelist_environment);
 use LTP::install qw(get_required_build_dependencies get_maybe_build_dependencies);
 use LTP::WhiteList;
 use publiccloud::utils;
+use publiccloud::zypper qw(pc_pkg_call pc_zypper_call pc_add_repo pc_available_packages);
 use publiccloud::ssh_interactive 'select_host_console';
 use JSON qw(decode_json);
 use Data::Dumper;
@@ -55,16 +56,11 @@ sub install_build_deps {
 
     push @deps, $kernel_devel_pkg;
 
-    if (is_transactional) {
-        $instance->ssh_assert_script_run(
-            cmd => sprintf('sudo transactional-update -n pkg in --no-recommends %s', join(' ', @deps)),
-            timeout => 300
-        );
-        $instance->softreboot();
-    } else {
-        $instance->zypper_call_remote(cmd => "install --no-recommends " . join(' ', @deps));
-    }
-
+    pc_pkg_call(
+        $instance,
+        'install --no-recommends ' . join(' ', @deps),
+        timeout => 300,
+    );
     install_optional_build_deps($instance);
 }
 
@@ -256,20 +252,12 @@ sub prepare_scripts {
 sub install_ltp {
     my ($instance, $ltp_repo_name, $ltp_repo_url, $ltp_package_name) = @_;
 
-    $instance->ssh_assert_script_run(
-        cmd => "sudo zypper -n addrepo -fG $ltp_repo_url $ltp_repo_name",
-        timeout => 600
+    pc_add_repo($instance, $ltp_repo_name, $ltp_repo_url);
+    pc_pkg_call(
+        $instance,
+        "install --no-recommends $ltp_package_name",
+        timeout => 300,
     );
-
-    if (is_transactional) {
-        $instance->ssh_assert_script_run(
-            cmd => sprintf('sudo transactional-update -n pkg in --no-recommends %s', $ltp_package_name),
-            timeout => 300
-        );
-        $instance->softreboot();
-    } else {
-        $instance->zypper_call_remote(cmd => "install --no-recommends " . $ltp_package_name);
-    }
 }
 
 sub prepare_skip_tests {
@@ -394,90 +382,27 @@ sub gen_ltp_env {
     return $self->{ltp_env};
 }
 
-=head2 get_installed_packages_remote
-
-get_installed_packages_remote($instance, $packages_ref)
-
-This function checks which packages from the provided list are installed on the remote instance.
-It returns an array reference containing the names of the installed packages.
-
-=cut
-
-sub get_installed_packages_remote {
-    my ($instance, $packages_ref) = @_;
-
-    my $pkg_list = join(' ', @$packages_ref);
-    my $cmd = "rpm -q --qf '%{NAME}|' $pkg_list 2>/dev/null";
-
-    my $output = $instance->ssh_script_output(
-        cmd => $cmd,
-        proceed_on_failure => 1
-    );
-
-    my %installed;
-    for my $entry (split /\|/, $output) {
-        next if $entry =~ /is not installed/i;
-        $installed{$entry} = 1;
-    }
-
-    my @found = grep { $installed{$_} } @$packages_ref;
-    return \@found;
-}
-
-=head2 get_available_packages_remote
-
-get_available_packages_remote($instance, $packages_ref)
-
-This function checks which packages from the provided list are available for installation on the remote instance.
-It returns an array reference containing the names of the available packages.
-It uses `zypper -x info` to query the availability of packages.
-
-=cut
-
-sub get_available_packages_remote {
-    my ($instance, $packages_ref) = @_;
-    die "Expected arrayref" unless ref($packages_ref) eq 'ARRAY';
-
-    my %installed = map { $_ => 1 } @{get_installed_packages_remote($instance, $packages_ref)};
-    my @not_installed = grep { !$installed{$_} } @$packages_ref;
-
-    return '' unless @not_installed;
-
-    my $pkg_list = join(' ', @not_installed);
-    my $output = $instance->ssh_script_output(
-        cmd => "zypper -x info $pkg_list 2>/dev/null",
-        proceed_on_failure => 1
-    );
-
-    # Grep all "Name           : <pkg>" lines
-    my %available = map { $_ => 1 } ($output =~ /^Name\s*:\s*(\S+)/mg);
-
-    my @result = grep { $available{$_} } @not_installed;
-    return join(' ', @result);
-}
-
-=head2 zypper_install_available_remote
+=head2 install_optional_build_deps
 
 install_optional_build_deps($instance)
 
-This function checks which packages from the get_maybe_build_dependencies list are available for installation on the remote instance.
-If any packages are available, it installs them using zypper_call_remote.
+This function checks which packages from the get_maybe_build_dependencies list
+are available for installation on the remote instance. If any packages are
+available, it installs them via C<pc_pkg_call>.
 
 =cut
 
 sub install_optional_build_deps {
     my ($instance) = @_;
-    my $available = get_available_packages_remote($instance, [get_maybe_build_dependencies()]);
-    return unless ($available && $available =~ /\S/);
-    if (is_transactional) {
-        $instance->ssh_assert_script_run(
-            cmd => sprintf('sudo transactional-update -n pkg in --no-recommends %s', $available),
-            timeout => 300
-        );
-        $instance->softreboot();
-    } else {
-        $instance->zypper_call_remote("install --no-recommends " . $available);
-    }
+    my $available = pc_available_packages(
+        $instance, [get_maybe_build_dependencies()]
+    );
+    return unless @$available;
+    pc_pkg_call(
+        $instance,
+        'install --no-recommends ' . join(' ', @$available),
+        timeout => 300,
+    );
 }
 
 sub test_flags {

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -15,7 +15,8 @@ use utils;
 use publiccloud::ssh_interactive "select_host_console";
 use maintenance_smelt qw(is_embargo_update);
 use version_utils qw(is_sle_micro is_sle);
-use publiccloud::utils qw(additional_repos zypper_call_remote);
+use publiccloud::utils qw(additional_repos);
+use publiccloud::zypper qw(pc_zypper_call);
 
 sub run {
     my ($self, $args) = @_;
@@ -78,7 +79,7 @@ sub run {
     if (is_sle_micro(">=6.0") || is_sle("16+")) {
         my $counter = 0;
         for my $repo (@repos) {
-            zypper_call_remote($instance, cmd => "ar -p10 " . $repodir . $repo . " ToTest_$counter");
+            pc_zypper_call($instance, "ar -p10 " . $repodir . $repo . " ToTest_$counter");
             $counter += 1;
         }
     }

--- a/tests/sles4sap/publiccloud/cluster_add_repos.pm
+++ b/tests/sles4sap/publiccloud/cluster_add_repos.pm
@@ -35,7 +35,8 @@ QE-SAP <qe-sap@suse.de>
 
 use Mojo::Base 'sles4sap::publiccloud_basetest';
 use sles4sap::publiccloud;
-use publiccloud::utils qw(zypper_call_remote is_azure);
+use publiccloud::utils qw(is_azure);
+use publiccloud::zypper qw(pc_zypper_call pc_refresh);
 use qam;
 use testapi;
 
@@ -57,14 +58,14 @@ sub run {
         }
         foreach my $instance (@{$self->{instances}}) {
             next if ($instance->{'instance_id'} !~ m/vmhana/);
-            zypper_call_remote($instance, cmd => "addrepo $repo TEST_$repo_index", timeout => 240, retry => 6, delay => 60);
+            pc_zypper_call($instance, "addrepo $repo TEST_$repo_index", timeout => 240, retry => 6, delay => 60);
         }
         $repo_index++;
     }
     my $ref_timeout = is_azure ? 900 : 240;
     foreach my $instance (@{$self->{instances}}) {
         next if ($instance->{'instance_id'} !~ m/vmhana/);
-        zypper_call_remote($instance, cmd => " --gpg-auto-import-keys ref", timeout => $ref_timeout, retry => 6, delay => 60);
+        pc_refresh($instance, timeout => $ref_timeout, retry => 6, delay => 60);
     }
 }
 

--- a/tests/sles4sap/publiccloud/general_patch_and_reboot.pm
+++ b/tests/sles4sap/publiccloud/general_patch_and_reboot.pm
@@ -44,7 +44,8 @@ use testapi;
 use registration;
 use utils;
 use publiccloud::ssh_interactive qw(select_host_console);
-use publiccloud::utils qw(zypper_call_remote is_azure);
+use publiccloud::utils qw(is_azure);
+use publiccloud::zypper qw(pc_refresh);
 
 sub test_flags {
     return {fatal => 1};
@@ -63,7 +64,7 @@ sub run {
 
         my $cmd_time = time();
         my $ref_timeout = is_azure ? 3600 : 240;
-        zypper_call_remote($instance, cmd => " --gpg-auto-import-keys ref", timeout => $ref_timeout, retry => 6, delay => 60);
+        pc_refresh($instance, timeout => $ref_timeout, retry => 6, delay => 60);
         record_info('zypper ref time', 'The command zypper -n ref took ' . (time() - $cmd_time) . ' seconds.');
         record_soft_failure('bsc#1195382 - Considerable decrease of zypper performance and increase of registration times') if ((time() - $cmd_time) > 240);
 


### PR DESCRIPTION
## Problem

`zypper_call_remote()` in `publiccloud/utils.pm` grew into a monolithic
function responsible for too many things at once: dispatching between
plain zypper and `transactional-update`, retry logic, log parsing, error
classification, and process-waiting — all interleaved.

This caused real bugs. `transactional-update` does not support repo
actions (`ref`, `addrepo`), so any caller that used `zypper_call_remote`
for those operations would silently wrap them in a transactional-update
command and fail. The workaround in `register_addons_in_pc` was a
hand-rolled SSH retry with a `# TODO: this is a hotfix` comment pointing
at poo#195920, bypassing `zypper_call_remote` entirely. The same class of
bug was latent in every other caller.

Additionally, `run_ltp.pm` carried its own duplicate
`get_installed_packages_remote` / `get_available_packages_remote` helpers
that reimplemented a subset of what `zypper_call_remote` already did.

## Solution

Introduce `lib/publiccloud/zypper.pm` — a dedicated module that:

- Exposes an explicit `pc_`-prefixed API, one function per operation
  (`pc_zypper_call`, `pc_transactional_call`, `pc_pkg_call`, `pc_refresh`,
  `pc_add_repo`, `pc_wait_quit`, `pc_installed_packages`,
  `pc_available_packages`, `pc_install_packages_local`)
- Encodes the rule **once**: `pc_refresh` and `pc_add_repo` always use
  plain zypper (never transactional-update); `pc_pkg_call` auto-dispatches
  based on `is_transactional()` — callers no longer need to know this
- Defines zypper exit codes as named constants (`EXIT_OK`, `EXIT_NO_REPOS`,
  `EXIT_LOCKED`, …) so error handling is readable and consistent
- Keeps retry logic, transient-failure detection, and log upload in one place

All 10 callers are migrated off `zypper_call_remote()` and
`wait_quit_zypper_pc()`. Both wrappers are **removed** from
`publiccloud::utils` — there is no fallback path.

## Why this fixes poo#195920

`pc_refresh` and `pc_add_repo` are hardcoded to call plain `zypper`,
so the transactional-update dispatch cannot interfere with repo operations
regardless of the system type. The hotfix workaround in
`register_addons_in_pc` is replaced by a direct `pc_refresh` call.

## Changes

- `lib/publiccloud/zypper.pm` — new module (632 lines)
- `lib/publiccloud/utils.pm` — removed `zypper_call_remote`, `wait_quit_zypper_pc`, ~200 lines of plumbing
- `lib/publiccloud/ec2.pm` — `_install_ec2_cloudwatch_agent` uses `pc_zypper_call`
- `lib/utils.pm` — reference update
- `tests/publiccloud/run_ltp.pm` — duplicate helpers removed, inline transactional branching gone
- `tests/publiccloud/{az_accelerated_net,registercloudguest,registration,transfer_repos}.pm` — migrated
- `tests/sles4sap/publiccloud/{cluster_add_repos,general_patch_and_reboot}.pm` — migrated
- `t/13_publiccloud.t` — mocks updated, `pc_wait_quit` unit tests added

## VR
latest:
run_ltp -> [sle-16.0-EC2-LTPStable-x86_64-Build20260529-LTPStable@64bit](https://openqa.suse.de/tests/22675004)
slem5.5 -> [sle-micro-5.5-GCE-BYOS-Updates-x86_64](https://openqa.suse.de/tests/22799163)


* [sle-15-SP6-Azure-BYOS-Updates-x86_64-Build20260416-1-publiccloud_registrationtests@az_Standard_B2s](https://openqa.suse.de/tests/21912780)
* [sle-micro-6.0-Azure-BYOS-Updates-x86_64-Build104.4-publiccloud_ltp@az_Standard_B4ms](https://openqa.suse.de/tests/21914239)
* [sle-15-SP6-GCE-SAP-BYOS-Incidents-saptune-x86_64-Build:smelt:43499:saptune-sles4sap_gnome_saptune_delete_rename@gce_n1_highmem_32](https://openqa.suse.de/tests/21921641)
* [sle-micro-6.0-EC2-BYOS-Updates-x86_64-Build104.4-publiccloud_slem_containers@ec2_t3a.small](https://openqa.suse.de/tests/21922253)