### PR TITLE
Setup a rule to force NM to skip SR-IOV VFs

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
+++ b/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
@@ -128,6 +128,17 @@ local agama_product_mode = if transactional == '1' then 'immutable' else 'standa
           #!/usr/bin/env bash
           systemctl enable sshd.service
         |||
+      },
+      {
+        name: "disable_nm_for_sriov_vfs",
+        chroot: true,
+        content: |||
+          #!/usr/bin/env bash
+          # Make a udev rule to force NM to skip SR-IOV VFs
+          rules_file="/etc/udev/rules.d/99-sriov-vfs-unmanaged.rules"
+          echo 'SUBSYSTEM=="net", ACTION=="add|change", TEST=="device/physfn", ENV{NM_UNMANAGED}="1"' > "$rules_file"
+          chmod 644 "$rules_file"
+        |||
       }
     ]
   }

--- a/data/virtualization/agama_virt_auto/sle_virt_default_staging.jsonnet
+++ b/data/virtualization/agama_virt_auto/sle_virt_default_staging.jsonnet
@@ -121,6 +121,17 @@ local urls = if repo != '' then std.split(repo, ',') else [];
             sed -i "/^[# ]*log_filters *=/{h;s%^[# ]*log_filters *=.*[0-9].*\$%log_filters = \"1:qemu 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci\"%};\${x;/^\$/{s%%log_filters = \"1:qemu 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci\"%;H};x}" $config_file
           done
         |||
+      },
+      {
+        name: "disable_nm_for_sriov_vfs",
+        chroot: true,
+        content: |||
+          #!/usr/bin/env bash
+          # Make a udev rule to force NM to skip SR-IOV VFs
+          rules_file="/etc/udev/rules.d/99-sriov-vfs-unmanaged.rules"
+          echo 'SUBSYSTEM=="net", ACTION=="add|change", TEST=="device/physfn", ENV{NM_UNMANAGED}="1"' > "$rules_file"
+          chmod 644 "$rules_file"
+        |||
       }
     ]
   }

--- a/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
+++ b/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
@@ -53,7 +53,7 @@ sub run_test {
     # Back up /etc/resolv.conf as it will refresh by creating VFs
     assert_script_run("cp /etc/resolv.conf /etc/resolv_before_enable_vf.conf");
 
-    record_info("Before enable VF", script_output("ip a"));
+    record_info("Before enabling VF", script_output("ip a"));
     script_run("ip r");
     script_run("nmcli con");
 
@@ -65,7 +65,7 @@ sub run_test {
         reset_consoles;
         select_console('root-ssh');
     }
-    script_run("ip a");
+    record_info("After enabling VF", script_output("ip a", proceed_on_failure => 1));
     script_run("nmcli con");
 
     # Restore /etc/resolv.conf after VFs are created


### PR DESCRIPTION
https://progress.opensuse.org/issues/200357

It helps to both fix the test failure and save IPs.

- Verification run: 
[sle16.0 QU2 sriov test](https://openqa.suse.de/tests/22052076)
[sle16.1 sriov test](https://openqa.suse.de/tests/22052131)
[MU sle16.0 sriov test](https://openqa.suse.de/tests/22052352)
[sle16.1 on aarch](https://openqa.suse.de/tests/22182500)
