### PR TITLE
kernel: Add support for new immutable flavors

### DIFF
--- a/lib/kernel.pm
+++ b/lib/kernel.pm
@@ -119,7 +119,7 @@ sub check_kernel_package {
 
 # Check if flavor is validation
 sub is_kernel_validation_flavor {
-    return get_var('FLAVOR', '') =~ /(Full-QR|Online-QR|Online|Online-Kernel-(RT|Base|Azure|Baremetal|(RT|64kb)-Baremetal))$/;
+    return get_var('FLAVOR', '') =~ /(Online-Immutable|Full-QR|Online-QR|Online|Online-Kernel-(RT|Base|Azure|Baremetal|(RT|64kb)-Baremetal))$/;
 }
 
 1;

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -34,7 +34,7 @@ sub load_kernel_tests {
     loadtest_kernel "../installation/bootloader" if (is_pvm && !get_var('LTP_BAREMETAL'));
 
     if (get_var('INSTALL_LTP')) {
-        if (is_transactional) {
+        if (is_transactional && (get_var('FLAVOR', '') !~ /Immutable/)) {
             # Handle specific boot requirements for different backends and architectures
             if (is_s390x) {
                 loadtest 'boot/boot_to_desktop';

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -684,6 +684,7 @@ if (is_jeos) {
 # load the tests in the right order
 if (is_kernel_test()) {
     load_kernel_tests();
+    return 1;
 }
 elsif (is_systemd_test()) {
     unless (is_jeos()) {

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -510,7 +510,7 @@ sub run {
 
     $self->{repos} = {};
 
-    if (((is_ipmi || is_pvm) && get_var('LTP_BAREMETAL')) || is_transactional) {
+    if (((is_ipmi || is_pvm) && get_var('LTP_BAREMETAL')) || (is_transactional && (get_var('FLAVOR', '') !~ /Immutable/))) {
         # System is already booted after installation, just switch terminal
         select_serial_terminal;
     } else {


### PR DESCRIPTION
We need to adapt to the new SLE 16.1 immutable installation, which
differs from transactional images. Since the system is already
installed, we must skip the traditional transactional image workflow.

We also had to ensure that no other tests, like
`load_common_opensuse_sle_tests`, are scheduled in `main.pm` after
`load_kernel_tests`.

- Related ticket: https://progress.opensuse.org/issues/200015
- Needles: NONE
- Verification run: https://openqa.suse.de/tests/overview?version=16.1&build=czerw%2Fos-autoinst-distri-opensuse%2325365&distri=sle

Micro: https://openqa.suse.de/tests/21960569
Standard SLE:  https://openqa.suse.de/tests/21960572
