### PR TITLE
Don't exit test job in zypp config checks

### DIFF
--- a/tests/microos/libzypp_config.pm
+++ b/tests/microos/libzypp_config.pm
@@ -47,4 +47,6 @@ sub post_fail_hook {
     tar_and_upload_log("@backup_dirs", "/tmp/zypp_conf_dir.tar.bz2", {gzip => 1}) if @backup_dirs;
 }
 
+sub test_flags { return {fatal => 0}; }
+
 1;


### PR DESCRIPTION
The test job dies on zypp config checks. This module should not be fatal

- Verification run: https://openqa.suse.de/tests/21966802#step/libzypp_config/11
