### PR TITLE
The 2nd attempt to implement expanding agama profile dynamic

### DIFF
--- a/data/autoyast_hanaperf/agama-config.libsonnet
+++ b/data/autoyast_hanaperf/agama-config.libsonnet
@@ -1,0 +1,60 @@
+// This libsonnet is used for generating unattended agama profile.
+// ARCH comes from openQA ARCH: x86_64, ppc64le and so on.
+// BUILD comes from openQA BUILD: GM, 40.1 and so on.
+// OSDISK comes from openQA OSDISK: sda, scsi-SATA_DELLBOSS_VD_b68e1f8449390010 and so on.
+// SCC_REGCODE comes from openQA SCC_REGCODE
+// ARCH,BUILD and OSDISK are mandatory parameters and set via openQA AGAMA_PROFILE_OPTIONS
+function(ARCH='', BUILD='', OSDISK='', SCC_REGCODE='') {
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard',
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    sshPublicKey: 'fake public key to enable sshd and open firewall',
+  },
+  software: {
+    packages: ['patterns-sap-minimal_sap','openssh-server-config-rootlogin'],
+  },
+  [if ARCH == 'x86_64' then 'bootloader']: {
+    extraKernelParams: 'tsx=auto intel_idle.max_cstate=1 panic=30',
+  },
+  product: {
+    id: 'SLES',
+    [if BUILD != 'GM' then 'registrationCode']: SCC_REGCODE,
+  },
+  storage: {
+    drives: [
+      {
+        search: '/dev/disk/by-id/' + OSDISK,
+        partitions: [
+          { search: '*', delete: true },
+          { generate: 'default' },
+        ],
+      },
+    ],
+  },
+  localization: {
+    language: 'en_US.UTF-8',
+    keyboard: 'us',
+    timezone: 'Asia/Shanghai',
+  },
+  scripts: {
+    pre: [
+      {
+        name: 'wipefs',
+        content: |||
+          #!/usr/bin/env bash
+          for i in `lsblk -n -l -o NAME -d -e 7,11,254`
+              do wipefs -af /dev/$i
+              sleep 1
+              sync
+          done
+        |||,
+      },
+    ],
+  },
+}

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -190,7 +190,7 @@ sub enter_o3_ipxe_boot_entry {
 sub set_bootscript_agama_cmdline_extra {
     my $cmdline_extra = " ";
     if (my $agama_auto = get_var('INST_AUTO')) {
-        my $agama_auto_url = autoyast::expand_agama_profile($agama_auto);
+        my $agama_auto_url = ($agama_auto =~ /\.libsonnet/) ? autoyast::generate_json_profile($agama_auto) : autoyast::expand_agama_profile($agama_auto);
         $cmdline_extra .= "inst.auto=$agama_auto_url inst.finish=stop ";
     }
     # Agama Installation repository URL


### PR DESCRIPTION
According to discussion in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25374#issuecomment-4303691487, this is the 2nd attempt to implement expanding agama dynamic.

This change is intended to implement dynamically expanding agama
profile based on openQA runtime variables. The goal is to allow
multiple test scenarios to share a single profile, reducing the
need to create new ones for every minor variation.

Following the first attempt using Mojo (similar to the previous
autoyast implementation) which was discouraged for JSON/Jsonnet.
This second attempt utilizes libsonnet functions.

agama-config.libsonnet: introduced as the agama profile template
in libsonnet format.

ipxe_install.pm: add logic to detect and handle libsonnet for
agama inst.auto option as bootloader_setup.pm to handle libsonnet.

- Related ticket: https://jira.suse.com/browse/TEAM-11185
- Needles: N/A
- Verification run: 

```INST_AUTO=autoyast_hanaperf/agama-config.libsonnet AGAMA_PROFILE_OPTIONS='BUILD="GM" OSDISK=%OSDISK% ARCH=%ARCH%'``` ==>http://10.200.129.6/tests/88456

```INST_AUTO=autoyast_hanaperf/agama-config.libsonnet AGAMA_PROFILE_OPTIONS='BUILD=%BUILD% ARCH=%ARCH% OSDISK=%OSDISK% SCC_REGCODE=%SCC_REGCODE%'``` ===>http://10.200.129.6/tests/88457 

(The merge request for adding AGAMA_PROFILE_OPTIONS in job group will be submitted once this solution is confirmed)