### PR TITLE
Does not include elemental3ctl sysext in tests

### DIFF
--- a/tests/elemental3/generate_image.pm
+++ b/tests/elemental3/generate_image.pm
@@ -36,7 +36,7 @@ sub build_installer_cmd {
     my $device = get_var('INSTALL_DISK', '/dev/vda');
 
     # Configure the systemd sysexts
-    my ($overlay_dir, $ctl_oci) = get_sysext(tmpdir => $args{config_dir}, timeout => $args{timeout});
+    my $overlay_dir = get_sysext(tmpdir => $args{config_dir}, timeout => $args{timeout});
 
     # OS configuration script
     assert_script_run(
@@ -217,7 +217,6 @@ sub get_sysext {
     my (%args) = @_;
     my $overlay_dir = "$args{tmpdir}/overlays";
     my $sysext_dir = "$overlay_dir/etc/extensions";
-    my $ctl_oci;
 
     record_info('SYSEXT', 'Download and configure systemd system extensions');
 
@@ -225,16 +224,15 @@ sub get_sysext {
     assert_script_run("mkdir -p $sysext_dir");
 
     # Get the system extensions
-    foreach my $img (split(/,/, get_required_var('SYSEXT_IMAGES_TO_TEST'))) {
+    foreach my $img (split(/,/, get_var('SYSEXT_IMAGES_TO_TEST'))) {
         assert_script_run(
             "elemental3ctl --debug unpack-image --image ${img} --target ${sysext_dir}",
             timeout => $args{timeout}
         );
-        $ctl_oci = $img if ($img =~ /\/elemental3ctl:/);
     }
 
     # Return systemd-sysexts file name
-    return ($overlay_dir, $ctl_oci);
+    return ($overlay_dir);
 }
 
 =head2 install_cmd
@@ -257,7 +255,7 @@ sub install_cmd {
     my $k8s_sysext_found;
 
     # Configure the systemd sysexts
-    my ($overlay_dir) = get_sysext(tmpdir => $args{config_dir}, timeout => $args{timeout});
+    my $overlay_dir = get_sysext(tmpdir => $args{config_dir}, timeout => $args{timeout});
 
     # OS configuration script
     assert_script_run(

--- a/tests/elemental3/generate_image.pm
+++ b/tests/elemental3/generate_image.pm
@@ -62,7 +62,7 @@ sub build_installer_cmd {
 
     # Generate OS image
     assert_script_run(
-"elemental3ctl --debug build-installer --type $args{type} --output . --name $args{img_filename} --os-image $image --cmdline '$isocmdline' --config $iso_config_file --overlay oci://$ctl_oci --install-overlay dir://$overlay_dir --install-config $config_file --install-cmdline '$krnlcmdline' --install-target $device",
+"elemental3ctl --debug build-installer --type $args{type} --output . --name $args{img_filename} --os-image $image --cmdline '$isocmdline' --config $iso_config_file --install-overlay dir://$overlay_dir --install-config $config_file --install-cmdline '$krnlcmdline' --install-target $device",
         timeout => $args{timeout}
     );
 

--- a/tests/elemental3/set_global_variables.pm
+++ b/tests/elemental3/set_global_variables.pm
@@ -75,11 +75,9 @@ sub run {
     set_var('ELEMENTAL3_IMAGE_TO_TEST', "$elemental3_uri") unless ($elemental3_uri eq '');
 
     # Export SYSEXT_IMAGES_TO_TEST
-    # TODO: remove as soon as element3ctl will be added in the OS image!
-    my $elemental3ctl_regex = ".*elemental3ctl-${uc_version}_\(.*\)-\(.*\).${arch}-.*.registry.txt";
-    ($file, $version, $build) = get_values(txt => ${files_list}, regex => ${elemental3ctl_regex});
-    my $elemental3ctl_uri = get_uri(file => "${totest_path}/containers/${file}", regex => "pull\\s+\(.*:${uc_version}_${version}-${build}\)");
-    set_var('SYSEXT_IMAGES_TO_TEST', "${elemental3ctl_uri}") unless ($elemental3ctl_uri eq '');
+    # Include sysext uris for the sysexts targeted for testing
+    my $sysext_uri;
+    set_var('SYSEXT_IMAGES_TO_TEST', "${sysext_uri}") unless ($sysext_uri eq '');
 
     # Export K8S_IMAGE_TO_TEST
     # beta-uc-rke2-tar-1.35.1_rke2r1-2.1.x86_64-2.1.tar.registry.txt

--- a/tests/elemental3/set_global_variables.pm
+++ b/tests/elemental3/set_global_variables.pm
@@ -74,11 +74,6 @@ sub run {
     my $elemental3_uri = get_uri(file => "${totest_path}/containers/${file}", regex => "pull\\s+\(.*:${version}-${build}\)");
     set_var('ELEMENTAL3_IMAGE_TO_TEST', "$elemental3_uri") unless ($elemental3_uri eq '');
 
-    # Export SYSEXT_IMAGES_TO_TEST
-    # Include sysext uris for the sysexts targeted for testing
-    my $sysext_uri;
-    set_var('SYSEXT_IMAGES_TO_TEST', "${sysext_uri}") unless ($sysext_uri eq '');
-
     # Export K8S_IMAGE_TO_TEST
     # beta-uc-rke2-tar-1.35.1_rke2r1-2.1.x86_64-2.1.tar.registry.txt
     # registry.suse.de/devel/unifiedcore/main/totest/containers/beta/uc/rke2-tar:1.35.1_rke2r1-2.1
@@ -108,7 +103,7 @@ sub run {
     }
 
     # Logs, could be useful for debugging purporses
-    foreach my $v ('ELEMENTAL3_IMAGE_TO_TEST', 'K8S_IMAGE_TO_TEST', 'SYSEXT_IMAGES_TO_TEST', 'RELEASE_MANIFEST_URI', 'CONTAINER_IMAGE_TO_TEST', 'REPO_TO_TEST', 'ISO_IMAGE_TO_TEST') {
+    foreach my $v ('ELEMENTAL3_IMAGE_TO_TEST', 'K8S_IMAGE_TO_TEST', 'RELEASE_MANIFEST_URI', 'CONTAINER_IMAGE_TO_TEST', 'REPO_TO_TEST', 'ISO_IMAGE_TO_TEST') {
         record_info("$v", get_var("$v"));
     }
 }


### PR DESCRIPTION
This commit removes the elemental3ctl sysext from the tests as this is currently included as part of the OS.

- Related PR: https://src.suse.de/UnifiedCore/uc-factory/pulls/298
- Related ticket: 
- Needles: 
- Verification run: 
