### PR TITLE
PC: Attempt to fix ssh_interactive_leave()

### DIFF
--- a/lib/publiccloud/ssh_interactive.pm
+++ b/lib/publiccloud/ssh_interactive.pm
@@ -99,7 +99,6 @@ sub ssh_interactive_leave {
         last if ($test->());
         sleep 5;    # some cool down after a failed attempt
     }
-    die "tunnel-console is not functional" if ($retries <= 0);
 
     select_console($prev_console) if ($prev_console !~ /tunnel-console/);
     set_var('_SSH_TUNNELS_INITIALIZED', 0);    # set after the last select_console!


### PR DESCRIPTION
Attempt to fix `publiccloud::ssh_interactive::pc_fix_ssh_interactive_leave()` as it may rarely freeze.

See related logs:
```
^C
true; echo l3Uoy-$?- > /dev/ttyS0
^C
true; echo l3Uoy-$?- > /dev/ttyS0
^C
true; echo l3Uoy-$?- > /dev/ttyS0
^C
true; echo l3Uoy-$?- > /dev/ttyS0
^C
true; echo l3Uoy-$?- > /dev/ttyS0
^C
true; echo l3Uoy-$?- > /dev/ttyS0
^C
true; echo l3Uoy-$?- > /dev/ttyS0
^C
true; echo l3Uoy-$?- > /dev/ttyS0
```
```
# Test died: tunnel-console is not functional at sle/lib/publiccloud/ssh_interactive.pm line 102.
	publiccloud::ssh_interactive::ssh_interactive_leave() called at sle/lib/publiccloud/ssh_interactive.pm line 124
	publiccloud::ssh_interactive::select_host_console("force", 1) called at sle/tests/publiccloud/destroy.pm line 20
	destroy::run(destroy=HASH(0x55eaedcae928), OpenQA::Test::RunArgs=HASH(0x55eaedc9aac8)) called at /usr/lib/os-autoinst/basetest.pm line 325
	basetest::runtest(destroy=HASH(0x55eaedcae928)) called at /usr/lib/os-autoinst/autotest.pm line 562
	autotest::runalltests() called at /usr/lib/os-autoinst/autotest.pm line 416
	autotest::run_all() called at /usr/lib/os-autoinst/autotest.pm line 470
	autotest::__ANON__(Mojo::IOLoop::ReadWriteProcess=HASH(0x55eaef4c79a8)) called at /usr/lib/perl5/vendor_perl/5.42.0/Mojo/IOLoop/ReadWriteProcess.pm line 329
	eval {...} called at /usr/lib/perl5/vendor_perl/5.42.0/Mojo/IOLoop/ReadWriteProcess.pm line 329
	Mojo::IOLoop::ReadWriteProcess::_fork(Mojo::IOLoop::ReadWriteProcess=HASH(0x55eaef4c79a8), CODE(0x55eaee0c9328)) called at /usr/lib/perl5/vendor_perl/5.42.0/Mojo/IOLoop/ReadWriteProcess.pm line 492
	Mojo::IOLoop::ReadWriteProcess::start(Mojo::IOLoop::ReadWriteProcess=HASH(0x55eaef4c79a8)) called at /usr/lib/os-autoinst/autotest.pm line 472
	autotest::start_process() called at /usr/lib/os-autoinst/OpenQA/Isotovideo/Runner.pm line 104
	OpenQA::Isotovideo::Runner::start_autotest(OpenQA::Isotovideo::Runner=HASH(0x55eae6afe3d0)) called at /usr/lib/os-autoinst/OpenQA/Isotovideo/Runner.pm line 251
	OpenQA::Isotovideo::Runner::init(OpenQA::Isotovideo::Runner=HASH(0x55eae6afe3d0)) called at /usr/bin/isotovideo line 190
```

- Related ticket: [poo#199820](https://progress.opensuse.org/issues/199820)
- Related failure: [openqa.suse.de/t22003425](https://openqa.suse.de/tests/22003425#step/destroy/17)
- Verification runs:
sle-15-SP7-EC2-Updates.aarch64	[publiccloud_consoletests@64bit](https://pdostal-workbench.qe.prg2.suse.org/tests/513)
sle-15-SP7-Azure-BYOS-Updates.aarch64	[publiccloud_consoletests@64bit](https://pdostal-workbench.qe.prg2.suse.org/tests/512)
sle-15-SP7-GCE-BYOS-Updates.x86_64	[publiccloud_consoletests@64bit](https://pdostal-workbench.qe.prg2.suse.org/tests/514)
