### PR TITLE
pynfs: Support transactional systems

### DIFF
--- a/tests/nfs/install.pm
+++ b/tests/nfs/install.pm
@@ -12,6 +12,7 @@ use Mojo::Base 'opensusebasetest';
 use utils;
 use testapi;
 use serial_terminal 'select_serial_terminal';
+use package_utils 'install_package';
 use version_utils qw(is_sle is_tumbleweed);
 
 sub install_dependencies_pynfs {
@@ -26,7 +27,7 @@ sub install_dependencies_pynfs {
       nfs-kernel-server
     );
     push(@deps, 'python3-standard-xdrlib') if (is_sle('16+') || is_tumbleweed);
-    zypper_call('in ' . join(' ', @deps));
+    install_package(join(' ', @deps), trup_apply => 1);
 }
 
 sub install_dependencies_cthon04 {
@@ -40,7 +41,7 @@ sub install_dependencies_cthon04 {
       libtirpc-devel
       time
     );
-    zypper_call('in ' . join(' ', @deps));
+    install_package(join(' ', @deps), trup_apply => 1);
 }
 
 sub install_testsuite {
@@ -76,7 +77,7 @@ sub install_testsuite {
 
 sub setup_nfs_server {
     my $nfsversion = shift;
-    assert_script_run('mkdir -p /exportdir && echo \'/exportdir *(rw,no_root_squash,insecure)\' >> /etc/exports');
+    assert_script_run('mkdir -p /var/exportdir && echo \'/var/exportdir *(rw,no_root_squash,insecure)\' >> /etc/exports');
 
     my $nfsgrace = get_var('NFS_GRACE_TIME', 15);
     assert_script_run("echo 'options lockd nlm_grace_period=$nfsgrace' >> /etc/modprobe.d/lockd.conf && echo 'options lockd nlm_timeout=5' >> /etc/modprobe.d/lockd.conf");

--- a/tests/nfs/run.pm
+++ b/tests/nfs/run.pm
@@ -22,14 +22,14 @@ sub run {
         my $version = get_required_var('NFSVERSION');
 
         assert_script_run("cd ~/pynfs/nfs$version");
-        script_run('./testserver.py -v --rundeps --hidepass --json results.json --maketree localhost:/exportdir all', 3600);
+        script_run('./testserver.py -v --rundeps --hidepass --json results.json --maketree localhost:/var/exportdir all', 3600);
     }
     elsif (get_var("CTHON04")) {
         script_run('cd ~/cthon04');
-        script_run('./runtests -b -t /exportdir | tee result_basic_test.txt');
-        script_run('./runtests -g -t /exportdir | tee result_general_test.txt');
-        script_run('./runtests -s -t /exportdir | tee result_special_test.txt');
-        script_run('./runtests -l -t /exportdir | tee result_lock_test.txt');
+        script_run('./runtests -b -t /var/exportdir | tee result_basic_test.txt');
+        script_run('./runtests -g -t /var/exportdir | tee result_general_test.txt');
+        script_run('./runtests -s -t /var/exportdir | tee result_special_test.txt');
+        script_run('./runtests -l -t /var/exportdir | tee result_lock_test.txt');
     }
 }
 


### PR DESCRIPTION
Migrate package installation to install_package and change /exportdir to /var/exportdir.


- Related ticket: https://progress.opensuse.org/issues/200324
- Needles: none
- Verification run: https://openqa.suse.de/tests/overview?version=16.1&distri=sle&build=czerw%2Fos-autoinst-distri-opensuse%2325424
