### PR TITLE
swtpm: discover nested guest IP from DHCP leases instead of ARP cache

### DIFF
--- a/data/swtpm/ssh_port_chk_script
+++ b/data/swtpm/ssh_port_chk_script
@@ -1,11 +1,17 @@
 #!/bin/bash
 set -euo pipefail
 
-ip_addr=$(ip n | awk '/192.168.122/ {print $1}')
-if [[ -n "$ip_addr" ]] && nc -zvw2 $ip_addr 22 2>/dev/null; then
-    echo "SSH is ONLINE"
+# Discover the guest IP from libvirt's DHCP lease table on the default
+# network. This is authoritative once dnsmasq has issued the lease and,
+# unlike `ip n`, does not depend on the guest emitting a gratuitous ARP
+# to populate the host's neighbor cache.
+ip_addr=$(virsh net-dhcp-leases default 2>/dev/null \
+    | awk '/ipv4/ && !found {sub(/\/.*/,"",$5); print $5; found=1}')
+
+if [[ -n "$ip_addr" ]] && nc -zvw2 "$ip_addr" 22 2>/dev/null; then
+    echo "SSH ONLINE at $ip_addr"
     exit 0
 else
-    echo "SSH still OFFLINE"
+    echo "SSH OFFLINE (ip='${ip_addr:-<none>}')"
     exit 1
 fi

--- a/lib/swtpmtest.pm
+++ b/lib/swtpmtest.pm
@@ -91,7 +91,9 @@ sub swtpm_verify {
     script_retry("bash $image_path/ssh_port_chk_script", retry => 20, fail_message => 'Could not SSH into the nested VM.');
 
     # Generate an SSH key and copy it into the VM
-    my $ip_addr = script_output("ip n | awk '/192\\.168\\.122/ {print \$1}'");
+    my $leases = script_output('virsh net-dhcp-leases default');
+    my ($ip_addr) = $leases =~ /ipv4\s+([\d.]+)\//;
+    die 'Could not find an IPv4 address in virsh leases' unless $ip_addr;
     assert_script_run('ssh-keygen -t rsa -b 4096 -f sshkey -N ""');
     enter_cmd("ssh-copy-id -i sshkey.pub -o 'StrictHostKeyChecking no' ${ip_addr}");
     wait_serial(qr/assword:/);


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/199592
VRs:
* 16.0: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=%3Agit%3A3992%3AImageMagick&groupid=431
* 15.6: https://openqa.suse.de/tests/overview?build=20260420-1&version=15-SP6&groupid=431&distri=sle