### PR TITLE
Use TD repos only for sle12sp3 tests

### DIFF
--- a/data/autoyast_qam/12-common_base_installation.xml.ep
+++ b/data/autoyast_qam/12-common_base_installation.xml.ep
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  % unless ($check_var->('VERSION', '12-SP3') and $check_var->('FLAVOR', 'Server-DVD-Updates-TERADATA')) {
   <suse_register>
     <do_registration config:type="boolean">true</do_registration>
     <email><%= $get_var->('SCC_EMAIL') %></email>
@@ -33,6 +34,7 @@
     </addons>
     %}
   </suse_register>
+  % }
   <add-on>
     <add_on_products config:type="list">
       % for my $repo (@$repos) {
@@ -59,6 +61,11 @@
         <media_url>http://dist.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-SP3-TERADATA/x86_64/update/</media_url>
         <name>12-SP3-TERADATA-Updates</name>
         <alias>12-SP3-TERADATA-Updates</alias>
+      </listentry>
+      <listentry>
+        <media_url>http://dist.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP3-TERADATA/x86_64/product/</media_url>
+        <name>12-SP3-TERADATA-Products</name>
+        <alias>12-SP3-TERADATA-Products</alias>
       </listentry>
       % }
     </add_on_products>


### PR DESCRIPTION
1. Don't register the system
2.  Only use TD repos instead

Kernel verion:
```
Welcome to SUSE Linux Enterprise Server 12 SP3  (x86_64) - Kernel 4.4.140-96.177.TDC-default (ttyS0).
```

VR: https://openqa.suse.de/tests/22089518