### PR TITLE
Enable expand agama profile by Mojo

### DIFF
--- a/data/autoyast_hanaperf/agama-config.jsonnet.ep
+++ b/data/autoyast_hanaperf/agama-config.jsonnet.ep
@@ -1,0 +1,65 @@
+{
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard',
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    sshPublicKey: 'enable ssh',
+  },
+  software: {
+    patterns: {
+      add: ['sles_sap_DB', 'sles_sap_APP']
+    },
+  },
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    % if (!$check_var->('BUILD', 'GM')) {
+    registrationCode: '{{SCC_REGCODE_SLES4SAP}}',
+    % }
+  },
+  storage: {
+    drives: [
+      {
+        search: '/dev/disk/by-id/{{OSDISK}}',
+        partitions: [
+          { search: '*', delete: true },
+          { generate: 'default' },
+        ],
+      },
+    ],
+  },
+  localization: {
+    language: 'en_US.UTF-8',
+    keyboard: 'us',
+    timezone: 'Asia/Shanghai',
+  },
+  scripts: {
+    pre: [
+      {
+        name: 'wipefs',
+        content: |||
+          #!/usr/bin/env bash
+          for i in `lsblk -n -l -o NAME -d -e 7,11,254`
+              do wipefs -af /dev/$i
+              sleep 1
+              sync
+          done
+        |||,
+      },
+    ],
+    post: [
+      {
+        name: 'enable root login',
+        chroot: true,
+        content: |||
+          #!/usr/bin/env bash
+          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
+        |||,
+      },
+    ],
+  },
+}

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -787,7 +787,20 @@ sub expand_agama_secrets {
 sub expand_agama_profile {
     my ($profile, $profile_expanded) = @_;
     $profile_expanded //= $profile;
-    my $content = expand_variables(expand_agama_secrets(expand_version(get_test_data($profile))));
+
+    my $test_data = get_test_data($profile);
+
+    # Expand by Mojo when EXPAND_AGAMA_PROFILE_BY_MOJO=1 and
+    # the file ending with jsonnet.ep or json.ep
+    if (check_var('EXPAND_AGAMA_PROFILE_BY_MOJO', '1')
+        && $profile_expanded =~ s/\.(json(?:net)?)\.ep$/.$1/) {
+        # Expand agama json/jsonnet by Mojo
+        $test_data = expand_template($test_data);
+        die $test_data if $test_data->isa('Mojo::Exception');
+        record_info('Mojo Expand', "Expanded profile: $profile_expanded");
+    }
+
+    my $content = expand_variables(expand_agama_secrets(expand_version($test_data)));
     save_tmp_file($profile_expanded, $content);
     my $profile_url = autoinst_url . "/files/$profile_expanded";
     upload_profile(path => $profile_expanded, profile => $content);


### PR DESCRIPTION
This change will enable expanding agama profile by mojo, so that openQA can expand some statements like if, get_var() and so on, that will reduce the duplicate agama json profile with less content difference. 

- Related ticket: https://jira.suse.com/browse/TEAM-11185
- Needles: N/A
- Verification run: 
With any parameter and use original agama.jsonnet: http://10.200.129.6/tests/88437
EXPAND_AGAMA_PROFILE_BY_MOJO=1 and agama-config.jsonnet.ep:  http://10.200.129.6/tests/88434

The openQA command line looks like
```openqa-cli api -X post isos DISTRI=sle VERSION=16.0 ARCH=x86_64 BUILD=GM FLAVOR=Full _GROUP_ID=61 MACHINE=64bit-ipmi-hana04 INST_AUTO=autoyast_hanaperf/agama-config.jsonnet.ep EXPAND_AGAMA_PROFILE_BY_MOJO=1```