### PR TITLE
Limit Cloud jobs to get pcmk_delay_max only on SBD scenario

### DIFF
--- a/lib/sles4sap/publiccloud.pm
+++ b/lib/sles4sap/publiccloud.pm
@@ -889,17 +889,13 @@ sub sbd_delay_formula() {
     # all commands below ($corosync_token, $corosync_consensus...)
     # are defined and imported from lib/hacluster.pm
 
-    # We need to know first the correct name of the fence_sbd primitive in the
-    # remote cluster configuration
-    my $primitive_name = get_fencing_ra_name($self->run_cmd(cmd => $crm_config_show_fence_sbd));
-
     my %params = (
         'corosync_token' => $self->run_cmd(cmd => $corosync_token),
         'corosync_consensus' => $self->run_cmd(cmd => $corosync_consensus),
         'sbd_watchdog_timeout' => $self->run_cmd(cmd => $sbd_watchdog_timeout),
         'sbd_delay_start' => $self->run_cmd(cmd => $sbd_delay_start),
-        'pcmk_delay_max' => get_var('FENCING_MECHANISM') eq 'sbd' ?
-          $self->run_cmd(cmd => pcmk_delay_max_cmd($primitive_name)) : 30
+        'pcmk_delay_max' => check_var('FENCING_MECHANISM', 'sbd') ?
+          $self->run_cmd(cmd => pcmk_delay_max_cmd(get_fencing_ra_name($self->run_cmd(cmd => $crm_config_show_fence_sbd)))) : 30
     );
     my $calculated_delay = calculate_sbd_start_delay(\%params);
     record_info('SBD wait', "Calculated SBD start delay: $calculated_delay");


### PR DESCRIPTION
Commit 75482e33d64ce51fc36a277dd8a54a6eafc00a8b changed the way the `pcmk_delay_max` attribute is queried in the cluster configuration. Now this is done in 2 steps:

1. First we run `$hacluster::crm_config_show_fence_sbd` in the remote system to get the correct name of the Fencing RA. It could be either `stonith-sbd` or `fencing-sbd` depending on the version of `crmsh`.
2. Then we use the name when calling `hacluster::pcmk_delay_max_cmd()` to get the command to query the `pcmk_delay_max`

These command only make sense when using `stonith-sbd` or `fencing-sbd`; it does not apply to native cloud fencing. However, the commit accidentally left the call to `$hacluster::crm_config_show_fence_sbd` for all scenarios, which has caused failures in Azure jobs using native fencing with SPN and MSI.

This commit fixes it by moving both commands after a check of the value of the **FENCING_MECHANISM** setting.

- Related Ticket: https://jira.suse.com/browse/TEAM-11181
- Needles: N/A
- Verification run: [12-SP5](https://openqaworker15.qe.prg2.suse.org/tests/364531) :green_circle: , [15-SP4](https://openqaworker15.qe.prg2.suse.org/tests/364496) :green_circle: , [15-SP5](https://openqaworker15.qe.prg2.suse.org/tests/364497) :green_circle: , [15-SP6](https://openqaworker15.qe.prg2.suse.org/tests/364498) :green_circle: , [15-SP7](https://openqaworker15.qe.prg2.suse.org/tests/364532) :green_circle: 
