### PR TITLE
Smoke test K3S in MinimalVM

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -21,7 +21,7 @@ use version_utils qw(is_sle is_microos is_public_cloud is_transactional is_sle_m
 use registration qw(add_suseconnect_product get_addon_fullname);
 use transactional qw(trup_call check_reboot_changes);
 
-our @EXPORT = qw(install_k3s uninstall_k3s install_kubectl install_helm apply_manifest wait_for_k8s_job_complete find_pods validate_pod_log get_pod_logs gather_k8s_logs);
+our @EXPORT = qw(check_k3s install_k3s uninstall_k3s install_kubectl install_helm apply_manifest wait_for_k8s_job_complete wait_for_pod_ready find_pods validate_pod_log get_pod_logs gather_k8s_logs dump_k3s_debug_info);
 
 sub check_k3s {
     record_info('k3s', "k3s version " . script_output("k3s --version") . " installed");
@@ -201,8 +201,8 @@ sub apply_manifest {
     assert_script_run("kubectl apply -f $path");
 }
 
-=head2 find_pods
-Find pods using kubectl queries
+=head2 wait_for_k8s_job_complete
+Wait until the job is complete
 =cut
 
 sub wait_for_k8s_job_complete {
@@ -211,8 +211,44 @@ sub wait_for_k8s_job_complete {
     script_retry($cmd, retry => 5, timeout => 360, die => 1);
 }
 
-=head2 wait_for_k8s_job_complete
-Wait until the job is complete
+=head2 wait_for_pod_ready
+
+    wait_for_pod_ready(labels => "app=myapp", timeout => 60, delay => 12, retry => 5)
+    wait_for_pod_ready(pod_name => "myapp-12345", timeout => 60, delay => 12, retry => 5)
+
+    Waits until the Pod is in Ready status. You can specify either a label selector or the full Pod name.
+
+=cut
+
+sub wait_for_pod_ready {
+    my (%args) = @_;
+    unless ($args{labels} || $args{pod_name}) {
+        die "wait_for_pod_ready requires 'labels' or 'pod_name' arguments";
+    }
+    $args{timeout} //= 60;
+    $args{delay} //= 12;
+    $args{retry} //= 5;
+
+    my $selector = "";
+    $selector .= ($args{pod_name} . " ") if $args{pod_name};
+    $selector .= "-l $args{labels}" if $args{labels};
+
+    my $cmd = "kubectl get pod $selector"
+      . " -o jsonpath='{.items[0].status.conditions[?(@.type==\"Ready\")].status}'";
+
+    validate_script_output_retry(
+        $cmd,
+        sub { $_ eq 'True' },
+        retry => $args{retry},
+        delay => $args{delay},
+        timeout => $args{timeout},
+        fail_message => 'Pod with selector ' . $selector . ' did not become Ready'
+    );
+}
+
+
+=head2 find_pods
+Find pods using kubectl queries
 =cut
 
 sub find_pods {
@@ -295,6 +331,21 @@ sub gather_k8s_logs {
         get_pod_logs($pod_name);
     }
 
+}
+
+=head2 dump_k3s_debug_info
+
+    dump_k3s_debug_info()
+
+    Dumps k3s and kubectl status and logs for debugging purposes.
+
+=cut
+
+sub dump_k3s_debug_info {
+    record_info('K3s status', script_output('systemctl status k3s', proceed_on_failure => 1));
+    script_run('journalctl -u k3s --no-pager');
+    record_info("kubectl get all", script_output("kubectl get all --all-namespaces", proceed_on_failure => 1));
+    record_info("kubectl describe all", script_output("kubectl describe all --all-namespaces", proceed_on_failure => 1));
 }
 
 1;

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -374,6 +374,11 @@ sub load_container_tests {
     }
 
     if ($runtime eq 'k3s') {
+        if ('CONTAINER_K3S_SMOKETEST') {
+            loadtest 'containers/k3s_helm_install';
+            loadtest 'containers/k3s_smoketest';
+            return;
+        }
         loadtest 'containers/run_container_in_k3s';
         return;
     }

--- a/tests/containers/k3s_smoketest.pm
+++ b/tests/containers/k3s_smoketest.pm
@@ -1,0 +1,85 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Run a simple smoketest for k3s, deploying a simple nc server and checking it works
+#
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'consoletest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils;
+use Utils::Architectures qw(is_ppc64le);
+use containers::k8s qw(apply_manifest wait_for_pod_ready check_k3s dump_k3s_debug_info);
+
+my $pod_name = 'simple-nc-server';
+my $labels = [['app', $pod_name]];
+my $labels_selector = join(',', map { "$_->[0]=$_->[1]" } @$labels);
+my $labels_yaml = join('', map { "    $_->[0]: $_->[1]\n" } @$labels);
+my $default_port = 8080;
+my $expected_response = 'PONG';
+my $content_length = length($expected_response);
+
+my $manifest = <<"EOT";
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $pod_name
+  labels:
+$labels_yaml
+spec:
+  containers:
+    - name: nc-server
+      image: registry.opensuse.org/opensuse/busybox:latest
+      command:
+        - /bin/sh
+        - -c
+        - |
+          echo "$expected_response" > /tmp/response
+          while true; do
+            nc -l -p $default_port < /tmp/response
+          done
+      readinessProbe:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo > /tmp/request
+              nc 127.0.0.1 $default_port < /tmp/request > /tmp/check
+              grep -qx "$expected_response" /tmp/check
+        initialDelaySeconds: 5
+        periodSeconds: 5
+EOT
+
+sub create_dummy {
+    record_info('manifest', $manifest);
+    apply_manifest($manifest);
+}
+
+sub delete_dummy {
+    assert_script_run("kubectl delete pod -l $labels_selector");
+}
+
+sub verify_dummy {
+    wait_for_pod_ready(labels => $labels_selector, timeout => 120);
+}
+
+sub run {
+    select_serial_terminal;
+
+    check_k3s();
+    create_dummy();
+    verify_dummy();
+    delete_dummy();
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    dump_k3s_debug_info();
+    delete_dummy();
+}
+
+1;

--- a/tests/containers/run_container_in_k3s.pm
+++ b/tests/containers/run_container_in_k3s.pm
@@ -15,7 +15,7 @@ use utils;
 use version_utils;
 use publiccloud::utils;
 use Utils::Architectures qw(is_ppc64le);
-use containers::k8s qw(install_k3s uninstall_k3s apply_manifest wait_for_k8s_job_complete find_pods validate_pod_log);
+use containers::k8s qw(install_k3s uninstall_k3s apply_manifest wait_for_k8s_job_complete find_pods validate_pod_log dump_k3s_debug_info);
 
 sub prepare_pod_yaml {
     record_info('Prep', 'Generate the yaml from a pod');
@@ -58,13 +58,7 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = @_;
-    record_info('K3s status', script_output('systemctl status k3s'));
-    script_run('journalctl -u k3s --no-pager');
-    record_info('K3s nodes', script_output('kubectl get nodes'));
-    script_run('kubectl describe nodes');
-    record_info('K3s pods', script_output('kubectl get pods --all-namespaces'));
-    script_run('kubectl describe pods --all-namespaces');
-    script_run('kubectl describe jobs --all-namespaces');
+    dump_k3s_debug_info();
 }
 
 sub post_run_hook {


### PR DESCRIPTION
Introduce a new smoke test for k3s in Minimal-VM.
Re-use existing functions ifrom lib/containers/k8s.pm as much as possible.

- Related ticket: https://progress.opensuse.org/issues/199595
- Verification run: 
  - [Simulated failure on Readiness Probe](https://openqa.suse.de/tests/22033423) 
  - [Tumbleweed](https://openqa.opensuse.org/tests/5879494)
  - [16.1](https://openqa.suse.de/tests/22030001) 
  - [15-SP4](https://openqa.suse.de/tests/22033346)