### PR TITLE
xfstests: Match kernel-default-extra version

### DIFF
--- a/lib/rdma.pm
+++ b/lib/rdma.pm
@@ -38,8 +38,14 @@ sub install_rdma_dependency {
       librdmacm-utils
       infiniband-diags
       libibverbs-utils
-      kernel-default-extra
     );
+    my $kernel_version = get_var('KERNEL_VERSION');
+    if ($kernel_version) {
+        my $kver = script_output("rpm -q kernel-default --queryformat '%{VERSION}-%{RELEASE}\\n' | grep '$kernel_version'");
+        push @deps, "kernel-default-extra=$kver";
+    } else {
+        push @deps, 'kernel-default-extra';
+    }
     my $packages = join(' ', @deps);
     script_run('zypper --gpg-auto-import-keys ref');
     install_package($packages, trup_reboot => 1);


### PR DESCRIPTION
xfstests rdma related test will install kernel-default-extra, and it doesn't point to the same kernel version, and installing the latest kernel version will involve problems
And because KERNEL_VERSION didn't include the second version after ".", we need to find the second version by looking into the kernel-default version. e.g. KERNEL_VERSION=6.12.0-160000.27, but kernel-default-extra version is kernel-default-extra-6.12.0-160000.27.1.x86_64

- Related ticket: https://progress.opensuse.org/issues/200279
- Verification run: https://openqa.suse.de/tests/22020534#step/partition/106
