### PR TITLE
nfs: Adapt NFS-multimachine tests to immutable systems

### DIFF
--- a/lib/Kernel/nfs.pm
+++ b/lib/Kernel/nfs.pm
@@ -1,0 +1,111 @@
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package Kernel::nfs;
+
+use base Exporter;
+
+use strict;
+use warnings;
+use testapi;
+
+our @EXPORT = qw(
+  mount_share
+  create_mount_and_export
+  nfs_verify_checksums
+  nfs_export_path
+  nfs_local_path
+);
+
+=head1 SYNOPSIS
+
+Shared helpers for kernel NFS tests.
+
+=cut
+
+=head2 mount_share
+
+    mount_share($server, $share, $local, $opts);
+
+Creates a local directory and mounts an NFS share with the given options.
+
+=cut
+
+sub mount_share {
+    my ($server, $share, $local, $opts) = @_;
+
+    assert_script_run("mkdir -p $local");
+    assert_script_run("mount -t nfs -o $opts $server:$share $local");
+}
+
+=head2 create_mount_and_export
+
+    create_mount_and_export($mountpoint, $client, $permissions);
+
+Create a server export directory and add it to F</etc/exports>.
+
+=cut
+
+sub create_mount_and_export {
+    my ($mountpoint, $client, $permissions) = @_;
+
+    assert_script_run("mkdir -p $mountpoint");
+    assert_script_run("chmod 777 $mountpoint");
+    assert_script_run("echo $mountpoint $client\\($permissions\\) >> /etc/exports");
+}
+
+=head2 nfs_verify_checksums
+
+    nfs_verify_checksums($path);
+
+Verify the checksum file created by the NFS client in the export directory.
+
+=cut
+
+sub nfs_verify_checksums {
+    my ($path) = @_;
+
+    record_info('NFS list files', script_output("ls -la $path"));
+    assert_script_run("cd $path && md5sum -c md5sum.txt");
+    record_info('NFS checksum', script_output("cat $path/md5sum.txt"));
+}
+
+=head2 nfs_export_path
+
+    nfs_export_path(version => 'V3', async => 0);
+
+Return the server-side export path for a given NFS version.
+
+=cut
+
+sub nfs_export_path {
+    my %args = @_;
+    my $version = $args{version} // die 'NFS version is required';
+    (my $version_number = $version) =~ s/^V//;
+    my $async = $args{async} // 0;
+    my $suffix = $async ? '_ASYNC' : '';
+    my $path_suffix = $async ? '_async' : '';
+
+    return get_var("NFS_MOUNT_NFS$version_number$suffix", "/var/lib/nfs-tests/shared_nfs$version_number$path_suffix");
+}
+
+=head2 nfs_local_path
+
+    nfs_local_path(version => 'V4', async => 1);
+
+Return the client-side local mount point for a given NFS version.
+
+=cut
+
+sub nfs_local_path {
+    my %args = @_;
+    my $version = $args{version} // die 'NFS version is required';
+    (my $version_number = $version) =~ s/^V//;
+    my $async = $args{async} // 0;
+    my $suffix = $async ? '_ASYNC' : '';
+    my $path_suffix = $async ? 'async' : '';
+
+    return get_var("NFS_LOCAL_NFS$version_number$suffix", "/var/lib/nfs-tests/localNFS$version_number$path_suffix");
+}
+
+1;

--- a/tests/kernel/kdump_over_nfs.pm
+++ b/tests/kernel/kdump_over_nfs.pm
@@ -23,6 +23,7 @@ sub run {
     my ($self) = @_;
     my $role = get_required_var('ROLE');
     my $nfs_server = get_var('NFS_SERVER', 'server-node00');
+    my $nfs_mount_nfs3 = get_var('NFS_MOUNT_NFS3', '/var/lib/nfs-tests/shared_nfs3');
 
     get_required_var('KDUMP_SAVEDIR');
 
@@ -30,7 +31,7 @@ sub run {
 
     #Specific wicked workaround for SLE15 - allow connection from all hosts
     if ($role eq 'nfs_server') {
-        assert_script_run("echo '/nfs/shared_nfs3 10.0.2.0/24(rw,sync,no_subtree_check,no_root_squash)' > /etc/exports");
+        assert_script_run("echo '$nfs_mount_nfs3 10.0.2.0/24(rw,sync,no_subtree_check,no_root_squash)' > /etc/exports");
         assert_script_run("exportfs -ra");
     }
 
@@ -38,7 +39,7 @@ sub run {
 
     if ($role eq 'nfs_client') {
         assert_script_run("mkdir -p /var/crash");
-        assert_script_run("echo \"$nfs_server:/nfs/shared_nfs3 /var/crash nfs nfsvers=3,sync,nofail,x-systemd.automount 0 0\" >> /etc/fstab");
+        assert_script_run("echo \"$nfs_server:$nfs_mount_nfs3 /var/crash nfs nfsvers=3,sync,nofail,x-systemd.automount 0 0\" >> /etc/fstab");
         assert_script_run("mount -a");
 
         configure_service(test_type => 'function', yast_interface => 'cli');

--- a/tests/kernel/kdump_over_nfs.pm
+++ b/tests/kernel/kdump_over_nfs.pm
@@ -30,7 +30,7 @@ sub run {
 
     #Specific wicked workaround for SLE15 - allow connection from all hosts
     if ($role eq 'nfs_server') {
-        assert_script_run("echo '/nfs/shared_nfs3 10.0.2.0/24(rw,sync,no_subtree_check,no_root_squash)' > /etc/exports");
+        assert_script_run("echo '/var/lib/nfs-tests/shared_nfs3 10.0.2.0/24(rw,sync,no_subtree_check,no_root_squash)' > /etc/exports");
         assert_script_run("exportfs -ra");
     }
 
@@ -38,7 +38,7 @@ sub run {
 
     if ($role eq 'nfs_client') {
         assert_script_run("mkdir -p /var/crash");
-        assert_script_run("echo \"$nfs_server:/nfs/shared_nfs3 /var/crash nfs nfsvers=3,sync,nofail,x-systemd.automount 0 0\" >> /etc/fstab");
+        assert_script_run("echo \"$nfs_server:/var/lib/nfs-tests/shared_nfs3 /var/crash nfs nfsvers=3,sync,nofail,x-systemd.automount 0 0\" >> /etc/fstab");
         assert_script_run("mount -a");
 
         configure_service(test_type => 'function', yast_interface => 'cli');

--- a/tests/kernel/nfs_client.pm
+++ b/tests/kernel/nfs_client.pm
@@ -15,6 +15,7 @@ use testapi;
 use serial_terminal "select_serial_terminal";
 use lockapi;
 use utils;
+use package_utils 'install_package';
 
 sub copy_file {
     my ($flag, $nfs_mount, $file) = @_;
@@ -26,12 +27,16 @@ sub run {
     record_info("hostname", script_output("hostname"));
     my $server_node = get_var('SERVER_NODE', 'server-node00');
 
-    zypper_call("in nfs-client");
+    install_package('nfs-client', trup_apply => 1);
 
-    my $local_nfs3 = get_var('NFS_LOCAL_NFS3', '/home/localNFS3');
-    my $local_nfs3_async = get_var('NFS_LOCAL_NFS3_ASYNC', '/home/localNFS3async');
-    my $local_nfs4 = get_var('NFS_LOCAL_NFS4', '/home/localNFS4');
-    my $local_nfs4_async = get_var('NFS_LOCAL_NFS4_ASYNC', '/home/localNFS4async');
+    my $nfs_mount_nfs3 = get_var('NFS_MOUNT_NFS3', '/var/lib/nfs-tests/shared_nfs3');
+    my $nfs_mount_nfs3_async = get_var('NFS_MOUNT_NFS3_ASYNC', '/var/lib/nfs-tests/shared_nfs3_async');
+    my $nfs_mount_nfs4 = get_var('NFS_MOUNT_NFS4', '/var/lib/nfs-tests/shared_nfs4');
+    my $nfs_mount_nfs4_async = get_var('NFS_MOUNT_NFS4_ASYNC', '/var/lib/nfs-tests/shared_nfs4_async');
+    my $local_nfs3 = get_var('NFS_LOCAL_NFS3', '/var/lib/nfs-tests/localNFS3');
+    my $local_nfs3_async = get_var('NFS_LOCAL_NFS3_ASYNC', '/var/lib/nfs-tests/localNFS3async');
+    my $local_nfs4 = get_var('NFS_LOCAL_NFS4', '/var/lib/nfs-tests/localNFS4');
+    my $local_nfs4_async = get_var('NFS_LOCAL_NFS4_ASYNC', '/var/lib/nfs-tests/localNFS4async');
     my $multipath = get_var('NFS_MULTIPATH', '0');
 
     # check kernel config options and set the variables
@@ -54,18 +59,18 @@ sub run {
 
     if ($kernel_nfs3 == 1) {
         record_info('INFO', 'Kernel has support for NFSv3');
-        assert_script_run("mkdir $local_nfs3 $local_nfs3_async");
-        assert_script_run("mount -t nfs -o nfsvers=3,sync $server_node:/nfs/shared_nfs3 $local_nfs3");
-        assert_script_run("mount -t nfs -o nfsvers=3 $server_node:/nfs/shared_nfs3_async $local_nfs3_async");
+        assert_script_run("mkdir -p $local_nfs3 $local_nfs3_async");
+        assert_script_run("mount -t nfs -o nfsvers=3,sync $server_node:$nfs_mount_nfs3 $local_nfs3");
+        assert_script_run("mount -t nfs -o nfsvers=3 $server_node:$nfs_mount_nfs3_async $local_nfs3_async");
     } else {
         record_info('INFO', 'Kernel has no support for NFSv3, skipping NFSv3 tests');
     }
 
     if ($kernel_nfs4 == 1) {
         record_info('INFO', 'Kernel has support for NFSv4');
-        assert_script_run("mkdir $local_nfs4 $local_nfs4_async");
-        assert_script_run("mount -t nfs -o nfsvers=4,sync $server_node:/nfs/shared_nfs4 $local_nfs4");
-        assert_script_run("mount -t nfs -o nfsvers=4 $server_node:/nfs/shared_nfs4_async $local_nfs4_async");
+        assert_script_run("mkdir -p $local_nfs4 $local_nfs4_async");
+        assert_script_run("mount -t nfs -o nfsvers=4,sync $server_node:$nfs_mount_nfs4 $local_nfs4");
+        assert_script_run("mount -t nfs -o nfsvers=4 $server_node:$nfs_mount_nfs4_async $local_nfs4_async");
     } else {
         record_info('INFO', 'Kernel has no support for NFSv4, skipping NFSv4tests');
     }

--- a/tests/kernel/nfs_client.pm
+++ b/tests/kernel/nfs_client.pm
@@ -16,6 +16,7 @@ use serial_terminal "select_serial_terminal";
 use lockapi;
 use utils;
 use package_utils 'install_package';
+use Kernel::nfs;
 
 sub copy_file {
     my ($flag, $nfs_mount, $file) = @_;
@@ -29,14 +30,14 @@ sub run {
 
     install_package('nfs-client', trup_apply => 1);
 
-    my $nfs_mount_nfs3 = get_var('NFS_MOUNT_NFS3', '/var/lib/nfs-tests/shared_nfs3');
-    my $nfs_mount_nfs3_async = get_var('NFS_MOUNT_NFS3_ASYNC', '/var/lib/nfs-tests/shared_nfs3_async');
-    my $nfs_mount_nfs4 = get_var('NFS_MOUNT_NFS4', '/var/lib/nfs-tests/shared_nfs4');
-    my $nfs_mount_nfs4_async = get_var('NFS_MOUNT_NFS4_ASYNC', '/var/lib/nfs-tests/shared_nfs4_async');
-    my $local_nfs3 = get_var('NFS_LOCAL_NFS3', '/var/lib/nfs-tests/localNFS3');
-    my $local_nfs3_async = get_var('NFS_LOCAL_NFS3_ASYNC', '/var/lib/nfs-tests/localNFS3async');
-    my $local_nfs4 = get_var('NFS_LOCAL_NFS4', '/var/lib/nfs-tests/localNFS4');
-    my $local_nfs4_async = get_var('NFS_LOCAL_NFS4_ASYNC', '/var/lib/nfs-tests/localNFS4async');
+    my $nfs_mount_nfs3 = nfs_export_path(version => 'V3');
+    my $nfs_mount_nfs3_async = nfs_export_path(version => 'V3', async => 1);
+    my $nfs_mount_nfs4 = nfs_export_path(version => 'V4');
+    my $nfs_mount_nfs4_async = nfs_export_path(version => 'V4', async => 1);
+    my $local_nfs3 = nfs_local_path(version => 'V3');
+    my $local_nfs3_async = nfs_local_path(version => 'V3', async => 1);
+    my $local_nfs4 = nfs_local_path(version => 'V4');
+    my $local_nfs4_async = nfs_local_path(version => 'V4', async => 1);
     my $multipath = get_var('NFS_MULTIPATH', '0');
 
     # check kernel config options and set the variables
@@ -59,18 +60,16 @@ sub run {
 
     if ($kernel_nfs3 == 1) {
         record_info('INFO', 'Kernel has support for NFSv3');
-        assert_script_run("mkdir -p $local_nfs3 $local_nfs3_async");
-        assert_script_run("mount -t nfs -o nfsvers=3,sync $server_node:$nfs_mount_nfs3 $local_nfs3");
-        assert_script_run("mount -t nfs -o nfsvers=3 $server_node:$nfs_mount_nfs3_async $local_nfs3_async");
+        mount_share($server_node, $nfs_mount_nfs3, $local_nfs3, 'nfsvers=3,sync');
+        mount_share($server_node, $nfs_mount_nfs3_async, $local_nfs3_async, 'nfsvers=3');
     } else {
         record_info('INFO', 'Kernel has no support for NFSv3, skipping NFSv3 tests');
     }
 
     if ($kernel_nfs4 == 1) {
         record_info('INFO', 'Kernel has support for NFSv4');
-        assert_script_run("mkdir -p $local_nfs4 $local_nfs4_async");
-        assert_script_run("mount -t nfs -o nfsvers=4,sync $server_node:$nfs_mount_nfs4 $local_nfs4");
-        assert_script_run("mount -t nfs -o nfsvers=4 $server_node:$nfs_mount_nfs4_async $local_nfs4_async");
+        mount_share($server_node, $nfs_mount_nfs4, $local_nfs4, 'nfsvers=4,sync');
+        mount_share($server_node, $nfs_mount_nfs4_async, $local_nfs4_async, 'nfsvers=4');
     } else {
         record_info('INFO', 'Kernel has no support for NFSv4, skipping NFSv4tests');
     }

--- a/tests/kernel/nfs_server.pm
+++ b/tests/kernel/nfs_server.pm
@@ -29,16 +29,7 @@ use lockapi;
 use utils;
 use Utils::Logging "export_logs_basic";
 use package_utils 'install_package';
-
-# create a mountpoint and the corresponding export with
-# specified permissions
-sub create_mount_and_export {
-    my ($mountpoint, $cl, $permissions) = @_;
-
-    assert_script_run "mkdir -p $mountpoint";
-    assert_script_run "chmod 777 $mountpoint";
-    assert_script_run "echo $mountpoint $cl\\($permissions\\) >> /etc/exports";
-}
+use Kernel::nfs;
 
 sub compare_checksums {
     my ($file) = @_;
@@ -67,10 +58,10 @@ sub run {
     select_serial_terminal();
     record_info("hostname", script_output("hostname"));
 
-    my $nfs_mount_nfs3 = get_var('NFS_MOUNT_NFS3', '/var/lib/nfs-tests/shared_nfs3');
-    my $nfs_mount_nfs3_async = get_var('NFS_MOUNT_NFS3_ASYNC', '/var/lib/nfs-tests/shared_nfs3_async');
-    my $nfs_mount_nfs4 = get_var('NFS_MOUNT_NFS4', '/var/lib/nfs-tests/shared_nfs4');
-    my $nfs_mount_nfs4_async = get_var('NFS_MOUNT_NFS4_ASYNC', '/var/lib/nfs-tests/shared_nfs4_async');
+    my $nfs_mount_nfs3 = nfs_export_path(version => 'V3');
+    my $nfs_mount_nfs3_async = nfs_export_path(version => 'V3', async => 1);
+    my $nfs_mount_nfs4 = nfs_export_path(version => 'V4');
+    my $nfs_mount_nfs4_async = nfs_export_path(version => 'V4', async => 1);
 
     my $nfs_permissions = get_var('NFS_PERMISSIONS', 'rw,sync,no_root_squash');
     my $nfs_permissions_async = get_var('NFS_PERMISSIONS_ASYNC', 'rw,async,no_root_squash');
@@ -132,8 +123,7 @@ sub run {
 
         assert_script_run("cd $nfs_mount_nfs3");
 
-        assert_script_run("md5sum -c md5sum.txt");
-        record_info("NFS3 checksum", script_output("md5sum -c md5sum.txt"));
+        nfs_verify_checksums($nfs_mount_nfs3);
         record_info("NFS3 checksum", script_output("cat md5sum.txt"));
 
         #check files copied with various flags: direct, dsync, sync
@@ -145,8 +135,7 @@ sub run {
         record_info("TESTS: NFS3 async");
 
         assert_script_run("cd $nfs_mount_nfs3_async");
-        assert_script_run("md5sum -c md5sum.txt");
-        record_info("NFS3 async checksum", script_output("md5sum -c md5sum.txt"));
+        nfs_verify_checksums($nfs_mount_nfs3_async);
 
         #check files copied with various flags: direct, dsync, sync
         compare_checksums($file_flag_direct);
@@ -159,8 +148,7 @@ sub run {
         record_info("TESTS: NFS4");
 
         assert_script_run("cd $nfs_mount_nfs4");
-        assert_script_run("md5sum -c md5sum.txt");
-        record_info("NFS4 checksum", script_output("md5sum -c md5sum.txt"));
+        nfs_verify_checksums($nfs_mount_nfs4);
 
         #check files copied with various flags: direct, dsync, sync
         compare_checksums($file_flag_direct);
@@ -171,8 +159,7 @@ sub run {
         record_info("TESTS: NFS4 async");
 
         assert_script_run("cd $nfs_mount_nfs4_async");
-        assert_script_run("md5sum -c md5sum.txt");
-        record_info("NFS4 async checksum", script_output("md5sum -c md5sum.txt"));
+        nfs_verify_checksums($nfs_mount_nfs4_async);
 
         #check files copied with various flags: direct, dsync, sync
         compare_checksums($file_flag_direct);

--- a/tests/kernel/nfs_server.pm
+++ b/tests/kernel/nfs_server.pm
@@ -28,6 +28,7 @@ use serial_terminal "select_serial_terminal";
 use lockapi;
 use utils;
 use Utils::Logging "export_logs_basic";
+use package_utils 'install_package';
 
 # create a mountpoint and the corresponding export with
 # specified permissions
@@ -66,10 +67,10 @@ sub run {
     select_serial_terminal();
     record_info("hostname", script_output("hostname"));
 
-    my $nfs_mount_nfs3 = get_var('NFS_MOUNT_NFS3', '/nfs/shared_nfs3');
-    my $nfs_mount_nfs3_async = get_var('NFS_MOUNT_NFS3_ASYNC', '/nfs/shared_nfs3_async');
-    my $nfs_mount_nfs4 = get_var('NFS_MOUNT_NFS4', '/nfs/shared_nfs4');
-    my $nfs_mount_nfs4_async = get_var('NFS_MOUNT_NFS4_ASYNC', '/nfs/shared_nfs4_async');
+    my $nfs_mount_nfs3 = get_var('NFS_MOUNT_NFS3', '/var/lib/nfs-tests/shared_nfs3');
+    my $nfs_mount_nfs3_async = get_var('NFS_MOUNT_NFS3_ASYNC', '/var/lib/nfs-tests/shared_nfs3_async');
+    my $nfs_mount_nfs4 = get_var('NFS_MOUNT_NFS4', '/var/lib/nfs-tests/shared_nfs4');
+    my $nfs_mount_nfs4_async = get_var('NFS_MOUNT_NFS4_ASYNC', '/var/lib/nfs-tests/shared_nfs4_async');
 
     my $nfs_permissions = get_var('NFS_PERMISSIONS', 'rw,sync,no_root_squash');
     my $nfs_permissions_async = get_var('NFS_PERMISSIONS_ASYNC', 'rw,async,no_root_squash');
@@ -88,7 +89,7 @@ sub run {
     my $file_flag_sync = 'testfile_oflag_sync';
 
     # provision NFS server(s) of various types
-    zypper_call("in nfs-kernel-server");
+    install_package('nfs-kernel-server', trup_apply => 1);
 
     # configure our exports
     if ($kernel_nfs3 == 1) {
@@ -125,7 +126,7 @@ sub run {
     barrier_wait("NFS_SERVER_CHECK");
 
     if ($kernel_nfs3 == 1) {
-        #checking files in /nfs/shared_nfs3
+        #checking files in NFSv3 sync export
         record_info("TESTS: NFS3");
         record_info("NFS3 list all files", script_output("ls $nfs_mount_nfs3"));
 
@@ -140,7 +141,7 @@ sub run {
         compare_checksums($file_flag_dsync);
         compare_checksums($file_flag_sync);
 
-        #checking files in /nfs/shared_nfs3_async
+        #checking files in NFSv3 async export
         record_info("TESTS: NFS3 async");
 
         assert_script_run("cd $nfs_mount_nfs3_async");
@@ -154,7 +155,7 @@ sub run {
     }
 
     if ($kernel_nfs4 == 1) {
-        #checking files in /nfs/shared_nfs4
+        #checking files in NFSv4 sync export
         record_info("TESTS: NFS4");
 
         assert_script_run("cd $nfs_mount_nfs4");
@@ -166,7 +167,7 @@ sub run {
         compare_checksums($file_flag_dsync);
         compare_checksums($file_flag_sync);
 
-        #checking files in /nfs/shared_nfs4_async
+        #checking files in NFSv4 async export
         record_info("TESTS: NFS4 async");
 
         assert_script_run("cd $nfs_mount_nfs4_async");

--- a/tests/kernel/nfs_server.pm
+++ b/tests/kernel/nfs_server.pm
@@ -28,6 +28,7 @@ use serial_terminal "select_serial_terminal";
 use lockapi;
 use utils;
 use Utils::Logging "export_logs_basic";
+use package_utils 'install_package';
 
 # create a mountpoint and the corresponding export with
 # specified permissions
@@ -66,10 +67,10 @@ sub run {
     select_serial_terminal();
     record_info("hostname", script_output("hostname"));
 
-    my $nfs_mount_nfs3 = get_var('NFS_MOUNT_NFS3', '/nfs/shared_nfs3');
-    my $nfs_mount_nfs3_async = get_var('NFS_MOUNT_NFS3_ASYNC', '/nfs/shared_nfs3_async');
-    my $nfs_mount_nfs4 = get_var('NFS_MOUNT_NFS4', '/nfs/shared_nfs4');
-    my $nfs_mount_nfs4_async = get_var('NFS_MOUNT_NFS4_ASYNC', '/nfs/shared_nfs4_async');
+    my $nfs_mount_nfs3 = get_var('NFS_MOUNT_NFS3', '/var/lib/nfs-tests/shared_nfs3');
+    my $nfs_mount_nfs3_async = get_var('NFS_MOUNT_NFS3_ASYNC', '/var/lib/nfs-tests/shared_nfs3_async');
+    my $nfs_mount_nfs4 = get_var('NFS_MOUNT_NFS4', '/var/lib/nfs-tests/shared_nfs4');
+    my $nfs_mount_nfs4_async = get_var('NFS_MOUNT_NFS4_ASYNC', '/var/lib/nfs-tests/shared_nfs4_async');
 
     my $nfs_permissions = get_var('NFS_PERMISSIONS', 'rw,sync,no_root_squash');
     my $nfs_permissions_async = get_var('NFS_PERMISSIONS_ASYNC', 'rw,async,no_root_squash');
@@ -88,7 +89,7 @@ sub run {
     my $file_flag_sync = 'testfile_oflag_sync';
 
     # provision NFS server(s) of various types
-    zypper_call("in nfs-kernel-server");
+    install_package('nfs-kernel-server', trup_apply => 1);
 
     # configure our exports
     if ($kernel_nfs3 == 1) {

--- a/tests/kernel/nfs_stress_ng.pm
+++ b/tests/kernel/nfs_stress_ng.pm
@@ -19,6 +19,7 @@ use utils;
 use registration;
 use version_utils 'is_sle';
 use repo_tools 'add_qa_head_repo';
+use package_utils 'install_package';
 
 sub check_nfs_mounts {
     my @paths = @_;
@@ -73,8 +74,8 @@ sub server {
 
 sub client {
     my ($self) = @_;
-    my $local_nfs4 = "/home/localNFS4";
-    my $local_nfs4_async = "/home/localNFS4async";
+    my $local_nfs4 = get_var('NFS_LOCAL_NFS4', '/var/lib/nfs-tests/localNFS4');
+    my $local_nfs4_async = get_var('NFS_LOCAL_NFS4_ASYNC', '/var/lib/nfs-tests/localNFS4async');
     my $stressor_timeout = get_var('NFS_STRESS_NG_TIMEOUT') // 3;
     my $exclude = get_var('NFS_STRESS_NG_EXCLUDE');
     # allow to override the default exports
@@ -98,7 +99,7 @@ sub client {
         }
     }
 
-    zypper_call("in stress-ng");
+    install_package('stress-ng', trup_apply => 1);
 
     select_user_serial_terminal;
     assert_script_run("stress-ng --class 'filesystem?'");

--- a/tests/kernel/nfs_stress_ng.pm
+++ b/tests/kernel/nfs_stress_ng.pm
@@ -17,7 +17,7 @@ use serial_terminal;
 use lockapi;
 use utils;
 use registration;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_transactional);
 use repo_tools 'add_qa_head_repo';
 use package_utils 'install_package';
 
@@ -99,7 +99,7 @@ sub client {
         }
     }
 
-    install_package('stress-ng', trup_apply => 1);
+    install_package('stress-ng', trup_continue => 1, trup_apply => 1);
 
     select_user_serial_terminal;
     assert_script_run("stress-ng --class 'filesystem?'");


### PR DESCRIPTION
Replace zypper_call with install_package(trup_apply => 1) so packages
can be installed on read-only root (transactional) systems.

Update default export and local-mount paths from /nfs/shared_* and
/home/localNFS* to /var/lib/nfs-tests/* which is writable on immutable
systems. All paths remain overridable via openQA variables.

- Related ticket: https://progress.opensuse.org/issues/199883

- Verification runs: 
  - immutable system: 
    - support_server: https://openqa.suse.de/tests/22689445
    - nfs_client: https://openqa.suse.de/tests/22689446
    - nfs_server: https://openqa.suse.de/tests/22689444
note: kdump over nfs fails, see: https://bugzilla.suse.com/show_bug.cgi?id=1262735
note the stress-ng works as expected.

  - regular system:
    - support_server: https://openqa.suse.de/tests/22689447
    - nfs_client: https://openqa.suse.de/tests/22689448
    - nfs_server: https://openqa.suse.de/tests/22689449