### PR TITLE
Fix: Remove snapshot number starting with 1

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -729,7 +729,7 @@
         "type": "ignore"
     },
     "update-test-broken": {
-        "description": "Installation of update-test-broken.* failed:|Error: Subprocess failed. Error: RPM failed: Command exited with status 1.|Problem occurred during or after installation or removal of packages:|Installation has been aborted as directed.|Please see the above error message for a hint|ERROR: zypper up on /.snapshots/1\\d/snapshot failed with exit code 8!|Use '--interactive' for manual problem resolution.|Removing snapshot #1\\d",
+        "description": "Installation of update-test-broken.* failed:|Error: Subprocess failed. Error: RPM failed: Command exited with status 1.|Problem occurred during or after installation or removal of packages:|Installation has been aborted as directed.|Please see the above error message for a hint|ERROR: zypper up on /.snapshots/\\d+/snapshot failed with exit code 8!|Use '--interactive' for manual problem resolution.|Removing snapshot #1\\d",
         "products": {
             "microos": [
                 "Tumbleweed"


### PR DESCRIPTION
A matching snapshot number must not start with a 1.

- Related failure: https://openqa.suse.de/tests/21921549#step/journal_check/22
- Verification run: https://openqa.suse.de/tests/21965707#step/journal_check/10
