### PR TITLE
blktests: Ignore not-run results in post_process

### DIFF
--- a/data/kernel/post_process
+++ b/data/kernel/post_process
@@ -5,6 +5,10 @@ check_for_errors() {
 	local error=0
 
 	for file in $(find ./results/$dir -type f); do
+		if is_not_run "$file"; then
+			continue
+		fi
+
 		while IFS= read -r line; do
 			if [[ "$line" == *"exit_status"* && "$line" == *"1"* ]]; then
 				error=1
@@ -15,6 +19,18 @@ check_for_errors() {
 	done
 
 	echo "$error"
+}
+
+is_not_run() {
+	local file="$1"
+
+	while IFS= read -r line; do
+		if [[ "$line" == "status"* && "$line" == *"not run"* ]]; then
+			return 0
+		fi
+	done < "$file"
+
+	return 1
 }
 
 get_test_description() {
@@ -41,6 +57,11 @@ generate_xunit_report() {
 	echo "<testsuite errors=\"$error\" name=\"$dir\">" > "./$results"
 
 	for file in $(find ./results/$dir -type f); do
+		if is_not_run "$file"; then
+			echo "not run: $file"
+			continue
+		fi
+
 		local test_name
 		test_name=$(get_test_description "$file")
 		local test_group
@@ -56,8 +77,6 @@ generate_xunit_report() {
 					echo "<testcase name=\"${test_group}::${test_name}\">" >> "./$results"
 					echo "  <failure message=\"$failure_message\"/>" >> "./$results"
 					echo "</testcase>" >> "./$results"
-				elif [[ "$line" == *"not run"* ]]; then
-					echo "not run: $file"
 				fi
 			fi
 		done < "$file"


### PR DESCRIPTION
Treat blktests result files with status not run as skipped before parsing exit_status or testcase details. Some of the new blktests add 'status not run' but still report 'exit status' as 1 which makes openqa xunit report tests as failed.

This is an intermediate solution until blktests is moved to a generic runner/result parser.

- Related ticket: https://progress.opensuse.org/issues/200090
- Verification run: https://openqa.suse.de/tests/22006255
https://openqa.suse.de/tests/22006320 - failing test is a different problem and it is being handled here: https://progress.opensuse.org/issues/200087
