### PR TITLE
Fix custodian_ttl tag time logic

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -967,11 +967,14 @@ This tag is needed to compare TTL vs Creation time in Cloud Custodian.
 =cut
 
 sub calculate_custodian_ttl {
-    my $ttl_in_seconds = @_;
+    my ($ttl_in_seconds) = @_;
 
-    # UTC time
-    my $now = gmtime;
-    my $expiration_time = $now + $ttl_in_seconds;
+    # Unix time in seconds
+    my $now_timestamp = time();
+    my $expiration_timestamp = $now_timestamp + $ttl_in_seconds;
+
+    # Convert to UTC
+    my $expiration_time = gmtime($expiration_timestamp);
 
     # convert to proper format
     my $custodian_expiration_date = $expiration_time->strftime("%Y-%m-%dT%H:%M:%SZ");


### PR DESCRIPTION
This MR fixes the logic behind the `custodian_ttl` tags. The tag's purpose is to provide a Cloud Custodian-native time representation of our `MAX_JOB_TIME / openqa_ttl` offset. 

The previous implementation was doing math with multiple different formats. This implementation converts everything to seconds , does the math in seconds and then formats it to ISO as needed.

- VR: https://openqa.suse.de/tests/21966972 
- VR in screnshot form (notice the difference between `custodian_ttl` and `openqa_created_date`: 

<img width="913" height="37" alt="Screenshot From 2026-04-21 18-10-15" src="https://github.com/user-attachments/assets/bd897701-b863-4f03-8d37-5736736e5dd3" />

