### PR TITLE
Improve QDevice/QNetd test for SLES 16.1

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -106,6 +106,7 @@ our @EXPORT = qw(
   get_crmsh_version
   get_fencing_ra_name
   pcmk_delay_max_cmd
+  get_bootstrap_properties
 );
 
 =head1 SYNOPSIS
@@ -2249,6 +2250,47 @@ whatever primitive name is provided as an argument.
 sub pcmk_delay_max_cmd {
     my $primitive_name = shift // get_fencing_ra_name(script_output($crm_config_show_fence_sbd));
     return "crm resource param $primitive_name show pcmk_delay_max | sed 's/[^0-9]*//g'";
+}
+
+=head2 get_bootstrap_properties
+
+    get_bootstrap_properties()
+
+Runs C<crm -D plain configure show cib-bootstrap-options> in the System Under Test and parses
+the output into a Perl HASH.
+
+For example, an output like:
+
+    property cib-bootstrap-options: \
+	dc-version="1.2.3.4" \
+	cluster-infrastructure=corosync \
+	have-watchdog=true \
+	cluster-name=hacluster \
+	stonith-enabled=true \
+	stonith-timeout=71 \
+	priority-fencing-delay=60 \
+	last-lrm-refresh=1777299458';
+
+Would produce a HASH like:
+
+    $VAR1 = {
+          'dc-version' => '"1.2.3.4"',
+          'cluster-infrastructure' => 'corosync',
+          'stonith-enabled' => 'true',
+          'last-lrm-refresh' => '1777299458',
+          'stonith-timeout' => '71',
+          'cluster-name' => 'hacluster',
+          'priority-fencing-delay' => '60',
+          'have-watchdog' => 'true'
+        };
+
+=cut
+
+sub get_bootstrap_properties {
+    my $out = script_output('crm -D plain configure show cib-bootstrap-options');
+    die "cib-bootstrap-options does not start with [property] keyword [$out]" unless ($out =~ /^property/);
+    my %properties = map { /(\S+)=(\S+)/ } split(/\n/, $out);
+    return \%properties;
 }
 
 1;

--- a/t/11_hacluster.t
+++ b/t/11_hacluster.t
@@ -1074,4 +1074,32 @@ subtest '[pcmk_delay_max_cmd] calculate fence_sbd primitive name' => sub {
     $hacluster::crm_config_show_fence_sbd = $orig_fence_sbd_var;
 };
 
+subtest '[get_bootstrap_properties]' => sub {
+    my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
+    my @test_data = ('property cib-bootstrap-options: \
+	dc-version="GENERATION_2" \
+	cluster-infrastructure=corosync \
+	have-watchdog=true \
+	cluster-name=k-tor-cluster \
+	stonith-enabled=true \
+	stonith-timeout=71 \
+	fencing-enabled=true \
+	fencing-timeout=71 \
+	priority-fencing-delay=60 \
+	last-lrm-refresh=1777299458', 'WRONGLY FORMATTED OUTPUT');
+    $hacluster->redefine(script_output => sub { return shift(@test_data); });
+    my $properties = get_bootstrap_properties();
+    is $properties->{'dc-version'}, '"GENERATION_2"', 'Correct dc-version';
+    is $properties->{'cluster-infrastructure'}, 'corosync', 'Correct cluster-infrastructure';
+    is $properties->{'have-watchdog'}, 'true', 'Correct have-watchdog value';
+    is $properties->{'cluster-name'}, 'k-tor-cluster', 'Correct cluster-name';
+    is $properties->{'stonith-enabled'}, 'true', 'Correct stonith-enabled value';
+    is $properties->{'stonith-timeout'}, 71, 'Correct stonith-timeout value';
+    is $properties->{'fencing-enabled'}, 'true', 'Correct fencing-enabled value';
+    is $properties->{'fencing-timeout'}, 71, 'Correct fencing-timeout value';
+    is $properties->{'priority-fencing-delay'}, 60, 'Correct priority-fencing-delay value';
+    is $properties->{'last-lrm-refresh'}, 1777299458, 'Correct last-lrm-refresh';
+    dies_ok { get_bootstrap_properties() } 'Test should die with unexpected output';
+};
+
 done_testing;

--- a/tests/ha/qnetd.pm
+++ b/tests/ha/qnetd.pm
@@ -21,6 +21,7 @@ use hacluster qw(choose_node
   save_state
   wait_for_idle_cluster
   wait_until_resources_started
+  get_bootstrap_properties
 );
 use utils qw(zypper_call exec_and_insert_password);
 use version_utils qw(is_sle);
@@ -80,6 +81,14 @@ sub qdevice_status {
 sub run {
     my $cluster_name = get_cluster_name;
     my $qdevice_check = "/etc/corosync/qdevice/check_master.sh";
+    my $fencing_property = 'stonith-enabled';
+
+    # We will require later in node 1 the correct name of the stonith-enabled/fencing-enabled property
+    if (is_node(1)) {
+        my $cluster_properties = get_bootstrap_properties();
+        $fencing_property = 'fencing-enabled' if (defined $cluster_properties->{'fencing-enabled'});
+        $fencing_property = 'stonith-enabled' if (defined $cluster_properties->{'stonith-enabled'});
+    }
 
     # As this module causes a fence operation, we need to prepare the console for assert_screen
     # on grub2 and bootmenu
@@ -104,20 +113,20 @@ sub run {
         # Add a promotable resource to check if the current node is hosting
         # master instance of the resource. If so, this cluster partition
         # is preferred to be given the vote from qnetd.
-        assert_script_run "EDITOR=\"sed -ie '\$ a primitive stateful-1 ocf:pacemaker:Stateful'\" crm configure edit";
-        assert_script_run "EDITOR=\"sed -ie '\$ a clone promotable-1 stateful-1 meta promotable=true'\" crm configure edit";
+        assert_script_run q|EDITOR="sed -ie '$ a primitive stateful-1 ocf:pacemaker:Stateful'" crm configure edit|;
+        assert_script_run q|EDITOR="sed -ie '$ a clone promotable-1 stateful-1 meta promotable=true'" crm configure edit|;
         save_state;
 
         # Qdevice should be started
         qdevice_status('started');
 
         # Remove qdevice
-        assert_script_run "crm cluster remove --qdevice -y";
+        assert_script_run 'crm -F cluster remove --qdevice -y';
         # Qdevice should be stopped
         qdevice_status('stopped');
 
         # Add qdevice to a running cluster with heuristic check
-        assert_script_run "crm cluster init qdevice --qnetd-hostname=$qnet_node_ip -y --qdevice-heuristics=/etc/corosync/qdevice/check_master.sh --qdevice-heuristics-mode=on";
+        assert_script_run "crm -F cluster init qdevice --qnetd-hostname=$qnet_node_ip -y --qdevice-heuristics=/etc/corosync/qdevice/check_master.sh --qdevice-heuristics-mode=on";
         handle_diskless_sbd_scenario_cluster_node;
         # Qdevice should be started again
         qdevice_status('started');
@@ -135,7 +144,7 @@ sub run {
     record_info('Split-brain info', 'Split brain test');
 
     record_info('Disabling stonith', 'Disable stonith to prevent fencing of node before our check');
-    assert_script_run 'crm configure property stonith-enabled="false"' if is_node(1);
+    assert_script_run qq|crm configure property $fencing_property="false"| if is_node(1);
     # Add firewall rules to provoke a split brain situation and confirm that
     # the qdevice node gives its vote to the node1 (where the master resource is running)
     # Firewall rules go in both nodes in multicast cluster, and only in node 2 in unicast
@@ -165,7 +174,7 @@ sub run {
     save_state if (is_node(1) || !(get_var('USE_DISKLESS_SBD') || check_var('QDEVICE_TEST_ROLE', 'qnetd_server')));
 
     # Restart stonith. This should fence node 2
-    assert_script_run 'crm configure property stonith-enabled="true"' if is_node(1);
+    assert_script_run qq|crm configure property $fencing_property="true"| if is_node(1);
 
     barrier_wait("QNETD_SERVER_DONE_$cluster_name");
 


### PR DESCRIPTION
This commit introduces 2 changes:

First, in `lib/hacluster.pm` a new function has been added that will use `crmsh` to get the cluster bootstrap properties and store them in a HASHREF. This function is then called in the `ha/qnetd` test module to determine whether the test should use the `stonith-enabled` or the `fencing-enabled` property.

Second, also on `ha/qnetd`, the flag `-F` has been added to the commands that remove and add back the QDevice into the cluster, as the force flag is required in the scenario "2 Nodes with Diskless SBD and QDevice". Force flag is not needed on the "2 Nodes with block device SBD", nor in versions previous to 16.1, but it should also not have a negative impact on the test.

- Related Tickets: https://jira.suse.com/browse/TEAM-11091 & https://jira.suse.com/browse/TEAM-11181
- Needles: N/A
- Verification runs: [16.1](http://mango.qe.nue2.suse.org/tests/overview?build=40.1&distri=sle&version=16.1) :green_circle: , [16.0](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR25448&distri=sle&version=16.0) :green_circle: , [15-SP7](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR25448&distri=sle&version=15-SP7) :green_circle: , [15-SP6](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR25448&distri=sle&version=15-SP6) :green_circle: , [15-SP5](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR25448&distri=sle&version=15-SP5) :green_circle: , [15-SP4](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR25448&distri=sle&version=15-SP4) :green_circle: 
