### PR TITLE
Install systemd-coredump on SLEM < 6.0 to catch coredumps

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -316,6 +316,7 @@ sub load_rcshell_tests {
 sub load_journal_check_tests {
     # Enclosing test cases
     loadtest 'console/journal_check';
+    loadtest 'console/coredump_collect';
     loadtest 'shutdown/shutdown';
 }
 

--- a/tests/transactional/install_updates.pm
+++ b/tests/transactional/install_updates.pm
@@ -37,6 +37,8 @@ sub run {
         assert_script_run 'update-ca-certificates -v';
     }
 
+    trup_call('--continue pkg install systemd-coredump') if (is_sle_micro("<6.0"));
+
     update_system;
 
     # Clean the journal to avoid capturing bugs that are fixed after installing updates


### PR DESCRIPTION
This PR reverts https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25108 and installs `systemd-coredump` on SLEM 5.x to enable coredump collection.  The `coredumpctl` command comes installed by default on SLEM 6.x.

Related ticket: https://progress.opensuse.org/issues/197969
Verification run: https://openqa.suse.de/tests/21961802