### PR TITLE
Adapt the logic to check default python version

### DIFF
--- a/lib/python_version_utils.pm
+++ b/lib/python_version_utils.pm
@@ -31,7 +31,7 @@ returns a string with the system's current python versions, for example 'python3
 =cut
 
 sub get_system_python_version() {
-    my $system_python_version = script_output(qq[zypper se --installed-only --provides '/usr/bin/python3' | awk -F '|' '/python3[0-9]*/ {gsub(" ", ""); print \$2}' | awk -F '-' '{print \$1}' | uniq | awk '{printf "%s ", \$0}']);
+    my $system_python_version = script_output(qq[rpm -qf \$(readlink -f /usr/bin/python3) | awk -F '-' '{print \$1}' | uniq | awk '{printf "%s ", \$0}']);
     return $system_python_version;
 }
 


### PR DESCRIPTION
Python 3 is split into several subpackages, based on external dependencies.
The main package 'python3' has soft dependencies on all subpackages needed to
assemble the standard library

https://src.suse.de/pool/python3/pulls/2

- Related ticket: https://progress.opensuse.org/issues/200183
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&build=rfan0424-1