### PR TITLE
Adapt code to support helm tests on SLES 16.0+

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -157,13 +157,20 @@ Installs kubectl from the respositories
 
 sub install_kubectl {
     return if (script_run("which kubectl") == 0);
-
-    # kubectl is in the container module
-    add_suseconnect_product(get_addon_fullname('contm')) if (is_sle("<16"));
     my $k8s_version = shift;
-    my $k8s_pkg = defined($k8s_version) ? "kubernetes$k8s_version-client" : get_var('K8S_CLIENT', 'kubernetes-client-provider');
-    zypper_call("in -C $k8s_pkg");
-    record_info('kubectl version', script_output('kubectl version --client'));
+
+    if (is_sle(">=16.0")) {
+        my $arch = (get_required_var("ARCH") eq "x86_64") ? "amd64" : "arm64";
+        $k8s_version = $k8s_version ? $k8s_version : script_output("curl -L -s https://dl.k8s.io/release/stable.txt");
+        assert_script_run "curl -Lo /usr/local/bin/kubectl 'https://dl.k8s.io/release/$k8s_version/bin/linux/$arch/kubectl'";
+        assert_script_run 'chmod +x /usr/local/bin/kubectl';
+    } else {
+        # kubectl is in the container module
+        add_suseconnect_product(get_addon_fullname('contm'));
+        my $k8s_pkg = $k8s_version ? "kubernetes$k8s_version-client" : get_var('K8S_CLIENT', 'kubernetes-client-provider');
+        zypper_call("in -C $k8s_pkg");
+        record_info('kubectl version', script_output('kubectl version --client'));
+    }
 }
 
 =head2 install_helm

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -346,10 +346,10 @@ sub gcloud_install {
     # WARNING:  Python 3.6.x is no longer officially supported by the Google Cloud CLI
     # and may not function correctly. Please use Python version 3.8 and up.
     my @pkgs = qw(curl tar gzip);
-    my $py_version = get_var('PYTHON_VERSION', '3.11');
+    my $py_version = is_sle(">=16.0") ? "3" : get_var('PYTHON_VERSION', '3.11');
     my $py_pkg_version = $py_version =~ s/\.//gr;
     push @pkgs, 'python' . $py_pkg_version;
-    add_suseconnect_product(get_addon_fullname('python3')) if is_sle('15-SP6+');
+    add_suseconnect_product(get_addon_fullname('python3')) if (is_sle('15-SP6+') && is_sle("<16.0"));
 
     zypper_call("in @pkgs", $timeout);
 


### PR DESCRIPTION
- `install_kubectl`: Fetch from upstream k8s on SLES 16.0 as no kubernetes provider package is available.
- `gcloud_install`: python3 module is not available on SLES 16.0

Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2818
Related ticket: https://progress.opensuse.org/issues/199754

Verification runs:
- SLES 16.0: https://openqa.suse.de/tests/22047633

Notes
- aws-cli & azure-cli are not present on SLES 16.1: https://openqa.suse.de/tests/22047632
- Update schedule in qac-openqa-yaml
