### PR TITLE
Improve package installation on transactional systems and migrate kernel extra tests

### DIFF
--- a/lib/package_utils.pm
+++ b/lib/package_utils.pm
@@ -10,7 +10,7 @@ package package_utils;
 use Mojo::Base qw(Exporter);
 use testapi;
 use version_utils qw(is_transactional);
-use transactional qw(trup_call reboot_on_changes);
+use transactional qw(trup_call reboot_on_changes trup_apply);
 use utils qw(zypper_call zypper_search);
 
 our @EXPORT = qw(install_package install_available_packages uninstall_package);
@@ -30,6 +30,13 @@ C<skip_trup> or C<skip_zypper> will return from fucntion,
 record_info is used if sentence is argument value.
 C<trup_reboot> parameter will run reboot_on_changes after trup_call,
 reboot if diff between the current FS and the new snapshot.
+C<trup_apply> parameter will apply pending changes from the new snapshot
+without rebooting, using C<transactional-update apply>.
+C<trup_reboot> and C<trup_apply> are mutually exclusive.
+
+B<Warning>: Only use C<trup_apply> for end user applications and server services.
+Do not use it for kernel packages or system libraries that require a reboot,
+as doing so may leave the system in an inconsistent state.
 
 =cut
 
@@ -40,6 +47,7 @@ sub install_package {
     my $timeout = $args{timeout} // 500;
 
     if (is_transactional) {
+        die "install_package: 'trup_reboot' and 'trup_apply' are mutually exclusive" if $args{trup_reboot} && $args{trup_apply};
         record_info('install_package', $args{skip_trup}) if $args{skip_trup} =~ /\w+/;
         return if $args{skip_trup};
         $packages .= ' ' . $args{trup_extra} // '';
@@ -47,6 +55,7 @@ sub install_package {
         $cmd = '-c ' . $cmd if $args{trup_continue} // 0;
         $ret = trup_call($cmd, timeout => $args{timeout});
         reboot_on_changes if $args{trup_reboot};
+        trup_apply if $args{trup_apply};
     }
     else {
         record_info('install_package', $args{skip_zypper}) if $args{skip_zypper} =~ /\w+/;
@@ -101,6 +110,13 @@ Without this parameter, any changes in the default snapshot will be
 discarded and a new snapshot will be created based on the active one.
 C<trup_reboot> parameter will run reboot_on_changes after trup_call,
 reboot if diff between the current FS and the new snapshot.
+C<trup_apply> parameter will apply pending changes from the new snapshot
+without rebooting, using C<transactional-update apply>.
+C<trup_reboot> and C<trup_apply> are mutually exclusive.
+
+B<Warning>: Only use C<trup_apply> for end user applications and server services.
+Do not use it for kernel packages or system libraries that require a reboot,
+as doing so may leave the system in an inconsistent state.
 
 =cut
 
@@ -111,6 +127,7 @@ sub uninstall_package {
     my $timeout = $args{timeout} // 500;
 
     if (is_transactional) {
+        die "uninstall_package: 'trup_reboot' and 'trup_apply' are mutually exclusive" if $args{trup_reboot} && $args{trup_apply};
         record_info('uninstall_package', $args{skip_trup}) if $args{skip_trup} =~ /\w+/;
         return if $args{skip_trup};
         $packages .= ' ' . $args{trup_extra} // '';
@@ -118,6 +135,7 @@ sub uninstall_package {
         $cmd = '-c ' . $cmd if $args{trup_continue} // 0;
         $ret = trup_call($cmd, timeout => $args{timeout});
         reboot_on_changes if $args{trup_reboot};
+        trup_apply if $args{trup_apply};
     }
     else {
         record_info('uninstall_package', $args{skip_zypper}) if $args{skip_zypper} =~ /\w+/;

--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -40,6 +40,7 @@ our @EXPORT = qw(
   exit_trup_shell_and_reboot
   reboot_on_changes
   record_kernel_audit_messages
+  trup_apply
 );
 
 # Download files needed for transactional update tests
@@ -414,6 +415,36 @@ sub reboot_on_changes {
     else {
         record_info("No reboot needed", "Reboot saved because there are no changes happened and no new snapshot generated");
     }
+}
+
+=head2 trup_apply
+
+  trup_apply([timeout => $seconds])
+
+Apply pending changes from the new snapshot without rebooting using
+C<transactional-update apply>.
+
+B<Warning>: Do not use this for kernel packages or system libraries that
+require a reboot to take effect. Applying those without a reboot may leave
+the system in an inconsistent state. This function is intended only for
+end user applications and server services.
+
+=over
+
+=item C<timeout>
+
+Timeout in seconds (default: 30).
+
+=back
+
+=cut
+
+sub trup_apply {
+    my (%args) = @_;
+    $args{timeout} //= 30;
+
+    record_info("Apply pending changes", "Applying pending changes without reboot into new snapshot");
+    trup_call('apply', timeout => $args{timeout});
 }
 
 1;

--- a/tests/hpc/rasdaemon.pm
+++ b/tests/hpc/rasdaemon.pm
@@ -25,6 +25,7 @@ use serial_terminal 'select_serial_terminal';
 use Utils::Architectures;
 use Utils::Logging 'export_logs_basic';
 use utils;
+use package_utils 'install_package';
 use version_utils qw(is_sle is_tumbleweed);
 
 our $file = 'tmpresults.xml';
@@ -59,7 +60,7 @@ sub run {
     # load kernel module
     assert_script_run('modprobe mce-inject') if is_x86_64;
 
-    my $rt = zypper_call('in rasdaemon');
+    my $rt = install_package('rasdaemon', trup_apply => 1);
     test_case('Installation', 'rasdaemon', $rt);
 
     # Skip functional tests on ppc64le and Tumbleweed. It is not fully supported,

--- a/tests/kernel/module_build.pm
+++ b/tests/kernel/module_build.pm
@@ -13,11 +13,12 @@ use Mojo::Base 'opensusebasetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
+use package_utils 'install_package';
 
 sub run {
     select_serial_terminal;
     # kernel live patch scenario has devel package already installed
-    zypper_call "in kernel-default-devel" unless get_var('KGRAFT');
+    install_package('kernel-default-devel', trup_apply => 1) unless get_var('KGRAFT');
     # Prepare module sources
     assert_script_run("curl -L -v " . autoinst_url . "/data/kernel/module > module.data && cpio -id < module.data && rm module.data");
     assert_script_run "cd data";


### PR DESCRIPTION
transactional-update supports switching to a new snapshot without reboot. We can use this feature for user-space tools installation where we know a reboot is not necessary.

`rasdaemon` and `module_build` from extra testst kernel were adapted to package installation with transactional-update apply feature.

- Related ticket: https://progress.opensuse.org/issues/200015
- Needles: none
- Verification run:  
SLE 16 immutable: https://openqa.suse.de/tests/22000241
SLE 16 standard: https://openqa.suse.de/tests/22000242
