### PR TITLE
Adapt package install logic for transactional system

### DIFF
--- a/lib/package_utils.pm
+++ b/lib/package_utils.pm
@@ -10,7 +10,7 @@ package package_utils;
 use Mojo::Base qw(Exporter);
 use testapi;
 use version_utils qw(is_transactional);
-use transactional qw(trup_call check_reboot_changes);
+use transactional qw(trup_call reboot_on_changes);
 use utils qw(zypper_call zypper_search);
 
 our @EXPORT = qw(install_package install_available_packages uninstall_package);
@@ -28,7 +28,7 @@ Parameters C<trup_extra> and C<zypper_extra> define transactional
 or zypper specific packages.
 C<skip_trup> or C<skip_zypper> will return from fucntion,
 record_info is used if sentence is argument value.
-C<trup_reboot> parameter will run check_reboot_changes after trup_call,
+C<trup_reboot> parameter will run reboot_on_changes after trup_call,
 reboot if diff between the current FS and the new snapshot.
 
 =cut
@@ -46,7 +46,7 @@ sub install_package {
         my $cmd = 'pkg in -l ' . $packages;
         $cmd = '-c ' . $cmd if $args{trup_continue} // 0;
         $ret = trup_call($cmd, timeout => $args{timeout});
-        check_reboot_changes if $args{trup_reboot};
+        reboot_on_changes if $args{trup_reboot};
     }
     else {
         record_info('install_package', $args{skip_zypper}) if $args{skip_zypper} =~ /\w+/;
@@ -99,7 +99,7 @@ record_info is used if sentence is argument value.
 C<trup_continue> parameter will add changes to the default snapshot.
 Without this parameter, any changes in the default snapshot will be
 discarded and a new snapshot will be created based on the active one.
-C<trup_reboot> parameter will run check_reboot_changes after trup_call,
+C<trup_reboot> parameter will run reboot_on_changes after trup_call,
 reboot if diff between the current FS and the new snapshot.
 
 =cut
@@ -117,7 +117,7 @@ sub uninstall_package {
         my $cmd = 'pkg remove ' . $packages;
         $cmd = '-c ' . $cmd if $args{trup_continue} // 0;
         $ret = trup_call($cmd, timeout => $args{timeout});
-        check_reboot_changes if $args{trup_reboot};
+        reboot_on_changes if $args{trup_reboot};
     }
     else {
         record_info('uninstall_package', $args{skip_zypper}) if $args{skip_zypper} =~ /\w+/;


### PR DESCRIPTION
Use 'reboot_on_chanage' logic instead of 'check_reboot_changes', Reboot the system after package is installed/upgraded.

1. Old logic is not strong as job will fail in case package is already installed
2. Reboot is required only diff  between the current FS and the new snapshot

- Related ticket: https://progress.opensuse.org/issues/199925
- Needles:  n/a
- Verification run: http://openqa.suse.de/tests/21977352 and http://openqa.suse.de/tests/21977429 [regression tests]