### PR TITLE
helm: Switch to cgroups v2 unconditionally

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -118,14 +118,12 @@ sub install_k3s {
         assert_script_run("curl $curl_opts https://get.k3s.io -o install_k3s.sh");
         assert_script_run("sh install_k3s.sh $disables", timeout => 300);
         script_run("rm -f install_k3s.sh");
-        zypper_call('in apparmor-parser') if is_sle('<15-SP4', get_var('HOST_VERSION', get_required_var('VERSION')));
         setup_and_check_k3s;
         return;
     }
 
     # k3s-install script is already packaged for several products
     my @pkgs = qw(k3s-install);
-    push @pkgs, 'apparmor-parser' if is_sle('<15-SP4');
 
     if (script_run(sprintf('rpm -q %s', join(" ", @pkgs))) != 0) {
         if (is_transactional) {

--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -43,6 +43,15 @@ sub run {
 
     if ($is_k3s) {
         install_k3s();
+
+        # Switch to cgroup v2 if not already active
+        # NOTE: Remove when SLES 15-SP5 is EOL
+        if (script_run("test -f /sys/fs/cgroup/cgroup.controllers") != 0) {
+            add_grub_cmdline_settings("systemd.unified_cgroup_hierarchy=1", update_grub => 1);
+            power_action('reboot', textmode => 1);
+            $self->wait_boot();
+            select_serial_terminal;
+        }
     }
     else {
         install_kubectl();


### PR DESCRIPTION
This test fails with the newer k3s v1.35.x on SLES 15-SP{4,5} that deprecated cgroups v1.  Switch to cgroups v2.

Failed jobs:
SLES 15-SP4: https://openqa.suse.de/tests/22088904
SLES 15-SP5: https://openqa.suse.de/tests/22088909

Verification run: https://openqa.suse.de/tests/22089787