### PR TITLE
Fix SL Micro migration for flavor agama-installer

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -29,7 +29,7 @@ sub is_image {
 }
 
 sub is_dvd {
-    return get_required_var('FLAVOR') =~ /dvd|agama-install/i;
+    return get_required_var('FLAVOR') =~ /dvd|^agama-install$/i;
 }
 
 sub is_regproxy_required {


### PR DESCRIPTION
##
### We need to fix flavor agama-installer for SL Micro migration to SLES 16.1.
In dev group we have FLAVOR=agama-installer and this [**PR change**](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/24688/changes#diff-2ffee9b285f89d71b469881dff942182ae0c412f172829f366304751dba73a6eL32) will cause SL Micro boot into `wait_boot` not `wait_boot_past_bootloader`.
- Relate PR:
  - #24688
- Related ticket: 
  - https://progress.opensuse.org/issues/195812
- Releted MR:
  - https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/769
- VR:
  - [**slmicro_migration**](https://openqa.suse.de/tests/overview?version=16.1&distri=sle&build=hjluo%2Fos-autoinst-distri-opensuse%23fix_slmicro_dev)



##