### PR TITLE
Remove useless guest access from virt tests

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_sev_es_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_sev_es_x86_64_agama_online_iso.xml
@@ -30,7 +30,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.0-Online-x86_64-Build12345.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.0-Online-x86_64-Build12345.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_sev_snp_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_sev_snp_x86_64_agama_online_iso.xml
@@ -30,7 +30,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.0-Online-x86_64-Build12345.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.0-Online-x86_64-Build12345.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_full_repo.xml
+++ b/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_full_repo.xml
@@ -23,7 +23,7 @@
     <guest_installation_automation_platform></guest_installation_automation_platform>
     <guest_installation_automation_file>sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet</guest_installation_automation_file>
     <guest_installation_method>location</guest_installation_method>
-    <guest_installation_extra_args>live.password=novell#console=ttyS0,115200#loglevel=5#plymouth.enable=0#ignore_loglevel</guest_installation_extra_args>
+    <guest_installation_extra_args>live.password=ROOTPASSWORD#console=ttyS0,115200#loglevel=5#plymouth.enable=0#ignore_loglevel</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others>kernel=boot/x86_64/loader/linux,initrd=boot/x86_64/loader/initrd</guest_installation_method_others>
     <guest_installation_media>http://openqa.suse.de/assets/repo/SLES-16.0-Full-x86_64-Build12345.install/</guest_installation_media>

--- a/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
@@ -29,7 +29,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.0-Online-x86_64-Build12345.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.0-Online-x86_64-Build12345.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_online_iso_qcow2_nvram.xml
+++ b/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_online_iso_qcow2_nvram.xml
@@ -29,7 +29,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.0-Online-x86_64-Build12345.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.0-Online-x86_64-Build12345.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_kvm_hvm_aarch64_agama_full_repo.xml
+++ b/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_kvm_hvm_aarch64_agama_full_repo.xml
@@ -23,7 +23,7 @@
     <guest_installation_automation_platform></guest_installation_automation_platform>
     <guest_installation_automation_file>sles_16_plus_kvm_hvm_guest_non_encrypted_storage_aarch64.jsonnet</guest_installation_automation_file>
     <guest_installation_method>location</guest_installation_method>
-    <guest_installation_extra_args>live.password=novell#console=ttyS0,115200#loglevel=5#plymouth.enable=0#ignore_loglevel</guest_installation_extra_args>
+    <guest_installation_extra_args>live.password=ROOTPASSWORD#console=ttyS0,115200#loglevel=5#plymouth.enable=0#ignore_loglevel</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others>kernel=boot/aarch64/loader/linux,initrd=boot/aarch64/loader/initrd</guest_installation_method_others>
     <guest_installation_media>http://openqa.suse.de/assets/repo/SLES-16.0-Full-aarch64-Build12345.install/</guest_installation_media>

--- a/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_kvm_hvm_aarch64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_kvm_hvm_aarch64_agama_online_iso.xml
@@ -29,7 +29,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.0-Online-aarch64-Build12345.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.0-Online-aarch64-Build12345.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyAMA0,115200 linuxrc.log=/dev/ttyAMA0 linuxrc.core=/dev/ttyAMA0 linuxrc.debug=4,trace ip=dhcp rd.neednet</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyAMA0,115200 linuxrc.log=/dev/ttyAMA0 linuxrc.core=/dev/ttyAMA0 linuxrc.debug=4,trace ip=dhcp rd.neednet</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_1_immutable_64_kvm_hvm_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_1_immutable_64_kvm_hvm_x86_64_agama_online_iso.xml
@@ -30,7 +30,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.1-Online-x86_64-Build12345.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.1-Online-x86_64-Build12345.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_aarch64_agama_full_repo.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_aarch64_agama_full_repo.xml
@@ -23,7 +23,7 @@
     <guest_installation_automation_platform></guest_installation_automation_platform>
     <guest_installation_automation_file>sles_16_plus_kvm_hvm_guest_non_encrypted_storage_aarch64.jsonnet</guest_installation_automation_file>
     <guest_installation_method>location</guest_installation_method>
-    <guest_installation_extra_args>live.password=novell#console=ttyS0,115200#loglevel=5#plymouth.enable=0#ignore_loglevel</guest_installation_extra_args>
+    <guest_installation_extra_args>live.password=ROOTPASSWORD#console=ttyS0,115200#loglevel=5#plymouth.enable=0#ignore_loglevel</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others>kernel=boot/aarch64/loader/linux,initrd=boot/aarch64/loader/initrd</guest_installation_method_others>
     <guest_installation_media>http://openqa.suse.de/assets/repo/SLES-16.1-Full-aarch64-Build12345.install/</guest_installation_media>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_aarch64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_aarch64_agama_online_iso.xml
@@ -29,7 +29,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.1-Online-aarch64-Build12345.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.1-Online-aarch64-Build12345.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyAMA0,115200 ip=dhcp rd.neednet arm64.nompam</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyAMA0,115200 ip=dhcp rd.neednet arm64.nompam</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_sev_es_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_sev_es_x86_64_agama_online_iso.xml
@@ -30,7 +30,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.1-Online-x86_64-Build12345.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.1-Online-x86_64-Build12345.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_sev_snp_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_sev_snp_x86_64_agama_online_iso.xml
@@ -30,7 +30,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.1-Online-x86_64-Build12345.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.1-Online-x86_64-Build12345.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_x86_64_agama_full_repo.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_x86_64_agama_full_repo.xml
@@ -23,7 +23,7 @@
     <guest_installation_automation_platform></guest_installation_automation_platform>
     <guest_installation_automation_file>sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet</guest_installation_automation_file>
     <guest_installation_method>location</guest_installation_method>
-    <guest_installation_extra_args>live.password=novell#console=ttyS0,115200#loglevel=5#plymouth.enable=0#ignore_loglevel</guest_installation_extra_args>
+    <guest_installation_extra_args>live.password=ROOTPASSWORD#console=ttyS0,115200#loglevel=5#plymouth.enable=0#ignore_loglevel</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others>kernel=boot/x86_64/loader/linux,initrd=boot/x86_64/loader/initrd</guest_installation_method_others>
     <guest_installation_media>http://openqa.suse.de/assets/repo/SLES-16.1-Full-x86_64-Build12345.install/</guest_installation_media>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_x86_64_agama_online_iso.xml
@@ -29,7 +29,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.1-Online-x86_64-Build12345.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.1-Online-x86_64-Build12345.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_x86_64_agama_online_iso_qcow2_nvram.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_x86_64_agama_online_iso_qcow2_nvram.xml
@@ -29,7 +29,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.1-Online-x86_64-Build12345.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.1-Online-x86_64-Build12345.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_sev_es_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_sev_es_x86_64_agama_online_iso.xml
@@ -30,7 +30,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/fixed/SLES-16.0-Online-x86_64-GM.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/fixed/SLES-16.0-Online-x86_64-GM.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_sev_snp_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_sev_snp_x86_64_agama_online_iso.xml
@@ -30,7 +30,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/fixed/SLES-16.0-Online-x86_64-GM.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/fixed/SLES-16.0-Online-x86_64-GM.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_full_repo.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_full_repo.xml
@@ -23,7 +23,7 @@
     <guest_installation_automation_platform></guest_installation_automation_platform>
     <guest_installation_automation_file>sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet</guest_installation_automation_file>
     <guest_installation_method>location</guest_installation_method>
-    <guest_installation_extra_args>live.password=novell#console=ttyS0,115200#loglevel=5#plymouth.enable=0#ignore_loglevel</guest_installation_extra_args>
+    <guest_installation_extra_args>live.password=ROOTPASSWORD#console=ttyS0,115200#loglevel=5#plymouth.enable=0#ignore_loglevel</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others>kernel=boot/x86_64/loader/linux,initrd=boot/x86_64/loader/initrd</guest_installation_method_others>
     <guest_installation_media>http://openqa.suse.de/assets/repo/SLES-16.0-Full-x86_64-Build12345.install/</guest_installation_media>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
@@ -29,7 +29,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/fixed/SLES-16.0-Online-x86_64-GM.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/fixed/SLES-16.0-Online-x86_64-GM.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso_qcow2_nvram.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso_qcow2_nvram.xml
@@ -29,7 +29,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/fixed/SLES-16.0-Online-x86_64-GM.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/fixed/SLES-16.0-Online-x86_64-GM.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_kvm_hvm_aarch64_agama_full_repo.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_kvm_hvm_aarch64_agama_full_repo.xml
@@ -23,7 +23,7 @@
     <guest_installation_automation_platform></guest_installation_automation_platform>
     <guest_installation_automation_file>sles_16_plus_kvm_hvm_guest_non_encrypted_storage_aarch64.jsonnet</guest_installation_automation_file>
     <guest_installation_method>location</guest_installation_method>
-    <guest_installation_extra_args>live.password=novell#console=ttyS0,115200#loglevel=5#plymouth.enable=0#ignore_loglevel</guest_installation_extra_args>
+    <guest_installation_extra_args>live.password=ROOTPASSWORD#console=ttyS0,115200#loglevel=5#plymouth.enable=0#ignore_loglevel</guest_installation_extra_args>
     <guest_installation_wait/>
     <guest_installation_method_others>kernel=boot/aarch64/loader/linux,initrd=boot/aarch64/loader/initrd</guest_installation_method_others>
     <guest_installation_media>http://openqa.suse.de/assets/repo/SLES-16.0-Full-aarch64-Build12345.install/</guest_installation_media>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_kvm_hvm_aarch64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_kvm_hvm_aarch64_agama_online_iso.xml
@@ -29,7 +29,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/fixed/SLES-16.0-Online-aarch64-GM.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/fixed/SLES-16.0-Online-aarch64-GM.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=novell console=ttyAMA0,115200 linuxrc.log=/dev/ttyAMA0 linuxrc.core=/dev/ttyAMA0 linuxrc.debug=4,trace ip=dhcp rd.neednet arm64.nompam</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyAMA0,115200 linuxrc.log=/dev/ttyAMA0 linuxrc.core=/dev/ttyAMA0 linuxrc.debug=4,trace ip=dhcp rd.neednet arm64.nompam</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_unattended_installation_files/ignition_config_encrypted_image.ign
+++ b/data/virt_autotest/guest_unattended_installation_files/ignition_config_encrypted_image.ign
@@ -6,7 +6,7 @@
     "users": [
       {
         "name": "root",
-        "passwordHash": "$2a$10$2qfKlKzzEp9tl3mde5CmhuxsEPd3DdlfJMQ.PNSI3rqXx4KztGYT6",
+        "passwordHash": "$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5",
         "sshAuthorizedKeys": [
           "##Authorized-Keys##"
         ]

--- a/data/virt_autotest/guest_unattended_installation_files/ignition_config_non_encrypted_image.ign
+++ b/data/virt_autotest/guest_unattended_installation_files/ignition_config_non_encrypted_image.ign
@@ -6,7 +6,7 @@
     "users": [
       {
         "name": "root",
-        "passwordHash": "$2a$10$2qfKlKzzEp9tl3mde5CmhuxsEPd3DdlfJMQ.PNSI3rqXx4KztGYT6",
+        "passwordHash": "$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5",
         "sshAuthorizedKeys": [
           "##Authorized-Keys##"
         ]

--- a/data/virt_autotest/guest_unattended_installation_files/slem_5_plus_kvm_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/slem_5_plus_kvm_hvm_guest_graphical_x86_64.xml
@@ -191,7 +191,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$2a$05$tvuIlgZ.sSzeCvQD6JN84uqsL26g17B7It3pTYPmJa.Qt7L03XjMu</user_password>
+      <user_password>$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_kvm_hvm_guest_graphical_aarch64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_kvm_hvm_guest_graphical_aarch64.xml
@@ -213,7 +213,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$2a$05$tvuIlgZ.sSzeCvQD6JN84uqsL26g17B7It3pTYPmJa.Qt7L03XjMu</user_password>
+      <user_password>$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_kvm_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_kvm_hvm_guest_graphical_x86_64.xml
@@ -213,7 +213,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$2a$05$tvuIlgZ.sSzeCvQD6JN84uqsL26g17B7It3pTYPmJa.Qt7L03XjMu</user_password>
+      <user_password>$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_kvm_hvm_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_kvm_hvm_guest_multi-user_x86_64.xml
@@ -214,7 +214,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$2a$05$tvuIlgZ.sSzeCvQD6JN84uqsL26g17B7It3pTYPmJa.Qt7L03XjMu</user_password>
+      <user_password>$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_hvm_guest_graphical_x86_64.xml
@@ -217,7 +217,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$2a$05$tvuIlgZ.sSzeCvQD6JN84uqsL26g17B7It3pTYPmJa.Qt7L03XjMu</user_password>
+      <user_password>$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_hvm_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_hvm_guest_multi-user_x86_64.xml
@@ -217,7 +217,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$2a$05$tvuIlgZ.sSzeCvQD6JN84uqsL26g17B7It3pTYPmJa.Qt7L03XjMu</user_password>
+      <user_password>$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_paravirt_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_paravirt_guest_graphical_x86_64.xml
@@ -218,7 +218,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$2a$05$tvuIlgZ.sSzeCvQD6JN84uqsL26g17B7It3pTYPmJa.Qt7L03XjMu</user_password>
+      <user_password>$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_paravirt_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_12_plus_xen_paravirt_guest_multi-user_x86_64.xml
@@ -218,7 +218,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$2a$05$tvuIlgZ.sSzeCvQD6JN84uqsL26g17B7It3pTYPmJa.Qt7L03XjMu</user_password>
+      <user_password>$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_graphical_aarch64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_graphical_aarch64.xml
@@ -252,7 +252,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$2a$05$tvuIlgZ.sSzeCvQD6JN84uqsL26g17B7It3pTYPmJa.Qt7L03XjMu</user_password>
+      <user_password>$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_graphical_x86_64.xml
@@ -263,7 +263,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$2a$05$tvuIlgZ.sSzeCvQD6JN84uqsL26g17B7It3pTYPmJa.Qt7L03XjMu</user_password>
+      <user_password>$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_kvm_hvm_guest_multi-user_x86_64.xml
@@ -263,7 +263,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$2a$05$tvuIlgZ.sSzeCvQD6JN84uqsL26g17B7It3pTYPmJa.Qt7L03XjMu</user_password>
+      <user_password>$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_hvm_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_hvm_guest_graphical_x86_64.xml
@@ -266,7 +266,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$2a$05$tvuIlgZ.sSzeCvQD6JN84uqsL26g17B7It3pTYPmJa.Qt7L03XjMu</user_password>
+      <user_password>$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_hvm_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_hvm_guest_multi-user_x86_64.xml
@@ -266,7 +266,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$2a$05$tvuIlgZ.sSzeCvQD6JN84uqsL26g17B7It3pTYPmJa.Qt7L03XjMu</user_password>
+      <user_password>$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_paravirt_guest_graphical_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_paravirt_guest_graphical_x86_64.xml
@@ -267,7 +267,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$2a$05$tvuIlgZ.sSzeCvQD6JN84uqsL26g17B7It3pTYPmJa.Qt7L03XjMu</user_password>
+      <user_password>$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_paravirt_guest_multi-user_x86_64.xml
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_15_plus_xen_paravirt_guest_multi-user_x86_64.xml
@@ -267,7 +267,7 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$2a$05$tvuIlgZ.sSzeCvQD6JN84uqsL26g17B7It3pTYPmJa.Qt7L03XjMu</user_password>
+      <user_password>$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5</user_password>
       <username>root</username>
     </user>
   </users>

--- a/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_aarch64.jsonnet
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_aarch64.jsonnet
@@ -19,7 +19,7 @@
     "hashedPassword": true
   },
   "root": {
-    "password": "$2a$10$2qfKlKzzEp9tl3mde5CmhuxsEPd3DdlfJMQ.PNSI3rqXx4KztGYT6",
+    "password": "$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5",
     "hashedPassword": true,
     "sshPublicKey": "##Authorized-Keys##"
   },

--- a/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet
@@ -20,7 +20,7 @@
     "hashedPassword": true
   },
   "root": {
-    "password": "$2a$10$2qfKlKzzEp9tl3mde5CmhuxsEPd3DdlfJMQ.PNSI3rqXx4KztGYT6",
+    "password": "$y$j9T$nRJRQUwZDai/K44Dn8RD40$tNACP3rJ5/oHQD1XIgVmj0MaBZKpD7GWN9nhpyDMgr5",
     "hashedPassword": true,
     "sshPublicKey": "##Authorized-Keys##"
   },

--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -2253,15 +2253,9 @@ sub config_guest_plain_password {
 
     $self->reveal_myself;
     if ($self->{virt_install_command_line} =~ /ROOTPASSWORD/) {
-        unless ($testapi::password) {
-            my $_root_password = get_required_var('_SECRET_ROOT_PASSWORD');
-            $self->{virt_install_command_line} =~ s/ROOTPASSWORD/$_root_password/;
-            $self->{virt_install_command_line_dryrun} =~ s/ROOTPASSWORD/$_root_password/;
-        }
-        else {
-            $self->{virt_install_command_line} =~ s/ROOTPASSWORD/$testapi::password/;
-            $self->{virt_install_command_line_dryrun} =~ s/ROOTPASSWORD/$testapi::password/;
-        }
+        my $_root_password = get_var('_SECRET_GUEST_PASSWORD', $testapi::password);
+        $self->{virt_install_command_line} =~ s/ROOTPASSWORD/$_root_password/;
+        $self->{virt_install_command_line_dryrun} =~ s/ROOTPASSWORD/$_root_password/;
     }
     return $self;
 }
@@ -2660,7 +2654,7 @@ sub setup_guest_agama_installation_shell {
             wait_still_screen;
             enter_cmd("timeout --kill-after=1 --signal=9 180 ssh-copy-id -f $_ssh_command_options root\@$self->{guest_ipaddr}", wait_still_screen => 5, timeout => 210);
             assert_screen('password-prompt', timeout => 30);
-            enter_cmd("novell", wait_screen_change => 60, max_interval => 1, timeout => 90);
+            enter_cmd(get_var('_SECRET_GUEST_PASSWORD', $testapi::password), wait_screen_change => 60, max_interval => 1, timeout => 90);
         }
         wait_still_screen(15);
         if (script_run("timeout --kill-after=1 --signal=9 60 ssh $_ssh_command_options root\@$self->{guest_ipaddr} ls") != 0) {
@@ -2669,7 +2663,7 @@ sub setup_guest_agama_installation_shell {
             enter_cmd("clear", wait_still_screen => 3);
             enter_cmd("timeout --kill-after=1 --signal=9 1800 ssh $_ssh_command_options root\@$self->{guest_ipaddr}", wait_still_screen => 5, timeout => 1850);
             assert_screen('password-prompt', timeout => 30);
-            enter_cmd("novell", wait_screen_change => 60, max_interval => 1, timeout => 90);
+            enter_cmd(get_var('_SECRET_GUEST_PASSWORD', $testapi::password), wait_screen_change => 60, max_interval => 1, timeout => 90);
             wait_still_screen(15);
             enter_cmd("timeout --kill-after=1 --signal=9 120 ip addr show", wait_still_screen => 5, timeout => 150);
         }
@@ -2760,7 +2754,7 @@ sub save_guest_agama_installation_logs {
         enter_cmd("clear", wait_still_screen => 3);
         enter_cmd("timeout --kill-after=1 --signal=9 1800 ssh $_ssh_command_options root\@$self->{guest_ipaddr}", wait_still_screen => 5, timeout => 1850);
         assert_screen('password-prompt', timeout => 30);
-        enter_cmd("novell", wait_screen_change => 60, max_interval => 1, timeout => 90);
+        enter_cmd(get_var('_SECRET_GUEST_PASSWORD', $testapi::password), wait_screen_change => 60, max_interval => 1, timeout => 90);
         wait_still_screen(15);
         enter_cmd("timeout --kill-after=1 --signal=9 120 mkdir /agama_installation_logs", timeout => 150);
         enter_cmd("timeout --kill-after=1 --signal=9 180 agama logs store -d /agama_installation_logs", timeout => 210);
@@ -2779,7 +2773,7 @@ sub save_guest_agama_installation_logs {
         foreach (@_agama_installation_logs) {
             enter_cmd("timeout --kill-after=1 --signal=9 180 scp -r $_ssh_command_options root\@$self->{guest_ipaddr}:$_ $self->{guest_log_folder}", timeout => 210);
             assert_screen('password-prompt', timeout => 30);
-            enter_cmd("novell", wait_screen_change => 60, max_interval => 1, timeout => 90);
+            enter_cmd(get_var('_SECRET_GUEST_PASSWORD', $testapi::password), wait_screen_change => 60, max_interval => 1, timeout => 90);
             wait_still_screen(15);
         }
     }

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1821,8 +1821,8 @@ sub exec_and_insert_password {
         send_key 'ret';
         assert_screen('password-prompt', 60);
     }
-    if (get_var("VIRT_PRJ1_GUEST_INSTALL") || get_var("VIRT_UNIFIED_GUEST_INSTALL")) {
-        type_password("novell");
+    if (get_var("VIRT_AUTOTEST")) {
+        type_password(get_required_var('_SECRET_GUEST_PASSWORD'));
     }
     else {
         type_password;

--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -73,7 +73,7 @@ sub install_package {
     #Switch all VM Passwords from installed settings files
     my $setting_file = "/usr/share/qa/virtautolib/data/settings." . locate_sourcefile;
     my $qa_password = $testapi::password;
-    my $vm_password = get_var('VIRTAUTO_VM_PASSWORD');
+    my $vm_password = get_required_var('_SECRET_GUEST_PASSWORD');
     my $cmd = "sed -i -e 's/vm.pass=/vm.pass=$vm_password/g' -e 's/xen.pass=/xen.pass=$vm_password/g' -e 's/migratee.pass=/migratee.pass=$vm_password/g' -e 's/vm.sshpassword=/vm.sshpassword=$qa_password/g' $setting_file";
     if (is_s390x) {
         lpar_cmd("$cmd");

--- a/tests/virt_autotest/libvirt_virtual_network_init.pm
+++ b/tests/virt_autotest/libvirt_virtual_network_init.pm
@@ -47,7 +47,7 @@ sub run_test {
         fail_message => "The SUT needs at least " . $expected_pool_size . "GiB available space of active pool for virtual network test");
 
     # SLES16 has done this in earlier setup
-    unless (is_sle('=16')) {
+    unless (is_sle('>=16')) {
         #Enable libvirt debug log
         turn_on_libvirt_debugging_log;
 


### PR DESCRIPTION
poo: https://progress.opensuse.org/issues/199727
related MR: https://gitlab.suse.de/qa-testsuites/openqa-job-group-yaml/-/merge_requests/393

- Remove pwd in test scripts, and use an openQA setting instead.
- Skip restarting module libvirt daemons as they have been configured in host agama profile, which can also unblock the test from the [bug#1260357](https://bugzilla.suse.com/show_bug.cgi?id=1260357).

Verification run: 
[sle16.1 online guest](https://openqa.suse.de/tests/22187209)
[sle15sp7 guest](https://openqa.suse.de/tests/22187210)
[win2025 guest](https://openqa.suse.de/tests/22216312)
[aach64](https://openqa.suse.de/tests/22187730)
[s390](https://openqa.suse.de/tests/22187203)
[oracle](https://openqa.suse.de/tests/22187218)
[sev-snp](https://openqa.suse.de/tests/22187221)
[full](https://openqa.suse.de/tests/22205241)
[slm6.2](https://openqa.suse.de/tests/22203675)
[sle16.1 SelfInstall](https://openqa.suse.de/tests/22236720)
[guest migration](https://openqa.suse.de/tests/22203673)
[hypverV](https://openqa.suse.de/tests/22216367)
[vmware](https://openqa.suse.de/tests/22216372)
[MU guest migration](https://openqa.suse.de/tests/22216317)

