### PR TITLE
containers/upgrade: Add missing select_serial_terminal

### DIFF
--- a/tests/containers/upgrade.pm
+++ b/tests/containers/upgrade.pm
@@ -150,6 +150,7 @@ sub run {
         upgrade_via_testrepos;
         power_action('reboot', textmode => 1);
         $self->wait_boot();
+        select_serial_terminal;
     }
 
     assert_script_run "rpm -qa | sort > /var/tmp/after", timeout => 180;


### PR DESCRIPTION

Failed job: testing on-demand upgrade for SLES 16.1 (`TEST_REPOS=https://download.opensuse.org/repositories/home:/danishprakash:/branches:/devel:/microos/16.1/home:danishprakash:branches:devel:microos.repo`)
https://openqa.suse.de/tests/22089826#step/upgrade/194

Verification run: https://openqa.suse.de/tests/22089871