### PR TITLE
xfstests: Fix link wrong install dir issue

### DIFF
--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -83,12 +83,7 @@ sub install_xfstests_from_repo {
     else {
         zypper_call('in ' . join(' ', @PACKAGES));
     }
-    if (is_sle) {
-        script_run 'ln -s /var/lib/xfstests /opt/xfstests';
-    }
-    elsif (is_tumbleweed || is_leap) {
-        script_run 'ln -s /usr/lib/xfstests /opt/xfstests';
-    }
+    script_run 'if [ -d /usr/lib/xfstests ]; then ln -s /usr/lib/xfstests /opt/xfstests; else ln -s /var/lib/xfstests /opt/xfstests; fi';
 }
 
 # Create log file used to generate junit xml report

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -134,7 +134,6 @@ sub do_partition_for_xfstests {
     # Create mount points
     script_run("mkdir $TEST_FOLDER $SCRATCH_FOLDER");
     # Setup configure file xfstests/local.config
-    script_run("mkdir -p \$(dirname $CONFIG_FILE)");
     script_run("echo 'export FSTYP=$para{fstype}' >> $CONFIG_FILE") if ($para{fstype} !~ /overlay/);
     script_run("echo 'export TEST_DEV=$test_dev' >> $CONFIG_FILE");
     set_var('XFSTESTS_TEST_DEV', $test_dev);


### PR DESCRIPTION
The ibs/obs xfstests repo has some changes to install xfstests from /var/lib/xfstest to /usr/lib/xfstests in some products. This makes the following steps write command to xfstests/local.config have some problems

- Related ticket: https://progress.opensuse.org/issues/199373
- Verification run: 
- New installation in SLE: https://openqa.suse.de/tests/22053060
- The following tests will not fail in the partition.pm part: https://openqa.suse.de/tests/22053106#step/partition/92
- New installation in TW: https://openqa.opensuse.org/tests/5881613 and its following subtests https://openqa.opensuse.org/tests/5881628