### PR TITLE
publiccloud: bump default OPENTOFU_VERSION to 1.11.6

### DIFF
--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -86,7 +86,7 @@ EOT
     validate_script_output("terraform -version", qr/$terraform_version/);
     record_info('Terraform', script_output('terraform -version'));
 
-    my $opentofu_version = get_var('OPENTOFU_VERSION', '1.9.1');
+    my $opentofu_version = get_var('OPENTOFU_VERSION', '1.11.6');
     # opentofu in a container
     my $opentofu_wrapper = <<EOT;
 #!/bin/bash -e

--- a/variables.md
+++ b/variables.md
@@ -303,7 +303,7 @@ The following variables are relevant for publiccloud related jobs. Keep in mind 
 Variable        | Type      | Default value | Details
 ---             | ---       | ---           | ---
 CLUSTER_TYPES | string | false | Set the type of cluster that have to be analyzed (example: "drbd hana").
-OPENTOFU_VERSION | string | "1.9.1" | Version of opentofu to include into PC Tools image
+OPENTOFU_VERSION | string | "1.11.6" | Version of opentofu to include into PC Tools image
 PUBLIC_AZURE_CLI_TEST | string | "vmss" | Azure CLI test names. This variable should list the test name which should be tested.
 PUBLIC_CLOUD | boolean | false | All Public Cloud tests have this variable set to true. Contact: qa-c@suse.de
 PUBLIC_CLOUD_ACCNET | boolean | false | If set, az_accelerated_net test module is added to the job.


### PR DESCRIPTION
1.9.1 predates the 1.10/1.11 releases.
ghcr.io/opentofu/opentofu:1.11.6 exists.

Reference: https://progress.opensuse.org/issues/198695
VR: https://openqa.suse.de/tests/22035077
Depends on #25426.