### PR TITLE
openSUSE Maintenance: Use temporary file to cope with serial_terminal limit of characters per row

### DIFF
--- a/tests/console/qam_verify_package_install.pm
+++ b/tests/console/qam_verify_package_install.pm
@@ -8,9 +8,10 @@ use Mojo::Base 'consoletest';
 use testapi;
 
 sub run {
-    # reuse console
-    my $packages = get_var("VERIFY_PACKAGE_VERSIONS");
-    assert_script_run("~$username/data/lsmfip --verbose --verify \$XDG_RUNTIME_DIR/install_packages.txt $packages | tee /dev/$serialdev");
+    save_tmp_file("packages-list", get_var("VERIFY_PACKAGE_VERSIONS"));
+    my $download_cmd = sprintf('curl -O "%s/files/%s"', autoinst_url, 'packages-list');
+    assert_script_run($download_cmd);
+    assert_script_run("~$username/data/lsmfip --verbose --verify \$XDG_RUNTIME_DIR/install_packages.txt \$(cat packages-list)");
 }
 
 1;


### PR DESCRIPTION
Some updates can have a very long `VERIFY_PACKAGE_VERSIONS` which cause the serial console to flow to the next row, causing openQA think the test didn't type the command fully making the test fail.

openqa: clone https://openqa.opensuse.org/tests/5871290

VR: https://openqa.opensuse.org/tests/5873845

#### Results from cloned jobs:
- [![https://openqa.opensuse.org/tests/5873858](https://openqa.opensuse.org/tests/5873858/badge)](https://openqa.opensuse.org/tests/5873858)

<sub>The above list is generated with a script with information from the "clone_mentioned_job" workflow.</sub>
