### PR TITLE
Don't handle install medium popup if asked to boot from disk

### DIFF
--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -62,7 +62,7 @@ Due to pre-installation setup, qemu boot order is always booting from CD-ROM.
 
 sub handle_installer_medium_bootup {
     return unless (check_var("BOOTFROM", "d") || (get_var('UEFI') && get_var('USBBOOT')));
-    return if is_agama && !(is_sle || is_leap);
+    return if (check_var("BOOTFROM", "c") && !(is_sle || is_leap("<16.1")));
     assert_screen 'inst-bootmenu', 180;
 
     # Layout of live is different from installation media


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/198458

Following up on #24809, Leap 16.1 doesn't have the boot from hard-disk
option either anymore, and after the Tumbleweed switch to systemd-boot
now all `USBBOOT` scenarios with UEFI should have also have `BOOTFROM=c`
in their settings.

Needs: https://github.com/os-autoinst/opensuse-jobgroups/pull/850

VR: https://openqa.opensuse.org/tests/overview?distri=opensuse&build=bootfrom

PS: Failures in VR aren't related


