### PR TITLE
Remove misleading deprecation message

### DIFF
--- a/lib/sles4sap/publiccloud.pm
+++ b/lib/sles4sap/publiccloud.pm
@@ -121,7 +121,6 @@ sub run_cmd {
     $self->{my_instance}->wait_for_ssh(timeout => $timeout);
     if ($args{rc_only}) {
         delete($args{rc_only});
-        record_info("LEGACY", "rc_only flag will be obsolete soon please try to avoid use of it");
         return $self->{my_instance}->ssh_script_run(cmd => "sudo $cmd", timeout => $timeout, %args);
     }
     else {


### PR DESCRIPTION
Remove message about rc_only argument usage. The argument has been already removed.

Related ticket : https://progress.opensuse.org/issues/190833

Follow up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/24359
