### PR TITLE
kubectl: Switch to cgroups v2 unconditionally

### DIFF
--- a/tests/containers/kubectl.pm
+++ b/tests/containers/kubectl.pm
@@ -14,11 +14,22 @@ use utils;
 use version_utils;
 use publiccloud::utils;
 use containers::k8s;
+use bootloader_setup qw(add_grub_cmdline_settings);
+use power_action_utils qw(power_action);
 
 sub run {
     my ($self, $args) = @_;
 
     select_serial_terminal;
+
+    # Switch to cgroup v2 if not already active
+    # NOTE: Remove when 15-SP5 LTSS is EOL
+    if (script_run("test -f /sys/fs/cgroup/cgroup.controllers") != 0) {
+        add_grub_cmdline_settings("systemd.unified_cgroup_hierarchy=1", update_grub => 1);
+        power_action('reboot', textmode => 1);
+        $self->wait_boot();
+        select_serial_terminal;
+    }
 
     my $k8s_version = $args->{k8s_version};
     install_kubectl($k8s_version);


### PR DESCRIPTION
This test fails with the newer k3s v1.35.x on SLES 15-SP{4,5} that deprecated cgroups v1.  Switch to cgroups v2.

Failed job: https://openqa.suse.de/tests/22074389#step/kubectl_1.23/107
Verification run: https://openqa.suse.de/tests/22076071