### PR TITLE
Split sles_use_existing_md_raid to perform installation and boot on different jobs

### DIFF
--- a/data/yam/agama/auto/lib/storage.libsonnet
+++ b/data/yam/agama/auto/lib/storage.libsonnet
@@ -129,9 +129,13 @@ local raid(level='raid0', boot_type='bios') = {
         },
         mdroot_partition,
         mdswap_partition,
+        {
+          size: '1024 MiB',
+          filesystem: { path: '/boot', type: 'xfs' },
+        },
       ],
     },
-    // Additional disks: EFI partition, not mounted
+    // Additional disks: EFI and boot partition, not mounted
     {
       search: '*',
       partitions: [
@@ -143,6 +147,10 @@ local raid(level='raid0', boot_type='bios') = {
         },
         mdroot_partition,
         mdswap_partition,
+        {
+          size: '1024 MiB',
+          filesystem: { type: 'xfs' },
+        },
       ],
     },
   ] else if boot_type == 'prep' then [
@@ -217,6 +225,17 @@ local search_raid0() = {
           filesystem: {
             path: '/boot/efi',
             type: 'vfat'
+          },
+        },
+        {
+          search: {
+            condition: {
+              size: '1024 MiB'
+            }
+          },
+          filesystem: {
+            path: '/boot',
+            type: 'xfs'
           },
         },
       ],

--- a/schedule/yam/agama_raid_unattended_use_existing_md_raid.yaml
+++ b/schedule/yam/agama_raid_unattended_use_existing_md_raid.yaml
@@ -1,12 +1,10 @@
 ---
 name: agama_raid_unattended_existing_md_raid
 description: >
-  Perform unattended installation with RAID and modify the RAID disk of swap.
+  Perform unattended installation with RAID and modify the RAID disk of swap, export disks for validation.
 schedule:
   - yam/agama/boot_agama
   - yam/agama/agama_auto
-  - yam/agama/agama_boot_from_hdd
-  - installation/first_boot
-  - console/validate_md_raid
-  - console/validate_raid
-  - yam/validate/validate_raid_swap
+  - yam/agama/boot_agama
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/schedule/yam/agama_validate_md_raid.yaml
+++ b/schedule/yam/agama_validate_md_raid.yaml
@@ -1,0 +1,9 @@
+---
+name: agama_validate_md_raid
+description: >
+  Perform multi-disk RAID validation from previous installation.
+schedule:
+  - installation/first_boot
+  - console/validate_md_raid
+  - console/validate_raid
+  - yam/validate/validate_raid_swap


### PR DESCRIPTION
We have modified the storage.jsonnet to include a new partition for boot which contains grub, this new partition will be only selected to install on first Agama detected disk. Then, after installation the grub is stored in the same disk as EFI partition dealing then with boot order issues.

- Related ticket: https://progress.opensuse.org/issues/198218
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/775
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=16.1&build=40.1&groupid=583
