### PR TITLE
Fix non-root iscsi setting and validation for /home partition

### DIFF
--- a/data/yam/agama/auto/lib/iscsi.libsonnet
+++ b/data/yam/agama/auto/lib/iscsi.libsonnet
@@ -7,7 +7,7 @@
         port: 3260,
         name: 'iqn.2016-02.openqa.de:for.openqa',
         interface: 'default',
-        startup: 'onboot',
+        startup: 'automatic',
       },
     ],
   },

--- a/schedule/yam/agama_iscsi_activate_unattended.yaml
+++ b/schedule/yam/agama_iscsi_activate_unattended.yaml
@@ -7,5 +7,6 @@ schedule:
   - yam/agama/agama_auto
   - installation/grub_test
   - installation/first_boot
+  - console/verify_separate_home
   - console/validate_partition_table
   - console/validate_blockdevices


### PR DESCRIPTION
##
For non-root iscsi volumes mounted automatically by iscsi.service unit should be set to "automatic" and We need to add validation for /home partition.

- Releted info: 
  - https://bugzilla.suse.com/show_bug.cgi?id=1255685#c47
- Related ticket: Quick PR
- Needles: 
  - N/A
- Verification run: 
  - https://openqa.suse.de/tests/22041182

##