### PR TITLE
[RFC] ci: enable automatic merge on fully approved PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,6 +23,8 @@ pull_request_rules:
     actions:
       review:
         type: APPROVE
+      merge:
+        method: merge
   - name: ask to resolve conflict
     conditions:
       - conflict

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,8 @@
+---
+merge_queue:
+  status_comments: none
+  queue_controls_comment: false
+
 pull_request_rules:
   - name: remove outdated reviews
     conditions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -28,3 +28,5 @@ pull_request_rules:
     actions:
       review:
         type: APPROVE
+      merge:
+        method: merge


### PR DESCRIPTION
Motivation:
After introduction of mergify to automatically approve we can now enable
automatic merge. We already have automatic merge based on mergify rules
for many years in other os-autoinst related projects like openQA where
it works well. It was observed that relying on humans to check all rules
sometimes leads to accidental merges when reviewers think all rules are
covered when they are not.

Design Choices:
Enable the mergify automatic merge rule. If authors or reviewers want
to prevent a merge, they can mark the PR as 'draft', add a 'WIP' prefix,
or add a 'notready' label. Furthermore, reviewers implicitly decide on
the merge because without their approval, there will be no auto-merge.

Benefits:
Trusting auto-merge prevents many accidental merges. Automatic merges
have increased the quality for os-autoinst projects because everybody
learns that their pull requests should be high quality as they will be
automatically merged. Additionally, it reduces the workload for
reviewers as they do not have to manually track and merge pull requests
once approved.