### PR TITLE
Replace deprecated cts-lab flags

### DIFF
--- a/tests/ha/pacemaker_cts_cluster_exerciser.pm
+++ b/tests/ha/pacemaker_cts_cluster_exerciser.pm
@@ -59,16 +59,25 @@ sub run {
 
         # Start pacemaker cts cluster exerciser
         my $cts_start_time = time;
-        my $cmd = join(' ',
-            $cts_bin, '--nodes', "'$node_01 $node_02'", '--stonith-type', $stonith_type,
-            '--stonith-args', $stonith_args, '--test-ip-base', $test_ip, '--no-loop-tests',
-            '--no-unsafe-tests', '--at-boot 1', '--outputfile', $log, '--once');
-        my $retval = script_run $cmd, $timeout;
+
+        my @cmd_seq = (
+            $cts_bin, '--nodes', "'$node_01 $node_02'", '--test-ip-base', $test_ip,
+            '--no-unsafe-tests', '--outputfile', $log, '--once'
+        );
+
+        if (package_version_cmp($pacemaker_cts_package_version, '3.0.1') >= 0) {
+            push @cmd_seq, '--fencing-agent', $stonith_type, '--fencing-params', $stonith_args;
+        } else {
+            push @cmd_seq, '--stonith-type', $stonith_type, '--stonith-args', $stonith_args,
+              '--no-loop-tests', '--at-boot 1';
+        }
+
+        my $retval = script_run(join(' ', @cmd_seq), $timeout);
         record_info 'CTS failed', "$cts_bin exited with retval=[$retval]" if ($retval);
         my $cts_end_time = time;
 
         # Parse the logs to get a better overview in openQA
-        $cmd = q|awk '($5 == "Test" && $6 != "Summary" && substr($6, length($6), 1) == ":") {print}' | . $log;
+        my $cmd = q|awk '($5 == "Test" && $6 != "Summary" && substr($6, length($6), 1) == ":") {print}' | . $log;
         my $output = script_output $cmd;
 
         my %results;


### PR DESCRIPTION
In `pacemaker-cts` >= 3.0.1, there are modified and deprecated/removed flags. This PR deals with them.

- The --stonith-type argument is now renamed to `--fencing-agent`, and `--stonith-args` to `--fencing-params` with commit
https://github.com/ClusterLabs/pacemaker/commit/49006112f65a0271a8632011f3dd3a943f32e926#diff-16834d6bcb3da3fd04a2143a55072c23b96c6c10a01205140a5230767e41a867R60

- the argument `--no-loop-tests` was dropped entirely with https://github.com/ClusterLabs/pacemaker/commit/b26bd8a42a67febf8b0748af2951ef2492a39871. It should be removed.

- the argument `--at-boot` was removed with https://github.com/ClusterLabs/pacemaker/commit/ea41ae7dfdcfe84f2e3887f6b5c5ac8220727234 and should also be dropped.

- Related ticket: https://jira.suse.com/browse/TEAM-11090
- Verification run: https://openqa.suse.de/tests/21977656
