### PR TITLE
Set UEFI boot loader password result to pass for SLE15-SP7

### DIFF
--- a/schedule/security/autoyast_stig_hardening.yaml
+++ b/schedule/security/autoyast_stig_hardening.yaml
@@ -42,7 +42,9 @@ test_data:
     CCE-83275-8:
       name: Set the UEFI Boot Loader Password
       sles_ref: SLES-15-010200
-      result: fail
+      results_by_version:
+        15-SP7: pass
+      default: fail
     CCE-83274-1:
       name: Set Boot Loader Password in grub2 (non-UEFI)
       sles_ref: SLES-15-010190


### PR DESCRIPTION


- Related ticket:https://progress.opensuse.org/issues/199817
- Needles: No
- Verification run: 
   15-SP6: https://openqa.suse.de/tests/21957963#
   15-SP7: https://openqa.suse.de/tests/21957961
