### PR TITLE
kernel: Support transactional systems in user space tests

### DIFF
--- a/tests/ipsec/ipsec3hosts.pm
+++ b/tests/ipsec/ipsec3hosts.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2023-2025 SUSE LLC
+# Copyright 2023-2026 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Multimachine IPsec test verifying connectivity, routing,
@@ -16,6 +16,7 @@ use serial_terminal 'select_serial_terminal';
 use utils;
 use lockapi;
 use network_utils;
+use package_utils 'install_package';
 use Kernel::net_tests qw(
   add_ipv6_addr
   add_ipv6_route
@@ -328,7 +329,7 @@ sub pre_run_hook {
     ensure_service_disabled($self->firewall);
     set_hostname(get_var('HOSTNAME', 'susetest'));
 
-    zypper_call('install tcpdump');
+    install_package('tcpdump', trup_apply => 1);
 }
 
 sub post_fail_hook {

--- a/tests/kernel/bcc.pm
+++ b/tests/kernel/bcc.pm
@@ -1,4 +1,4 @@
-# Copyright 2023 SUSE LLC
+# Copyright 2023-2026 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Package: bpftrace
@@ -7,14 +7,14 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
-use utils 'zypper_call';
+use package_utils 'install_package';
 use version_utils 'is_sle';
 use serial_terminal 'select_serial_terminal';
 
 sub run {
     select_serial_terminal;
 
-    zypper_call('in bcc-tools');
+    install_package('bcc-tools', trup_apply => 1);
 
     my $tools_dir = '/usr/share/bcc/tools';
 

--- a/tests/kernel/bpf.pm
+++ b/tests/kernel/bpf.pm
@@ -1,4 +1,4 @@
-# Copyright 2025 SUSE LLC
+# Copyright 2025-2026 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Package: bpf
@@ -8,6 +8,7 @@
 use Mojo::Base 'opensusebasetest';
 use testapi;
 use utils;
+use package_utils 'install_package';
 use version_utils qw(is_sle);
 use registration qw(add_suseconnect_product get_addon_fullname is_phub_ready);
 use serial_terminal qw(select_serial_terminal);
@@ -24,9 +25,9 @@ sub run {
             return;
         }
         add_suseconnect_product(get_addon_fullname('phub'));    # For clang
-
+        zypper_call("--gpg-auto-import-keys ref");
     }
-    zypper_call("in clang bpftool libbpf-devel");
+    install_package('clang bpftool libbpf-devel', trup_apply => 1);
 
     # Build the BPF program
     assert_script_run('curl -sO ' . data_url('kernel/trace_output.bpf.c'));

--- a/tests/kernel/bpftrace.pm
+++ b/tests/kernel/bpftrace.pm
@@ -1,4 +1,4 @@
-# Copyright 2023 SUSE LLC
+# Copyright 2023-2026 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Package: bpftrace
@@ -7,7 +7,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
-use utils 'zypper_call';
+use package_utils 'install_package';
 use version_utils 'is_sle';
 use serial_terminal;
 use Mojo::File 'path';
@@ -15,7 +15,7 @@ use Mojo::File 'path';
 sub run {
     select_serial_terminal;
 
-    zypper_call('in bpftrace bpftrace-tools');
+    install_package('bpftrace bpftrace-tools', trup_apply => 1);
 
     assert_script_run('bpftrace --info');
 

--- a/tests/kernel/io_uring.pm
+++ b/tests/kernel/io_uring.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2023-2025 SUSE LLC
+# Copyright 2023-2026 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Executes liburing testing suite
@@ -12,6 +12,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use LTP::WhiteList;
+use package_utils 'install_package';
 
 sub run {
     my $self = shift;
@@ -33,8 +34,8 @@ sub run {
     $pkgs .= " liburing2" if script_run('rpm -q liburing2');
 
     # install dependences
-    zypper_call("in -t pattern devel_basis");
-    zypper_call("in $pkgs");
+    install_package('-t pattern devel_basis');
+    install_package($pkgs, trup_continue => 1, trup_apply => 1);
 
     # select latest liburing version which is supported by the system
     if ($version eq '') {

--- a/tests/kernel/kernel_kexec.pm
+++ b/tests/kernel/kernel_kexec.pm
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 SUSE LLC
+# Copyright 2017-2026 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Package: kexec-tools systemd
@@ -9,22 +9,27 @@ use Mojo::Base 'opensusebasetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
+use version_utils qw(is_transactional);
+use transactional qw(enter_trup_shell exit_trup_shell_and_reboot);
 
 sub run {
     my $self = shift;
     select_serial_terminal;
+
     # Copy kernel image and rename it
     my $find_output = script_output('find /boot -maxdepth 1 -name "*$(uname -r)"', 600);
     record_info('Find output', $find_output);
     my @filtered = grep { /image|vmlinu/i } split /\n/, $find_output;
     my $kernel_orig = $filtered[0];
     (my $kernel_new = $kernel_orig) =~ s/-default$/-kexec/;
+    enter_trup_shell if (is_transactional);
     assert_script_run("cp $kernel_orig $kernel_new");
 
     # Copy initrd image and rename it
     my $initrd_orig = script_output('find /boot -maxdepth 1 -name "initrd-$(uname -r)"', 120);
     (my $initrd_new = $initrd_orig) =~ s/-default$/-kexec/;
     assert_script_run("cp $initrd_orig $initrd_new");
+    exit_trup_shell_and_reboot if is_transactional;
 
     # kernel cmdline parameter
     $_ = script_output("cat /proc/cmdline", 120);
@@ -36,7 +41,10 @@ sub run {
     assert_script_run("kexec -l $kernel_new --initrd=$initrd_new --command-line='$cmdline'");
     # kexec -e
     # don't use built-in systemctl api, see poo#31180
+    select_console 'root-console';
+    record_info('KEXEC', 'systemctl kexec');
     script_run("systemctl kexec", 0);
+    save_screenshot;
     reset_consoles;
     $self->wait_boot_past_bootloader;
     select_serial_terminal;

--- a/tests/kernel/multipath_iscsi.pm
+++ b/tests/kernel/multipath_iscsi.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2023 SUSE LLC
+# Copyright 2023-2026 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Summary: Smoke test for multipath over iscsi
@@ -11,6 +11,7 @@
 use Mojo::Base 'opensusebasetest';
 use testapi;
 use utils;
+use package_utils 'install_package';
 use iscsi;
 use serial_terminal 'select_serial_terminal';
 
@@ -25,7 +26,7 @@ sub run {
     ping_size_check($target);
 
     # Install iscsi and make sure multipath-tools are installed
-    zypper_call("in open-iscsi multipath-tools");
+    install_package('open-iscsi multipath-tools', trup_apply => 1);
 
     # Start isci and multipath services
     systemctl 'start iscsid';


### PR DESCRIPTION
Following tests were adapted for testing on transactional system:
- ipsec3hosts
- bcc
- bpftrace
- io_uring
- bpf
- kernel_kexec
- multipath_iscsi

Related ticket: https://progress.opensuse.org/issues/200015
Needles: 
Verification run:  https://openqa.suse.de/tests/overview?build=czerw%2Fos-autoinst-distri-opensuse%2325414&distri=sle&version=16.1

`io_uring` fail is not related and is expected.
