### PR TITLE
Follow up: Prevent possible serial_terminal overflow in install_packages

### DIFF
--- a/tests/console/install_packages.pm
+++ b/tests/console/install_packages.pm
@@ -15,10 +15,13 @@ use utils 'zypper_call';
 sub run {
     select_console 'root-console';
 
-    my $packages = get_var("INSTALL_PACKAGES");
-
     zypper_call('in -l perl-solv perl-Data-Dump');
-    my $ex = script_run("~$username/data/lsmfip --verbose $packages > \$XDG_RUNTIME_DIR/install_packages.txt 2> /tmp/lsmfip.log");
+
+    save_tmp_file("packages", get_var("INSTALL_PACKAGES"));
+    my $download_cmd = sprintf('curl -O "%s/files/%s"', autoinst_url, 'packages');
+    assert_script_run($download_cmd);
+
+    my $ex = script_run("~$username/data/lsmfip --verbose \$(cat packages) > \$XDG_RUNTIME_DIR/install_packages.txt 2> /tmp/lsmfip.log");
     record_info("install_packages.txt", script_output("cat \$XDG_RUNTIME_DIR/install_packages.txt"));
     upload_logs '/tmp/lsmfip.log';
     if ($ex) {


### PR DESCRIPTION
Follows #25420

Some updates can have very long `INSTALL_PACKAGES` which can cause the
serial console to flow to the next row, causing openQA to think the test
didn't finish typing, causing the test to fail

openqa: clone https://openqa.opensuse.org/tests/5871290
openqa: clone https://openqa.opensuse.org/tests/5879298


#### Results from cloned jobs:
- [![https://openqa.opensuse.org/tests/5879375](https://openqa.opensuse.org/tests/5879375/badge)](https://openqa.opensuse.org/tests/5879375)
- [![https://openqa.opensuse.org/tests/5879376](https://openqa.opensuse.org/tests/5879376/badge)](https://openqa.opensuse.org/tests/5879376)

<sub>The above list is generated with a script with information from the "clone_mentioned_job" workflow.</sub>
