### PR TITLE
pc: Use predictable name in console log

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -17,7 +17,6 @@ use utils qw(script_retry script_output_retry);
 use publiccloud::azure_client;
 use publiccloud::ssh_interactive 'select_host_console';
 use Data::Dumper;
-use DateTime;
 
 has resource_group => 'openqa-upload';
 has container => 'sle-images';
@@ -536,10 +535,7 @@ sub upload_boot_diagnostics {
     # Wait until the bootlog blob is created
     script_retry("az vm boot-diagnostics get-boot-log-uris $names", delay => 15, retry => 12, die => 1);
 
-    my $dt = DateTime->now;
-    my $time = $dt->hms;
-    $time =~ s/:/-/g;
-    my $asset_path = "/tmp/console-$time.txt";
+    my $asset_path = "/tmp/console.txt";
     script_run("timeout 110 az vm boot-diagnostics get-boot-log $names | jq -Mr '.' > $asset_path", timeout => 120);
     if (script_output("du $asset_path | cut -f1") < 8) {
         record_info("EMPTY", "The console log is empty. `cat $asset_path`:\n" . script_output("cat $asset_path"));

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -14,7 +14,6 @@ use testapi;
 use publiccloud::utils "is_byos";
 use publiccloud::aws_client;
 use publiccloud::ssh_interactive 'select_host_console';
-use DateTime;
 
 has ssh_key_pair => undef;
 use constant SSH_KEY_PEM => 'QA_SSH_KEY.pem';
@@ -169,10 +168,7 @@ sub upload_boot_diagnostics {
         record_info('UNDEF. diagnostics', 'upload_boot_diagnostics: on ec2, undefined instance');
         return;
     }
-    my $dt = DateTime->now;
-    my $time = $dt->hms;
-    $time =~ s/:/-/g;
-    my $asset_path = "/tmp/console-$time.txt";
+    my $asset_path = "/tmp/console.txt";
     script_run("aws ec2 get-console-output --latest --color=off --no-paginate --output text --instance-id $instance_id &> $asset_path", proceed_on_failure => 1);
     if (script_output("du $asset_path | cut -f1") < 8) {
         record_info("EMPTY", "The console log is empty. `cat $asset_path`:\n" . script_output("cat $asset_path"));
@@ -182,7 +178,7 @@ sub upload_boot_diagnostics {
         upload_logs("$asset_path", failok => 1);
     }
 
-    $asset_path = "/tmp/console-$time.jpg";
+    $asset_path = "/tmp/console.jpg";
     script_run("aws ec2 get-console-screenshot --instance-id $instance_id | jq -r '.ImageData' | base64 --decode > $asset_path");
     if (script_output("du $asset_path | cut -f1") < 8) {
         record_info('empty screenshot', 'The console screenshot is empty.');

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -14,7 +14,6 @@ use Mojo::JSON 'decode_json';
 use testapi;
 use utils;
 use publiccloud::ssh_interactive 'select_host_console';
-use DateTime;
 
 sub init {
     my ($self, %params) = @_;
@@ -211,10 +210,7 @@ sub upload_boot_diagnostics {
         record_info('UNDEF. diagnostics', 'upload_boot_diagnostics: on gce, undefined instance or region or availability zone');
         return;
     }
-    my $dt = DateTime->now;
-    my $time = $dt->hms;
-    $time =~ s/:/-/g;
-    my $asset_path = "/tmp/console-$time.txt";
+    my $asset_path = "/tmp/console.txt";
     # gce provides full serial log, so extended timeout
     script_run("gcloud compute --project=$project instances get-serial-port-output $instance_id --zone=$region-$availability_zone --port=1 > $asset_path", timeout => 180);
     if (script_output("du $asset_path | cut -f1") < 8) {


### PR DESCRIPTION
Right now the console log is being uploaded with a date:
https://openqa.suse.de/tests/21936810/logfile?filename=destroy-console-02-13-13.txt

This is not needed because the file is uploaded only once in the `upload_boot_diagnostics function` which is is only called by the `destroy` module. The file is also prefixed by the module anyway.

Use a predictable name to make any automated log extraction easier.
