### PR TITLE
Add retry 4 PAYG SUSEConnect Invalid credentials

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -51,6 +51,7 @@ our @EXPORT = qw(
   ipaddr2_internal_key_gen
   ipaddr2_scc_check
   ipaddr2_scc_register
+  ipaddr2_scc_registration_workaround_PAYG
   ipaddr2_scc_addons
   ipaddr2_billing_model_get
   ipaddr2_crm_move
@@ -1505,12 +1506,15 @@ Return 1 if all modules are registered, 0 if at least one is not.
 sub ipaddr2_scc_check(%args) {
     croak("Argument < id > missing") unless $args{id};
     $args{bastion_ip} //= ipaddr2_bastion_pubip();
+    my $cmd = 'sudo SUSEConnect -s';
+
+    return 0 if ipaddr2_ssh_internal(id => $args{id}, cmd => $cmd, bastion_ip => $args{bastion_ip}, no_assert => 1);
 
     # Initially suppose is registered
     my $registered = 1;
     my $json = decode_json(ipaddr2_ssh_internal_output(
             id => $args{id},
-            cmd => 'sudo SUSEConnect -s',
+            cmd => $cmd,
             bastion_ip => $args{bastion_ip}));
     foreach (@$json) {
         if ($_->{status} =~ '^Not Registered') {
@@ -1519,6 +1523,100 @@ sub ipaddr2_scc_check(%args) {
         }
     }
     return $registered;
+}
+
+=head2 ipaddr2_scc_registration_workaround_PAYG
+
+    my ipaddr2_scc_registration_workaround_PAYG(id => 1);
+
+Workaround for PAYG image scc registration.
+Do cleanup, reboot and re-register.
+Do debug.
+
+=over
+
+=item B<id> - VM id where to install and configure the web server
+
+=item B<bastion_ip> - Public IP address of the bastion. Calculated if not provided.
+                      Providing it as an argument is recommended
+                      to avoid having to query Azure to get it.
+
+=back
+=cut
+
+sub ipaddr2_scc_registration_workaround_PAYG(%args) {
+    croak("Argument < id > missing") unless $args{id};
+    $args{bastion_ip} //= ipaddr2_bastion_pubip();
+
+    # Debug purpose
+    record_info('Debug: check guestregister.service before reboot');
+    ipaddr2_ssh_internal(
+        id => $args{id},
+        cmd => 'sudo systemctl is-enabled guestregister.service',
+        bastion_ip => $args{bastion_ip},
+        no_assert => 1);
+
+    # Enable and start guestregister.service as it is 'disabled' sometime
+    ipaddr2_ssh_internal(
+        id => $args{id},
+        cmd => 'sudo systemctl enable --now guestregister.service',
+        bastion_ip => $args{bastion_ip});
+
+    # Clean registration before reboot
+    # NOTE: without cleanup the re-register will be failed when hit 'Credentials are invalid' error
+    ipaddr2_ssh_internal(
+        id => $args{id},
+        cmd => 'sudo registercloudguest --clean',
+        bastion_ip => $args{bastion_ip});
+
+    # Reboot: during 'reboot' it will do registration automatically if not
+    ipaddr2_ssh_internal(id => $args{id},
+        cmd => 'sudo reboot',
+        timeout => 60,
+        no_assert => 1,
+        bastion_ip => $args{bastion_ip});
+
+    # Check if reboot was done successfully
+    my $timeout = 600;
+    my $ip = ipaddr2_get_internal_vm_private_ip(id => $_);
+    while ($timeout > 0) {
+        if (script_run("ssh $args{bastion_ip} 'nc -vz -w 1 $ip 22'") != 0) {
+            record_info("waiting $ip boot");
+            sleep 60;
+            $timeout = $timeout - 60;
+        }
+        else {
+            record_info("$ip reboot successfully");
+            last;
+        }
+    }
+
+    # Debug purpose
+    record_info('Debug: check guestregister.service after reboot');
+    ipaddr2_ssh_internal(
+        id => $args{id},
+        cmd => 'sudo systemctl is-enabled guestregister.service',
+        bastion_ip => $args{bastion_ip},
+        no_assert => 1);
+    record_info('Debug: check SUSEConnect -s after reboot');
+    ipaddr2_ssh_internal(
+        id => $args{id},
+        cmd => 'sudo SUSEConnect -s',
+        bastion_ip => $args{bastion_ip},
+        no_assert => 0);
+
+    # Try registration cleaup and registercloudguest again manually
+    # NOTE: reboot automatic registration can not fully register all modules sometime
+    # Clean registration
+    ipaddr2_ssh_internal(
+        id => $args{id},
+        cmd => 'sudo registercloudguest --clean',
+        bastion_ip => $args{bastion_ip});
+    # Re-register
+    ipaddr2_ssh_internal(
+        id => $args{id},
+        cmd => 'sudo registercloudguest --force-new',
+        bastion_ip => $args{bastion_ip});
 }
 
 =head2 ipaddr2_scc_register

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -816,6 +816,7 @@ subtest '[ipaddr2_scc_check] all registered' => sub {
             # due to the internal implementation of the
             # function under test, this status is equivalent to `Registered`
             return '[{"status":"Bialetti"}]'; });
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub { return 0; });
 
     my $ret = ipaddr2_scc_check(id => 42);
 
@@ -833,11 +834,37 @@ subtest '[ipaddr2_scc_check] one not registered' => sub {
             # due to the internal implementation of the
             # function under test, this status is equivalent to `Registered`
             return '[{"status":"Bialetti"}, {"status":"Not Registered"}]'; });
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub { return 0; });
 
     my $ret = ipaddr2_scc_check(id => 42);
 
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok(($ret eq 0), "Is not registered ret:$ret");
+};
+
+subtest '[ipaddr2_scc_check] SUSEConnect execution failed' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    my @calls;
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub { return 1; });
+
+    my $ret = ipaddr2_scc_check(id => 42);
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok(($ret eq 0), "Is not registered ret:$ret");
+};
+
+subtest '[ipaddr2_scc_registration_workaround_PAYG] apply registration workaround' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub { return 0; });
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $ipaddr2->redefine(ipaddr2_get_internal_vm_private_ip => sub { '192.168.1.1'; });
+    $ipaddr2->redefine(script_run => sub { return 0; });
+
+    ipaddr2_scc_registration_workaround_PAYG(id => 42);
+
+    ok('Workaround applying passed');
 };
 
 subtest '[ipaddr2_scc_register]' => sub {

--- a/tests/sles4sap/ipaddr2/registration.pm
+++ b/tests/sles4sap/ipaddr2/registration.pm
@@ -70,7 +70,8 @@ use sles4sap::ipaddr2 qw(
   ipaddr2_repo_list
   ipaddr2_bastion_pubip
   ipaddr2_cleanup
-  ipaddr2_logs_collect);
+  ipaddr2_logs_collect
+  ipaddr2_scc_registration_workaround_PAYG);
 
 sub run {
     my ($self) = @_;
@@ -85,12 +86,28 @@ sub run {
     if (check_var('IPADDR2_CLOUDINIT', 0)) {
         foreach (1 .. 2) {
             my $type = ipaddr2_billing_model_get(id => $_, bastion_ip => $bastion_ip);
+
             # Check if somehow the image is already registered or not
             my $is_registered = ipaddr2_scc_check(
                 bastion_ip => $bastion_ip,
                 id => $_);
             record_info('REG INITIAL', "type:$type is_registered:$is_registered");
-            if (($is_registered ne 1) || ($type eq 'BYOS')) {
+
+            # Apply registration clean and reboot to redo registercloudguest if failed on PAYG image
+            if (($is_registered ne 1) && ($type eq 'PAYG')) {
+                ipaddr2_scc_registration_workaround_PAYG(
+                    bastion_ip => $bastion_ip,
+                    id => $_);
+
+                # Record softfail and check again if image is fully registered
+                record_soft_failure('bsc#1254984 - Occasional registration issues on Azure and GCE OnDemand issues');
+                my $is_registered = ipaddr2_scc_check(
+                    bastion_ip => $bastion_ip,
+                    id => $_);
+                record_info('REG WORKAROUND', "type:$type is_registered:$is_registered");
+            }
+
+            if (($is_registered ne 1) && ($type eq 'BYOS')) {
                 # Conditionally register the SLES for SAP instance.
                 # Registration is attempted only if the instance is not currently registered and a
                 # registration code ('SCC_REGCODE_SLES4SAP') is available.


### PR DESCRIPTION
Add retry 4 PAYG SUSEConnect Invalid credentials  

Add retry to fix Azure PAYG ipaddr2 test case "SUSEConnect -s" reports "Invalid credentials" failure   
1. It mainly checks registration and does reboot to redo registercloudguest if registration failed on PAYG image  
2. The key fix is do `"registercloudguest --clean"` before `reboot`, `"reboot"` system and redo registration after reboot
3. Do registration cleanup up before reboot
4. The registration will be done automatically during reboot 
5. Do registration manually again after reboot (sometime reboot can not make all modules registered fully)
6. Add debug info for review purpose
7. Add softfail with a product bug (bsc#[1254984](https://bugzilla.suse.com/show_bug.cgi?id=1254984) - Occasional registration issues on Azure and GCE OnDemand issues)

- Related ticket:   
[TEAM-11097](https://jira.suse.com/browse/TEAM-11097) - [PC][PAYG][sporadic] SUSEConnect -s reports "Invalid system credentials, probably because the registered system was deleted in SUSE Customer Center"

VRs:
- VRs for `SUSEConnect -s` failed on `Error: Invalid system credentials`:  
https://openqa.suse.de/tests/21956312#step/registration/85 (passed)
https://openqa.suse.de/tests/21956307#step/registration/15 (passed)
https://openqa.suse.de/tests/21956305#step/registration/15 (`Error: Invalid system credentials` detected)
https://openqa.suse.de/tests/21956305#step/registration/27 (do 'registercloudguest --clean')
https://openqa.suse.de/tests/21956305#step/registration/30 (do `reboot`)
https://openqa.suse.de/tests/21956305#step/registration/77 (`re-register` done successfully during `reboot`)
https://openqa.suse.de/tests/21956305#step/registration/83 (do `registercloudguest --force-new` manually successfully)
https://openqa.suse.de/tests/21956305#step/registration/93 (registration check passed)

- VRs for `SUSEConnect -s` passed but there are `4` modules are `"status":"Not Registered"`
https://openqa.suse.de/tests/21956310#step/registration/15 (4 modules are `"status":"Not Registered"` detected)
https://openqa.suse.de/tests/21956310#step/registration/101 (did retry mechanism as above VR and registration check passed)
(Please ignore the `sanity_os` failure as it is not related to this PR)

- VRs for `SUSEConnect -s` passed but `all` modules are `"status":"Not Registered"`
https://openqa.suse.de/tests/21956022#step/registration/23 (code is not the latest one) (did retry mechanism as above VR and registration check passed)

- VRs for  `SUSEConnect -s` passed but `1` module is `"status":"Not Registered"`
https://openqa.suse.de/tests/21956308#step/registration/15 (`SUSEConnect -s` passed but 1 module is `"status":"Not Registered"` detected) 
`{"identifier":"sle-module-live-patching","version":"15.5","arch":"x86_64","status":"Not Registered"}`
https://openqa.suse.de/tests/21956308#step/registration/88 (`SUSEConnect -s` passed but `all` modules are `"status":"Not Registered"` detected after `reboot`)
https://openqa.suse.de/tests/21956308#step/registration/103 (manual re-register takes effect)

- VRs for `SUSEConnect -s`  failed on `System management is locked by the application with pid 3375 (/usr/bin/zypper)` 
https://openqa.suse.de/tests/21941422#step/registration/42  (code is not the latest one)  (`System management is locked by the application with pid 3375 (/usr/bin/zypper)` detected re-register passed)

Regression VRs:
https://openqa.suse.de/tests/21957913 (12-SP5-Azure-SAP-BYOS ipaddr2) (passed)
https://openqa.suse.de/tests/21957917 (12-SP5-Azure-SAP-PAYG ipaddr2) (passed)
https://openqa.suse.de/tests/21957919 (15-SP4-Azure-SAP-PAYG ipaddr2) (passed)
https://openqa.suse.de/tests/21957921 (15-SP6-Azure-SAP-BYOS ipaddr2) (passed)
https://openqa.suse.de/tests/21957923 (15-SP7-Azure-SAP-PAYG ipaddr2) (passed)




