### PR TITLE
Run transactional role tests only when required

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2874,7 +2874,7 @@ sub load_common_opensuse_sle_tests {
     load_create_hdd_tests if (get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1")) && !is_public_cloud();
     loadtest 'console/network_hostname' if get_var('NETWORK_CONFIGURATION');
     load_installation_validation_tests if get_var('INSTALLATION_VALIDATION');
-    load_transactional_role_tests if is_transactional && (get_var('ARCH') !~ /ppc64|s390/) && !get_var('INSTALLONLY');
+    load_transactional_role_tests if get_var('TRANSACTIONAL_VALIDATION');
 }
 
 sub load_ssh_key_import_tests {

--- a/variables.md
+++ b/variables.md
@@ -240,6 +240,7 @@ TEST_CONTEXT | string | | Defines the class name to be used as the context insta
 TEST_TIME | integer | | Set time parameter for `iperf -t N` option. Used in Azure Public Cloud testing of Accelerated NICs
 TOGGLEHOME | boolean | false | Changes the state of partitioning to have or not to have separate home partition in the proposal.
 TUNNELED | boolean | false | Enables the use of normal consoles like "root-consoles" on a remote SUT while configuring the tunnel in a local "tunnel-console"
+TRANSACTIONAL_VALIDATION | boolean | false | Runs checks of the transactional filesystem and related tools.
 TYPE_BOOT_PARAMS_FAST | boolean | false | When set, forces `bootloader_setup::type_boot_parameters` to use the default typing interval.
 UEFI | boolean | false | Indicates UEFI in the testing environment.
 ULP_THREAD_COUNT | integer | 1000 | Number of threads to create in `ulp_threads` test module.


### PR DESCRIPTION
Run the transactional role tests only if explicitly required by setting. This is necessary because running those tests unconditionally for every scenario based on a transactional system is excessive and unnecessary.

- Related ticket: https://progress.opensuse.org/issues/200063

**IMPORTANT: This PR and the Related ones below in the "Related settings changes" section need to be merged together.**

### Related settings changes

* MicroOS: https://github.com/os-autoinst/opensuse-jobgroups/pull/846
SLEM Product increments (`slem_image_default` scenario): https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2812 and https://gitlab.suse.de/qe-core/qa-sle-functional-userspace/-/merge_requests/336
SLES 16.1 Transactional Images: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2812 

### Verification runs

* MicroOS: https://duck-norris.qe.suse.de/tests/61
* SLEM 6.2: https://duck-norris.qe.suse.de/tests/64
* SLEM 5.5: https://duck-norris.qe.suse.de/tests/70 (unrelated failure)
* SLES 16.1 Transactional Images: https://duck-norris.qe.suse.de/tests/73 (unrelated failure)
* SLES 16.1 LTP on Transactional Images: https://duck-norris.qe.suse.de/tests/76 (unrelated failure)
