### PR TITLE
install_ltp: Always lock kernel-default before installing LTP

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -516,10 +516,6 @@ sub get_default_pkg {
 }
 
 sub install_from_repo {
-    # Workaround for kernel-64kb, until we add multibuild support to LTP package
-    # Lock kernel-default to don't pull it as LTP dependency
-    zypper_call 'al kernel-default' if get_kernel_flavor eq 'kernel-64kb';
-
     my @pkgs = split(/\s* \s*/, get_var('LTP_PKG', get_default_pkg));
 
     if (is_transactional) {

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -314,9 +314,9 @@ sub run {
     # Enables repositories on full installation medium
     zypper_enable_install_dvd if (get_var('FLAVOR') eq 'Full-QR');
 
-    # Lock kernel default on transactional system, RT flavors and MinimalVM
-    # This is workaround for poo#165036 to prevent kernel-default and kernel-default-base installation
-    zypper_call("al kernel-default kernel-default-base") if (is_transactional && (get_var('FLAVOR', '') =~ /Base-RT-Updates|Base-RT|Base-RT-encrypted|Base-Kernel-RT/) || is_jeos);
+    # Lock kernel-default to avoid accidentally triggering its update or
+    # installing the wrong kernel flavor through LTP dependencies.
+    zypper_call("al kernel-default kernel-default-base");
 
     # Register Extras repository on SL Micro 6.0+
     add_suseconnect_product('SL-Micro-Extras', get_var('VERSION')) if (is_sle_micro('6.0+'));


### PR DESCRIPTION
Unconditionally lock kernel-default before installing LTP to avoid accidentally updating it or installing the wrong kernel flavor through LTP dependencies.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - SLE-16.0 kernel-default-base: https://openqa.suse.de/tests/21985009
  - SLE-15SP5 kernel-livepatch: https://openqa.suse.de/tests/21987838
  - SLE-15SP7 kernel-rt: https://openqa.suse.de/tests/21987741
  - SLE-15SP7 kernel-64kb: https://openqa.suse.de/tests/21989253
  - SLE-15SP4 KOTD: https://openqa.suse.de/tests/21989221
