### PR TITLE
cleanup_known_coredumps: Process command line in Perl

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -181,7 +181,8 @@ sub cleanup_known_coredumps {
     for my $pid (split(/\n/, script_output(q(coredumpctl -q --no-pager --no-legend | awk '$9 == "present" { print $5 }'), proceed_on_failure => 1))) {
         for my $known (keys %known_coredumps) {
             my $coredump_info = script_output("time coredumpctl info --no-pager $pid", proceed_on_failure => 1);
-            if (script_output("echo \"$coredump_info\" | sed -n 's/^ *Command Line: //p'") =~ /$known_coredumps{$known}/) {
+            my ($cmdline) = $coredump_info =~ /^\s+Command Line: (.*)$/m;
+            if ($cmdline =~ /$known_coredumps{$known}/) {
                 record_info('Known dump', $coredump_info);
                 script_output("rm -vf \$(echo \"$coredump_info\" | awk '/Storage:/ {print \$2}')");
             }

--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -171,8 +171,8 @@ fail on present unexpected coredump
 
 sub cleanup_known_coredumps {
     my %known_coredumps = (
-        # don't add ", it will get lost in compared string
-        'poo#198596' => q(openssl3-conf\/base_only.cnf -p \$'hello'),
+        # Note: These are literal strings, not regexes
+        'poo#198596' => q(openssl3-conf/base_only.cnf -p $'"hello"'),
         'bsc#1129403' => q(unzip-mem  v files.zip),
         'bsc#1261358' => q(gvfs-udisks2-volume-monitor),
         'bsc#1261625' => q(ovs-vswitchd unix:),
@@ -182,7 +182,7 @@ sub cleanup_known_coredumps {
         for my $known (keys %known_coredumps) {
             my $coredump_info = script_output("time coredumpctl info --no-pager $pid", proceed_on_failure => 1);
             my ($cmdline) = $coredump_info =~ /^\s+Command Line: (.*)$/m;
-            if ($cmdline =~ /$known_coredumps{$known}/) {
+            if (index($cmdline, $known_coredumps{$known}) >= 0) {
                 record_info('Known dump', $coredump_info);
                 script_output("rm -vf \$(echo \"$coredump_info\" | awk '/Storage:/ {print \$2}')");
             }


### PR DESCRIPTION
Piping the multiline coredump information through double-quotes can misfire badly. 

Also use literal strings instead of regexes.

Related ticket: https://progress.opensuse.org/issues/197969

Verification run: https://openqa.suse.de/tests/21959074
