### PR TITLE
provider: improve terraform create and destroy timeout handling

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -471,7 +471,7 @@ Calls terraform tool and applies the corresponding configuration .tf file
 sub terraform_apply {
     my ($self, %args) = @_;
     my $terraform_timeout = get_var('TERRAFORM_TIMEOUT', TERRAFORM_TIMEOUT);
-    my $terraform_vm_create_timeout = get_var('TERRAFORM_VM_CREATE_TIMEOUT');
+    my $terraform_vm_create_timeout = get_var('TERRAFORM_VM_CREATE_TIMEOUT', ($terraform_timeout - 60));
 
     my $image_uri = $self->get_image_uri();
     my $image_id = $self->get_image_id();
@@ -534,7 +534,7 @@ sub terraform_apply {
         $vars{name} = $self->resource_name;
         $vars{project} = $args{project} if ($args{project});
         $vars{cloud_init} = TERRAFORM_DIR . "/cloud-init.yaml" if (get_var('PUBLIC_CLOUD_CLOUD_INIT'));
-        $vars{vm_create_timeout} = $terraform_vm_create_timeout if $terraform_vm_create_timeout;
+        $vars{vm_create_timeout} = $terraform_vm_create_timeout;
         $vars{enable_confidential_vm} = 'true' if ($args{confidential_compute} && is_gce());
         $vars{enable_confidential_vm} = 'enabled' if ($args{confidential_compute} && is_ec2());
         my $root_size = get_var('PUBLIC_CLOUD_ROOT_DISK_SIZE');
@@ -563,7 +563,6 @@ sub terraform_apply {
     # https://developer.hashicorp.com/terraform/internals/debugging
     my $tf_log = get_var("TERRAFORM_LOG", "");
 
-    # The $terraform_timeout must higher than $terraform_vm_create_timeout (See also var.vm_create_timeout in *.tf file)
     my $ret = script_run("set -o pipefail; TF_LOG=$tf_log $runner apply -no-color -input=false myplan 2>&1 | tee tf_apply_output", timeout => $terraform_timeout);
     my $tf_apply_output = script_output('cat tf_apply_output', proceed_on_failure => 1);
     $self->terraform_applied(1);    # Must happen here to prevent resource leakage

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -688,7 +688,7 @@ sub terraform_destroy {
     my $cmd = terraform_cmd($runner . ' destroy -no-color -auto-approve -lock=false', %vars);
     # Retry 3 times with considerable delay. This has been introduced due to poo#95932 (RetryableError)
     # terraform keeps track of the allocated and destroyed resources, so its safe to run this multiple times.
-    my $ret = script_retry($cmd, retry => 3, delay => 60, timeout => get_var('TERRAFORM_TIMEOUT', TERRAFORM_TIMEOUT), die => 0);
+    my $ret = script_retry($cmd, retry => 9, delay => 180, timeout => get_var('TERRAFORM_TIMEOUT', TERRAFORM_TIMEOUT), die => 0);
     unless (defined $ret) {
         if (is_serial_terminal()) {
             type_string(qq(\c\\));    # Send QUIT signal

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -471,7 +471,7 @@ Calls terraform tool and applies the corresponding configuration .tf file
 sub terraform_apply {
     my ($self, %args) = @_;
     my $terraform_timeout = get_var('TERRAFORM_TIMEOUT', TERRAFORM_TIMEOUT);
-    my $terraform_vm_create_timeout = get_var('TERRAFORM_VM_CREATE_TIMEOUT', ($terraform_timeout - 60));
+    my $terraform_vm_create_timeout = $terraform_timeout - 60;
 
     my $image_uri = $self->get_image_uri();
     my $image_id = $self->get_image_id();

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -471,6 +471,7 @@ Calls terraform tool and applies the corresponding configuration .tf file
 sub terraform_apply {
     my ($self, %args) = @_;
     my $terraform_timeout = get_var('TERRAFORM_TIMEOUT', TERRAFORM_TIMEOUT);
+    die('TERRAFORM_TIMEOUT must be greater than 60') if ($terraform_timeout <= 60);
     my $terraform_vm_create_timeout = ($terraform_timeout - 60) . 's';
 
     my $image_uri = $self->get_image_uri();

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -471,7 +471,7 @@ Calls terraform tool and applies the corresponding configuration .tf file
 sub terraform_apply {
     my ($self, %args) = @_;
     my $terraform_timeout = get_var('TERRAFORM_TIMEOUT', TERRAFORM_TIMEOUT);
-    my $terraform_vm_create_timeout = $terraform_timeout - 60;
+    my $terraform_vm_create_timeout = ($terraform_timeout - 60) . 's';
 
     my $image_uri = $self->get_image_uri();
     my $image_id = $self->get_image_id();

--- a/variables.md
+++ b/variables.md
@@ -413,7 +413,6 @@ SCC_PROXY_USERNAME | string | "" | Credentials username for registry which requi
 SCC_PROXY_PASSWORD | string | "" | Credentials password for registry which requires SCC login
 TERRAFORM_VERSION | string | "1.5.7" | Version of terraform to include into PC Tools image
 TERRAFORM_TIMEOUT | integer | 1800 | Set timeout for terraform actions
-TERRAFORM_VM_CREATE_TIMEOUT | string | "20m" | Terraform timeout for creating the virtual machine resource.
 _SECRET_PUBLIC_CLOUD_INSTANCE_SSH_KEY | string | "" | The `~/.ssh/id_rsa` existing key allowed by `PUBLIC_CLOUD_INSTANCE_IP` instance
 _SECRET_PUBLIC_CLOUD_PERF_DB_TOKEN | string | "" | this required variable is the token to access PUBLIC_CLOUD_PERF_DB_URI (defined in `salt workerconf`)
 


### PR DESCRIPTION
Set vm_create_timeout default to (TERRAFORM_TIMEOUT - 60) so it is always passed to terraform, and increase the terraform destroy retry count from 3 to 9 with delay from 60s to 180s to reduce transient failures.

It creates: `-var 'vm_create_timeout=1740s'`

- Related ticket: https://progress.opensuse.org/issues/199820
- Needles: N/A
- Verification run: https://pdostal-workbench.qe.prg2.suse.org/tests/520