### PR TITLE
Windows installation: Disable password max age for local accounts

### DIFF
--- a/data/wsl/Autounattend_Arm64.xml
+++ b/data/wsl/Autounattend_Arm64.xml
@@ -358,6 +358,10 @@
             <Order>59</Order>
             <Path>powershell.exe Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux -NoRestart; Enable-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform /Y</Path>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>60</Order>
+          <Path>%windir%\System32\net.exe accounts /maxpwage:UNLIMITED</Path>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
   </settings>

--- a/data/wsl/Autounattend_UEFI.xml
+++ b/data/wsl/Autounattend_UEFI.xml
@@ -398,6 +398,10 @@
           <Order>68</Order>
           <Path>%windir%\System32\reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Edge" /v HideFirstRunExperience /t REG_DWORD /d 1 /f</Path>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>69</Order>
+          <Path>%windir%\System32\net.exe accounts /maxpwage:UNLIMITED</Path>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
   </settings>

--- a/tests/wsl/install/win_installation.pm
+++ b/tests/wsl/install/win_installation.pm
@@ -65,4 +65,7 @@ sub run {
     $self->close_powershell;
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
 1;

--- a/tests/wsl/install/win_installation.pm
+++ b/tests/wsl/install/win_installation.pm
@@ -56,6 +56,12 @@ sub run {
             }
         }
     );
+    $self->run_in_powershell(
+        cmd => '$port.WriteLine($(Get-LocalUser | Where-Object { $_.Enabled } | Select Name,PasswordExpires))',
+        code => sub {
+            wait_serial("Name=Bernhard.*PasswordExpires=(?>)}") || die "Failed to disable max password age";
+        }
+    );
     $self->close_powershell;
 }
 


### PR DESCRIPTION
By default the local account created during install has a maximum age
for its password, after which the user must change their password before
the next logon, so disabling this behavior during installation helps us
circumvent this and avoid test failures due to [expired password](https://openqa.opensuse.org/tests/5853930#step/boot_windows/5)

VR: https://openqa.opensuse.org/tests/5863059#step/win_installation/50
