### PR TITLE
Check cluster configuration to determine fence_sbd primitive name

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -37,7 +37,7 @@ our @EXPORT = qw(
   $corosync_consensus
   $sbd_watchdog_timeout
   $sbd_delay_start
-  $pcmk_delay_max
+  $crm_config_show_fence_sbd
   sync_file
   sync_path
   exec_csync
@@ -103,6 +103,9 @@ our @EXPORT = qw(
   sbd_device_report
   get_fencing_type
   check_crm_nonroot
+  get_crmsh_version
+  get_fencing_ra_name
+  pcmk_delay_max_cmd
 );
 
 =head1 SYNOPSIS
@@ -132,7 +135,7 @@ Extension (HA or HAE) tests.
 
 =item * B<$sbd_delay_start>: command to extract the value of C<SBD_DELAY_START> from C</etc/sysconfig/sbd>
 
-=item * B<$pcmk_delay_max>: command to get the value of the C<pcmd_delay_max> parameter from the STONITH resource in the cluster configuration.
+=item * B<$crm_config_show_fence_sbd>: command to extract the part of the cluster configuration relating to B<fence_sbd>
 
 =back
 
@@ -146,7 +149,7 @@ our $corosync_token = q@corosync-cmapctl | awk -F " = " '/runtime.config.totem.t
 our $corosync_consensus = q@corosync-cmapctl | awk -F " = " '/runtime.config.totem.consensus\s/ {print int($2/1000)}'@;
 our $sbd_watchdog_timeout = q@grep -oP '(?<=^SBD_WATCHDOG_TIMEOUT=)[[:digit:]]+' /etc/sysconfig/sbd@;
 our $sbd_delay_start = q@grep -oP '(?<=^SBD_DELAY_START=)([[:digit:]]+|yes|no)+' /etc/sysconfig/sbd@;
-our $pcmk_delay_max = q@crm resource param stonith-sbd show pcmk_delay_max| sed 's/[^0-9]*//g'@;
+our $crm_config_show_fence_sbd = 'crm -D plain configure show 2>&1 | grep sbd';
 
 # Private functions
 sub _just_the_ip {
@@ -820,8 +823,7 @@ sub check_cluster_state {
 
     # If running with versions of crmsh older than 4.4.2, do not use check_online_nodes (see POD below)
     # Fall back to the older method of checking Online vs. Configured nodes
-    my $out = script_output(q|rpm -q --qf 'crmshver=%{VERSION}\n' crmsh|);
-    my ($ver) = $out =~ /crmshver=(\S+)/m or die "Couldn't parse crmsh version from: $out";
+    my $ver = get_crmsh_version();
     my $cmp_result = package_version_cmp($ver, '4.4.2');
     if ($cmp_result < 0) {
         $cmd_sub->(q/crm_mon -s | grep "$(crm node list | grep -E -c ': member|: normal') nodes online"/);
@@ -1285,7 +1287,7 @@ sub collect_sbd_delay_parameters {
           script_output_retry_check(cmd => $sbd_delay_start, regex_string => '^\d+$|yes|no', sleep => '3', retry => '3'),
         # pcmk_delay_max is not always present for example in 3 node clusters or diskless SBD scenario
         'pcmk_delay_max' => get_var('USE_DISKLESS_SBD') ? 30 :
-          script_output_retry_check(cmd => $pcmk_delay_max, regex_string => '^\d+$', sleep => '3', retry => '3', ignore_failure => 1) // 0
+          script_output_retry_check(cmd => pcmk_delay_max_cmd(), regex_string => '^\d+$', sleep => '3', retry => '3', ignore_failure => 1) // 0
     );
 
     return (%params);
@@ -1909,8 +1911,7 @@ B<Return values:>
 sub crm_list_options {
     my (%args) = @_;
 
-    my $outver = script_output(q|rpm -q --qf 'crmshver=%{VERSION}\n' crmsh|);
-    my ($ver) = $outver =~ /crmshver=(\S+)/m or die "Couldn't parse crmsh version from: $outver";
+    my $ver = get_crmsh_version();
     my $cmp_result = package_version_cmp($ver, '5.0.0');
     return 0 if ($cmp_result < 0);
     my $out;
@@ -2201,6 +2202,53 @@ sub check_crm_nonroot {
     wait_serial $orig_prompt, no_regex => 1, timeout => 2;
 
     select_serial_terminal();
+}
+
+=head2 get_crmsh_version
+
+    get_crmsh_version();
+
+Gets the B<crmsh> package version from the SUT.
+
+=cut
+
+sub get_crmsh_version {
+    my $out = script_output(q|rpm -q --qf 'crmshver=%{VERSION}\n' crmsh|);
+    $out =~ /crmshver=(\S+)/m or die "Couldn't parse crmsh version from: $out";
+    return ($1);
+}
+
+=head2 get_fencing_ra_name
+
+    get_fencing_ra_name($crm_config_output);
+
+Gets the correct name of the B<fence_sbd> primitive from a snippet of the cluster
+configuration provided as an argument, such as the output of the command stored
+in C<$crm_config_show_fence_sbd>.
+
+=cut
+
+sub get_fencing_ra_name {
+    my $conf = shift;
+    $conf =~ m/primitive (\S+) \S+:.+sbd/ or die "Found no primitive matching [sbd] in conf:[$conf]";
+    return ($1);
+}
+
+=head2 pcmk_delay_max_cmd
+
+    pcmk_delay_max_cmd();
+    pcmk_delay_max_cmd($primitive_name);
+
+Returns the command required to get the value of the attribute C<pcmk_delay_max> in the
+cluster configuration. If no argument is provided, it will try to determine the correct
+name for the B<fence_sbd> primitive using C<get_fencing_ra_name>, otherwise it will use
+whatever primitive name is provided as an argument.
+
+=cut
+
+sub pcmk_delay_max_cmd {
+    my $primitive_name = shift // get_fencing_ra_name(script_output($crm_config_show_fence_sbd));
+    return "crm resource param $primitive_name show pcmk_delay_max | sed 's/[^0-9]*//g'";
 }
 
 1;

--- a/lib/sles4sap/publiccloud.pm
+++ b/lib/sles4sap/publiccloud.pm
@@ -888,13 +888,18 @@ sub sbd_delay_formula() {
     my ($self) = @_;
     # all commands below ($corosync_token, $corosync_consensus...)
     # are defined and imported from lib/hacluster.pm
+
+    # We need to know first the correct name of the fence_sbd primitive in the
+    # remote cluster configuration
+    my $primitive_name = get_fencing_ra_name($self->run_cmd(cmd => $crm_config_show_fence_sbd));
+
     my %params = (
         'corosync_token' => $self->run_cmd(cmd => $corosync_token),
         'corosync_consensus' => $self->run_cmd(cmd => $corosync_consensus),
         'sbd_watchdog_timeout' => $self->run_cmd(cmd => $sbd_watchdog_timeout),
         'sbd_delay_start' => $self->run_cmd(cmd => $sbd_delay_start),
         'pcmk_delay_max' => get_var('FENCING_MECHANISM') eq 'sbd' ?
-          $self->run_cmd(cmd => $pcmk_delay_max) : 30
+          $self->run_cmd(cmd => pcmk_delay_max_cmd($primitive_name)) : 30
     );
     my $calculated_delay = calculate_sbd_start_delay(\%params);
     record_info('SBD wait', "Calculated SBD start delay: $calculated_delay");

--- a/t/11_hacluster.t
+++ b/t/11_hacluster.t
@@ -22,7 +22,6 @@ my %original_hacluster_sbd_delay_params = (
     corosync_consensus => $hacluster::corosync_consensus,
     sbd_watchdog_timeout => $hacluster::sbd_watchdog_timeout,
     sbd_delay_start => $hacluster::sbd_delay_start,
-    pcmk_delay_max => $hacluster::pcmk_delay_max
 );
 
 sub mock_hacluster_sbd_delay_parameters {
@@ -31,7 +30,6 @@ sub mock_hacluster_sbd_delay_parameters {
     $hacluster::corosync_consensus = $args{corosync_consensus} // 2;
     $hacluster::sbd_watchdog_timeout = $args{sbd_watchdog_timeout} // 3;
     $hacluster::sbd_delay_start = $args{sbd_delay_start} // 4;
-    $hacluster::pcmk_delay_max = $args{pcmk_delay_max} // 42;
 }
 
 sub reset_hacluster_sbd_delay_parameters {
@@ -39,7 +37,6 @@ sub reset_hacluster_sbd_delay_parameters {
     $hacluster::corosync_consensus = $original_hacluster_sbd_delay_params{corosync_consensus};
     $hacluster::sbd_watchdog_timeout = $original_hacluster_sbd_delay_params{sbd_watchdog_timeout};
     $hacluster::sbd_delay_start = $original_hacluster_sbd_delay_params{sbd_delay_start};
-    $hacluster::pcmk_delay_max = $original_hacluster_sbd_delay_params{pcmk_delay_max};
 }
 
 subtest '[calculate_sbd_start_delay] Check sbd_delay_start values' => sub {
@@ -103,6 +100,8 @@ subtest '[collect_sbd_delay_parameters] retry corosync-cmapctl' => sub {
     $hacluster->redefine(script_output => sub { return $_[0]; });
     my @retry_cmds = ();
     $hacluster->redefine(script_retry => sub { push @retry_cmds, @_; });
+    # collect_sbd_delay_parameters() uses pcmk_delay_max_cmd()
+    $hacluster->redefine(pcmk_delay_max_cmd => sub { return 42; });
 
     mock_hacluster_sbd_delay_parameters();
     collect_sbd_delay_parameters();
@@ -119,6 +118,8 @@ subtest '[collect_sbd_delay_parameters] SBD scenario' => sub {
     # Just returns whatever you put as command
     $hacluster->redefine(script_output => sub { return $_[0]; });
     $hacluster->redefine(script_retry => sub { return 0; });
+    # collect_sbd_delay_parameters() uses pcmk_delay_max_cmd()
+    $hacluster->redefine(pcmk_delay_max_cmd => sub { return 42; });
 
     mock_hacluster_sbd_delay_parameters();
     my %params = collect_sbd_delay_parameters();
@@ -137,6 +138,8 @@ subtest '[collect_sbd_delay_parameters] SBD scenario - undefined pcmk_delay_max'
     # Just returns whatever you put as command
     $hacluster->redefine(script_output => sub { return $_[0]; });
     $hacluster->redefine(script_retry => sub { return 0; });
+    # collect_sbd_delay_parameters() uses pcmk_delay_max_cmd()
+    $hacluster->redefine(pcmk_delay_max_cmd => sub { return 'asdf'; });
 
     mock_hacluster_sbd_delay_parameters(pcmk_delay_max => 'asdf');
     my %params = collect_sbd_delay_parameters();
@@ -788,6 +791,7 @@ subtest '[crm_list_options] invalid xml' => sub {
 END
     });
     $hacluster->redefine(record_info => sub { note(join(' ', "RECORD_INFO ( $this_test_ver )-->", @_)); });
+    $hacluster->redefine(diag => sub { note(join(' ', "DIAG ( $this_test_ver )-->", @_)); });
 
     $this_test_ver = '5.0.0';
     my $res = crm_list_options();
@@ -1012,7 +1016,62 @@ subtest '[sync_path] csync2' => sub {
     ok($results[0] =~ m|w./etc/csync2/csync2.cfg|, 'Checking csync2.cfg is writable');
     ok($results[1] =~ /grep.+$test_path.+sed.+$test_path/, 'Checking file in csyn2.cfg and adding it');
     ok($results[1] =~ m|/etc/csync2/csync2.cfg|, 'Adding file to csync2.cfg');
-    ok($results[2] eq 'csync2 -vxF ; sleep 2 ; csync2 -vxF', 'Using csyn2');
+    is $results[2], 'csync2 -vxF ; sleep 2 ; csync2 -vxF', 'Using csyn2';
+};
+
+subtest '[get_crmsh_vesion]' => sub {
+    my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
+    my $test_version = 'THIS_IS_MY_VERSION';
+    $hacluster->redefine(script_output => sub { return "crmshver=$test_version"; });
+    my $version = get_crmsh_version();
+    is $version, $test_version, 'Expected crmsh version match';
+    $test_version = '1.2.3.4';
+    $version = get_crmsh_version();
+    is $version, $test_version, 'Expected crmsh version match';
+};
+
+subtest '[get_fencing_ra_name] - expected config' => sub {
+    my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
+    my @test_data = ("primitive stonith-sbd stonith:external/sbd \\\n\tparams pcmk_delay_max=30s",
+        "primitive stonith-sbd stonith:fence_sbd \\\n\tparams pcmk_delay_max=30s",
+        "primitive fencing-sbd stonith:external/sbd \\\n\tparams pcmk_delay_max=30s",
+        "primitive fencing-sbd stonith:fence_sbd \\\n\tparams pcmk_delay_max=30s");
+    my $fencing_ra = '';
+    foreach (1 .. 2) {
+        $fencing_ra = get_fencing_ra_name(shift(@test_data));
+        is $fencing_ra, 'stonith-sbd', 'Fencing RA correctly set to `stonith-sbd`';
+    }
+    foreach (1 .. 2) {
+        $fencing_ra = get_fencing_ra_name(shift(@test_data));
+        is $fencing_ra, 'fencing-sbd', 'Fencing RA correctly set to `stonith-sbd`';
+    }
+};
+
+subtest '[get_fencing_ra_name] - unexpected config' => sub {
+    my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
+    dies_ok { get_fencing_ra_name('unexpected output') } 'Test should die with unexpected config';
+};
+
+subtest '[pcmk_delay_max_cmd] provide fence_sbd primitive name' => sub {
+    my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
+    foreach (qw(fencing-sbd stonith-sbd MICKEY PLUTO GOOFY)) {
+        my $pcmk_delay_max_cmd = pcmk_delay_max_cmd($_);
+        ok($pcmk_delay_max_cmd =~ /^crm resource param $_ show pcmk_delay_max/, "Command to get pcmk_delay_max correct for [$_] input");
+    }
+};
+
+subtest '[pcmk_delay_max_cmd] calculate fence_sbd primitive name' => sub {
+    my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
+    $hacluster->redefine(script_output => sub { return $_[0]; });
+    my $orig_fence_sbd_var = $hacluster::crm_config_show_fence_sbd;
+    foreach (qw(fencing-sbd stonith-sbd MICKEY PLUTO GOOFY)) {
+        # Mock hacluster package variable for test
+        $hacluster::crm_config_show_fence_sbd = "primitive $_ stonith:fence_sbd";
+        my $pcmk_delay_max_cmd = pcmk_delay_max_cmd();
+        ok($pcmk_delay_max_cmd =~ /^crm resource param $_ show pcmk_delay_max/, "Calculated command to get pcmk_delay_max correct for [$_]");
+    }
+    # Set original value back
+    $hacluster::crm_config_show_fence_sbd = $orig_fence_sbd_var;
 };
 
 done_testing;

--- a/tests/ha/priority_fencing_delay.pm
+++ b/tests/ha/priority_fencing_delay.pm
@@ -58,7 +58,8 @@ sub run {
     if (is_node(1)) {
         assert_script_run "crm configure primitive stateful-1 ocf:pacemaker:Stateful meta priority=129";
         assert_script_run "crm configure clone promotable-1 stateful-1 meta promotable=true";
-        assert_script_run "crm resource param stonith-sbd set pcmk_delay_max 15";
+        my $fencing_ra = get_fencing_ra_name(script_output($crm_config_show_fence_sbd));
+        assert_script_run "crm resource param $fencing_ra set pcmk_delay_max 15";
         assert_script_run "crm configure property priority-fencing-delay=30";
         # Workaround for bsc#1244437
         if (is_sle('16+') and get_var("WORKAROUND_BSC1244437")) {

--- a/tests/ha/remove_rsc.pm
+++ b/tests/ha/remove_rsc.pm
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: FSFAP
 
 # Package: crmsh
-# Summary: Remove all the resources except stonith/sbd
+# Summary: Remove all the resources except stonith-sbd/fencing-sbd
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
 use Mojo::Base 'haclusterbasetest';
@@ -19,11 +19,12 @@ sub run {
     barrier_wait("RSC_REMOVE_INIT_$cluster_name");
 
     if (is_node(1)) {
-        # Stop all the running or failed resources except stonith-sbd
+        # Stop all the running or failed resources except stonith-sbd/fencing-sbd
         # NOTE: In a production environment, this could be more proper to stop the resource group
         # to avoid misconfiguration but it works here as we are going to delete the resources in the next step
         save_state;
-        assert_script_run("for rsc in \$($crm_mon_cmd | awk '/(Started\$|FAILED)/ { if (!seen[\$0]++ && \$0 !~ /stonith-sbd/) print \$1}'); do crm resource stop \$rsc; done");
+        my $fencing_ra = get_fencing_ra_name(script_output($crm_config_show_fence_sbd));
+        assert_script_run("for rsc in \$($crm_mon_cmd | awk '/(Started\$|FAILED)/ { if (!seen[\$0]++ && \$0 !~ /$fencing_ra/) print \$1}'); do crm resource stop \$rsc; done");
         sleep 5;
         save_state;
 

--- a/tests/ha/sbd.pm
+++ b/tests/ha/sbd.pm
@@ -33,7 +33,9 @@ sub run {
         exec_csync;
 
         # Add stonith/sbd resource
-        assert_script_run "crm configure primitive stonith-sbd stonith:external/sbd params pcmk_delay_max=30s";
+        my $fencing_ra = get_fencing_ra_name(script_output($crm_config_show_fence_sbd));
+        $fencing_ra =~ s/-sbd$//;
+        assert_script_run "crm configure primitive $fencing_ra-sbd $fencing_ra:external/sbd params pcmk_delay_max=30s";
         sleep 5;
         save_state;
     }


### PR DESCRIPTION
This commit updates `lib/hacluster.pm` and some HA test modules so they use the new name for the Fencing Resource - `fencing-sbd` - instead of the old one - `stonith-sbd` - when the new name is detected in the cluster configuration.

Commit introduces 3 new functions in `lib/hacluster.pm`:

* `get_crmsh_version`: to query the version of `crmsh` in the SUT
* `get_fencing_ra_name`: to get the name of the Fencing primitive from the cluster configuration.
* `pcmk_delay_max_cmd`: produces the `crmsh` command to get the value of `pcmk_delay_max` from the cluster configuration. Replaces `$hacluster::pcmk_delay_max`.

Additionally a new global variable was defined in `lib/hacluster.pm` with the command to get the snippet of the cluster configuration containing the `fence_sbd` primitive.

With with the new `get_crmsh_version` function, old code in `lib/hacluster.pm` which was querying the `crmsh` version directly, has been refactored to use the new function, as well as test modules and libraries which were using `$hacluster::pcmk_delay_max` have been changed to use `hacluster::pcmk_delay_max_cmd()` instead.

Finally, test modules which were using `stonith-sbd` directly, have been modified to instead call `get_fencing_ra_name` and select the appropriate name of the Fencing Resource depending on the conditions of the SUT.

- Related Ticket: https://jira.suse.com/browse/TEAM-11181
- Needles: N/A
- Verification run: [16.1](http://mango.qe.nue2.suse.org/tests/overview?build=40.1&distri=sle&version=16.1) :green_circle: , [16.0 new crmsh](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR25402&distri=sle&version=16.0) :green_circle: , [16.0 old crmsh](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR25402-oldcrmsh&distri=sle&version=16.0) :green_circle: , [15-SP7](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR25402&distri=sle&version=15-SP7) :green_circle: , [15-SP4](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR25402&distri=sle&version=15-SP4) :green_circle: , [12-SP5](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR25402&distri=sle&version=12-SP5) :green_circle: , [15-SP7 in Azure](https://openqaworker15.qe.prg2.suse.org/tests/364078) :green_circle: , [12-SP5 in Azure](https://openqaworker15.qe.prg2.suse.org/tests/364115) :green_circle: 
