### PR TITLE
feat(boottime): refactor publicclud-boottime management

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -770,7 +770,7 @@ sub measure_boottime() {
 
     record_info("BOOT TIME", 'systemd_analyze');
     # first deployment analysis
-    my ($systemd_analyze, $systemd_blame) = $instance->do_systemd_analyze_time();
+    my ($systemd_analyze, $systemd_blame) = $instance->_do_systemd_analyze_time();
     return 0 unless ($systemd_analyze && $systemd_blame);
 
     $ret->{analyze}->{$_} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));
@@ -858,7 +858,7 @@ sub store_boottime_db() {
     return $res;
 }
 
-sub systemd_time_to_second
+sub _systemd_time_to_second
 {
     my $str_time = trim(shift);
 
@@ -872,7 +872,7 @@ sub systemd_time_to_second
     return $sec;
 }
 
-sub extract_analyze_time {
+sub _extract_analyze_time {
     my $str_time = shift;
     my $res = {};
     ($str_time) = split(/\r?\n/, $str_time, 2);
@@ -881,26 +881,26 @@ sub extract_analyze_time {
     for my $time (split(/\s*\+\s*/, $str_time)) {
         $time = trim($time);
         my ($time, $type) = $time =~ /^(.+)\s*\((\w+)\)$/;
-        $res->{$type} = systemd_time_to_second($time);
+        $res->{$type} = _systemd_time_to_second($time);
         return 0 if ($res->{$type} == -1);
     }
     foreach (qw(kernel initrd userspace overall)) { return 0 unless exists($res->{$_}); }
     return $res;
 }
 
-sub extract_blame_time {
+sub _extract_blame_time {
     my $str_time = shift;
     my $ret = {};
     for my $line (split(/\r?\n/, $str_time)) {
         $line = trim($line);
         my ($time, $service) = $line =~ /^(.+)\s+(\S+)$/;
-        $ret->{$service} = systemd_time_to_second($time);
+        $ret->{$service} = _systemd_time_to_second($time);
         return 0 if ($ret->{$service} == -1);
     }
     return $ret;
 }
 
-sub do_systemd_analyze_time {
+sub _do_systemd_analyze_time {
     my ($instance, %args) = @_;
     $args{timeout} = 120;
     my $start_time = time();
@@ -919,10 +919,10 @@ sub do_systemd_analyze_time {
         # handle_boot_failure: soft exit from measurement.
         return (0, 0);
     }
-    push @ret, extract_analyze_time($output);
+    push @ret, _extract_analyze_time($output);
 
     $output = $instance->ssh_script_output(cmd => 'systemd-analyze blame', proceed_on_failure => 1);
-    push @ret, extract_blame_time($output);
+    push @ret, _extract_blame_time($output);
 
     return @ret;
 }

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -756,10 +756,9 @@ Set PUBLIC_CLOUD_PERF_COLLECT true or >0, to activate boottime measurements.
 =cut
 
 sub measure_boottime() {
-    my ($self, $instance, $type) = @_;
-    my $data_collect = get_var('PUBLIC_CLOUD_PERF_COLLECT', 1);
-
-    return 0 if !$data_collect;
+    my ($instance, $type) = @_;
+    return 0 unless (get_var('PUBLIC_CLOUD_PERF_COLLECT', 1) == 1);
+    my $max_boot_time = get_var('PUBLIC_CLOUD_BOOTTIME_MAX');
 
     my $ret = {
         kernel_release => undef,
@@ -771,14 +770,14 @@ sub measure_boottime() {
 
     record_info("BOOT TIME", 'systemd_analyze');
     # first deployment analysis
-    my ($systemd_analyze, $systemd_blame) = do_systemd_analyze_time($instance);
+    my ($systemd_analyze, $systemd_blame) = $instance->do_systemd_analyze_time();
     return 0 unless ($systemd_analyze && $systemd_blame);
 
     $ret->{analyze}->{$_} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));
     $ret->{blame} = $systemd_blame;
     $ret->{type} = $type;
-    # $ret->{analyze}->{ssh_access} = $startup_time; # placeholder for next implementation
-    record_info("WARN", "High overall value:" . $ret->{analyze}->{overall}, result => 'fail') if ($ret->{analyze}->{overall} >= 3600.0);
+    my $boottime = $ret->{analyze}->{overall};
+    record_info("WARN", "High overall value:" . $boottime, result => 'fail') if ($boottime >= 3600.0);
 
     # Collect kernel version
     $ret->{kernel_release} = $instance->ssh_script_output(cmd => 'uname -r', proceed_on_failure => 1);
@@ -789,10 +788,12 @@ sub measure_boottime() {
     my @logs = qw(cloudregister cloud-init.log cloud-init-output.log messages NetworkManager);
     $instance->upload_check_logs_tar(map { "$dir/$_" } @logs);
 
+    # check boot time limits
+    croak("Boot time $boottime out of limit $max_boot_time") if $max_boot_time && $boottime > $max_boot_time;
+
     record_info("RESULTS", Dumper($ret));
     return $ret;
 }
-
 
 =head2 store_boottime_db
 
@@ -908,7 +909,7 @@ sub do_systemd_analyze_time {
 
     # calling systemd-analyze time & blame
     # guestregister check executed in create_instances
-    while ($output !~ /Startup finished in/ && time() - $start_time < $args{timeout}) {
+    while ($output !~ /Startup finished in/i && time() - $start_time < $args{timeout}) {
         $output = $instance->ssh_script_output(cmd => 'systemd-analyze time', proceed_on_failure => 1);
         sleep 5;
     }

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -744,26 +744,29 @@ sub enable_kdump() {
     $self->softreboot();
 }
 
-=head2 measure_boottime
+=head2 check_system_boottime
 
-    measure_boottime();
+    check_system_boottime();
 
-Perfomrance measurement of the system Boot time. 
-Mainly used C<systemd-analyze> command for the data extraction.
-Data is then collected in an internal record, ready for storing in a DB.
-Set PUBLIC_CLOUD_PERF_COLLECT true or >0, to activate boottime measurements.
+Performance measurement of the system Boot time. 
+C<systemd-analyze> command used for the data extraction.
+Data is then collected in an internal record.
+Set PUBLIC_CLOUD_BOOTTIME_MAX or max_boot_time to a positive number 
+to activate the routine; assign zero instead, to skip the check.
 
 =cut
 
-sub measure_boottime() {
-    my ($instance, $type) = @_;
-    return 0 unless (get_var('PUBLIC_CLOUD_PERF_COLLECT', 1) == 1);
-    my $max_boot_time = get_var('PUBLIC_CLOUD_BOOTTIME_MAX');
+sub check_system_boottime() {
+    my ($instance, $max_boot_time) = @_;
+    use constant WARN_LIMIT_BOOTTIME => 900;
+    $max_boot_time //= get_var('PUBLIC_CLOUD_BOOTTIME_MAX', 600);
+    # check disablePUBLIC_CLOUD_BOOTTIME_MAX = 0
+    return unless ($max_boot_time);
 
     my $ret = {
         kernel_release => undef,
         kernel_version => undef,
-        type => undef,
+        type => 'boottime',
         analyze => {},
         blame => {},
     };
@@ -771,27 +774,33 @@ sub measure_boottime() {
     record_info("BOOT TIME", 'systemd_analyze');
     # first deployment analysis
     my ($systemd_analyze, $systemd_blame) = $instance->_do_systemd_analyze_time();
-    return 0 unless ($systemd_analyze && $systemd_blame);
+    return unless ($systemd_analyze && $systemd_blame);
 
     $ret->{analyze}->{$_} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));
     $ret->{blame} = $systemd_blame;
-    $ret->{type} = $type;
     my $boottime = $ret->{analyze}->{overall};
-    record_info("WARN", "High overall value:" . $boottime, result => 'fail') if ($boottime >= 3600.0);
 
     # Collect kernel version
     $ret->{kernel_release} = $instance->ssh_script_output(cmd => 'uname -r', proceed_on_failure => 1);
     $ret->{kernel_version} = $instance->ssh_script_output(cmd => 'uname -v', proceed_on_failure => 1);
 
     $Data::Dumper::Sortkeys = 1;
+    record_info("RESULTS", Dumper($ret));
     my $dir = "/var/log";
     my @logs = qw(cloudregister cloud-init.log cloud-init-output.log messages NetworkManager);
     $instance->upload_check_logs_tar(map { "$dir/$_" } @logs);
 
     # check boot time limits
-    croak("Boot time $boottime out of limit $max_boot_time") if $max_boot_time && $boottime > $max_boot_time;
-
-    record_info("RESULTS", Dumper($ret));
+    if ($boottime > $max_boot_time) {
+        if ($boottime <= WARN_LIMIT_BOOTTIME) {
+            # threshold exceeded
+            die("Boot time $boottime out of limit $max_boot_time");
+        } else {
+            # anomalous high value
+            record_info("WARN", "Unexpected high overall value:" . $boottime);
+            record_soft_failure('bsc#1262587 -  [QE] openQA publiccloud tests have anomalous-high boot-time from systemd-analyze');
+        }
+    }
     return $ret;
 }
 
@@ -799,7 +808,7 @@ sub measure_boottime() {
 
     store_boottime_db();
 
-Save data collected with measure_boottime in a DB;
+Save data collected with check_system_boottime in a DB;
 Mainly stored on a remote InfluxDB on a Grafana server.
 To activate boottime push, shall be available results and
   PUBLIC_CLOUD_PERF_PUSH_DATA true/not 0 and

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -389,7 +389,7 @@ sub create_instances {
             my $start_time = $instance->wait_for_ssh(timeout => $args{timeout},
                 proceed_on_failure => $args{proceed_on_failure}, scan_ssh_host_key => 1);
             # Performance data: boottime
-            my $btime = $instance->measure_boottime('first') if $start_time;
+            $instance->measure_boottime('first') if $start_time;
         }
     }
     return @vms;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -389,7 +389,7 @@ sub create_instances {
             my $start_time = $instance->wait_for_ssh(timeout => $args{timeout},
                 proceed_on_failure => $args{proceed_on_failure}, scan_ssh_host_key => 1);
             # Performance data: boottime
-            $instance->measure_boottime('first') if $start_time;
+            $instance->check_system_boottime() if $start_time;
         }
     }
     return @vms;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -383,24 +383,13 @@ sub create_instances {
 
     foreach my $instance (@vms) {
         record_info("INSTANCE", $instance->{instance_id});
+        $self->show_instance_details();
         if ($args{check_connectivity}) {
             # An error in VM-up causes test to stop
-            $instance->wait_for_ssh(timeout => $args{timeout},
+            my $start_time = $instance->wait_for_ssh(timeout => $args{timeout},
                 proceed_on_failure => $args{proceed_on_failure}, scan_ssh_host_key => 1);
-        }
-        $self->show_instance_details();
-
-        # Performance data: boottime
-
-        if (is_ok_url($url)) {
-            local $@;
-            eval {
-                my $btime = $instance->measure_boottime($instance, 'first');
-                $instance->store_boottime_db($btime, $url);
-            };
-            record_info("WARN", "Boottime measures cannot be provided", result => 'fail') if ($@);
-        } else {
-            record_info("WARN", "Cannot connect url:" . $url, result => 'fail');
+            # Performance data: boottime
+            my $btime = $instance->measure_boottime('first') if $start_time;
         }
     }
     return @vms;

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -39,7 +39,10 @@ sub run {
     $instance_args{use_extra_disk} = {size => $additional_disk_size, type => $additional_disk_type} if ($additional_disk_size > 0);
     $args->{my_provider} = $self->provider_factory();
     $args->{my_instance} = $args->{my_provider}->create_instance(%instance_args);
-    $args->{my_instance}->wait_for_ssh(scan_ssh_host_key => 1);
+    if (defined($instance_args{check_connectivity}) && $instance_args{check_connectivity} eq 0) {
+        my $start_time = $args->{my_instance}->wait_for_ssh(scan_ssh_host_key => 1);
+        $args->{my_instance}->measure_boottime('first') if $start_time;
+    }
     $args->{my_instance}->wait_for_guestregister() if (is_ondemand);
     my $provider = $self->{my_provider} = $args->{my_provider};
     my $instance = $args->{my_instance};

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -39,9 +39,9 @@ sub run {
     $instance_args{use_extra_disk} = {size => $additional_disk_size, type => $additional_disk_type} if ($additional_disk_size > 0);
     $args->{my_provider} = $self->provider_factory();
     $args->{my_instance} = $args->{my_provider}->create_instance(%instance_args);
-    if (defined($instance_args{check_connectivity}) && $instance_args{check_connectivity} eq 0) {
+    if (defined($instance_args{check_connectivity}) && $instance_args{check_connectivity} == 0) {
         my $start_time = $args->{my_instance}->wait_for_ssh(scan_ssh_host_key => 1);
-        $args->{my_instance}->measure_boottime('first') if $start_time;
+        $args->{my_instance}->check_system_boottime() if $start_time;
     }
     $args->{my_instance}->wait_for_guestregister() if (is_ondemand);
     my $provider = $self->{my_provider} = $args->{my_provider};

--- a/variables.md
+++ b/variables.md
@@ -318,6 +318,7 @@ PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID | string | "" | Used to create the service ac
 PUBLIC_CLOUD_AZURE_AITL_IMAGE | string | "registry.opensuse.org/devel/opensuse/qa/qac/containers/15.6/aitl-lisa:leap" | Define docker image containing aitl CLI to be used for Azure AITL LISA testing
 PUBLIC_CLOUD_AZ_API | string | "http://169.254.169.254/metadata/instance/compute" | For Azure, it is the metadata API endpoint.
 PUBLIC_CLOUD_AZ_API_VERSION | string | "2021-02-01" | For Azure, it is the API version used whe querying metadata API.
+PUBLIC_CLOUD_BOOTTIME_MAX | integer | 600 | Positive values > 0 enable check_system_boottime check of the boot time.
 PUBLIC_CLOUD_BTRFS | boolean | false | If set, it schedules `publiccloud/btrfs` job.
 PUBLIC_CLOUD_BUILD | string | "" | The image build number. Used only when we use custom built image.
 PUBLIC_CLOUD_BUILD_KIWI | string | "" | The image kiwi build number. Used only when we use custom built image.
@@ -371,11 +372,9 @@ PUBLIC_CLOUD_FUNCTIONAL | boolean | false | Schedule the functional test suite.
 PUBLIC_CLOUD_ENABLE_KDUMP | boolean | false | Enable kdump
 PUBLIC_CLOUD_MIGRATE_SLEM | boolean | false | Enable module for SL micro 6.x version upgrade to higher
 PUBLIC_CLOUD_NVIDIA | boolean | 0 | If enabled, nvidia module would be scheduled. This variable should be enabled only sle15SP4 and above.
-PUBLIC_CLOUD_PERF_COLLECT | boolean | 1 | To enable `boottime` measures collection, at end of `create_instance` routine.
 PUBLIC_CLOUD_PERF_DB | string | "perf_2" | defines the bucket in which the performance metrics are stored on PUBLIC_CLOUD_PERF_DB_URI
 PUBLIC_CLOUD_PERF_DB_ORG | string | "qec" | defines the organization in which the performance metrics are stored on PUBLIC_CLOUD_PERF_DB_URI
 PUBLIC_CLOUD_PERF_DB_URI | string | "http://publiccloud-ng.qe.suse.de:8086" | bootup time measures get pushed to this Influx database url.
-PUBLIC_CLOUD_PERF_PUSH_DATA | boolean | 1 | To enable the test to push it's metrics to the InfluxDB, when PUBLIC_CLOUD_PERF_COLLECT true.
 PUBLIC_CLOUD_PREPARE_TOOLS | boolean | false | Activate prepare_tools test module by setting this variable.
 PUBLIC_CLOUD_PROVIDER | string | "" | The type of the CSP (e.g. AZURE, EC2, GCE).
 PUBLIC_CLOUD_PY_AZURE_REPO | string | "" | PY azure repo URL for azure_more_cli_test.
@@ -407,6 +406,7 @@ PUBLIC_CLOUD_TTL_OFFSET | integer | 300 | This number + MAX_JOB_TIME equals the 
 PUBLIC_CLOUD_UPLOAD_IMG | boolean | false | If set, `publiccloud/upload_image` test module is added to the job.
 PUBLIC_CLOUD_USER | string | "" | The public cloud instance system user.
 PUBLIC_CLOUD_XEN | boolean | false | Indicates if this is a Xen test run.
+
 SCC_REGISTRY | string | "" | Registry which requires SCC login
 SCC_PROXY_USERNAME | string | "" | Credentials username for registry which requires SCC login
 SCC_PROXY_PASSWORD | string | "" | Credentials password for registry which requires SCC login


### PR DESCRIPTION
- Remove from create_instance the call store_boottime_db:stop sending data to db
- Fix in prepare_instance the measure_boottime call according to wait_for_ssh conditioned by check_connectivity.
- Prepare the code for the boottime threshold as AC1 AC2 in the ticktet:
  - complete the threshold enforcement asap in next commits

- Ref.tkt https://progress.opensuse.org/issues/198947

- Verification run:
  sle-16.0-Azure-BYOS-aarch64 https://openqa.suse.de/tests/21960506
  sle-16.0-Azure-Hardened-BYOS-x86_64 https://openqa.suse.de/tests/21960582 
  sle-15-SP7-Azure-SAP-BYOS-x86_64 https://openqa.suse.de/tests/21960584 
  sle-micro-5.5-Azure-BYOS-x86_64 https://openqa.suse.de/tests/21960586 

  