### PR TITLE
Fix SCC_URL for slmicro_migration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -1064,11 +1064,10 @@ sub runtime_registration {
     return if get_var('HDD_SCC_REGISTERED');
     my $cmd = ' -r ' . get_required_var 'SCC_REGCODE';
     my $scc_addons = get_var 'SCC_ADDONS', '';
-    # fake scc url pointing to synced repos on openQA
-    # valid only for products currently in development
-    # please unset in job def *SCC_URL* if not required
-    my $fake_scc = get_var 'SCC_URL', '';
-    $cmd .= ' --url ' . $fake_scc if $fake_scc;
+    my $scc_url = get_var('SCC_URL', '');
+    # we skip proxy scc for slm when doing 16.1+ migration.
+    my $skip_scc = is_sle('16.1+') && is_transactional && get_var('TARGET_VERSION');
+    $cmd .= " --url $scc_url" if $scc_url && !$skip_scc;
     my $retries = 5;    # number of retries to run SUSEConnect commands
     my $delay = 60;    # time between retries to run SUSEConnect commands
 


### PR DESCRIPTION
##
### For SCC_URL now we use all not Product-SLES and we need to adapt it.

- [**Error job**](https://openqa.suse.de/tests/22056176#step/suseconnect_scc/109)
- Related ticket: https://progress.opensuse.org/issues/195812
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/788
- VR:
  - [**prod slmicro_migration Build41.4 **](https://openqa.suse.de/tests/overview?test=slmicro_migration%40hjluo%2Fos-autoinst-distri-opensuse%23fix_slm_scc&version=16.1&distri=sle&build=hjluo%2Fos-autoinst-distri-opensuse%23fix_slm_scc)
  - [**dev slmicro_migration**](https://openqa.suse.de/tests/22244014)
  - [**slem_migration_6.1_to_6.2**](https://openqa.suse.de/tests/22244016)

##
