### PR TITLE
Fix azure tag expansion

### DIFF
--- a/tests/publiccloud/azure_aitl.pm
+++ b/tests/publiccloud/azure_aitl.pm
@@ -65,7 +65,7 @@ sub run {
     assert_script_run("$aitl_job --help");
 
     # Create Resource group in $region
-    assert_script_run("az group create -n $resource_group -l $region --tags '$tags'");
+    assert_script_run("az group create -n $resource_group -l $region --tags $tags");
 
     # Get manifest from data folder
     assert_script_run("curl " . data_url("publiccloud/aitl/$aitl_manifest") . " -o /tmp/$aitl_manifest");

--- a/tests/publiccloud/azure_cli.pm
+++ b/tests/publiccloud/azure_cli.pm
@@ -53,11 +53,11 @@ sub run {
 
     # Check resource group creation/deletion
     my $temp_rg = "openqa-cli-test-rg-$job_id-check-delete";
-    assert_script_run("az group create -n $temp_rg --tags '$tags'");
+    assert_script_run("az group create -n $temp_rg --tags $tags");
     assert_script_run("az group delete --resource-group $temp_rg --yes", 360);
 
     # Create Resource group
-    assert_script_run("az group create -n $resource_group --tags '$tags'");
+    assert_script_run("az group create -n $resource_group --tags $tags");
 
     # Pint - command line tool to query pint.suse.com to get the current image name
     my $image_name = script_output(qq/pint microsoft images --inactive --json | jq -r '[.images[] | select( .urn | contains("sles-15-sp5:gen2") )][0].urn'/);
@@ -65,7 +65,7 @@ sub run {
     record_info("PINT", "Pint query: " . $image_name);
 
     # VM creation
-    my $vm_create = "az $silent vm create --resource-group $resource_group --name $machine_name --public-ip-sku Standard --tags '$tags'";
+    my $vm_create = "az $silent vm create --resource-group $resource_group --name $machine_name --public-ip-sku Standard --tags $tags";
     $vm_create .= " --image $image_name --size Standard_B1ms --admin-username azureuser --ssh-key-values ~/.ssh/id_rsa.pub";
     my $output = script_output($vm_create, timeout => 600);
     die('Failed to start/stop vms with azure cli') if ($output =~ /ValidationError.*object has no attribute/);

--- a/tests/publiccloud/azure_more_cli.pm
+++ b/tests/publiccloud/azure_more_cli.pm
@@ -103,7 +103,7 @@ sub run {
 
     # Configure default location and create Resource group
     assert_script_run("az configure --defaults location=$location");
-    assert_script_run("az group create -n $resource_group --tags '$tags'");
+    assert_script_run("az group create -n $resource_group --tags $tags");
 
     # Pint - command line tool to query pint.suse.com to get the current image name
     my $image_name = script_output(


### PR DESCRIPTION
In Azure, the way the tests were written (and I assume copied later on), and the way the CLI works, the tags would end up being a single tag like so:

`openqa-cli-test-tag : 21301959 openqa_created_by=openqa.suse.de/t21301959 openqa_ttl=7500 openqa_var_server=openqa.suse.de openqa_var_job_id=21301959 custodian_ttl=2026-03-11T13:57:37Z`

^ This is one tag - `openqa-cli-test-tag` with everything else being the value. This is because the `az cli` expects the following `--tags KEY1=VALUE1 KEY2=VALUE2 ...` so when we pass everything wrapped into quotes, it takes the first part as the key and the rest as the value.


- Verification runs:
  -  AITL: https://openqa.suse.de/tests/22187199 - <img width="828" height="33" alt="aitl" src="https://github.com/user-attachments/assets/31393229-2ec6-4ac8-9ded-86dfe7dd010f" />
  - Test currently fails for unrelated reason :/ https://openqa.suse.de/tests/22187743#step/azure_cli/30 I believe it is fixed  though.

