### PR TITLE
containers: Collect coredumps on SLEM 6.x like other teams do

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -427,5 +427,5 @@ sub load_container_tests {
         }
     }
     loadtest 'containers/bci_logs' if (get_var('BCI_TESTS'));
-    loadtest 'console/coredump_collect' unless (is_public_cloud || is_jeos || is_sle_micro || is_microos || is_leap_micro || get_var('BCI_TESTS') || is_centos_host || is_ubuntu_host || is_expanded_support_host);
+    loadtest 'console/coredump_collect' unless (is_public_cloud || is_jeos || is_sle_micro("<6.0") || is_microos || is_leap_micro || get_var('BCI_TESTS') || is_centos_host || is_ubuntu_host || is_expanded_support_host);
 }


### PR DESCRIPTION
Other teams are collecting coredumps like [here](https://openqa.suse.de/tests/21060817#step/coredump_collect/3)

Skipping on SLEM 5.x makes sense because the systemd-coredump package is not available.

Related ticket: https://progress.opensuse.org/issues/197969

Verification run: https://openqa.suse.de/tests/21963794#step/coredump_collect/11