### PR TITLE
pc_tools: bump Cloud:Tools:CI repo to SLE_15_SP7

### DIFF
--- a/data/autoyast_sle15/pc_tools.xml
+++ b/data/autoyast_sle15/pc_tools.xml
@@ -19,7 +19,7 @@
   <add-on>
     <add_on_products config:type="list">
       <listentry>
-        <media_url>https://download.opensuse.org/repositories/Cloud:/Tools:/CI/SLE_15_SP5/</media_url>
+        <media_url>https://download.opensuse.org/repositories/Cloud:/Tools:/CI/SLE_15_SP7/</media_url>
         <product>public_cloud_devel</product>
         <alias>Public Cloud Devel</alias>
         <product_dir>/</product_dir>


### PR DESCRIPTION
The Cloud:Tools:CI/SLE_15_SP5 OBS repo is no longer available and gives 404.

Bump to SLE_15_SP7 to match the SLES build the job already targets
(https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2466 bumped the YAML side but missed this profile).