### PR TITLE
Improve reliability of display manager password prompt detection

### DIFF
--- a/tests/x11/remote_desktop/xrdp_server.pm
+++ b/tests/x11/remote_desktop/xrdp_server.pm
@@ -83,8 +83,7 @@ sub run {
     }
 
     else {
-        send_key 'ret';
-        assert_screen "displaymanager-password-prompt";
+        send_key_until_needlematch('displaymanager-password-prompt', 'ret', 4, 3);
         type_password;
         wait_still_screen 3;
         send_key "ret";


### PR DESCRIPTION
Used send_key_until_needlematch for display manager password prompt.

VR:https://openqa.suse.de/tests/21939459#

