### PR TITLE
Adapt to changes in zypper config files

### DIFF
--- a/data/yam/agama/auto/lib/scripts_post_partitioning.libsonnet
+++ b/data/yam/agama/auto/lib/scripts_post_partitioning.libsonnet
@@ -1,10 +1,10 @@
 {
   create_zypp_conf: {
-    name: 'create zypp.conf',
+    name: 'create zypper.conf',
     content: |||
       #!/usr/bin/env bash
       mkdir -vp /mnt/etc/zypp
-      echo '# QE-Yam Test' > /mnt/etc/zypp/zypp.conf
+      echo '# QE-Yam Test' > /mnt/etc/zypp/zypper.conf
     |||
   }
 }

--- a/tests/yam/validate/validate_post_partitioning.pm
+++ b/tests/yam/validate/validate_post_partitioning.pm
@@ -13,7 +13,7 @@ use utils;
 
 sub run {
     select_console 'root-console';
-    assert_script_run("ls /etc/zypp/zypp.conf.rpmnew");
+    assert_script_run("ls /etc/zypp/zypper.conf.rpmnew");
 }
 
 1;


### PR DESCRIPTION
- /etc/zypp/zypp.conf is no longer considcered a configuration file
  (starting at SLES 16.1 build 40.1)
- Therefore we switch to /etc/zypp/zypper.conf for the
  validation of post partitioning scripts.
- Verification runs:
  - x86_64: https://openqa.suse.de/tests/21939811
  - aarch64: https://openqa.suse.de/tests/21939997
  - ppc64le: https://openqa.suse.de/tests/21940003
  - s390x: https://openqa.suse.de/tests/21940006
  - x86_64 on SLES 16.0 QU1: https://openqa.suse.de/tests/21940125 (to be sure that nothing breaks)