### PR TITLE
Adjust test data for validate_md_raid on ppc64le for single PRep partition in 1st disk

### DIFF
--- a/test_data/yast/raid/raid_prep.yaml
+++ b/test_data/yast/raid/raid_prep.yaml
@@ -56,9 +56,9 @@ mds:
     raid_level: "%RAIDLEVEL%"
     devices:
       - vda2
-      - vdb2
-      - vdc2
-      - vdd2
+      - vdb1
+      - vdc1
+      - vdd1
     partition:
       role: operating-system
       formatting_options:
@@ -72,9 +72,9 @@ mds:
     raid_level: 0
     devices:
       - vda3
-      - vdb3
-      - vdc3
-      - vdd3
+      - vdb2
+      - vdc2
+      - vdd2
     partition:
       role: swap
       formatting_options:

--- a/tests/console/validate_raid.pm
+++ b/tests/console/validate_raid.pm
@@ -25,7 +25,7 @@ my $raid_partitions_2_arrays = qr/(md(0|1).*){8}|(md(0|1).*){2}/s;
 # 12 raid partitions, with new lsblk output partitions are listed only once
 my $raid_partitions_3_arrays = qr/(md(0|1|2).*){12}|(md(0|1|2).*){3}/s;
 # 8 linux raid members
-my $linux_raid_member_2_arrays = qr/((v|s)d(a|b|c|d)(2|3).+linux_raid_member.*){8}/s;
+my $linux_raid_member_2_arrays = qr/((v|s)d(a|b|c|d)(1|2|3).+linux_raid_member.*){8}/s;
 # 12 linux raid members
 my $linux_raid_member_3_arrays = qr/((v|s)d(a|b|c|d)(1|2|3|4).+linux_raid_member.*){12}/s;
 # 4 hard disks


### PR DESCRIPTION
Adjust test data for validate_md_raid on ppc64le for single PRep partition in 1st disk

- Related ticket: 
  https://progress.opensuse.org/issues/198107

- Verification run:  
  [SLES16.1](https://openqa.suse.de/tests/overview?distri=sle&build=chcao_poo_198107&version=16.1) || [SLES16.0](https://openqa.suse.de/tests/overview?distri=sle&build=chcao_poo_198107&version=16.0) || [Tumbleweed](https://openqa.opensuse.org/tests/overview?version=Tumbleweed&build=chcao_poo_198107&distri=opensuse)