### PR TITLE
ltp: Add LTP_MIN_UPTIME configuration for minimum uptime

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -375,6 +375,16 @@ sub schedule_tests {
     record_info("LTP version", $environment->{ltp_version});
     record_info("env", script_output('env'));
 
+    # Wait for minimum system uptime before running tests
+    if (my $min_uptime = get_var('LTP_MIN_UPTIME')) {
+        my $current_uptime = int(script_output("awk '{print int(\$1)}' /proc/uptime"));
+        my $wait = $min_uptime - $current_uptime;
+        if ($wait > 0) {
+            record_info('LTP_MIN_UPTIME', "Waiting $wait seconds for minimum uptime $min_uptime seconds.");
+            script_run("sleep $wait", timeout => $wait + 5);
+        }
+    }
+
     $test_result_export->{environment} = $environment;
 
     if ($cmd_file =~ m/ltp-aiodio.part[134]/) {

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -541,6 +541,11 @@ Comma separated list of debug features to enable during test run.
 - C<tcpdump>: Capture all packets sent or received during each test.
 - C<supportconfig>: Run supportconfig after boot and before shutdown.
 
+=head2 LTP_MIN_UPTIME
+
+Minimum uptime in seconds before LTP tests start. It applies only to the
+native openQA runner, not to tests run by kirk.
+
 =head2 LTP_REBOOT_AFTER_TEST
 
 Reboot SUT after each test (unless last test or TCONF). It prolongs testing

--- a/variables.md
+++ b/variables.md
@@ -146,6 +146,7 @@ LTP_COMMAND_FILE | string | | The LTP test command file (e.g. syscalls, cve)
 LTP_COMMAND_EXCLUDE | string | | This regex is used to exclude tests from LTP command file.
 LTP_EXEC_TIMEOUT | integer | 1200 |Used to define --exec-timeout value passed to kirk
 LTP_KNOWN_ISSUES | string | | Used to specify a url for a json file with well known LTP issues. If an error occur which is listed, then the result is overwritten with softfailure.
+LTP_MIN_UPTIME | integer | | Minimum uptime in seconds before LTP tests start. It applies only to the native openQA runner, not to tests run by kirk.
 LTP_REPO | string | | The repo which will be added and is used to install LTP package.
 LTP_RUN_NG_BRANCH | string | master | Define the branch of the LTP_RUN_NG_REPO.
 LTP_RUN_NG_REPO | string | https://github.com/linux-test-project/kirk.git | Define the runltp-ng repo to be used.


### PR DESCRIPTION
Fix poo#200516: Added a new variable `LTP_MIN_UPTIME` to specify the
minimum system uptime in seconds before LTP tests start, allowing the
system to reach a stable state before running tests.

`irqbalance` performs interrupt load balancing at fixed time intervals
(default is 10s). `ltp_irq` needs this setup to avoid sporadic
failures.


- Related ticket: https://progress.opensuse.org/issues/200516
- Needles: none
- Verification run: https://openqa.suse.de/tests/overview?build=czerw%2Fos-autoinst-distri-opensuse%2325462&distri=sle&version=16.1


VR contain multiple time settings, we can safely set 15s in `ltp_irq` YAML job group configuration.
https://gitlab.suse.de/kernel-qa/kernelqa-openqa-yaml/-/merge_requests/944