### PR TITLE
virt_autotest: Support SLES 16+ versioning scheme

### DIFF
--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -32,12 +32,6 @@ sub get_script_run {
     my ($regcode, $regcode_ltss) = get_guest_regcode(separator => '|');
     my $kernel_params = get_guest_settings(settings => 'GUEST_EXT_KERNEL_PARAMS', separator => '|');
     $pre_test_cmd .= " -f \"" . $guest_pattern . "\" -n " . $parallel_num . " -r " . " -e \"" . $regcode . "\" -E \"" . $regcode_ltss . "\" -k \"" . $kernel_params->{'GUEST_EXT_KERNEL_PARAMS'} . "\"";
-    if ($guest_pattern =~ /sles-16/) {
-        my $agama_mirror_repo = get_var('MIRROR_HTTP');
-        if ($agama_mirror_repo) {
-            $pre_test_cmd .= " -l \"" . $agama_mirror_repo . "\"";
-        }
-    }
     $pre_test_cmd .= " 2>&1 | tee /tmp/s390x_guest_install_test.log" if (is_s390x);
 
     return $pre_test_cmd;

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -93,9 +93,7 @@ sub get_version_for_daily_build_guest {
         $version = get_var("VERSION", '');
     }
     $version = lc($version);
-    if ($version !~ /sp/m) {
-        $version = $version . "-fcs";
-    }
+    $version =~ s/\./-/g;
     return $version;
 }
 


### PR DESCRIPTION
**Description:**
**Context & Motivation**
Starting with SLES 16, the OS versioning scheme has transitioned from the traditional Service Pack nomenclature (e.g., 15-SP3) to a dot-separated decimal format (e.g., 16.0, 16.1, 17.0). The get_version_for_daily_build_guest function constructs the version string used for fetching daily build repositories. Because backward compatibility with SLES 15 is no longer required for this specific logic, the function needs to be modernized to handle the new format exclusively.
**Changes Included**
- Removed legacy `SP`/`FCS` logic: Dropped the conditional block `(if ($version !~ /sp/m))` that appended` -fcs` to versions without the `sp` keyword.
- Added dot-to-hyphen conversion: Introduced a regex substitution `($version =~ s/\./-/g;)` to automatically convert decimal versions `(like 16.1)` into the hyphenated format `(16-1) `required by the repository URL structures.
- Removed static mirror injection for SLES 16: Deleted the hardcoded logic that filtered for `$guest_pattern =~ /sles-16/` to fetch the `MIRROR_HTTP` variable and append it as the `-l` parameter `($agama_mirror_repo)`. This static approach is no longer needed.

**Related ticket:** https://progress.opensuse.org/issues/195110
**Verification run:** 
[gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/22036039) PASS
[gi-online-guest_developing-on-host_sles15sp7-kvm](https://openqa.suse.de/tests/22041696) PASS
[gi-online-guest_developing-on-host_sles16.0-kvm](https://openqa.suse.de/tests/22041923) PASS
[gi-online-guest_sles16.0-on-host_developing-kvm](https://openqa.suse.de/tests/22036040) PASS
[gi-guest_sles15sp7-on-host_developing-kvm](https://openqa.suse.de/tests/22036043) PASS