### PR TITLE
Adapt helm test code to work on SLES 16.1

### DIFF
--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -69,7 +69,8 @@ sub run {
         elsif ($k8s_backend eq 'AZURE') {
             add_suseconnect_product(get_addon_fullname('pcm'), (is_sle('=12-sp5') ? '12' : undef)) if is_sle("<16");
             add_suseconnect_product(get_addon_fullname('phub')) if is_sle('=12-sp5');
-            zypper_call('in jq azure-cli', timeout => 300);
+            my $az_cli_pkg = is_sle(">16.0") ? 'az-cli-cmd' : 'azure-cli';
+            zypper_call("in jq $az_cli_pkg", timeout => 300);
 
             # publiccloud::azure_client needs to demand PUBLIC_CLOUD_REGION due to other places where
             # we don't want to have defaults and want tests to fail when region is not defined

--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -53,7 +53,12 @@ sub run {
         if ($k8s_backend eq "EC2") {
             add_suseconnect_product(get_addon_fullname('pcm')) if is_sle("<16");
             my $aws_cli_pkg = is_sle(">16.0") ? 'aws-cli-cmd' : 'aws-cli';
-            zypper_call("in jq $aws_cli_pkg", timeout => 300);
+            my $rc = zypper_call("in jq $aws_cli_pkg", exitcode => [0, 104], timeout => 300);
+            if ($rc && is_sle(">16.0")) {
+                # https://src.suse.de/products/SLFO/pulls/4071
+                record_soft_failure("ssd#products/SLFO#4071 - New packages: aws-cli-cmd, az-cli-cmd");
+                return;
+            }
 
             # publiccloud::aws_client needs to demand PUBLIC_CLOUD_REGION due to other places where
             # we don't want to have defaults and want tests to fail when region is not defined
@@ -70,7 +75,12 @@ sub run {
             add_suseconnect_product(get_addon_fullname('pcm'), (is_sle('=12-sp5') ? '12' : undef)) if is_sle("<16");
             add_suseconnect_product(get_addon_fullname('phub')) if is_sle('=12-sp5');
             my $az_cli_pkg = is_sle(">16.0") ? 'az-cli-cmd' : 'azure-cli';
-            zypper_call("in jq $az_cli_pkg", timeout => 300);
+            my $rc = zypper_call("in jq $az_cli_pkg", exitcode => [0, 104], timeout => 300);
+            if ($rc && is_sle(">16.0")) {
+                # https://src.suse.de/products/SLFO/pulls/4071
+                record_soft_failure("ssd#products/SLFO#4071 - New packages: aws-cli-cmd, az-cli-cmd");
+                return;
+            }
 
             # publiccloud::azure_client needs to demand PUBLIC_CLOUD_REGION due to other places where
             # we don't want to have defaults and want tests to fail when region is not defined

--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -52,7 +52,8 @@ sub run {
         # Configure the public cloud kubernetes
         if ($k8s_backend eq "EC2") {
             add_suseconnect_product(get_addon_fullname('pcm')) if is_sle("<16");
-            zypper_call("in jq aws-cli", timeout => 300);
+            my $aws_cli_pkg = is_sle(">16.0") ? 'aws-cli-cmd' : 'aws-cli';
+            zypper_call("in jq $aws_cli_pkg", timeout => 300);
 
             # publiccloud::aws_client needs to demand PUBLIC_CLOUD_REGION due to other places where
             # we don't want to have defaults and want tests to fail when region is not defined


### PR DESCRIPTION
SLES 16.1 will have shiny new packages replacing aws-cli & azure-cli: aws-cli-cmd & azure-cli-cmd.  SLES 16.0 has both.

Add soft-failure to be removed when https://src.suse.de/products/SLFO/pulls/4071 is solved.

Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2823
Related ticket: https://progress.opensuse.org/issues/199754
Verification run: https://openqa.suse.de/tests/22065432
