### PR TITLE
Record soft failure for bsc#1262599 on Xen PV guests srivo testing

### DIFF
--- a/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
+++ b/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
@@ -77,6 +77,10 @@ sub run_test {
             record_info("Skip SR-IOV test on $guest", "SEV/SEV-ES guest $guest does not support SR-IOV");
             next;
         }
+        if (is_pv_guest($guest)) {
+            record_soft_failure("bsc#1262599 - SR-IOV PCI passthrough is not supported on Xen PV guest $guest, skipping.");
+            next;
+        }
         record_info("Test $guest");
         prepare_guest_for_sriov_passthrough($guest);
         save_network_device_status_logs($guest, "1-initial");


### PR DESCRIPTION
On hosts where BIOS assigns VF BARs inside the PCI MMIO window starting at 0x90000000 (e.g. Supermicro X10DRW-i/Intel C612), Xen balloon driver places guest RAM at the same addresses when e820_host=1, causing pcifront BAR claim failure and igbvf probe error -22.

Fix: Skip SR-IOV PCI passthrough test for Xen PV guests entirely at the top of the guest loop, before any VF detach/attach operations.

- Related ticket: https://progress.opensuse.org/issues/199622
- Needles: na
- Verification run:  https://openqa.suse.de/tests/22267492（https://openqa.suse.de/tests/22267492#step/sriov_network_card_pci_passthrough/1765）
