### PR TITLE
feat(boottime): update publicclud boot-time management

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -744,55 +744,61 @@ sub enable_kdump() {
     $self->softreboot();
 }
 
-=head2 measure_boottime
+=head2 check_system_boottime
 
-    measure_boottime();
+    check_system_boottime();
 
-Perfomrance measurement of the system Boot time. 
-Mainly used C<systemd-analyze> command for the data extraction.
-Data is then collected in an internal record, ready for storing in a DB.
-Set PUBLIC_CLOUD_PERF_COLLECT true or >0, to activate boottime measurements.
+Check the system boot time, measured by C<systemd-analyze>, to be under a threshold.
+Assign the threshold in seconds to PUBLIC_CLOUD_BOOTTIME_MAX in test settings.
+The boot time is saved in a local json structure, then printed in the test's logs:
+when the threshold is exceeded the job is stopped.
+The routine is skipped when the threshold is undefined or zero.
 
 =cut
 
-sub measure_boottime() {
-    my ($self, $instance, $type) = @_;
-    my $data_collect = get_var('PUBLIC_CLOUD_PERF_COLLECT', 1);
-
-    return 0 if !$data_collect;
+sub check_system_boottime() {
+    my ($instance, %args) = @_;
+    my $max_boot_time = get_var('PUBLIC_CLOUD_BOOTTIME_MAX');
+    return unless ($max_boot_time);
 
     my $ret = {
         kernel_release => undef,
         kernel_version => undef,
-        type => undef,
+        type => 'boottime',
         analyze => {},
         blame => {},
     };
 
     record_info("BOOT TIME", 'systemd_analyze');
     # first deployment analysis
-    my ($systemd_analyze, $systemd_blame) = do_systemd_analyze_time($instance);
-    return 0 unless ($systemd_analyze && $systemd_blame);
+    my ($systemd_analyze, $systemd_blame) = $instance->do_systemd_analyze_time(%args);
+    die("failed to obtain boottime from systemd") unless ($systemd_analyze && $systemd_blame);
 
     $ret->{analyze}->{$_} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));
     $ret->{blame} = $systemd_blame;
-    $ret->{type} = $type;
-    # $ret->{analyze}->{ssh_access} = $startup_time; # placeholder for next implementation
-    record_info("WARN", "High overall value:" . $ret->{analyze}->{overall}, result => 'fail') if ($ret->{analyze}->{overall} >= 3600.0);
+    my $boottime = $ret->{analyze}->{overall};
 
     # Collect kernel version
     $ret->{kernel_release} = $instance->ssh_script_output(cmd => 'uname -r', proceed_on_failure => 1);
     $ret->{kernel_version} = $instance->ssh_script_output(cmd => 'uname -v', proceed_on_failure => 1);
 
     $Data::Dumper::Sortkeys = 1;
+    record_info("RESULTS", Dumper($ret));
     my $dir = "/var/log";
     my @logs = qw(cloudregister cloud-init.log cloud-init-output.log messages NetworkManager);
     $instance->upload_check_logs_tar(map { "$dir/$_" } @logs);
 
-    record_info("RESULTS", Dumper($ret));
-    return $ret;
+    # Boot time overall limit check
+    if ($boottime > $max_boot_time) {
+        if (is_azure()) {
+            # Unreliable userspace boot time in Azure.
+            record_soft_failure("bsc#1262587 - openQA publiccloud tests have anomalous-high boot-time from systemd-analyze");
+        } else {
+            # threshold exceeded
+            die("System boot time overall $boottime is out of limit $max_boot_time");
+        }
+    }
 }
-
 
 =head2 store_boottime_db
 
@@ -901,21 +907,18 @@ sub extract_blame_time {
 
 sub do_systemd_analyze_time {
     my ($instance, %args) = @_;
-    $args{timeout} = 120;
+    my $timeout = $args{timeout} // 120;
     my $start_time = time();
     my $output = "";
     my @ret;
 
     # calling systemd-analyze time & blame
-    # guestregister check executed in create_instances
-    while ($output !~ /Startup finished in/ && time() - $start_time < $args{timeout}) {
+    while ($output !~ /Startup finished in/i && time() - $start_time < $timeout) {
         $output = $instance->ssh_script_output(cmd => 'systemd-analyze time', proceed_on_failure => 1);
         sleep 5;
     }
-
-    unless ($output && (time() - $start_time < $args{timeout})) {
-        record_info("WARN", "Unable to get system-analyze in $args{timeout} seconds", result => 'fail');
-        # handle_boot_failure: soft exit from measurement.
+    unless (time() - $start_time < $timeout) {
+        record_info("WARN", "Unable to get systemd-analyze in ${timeout}s", result => 'fail');
         return (0, 0);
     }
     push @ret, extract_analyze_time($output);

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -379,26 +379,14 @@ sub create_instances {
     my ($self, %args) = @_;
     $args{check_connectivity} //= 1;
     my @vms = $self->terraform_apply(%args);
-    my $url = get_var('PUBLIC_CLOUD_PERF_DB_URI', 'http://larry.qe.suse.de:8086');
 
     foreach my $instance (@vms) {
         record_info("INSTANCE", $instance->{instance_id});
         $self->show_instance_details();
         if ($args{check_connectivity}) {
             # An error in VM-up causes test to stop
-            my $result = $instance->wait_for_ssh(timeout => $args{timeout},
+            $instance->wait_for_ssh(timeout => $args{timeout},
                 proceed_on_failure => $args{proceed_on_failure}, scan_ssh_host_key => 1);
-            # Performance data: boottime
-            if ($result && is_ok_url($url)) {
-                local $@;
-                eval {
-                    my $btime = $instance->measure_boottime($instance, 'first');
-                    $instance->store_boottime_db($btime, $url);
-                };
-                record_info("WARN", "Boottime measures cannot be provided", result => 'fail') if ($@);
-            } else {
-                record_info("WARN", "Cannot connect url:" . $url, result => 'fail');
-            }
         }
     }
     return @vms;

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -42,8 +42,9 @@ sub run {
     $args->{my_instance} = $args->{my_provider}->create_instance(%instance_args);
     my $provider = $self->{my_provider} = $args->{my_provider};
     my $instance = $args->{my_instance};
-    my $result = $instance->wait_for_ssh(scan_ssh_host_key => 1);
-    $instance->measure_boottime($instance, 'first') if $result;
+    # check needed when not-executed in create_instance
+    $instance->wait_for_ssh(scan_ssh_host_key => 1) if ($instance_args{check_connectivity} == 0);
+    $instance->check_system_boottime();
     $instance->wait_for_guestregister() if (is_ondemand);
 
     $instance->network_speed_test();

--- a/variables.md
+++ b/variables.md
@@ -319,6 +319,7 @@ PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID | string | "" | Used to create the service ac
 PUBLIC_CLOUD_AZURE_AITL_IMAGE | string | "registry.opensuse.org/devel/opensuse/qa/qac/containers/15.6/aitl-lisa:leap" | Define docker image containing aitl CLI to be used for Azure AITL LISA testing
 PUBLIC_CLOUD_AZ_API | string | "http://169.254.169.254/metadata/instance/compute" | For Azure, it is the metadata API endpoint.
 PUBLIC_CLOUD_AZ_API_VERSION | string | "2021-02-01" | For Azure, it is the API version used whe querying metadata API.
+PUBLIC_CLOUD_BOOTTIME_MAX | integer | undef | To set the 'overall' `boot time` threshold in check_system_boottime.
 PUBLIC_CLOUD_BTRFS | boolean | false | If set, it schedules `publiccloud/btrfs` job.
 PUBLIC_CLOUD_BUILD | string | "" | The image build number. Used only when we use custom built image.
 PUBLIC_CLOUD_BUILD_KIWI | string | "" | The image kiwi build number. Used only when we use custom built image.
@@ -372,7 +373,6 @@ PUBLIC_CLOUD_FUNCTIONAL | boolean | false | Schedule the functional test suite.
 PUBLIC_CLOUD_ENABLE_KDUMP | boolean | false | Enable kdump
 PUBLIC_CLOUD_MIGRATE_SLEM | boolean | false | Enable module for SL micro 6.x version upgrade to higher
 PUBLIC_CLOUD_NVIDIA | boolean | 0 | If enabled, nvidia module would be scheduled. This variable should be enabled only sle15SP4 and above.
-PUBLIC_CLOUD_PERF_COLLECT | boolean | 1 | To enable `boottime` measures collection, at end of `create_instance` routine.
 PUBLIC_CLOUD_PERF_DB | string | "perf_2" | defines the bucket in which the performance metrics are stored on PUBLIC_CLOUD_PERF_DB_URI
 PUBLIC_CLOUD_PERF_DB_ORG | string | "qec" | defines the organization in which the performance metrics are stored on PUBLIC_CLOUD_PERF_DB_URI
 PUBLIC_CLOUD_PERF_DB_URI | string | "http://publiccloud-ng.qe.suse.de:8086" | bootup time measures get pushed to this Influx database url.


### PR DESCRIPTION
This PR follows PR[25416](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25416), As by note-14 of poo198947:

\- rename measure_boottime as chk_system_boottime
\- define a max healthy system boot time threshold,for initialized instances, based on hystorical boot time data in influxdb/perf2,as by tkt requirements
\- implement a boot time control stopping instances exceeding a positive input limit, but skip the check when the limit is undefined.
\- trigger chk_system_boottime with the parameter `PUBLIC_CLOUD_BOOTTIME_MAX>0`
\- remove the boottime measure from create_instance
\- call boottime measure,on demand, after successful ssh and system-up check
\- fix the boottime routine call syntax in prepare_instance
\- stop uploading measures to influxdb, as requested in the ticket

- Ref.ticket: https://progress.opensuse.org/issues/198947
- Verification run: see next posts