### PR TITLE
Run efi verification module only on x86_64 and arm64

### DIFF
--- a/schedule/jeos/sle/minimalvm-main.yaml
+++ b/schedule/jeos/sle/minimalvm-main.yaml
@@ -33,8 +33,10 @@ conditional_schedule:
             'ppc64le-p10':
                 - installation/bootloader_uefi
     efi:
-        UEFI:
-            '1':
+        MACHINE:
+            'uefi-virtio-vga':
+                - console/verify_efi_mok
+            'aarch64':
                 - console/verify_efi_mok
     maintenance:
         FLAVOR:


### PR DESCRIPTION
Main motivation is that NVRAM in vmware hosts sporadically report NVRAM space issues as
https://openqa.suse.de/tests/22026676#step/verify_efi_mok/6.

As we are not admins of the machines, lets for now, run the test module only on intel and arm machines.

- Verification run: N/A
