### PR TITLE
Restructure SDAF credentials file on larry

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -160,7 +160,8 @@ sub export_credentials {
         };
     } else {
         record_info('Credentials', 'Fetching credentials from remote server');
-        $data = get_credentials(url_suffix => 'azure.json');
+        $data = get_credentials(namespace => 'sdaf', url_suffix => 'azure.json');
+        $data = $data->{get_required_var('PUBLIC_CLOUD_NAMESPACE')}->{get_required_var('SDAF_ENV_CODE')};
     }
 
     my @variables = (

--- a/t/20_sdaf_deployment_library.t
+++ b/t/20_sdaf_deployment_library.t
@@ -158,10 +158,16 @@ subtest '[set_common_sdaf_os_env]' => sub {
 subtest '[az_login] Get credentials from server' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
     my $env_variable_file_content;
-    my %credentrials = (client_id => 'Potato', client_secret => 'Patata', tenant_id => 'Zemiak', subscription_id => 'Batata');
+    my $credentrials = {
+        'sdaf' => {
+            'PRD' => {client_id => 'Potato', client_secret => 'Patata', tenant_id => 'Zemiak', subscription_id => 'Batata'}
+        }
+    };
+    set_var('PUBLIC_CLOUD_NAMESPACE', 'sdaf');
+    set_var('SDAF_ENV_CODE', 'PRD');
 
     $ms_sdaf->noop(qw(record_info assert_script_run script_output));
-    $ms_sdaf->redefine(get_credentials => sub { return \%credentrials; });
+    $ms_sdaf->redefine(get_credentials => sub { return $credentrials; });
     $ms_sdaf->redefine(write_sut_file => sub { $env_variable_file_content = $_[1]; });
 
     az_login();


### PR DESCRIPTION
Restructure SDAF credentials file on larry

Related ticket:
TEAM-11086 - [SDAF] Restructure credentials file on larry

Verification run:  
Please ignore the failures, it is `die on purpose` as we only need to verify the `az login` works
  
`sdaf` `PRD` env:
https://openqaworker15.qe.prg2.suse.org/tests/364328#step/create_deployer_vm/156 (`az login` passed)

`sdaf_sponsored` `LAB` env:
http://openqaworker15.qe.prg2.suse.org/tests/364329#step/create_deployer_vm/156 (`az login` passed)
