### PR TITLE
Re-enable coredump_collect on SLEM 6.x & MicroOS

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -316,6 +316,8 @@ sub load_rcshell_tests {
 sub load_journal_check_tests {
     # Enclosing test cases
     loadtest 'console/journal_check';
+    # systemd-coredump is not available on SLEM 5.x
+    loadtest 'console/coredump_collect' unless (is_sle_micro("<6.0"));
     loadtest 'shutdown/shutdown';
 }
 


### PR DESCRIPTION
On os-autoinst/os-autoinst-distri-opensuse#25108 we disabled this module without taking into account that coredumpctl is not available only on SLEM 5.x.  It was running a month ago: https://openqa.suse.de/tests/21060817#step/coredump_collect/3

- Related ticket: https://progress.opensuse.org/issues/197969
- Verification run: https://openqa.suse.de/tests/21963794