### PR TITLE
feat(boottime): fix the boot time measure call in prepare_instance

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -383,24 +383,22 @@ sub create_instances {
 
     foreach my $instance (@vms) {
         record_info("INSTANCE", $instance->{instance_id});
+        $self->show_instance_details();
         if ($args{check_connectivity}) {
             # An error in VM-up causes test to stop
-            $instance->wait_for_ssh(timeout => $args{timeout},
+            my $result = $instance->wait_for_ssh(timeout => $args{timeout},
                 proceed_on_failure => $args{proceed_on_failure}, scan_ssh_host_key => 1);
-        }
-        $self->show_instance_details();
-
-        # Performance data: boottime
-
-        if (is_ok_url($url)) {
-            local $@;
-            eval {
-                my $btime = $instance->measure_boottime($instance, 'first');
-                $instance->store_boottime_db($btime, $url);
-            };
-            record_info("WARN", "Boottime measures cannot be provided", result => 'fail') if ($@);
-        } else {
-            record_info("WARN", "Cannot connect url:" . $url, result => 'fail');
+            # Performance data: boottime
+            if ($result && is_ok_url($url)) {
+                local $@;
+                eval {
+                    my $btime = $instance->measure_boottime($instance, 'first');
+                    $instance->store_boottime_db($btime, $url);
+                };
+                record_info("WARN", "Boottime measures cannot be provided", result => 'fail') if ($@);
+            } else {
+                record_info("WARN", "Cannot connect url:" . $url, result => 'fail');
+            }
         }
     }
     return @vms;

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -37,12 +37,14 @@ sub run {
     my %instance_args;
     $instance_args{check_connectivity} = 0;    # Don't run wait_for_ssh() inside create_instance()
     $instance_args{use_extra_disk} = {size => $additional_disk_size, type => $additional_disk_type} if ($additional_disk_size > 0);
+
     $args->{my_provider} = $self->provider_factory();
     $args->{my_instance} = $args->{my_provider}->create_instance(%instance_args);
-    $args->{my_instance}->wait_for_ssh(scan_ssh_host_key => 1);
-    $args->{my_instance}->wait_for_guestregister() if (is_ondemand);
     my $provider = $self->{my_provider} = $args->{my_provider};
     my $instance = $args->{my_instance};
+    my $result = $instance->wait_for_ssh(scan_ssh_host_key => 1);
+    $instance->measure_boottime($instance, 'first') if $result;
+    $instance->wait_for_guestregister() if (is_ondemand);
 
     $instance->network_speed_test();
     $instance->check_cloudinit() if (is_cloudinit_supported);


### PR DESCRIPTION
- Enforce the boottime management, done by `measure_boottime`, to run after `wait_for_ssh` validation
- Implement the boottime management in `create_instance` only when the `check_connectivity` option is true.
- Apply this ssh validation in `prepare_instance` too,but simpler and without data storing (preparation for a next PR).

Note: the `sub measure_boottime` modificatons expected by the ticket's ACs will be applied in the next coming PR, on top of this code, after it will be merged.

- Ref.tkt poo#[198947](https://progress.opensuse.org/issues/198947#note-15)

- Verification run: following in next PR posts.
