### PR TITLE
bats/buildah: Add test to ignore list

### DIFF
--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -44,6 +44,9 @@ sub run_tests {
         "bud.bats::bud with --layers and --no-cache flags",
         "bud.bats::bud with --rm flag",
         "bud.bats::bud with no --layers comment",
+        # This test fails because the test image no longer has a label
+        # and we can't backport PR 6634 to fix it
+        "config.bats::config --unsetlabel",
         "images.bats::images all test",
         "rmi.bats::rmi with cached images",
     ) if (version->parse(numeric_version($version)) <= version->parse("1.39.5"));


### PR DESCRIPTION
The `config.bats::config --unsetlabel` test fails because the test image no longer has a label and we can't backport https://github.com/containers/buildah/pull/6634 to buildah <= 1.39.5 to change the test image.

Failed jobs:
- 15-SP4: https://openqa.suse.de/tests/22088949
- 15-SP5: https://openqa.suse.de/tests/22088945
- 15-SP6: https://openqa.suse.de/tests/22088960
- 15-SP7: https://openqa.suse.de/tests/22088962
