### PR TITLE
Fix helm tests on 15-SP4 & 15-SP5

### DIFF
--- a/lib/containers/k8s.pm
+++ b/lib/containers/k8s.pm
@@ -125,7 +125,6 @@ sub install_k3s {
 
     # k3s-install script is already packaged for several products
     my @pkgs = qw(k3s-install);
-    push @pkgs, 'apparmor-parser' if is_sle('<15-SP4');
 
     if (script_run(sprintf('rpm -q %s', join(" ", @pkgs))) != 0) {
         if (is_transactional) {

--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -244,8 +244,12 @@ sub load_host_tests_helm {
     my ($run_args) = @_;
     my $backends = undef;
 
-    if (is_sle('15-sp3+')) {
+    # k3s v1.35.x is supported on SLES 15-SP6+ only:
+    # https://www.suse.com/suse-k3s/support-matrix/all-supported-versions/k3s-v1-35/
+    if (is_sle('15-sp6+')) {
         $backends = get_var("PUBLIC_CLOUD_PROVIDER", "GCE,EC2,AZURE,K3S");
+    } elsif (is_sle('15-sp4+')) {
+        $backends = get_var("PUBLIC_CLOUD_PROVIDER", "GCE,EC2,AZURE");
     } elsif (is_opensuse) {
         $backends = get_var("PUBLIC_CLOUD_PROVIDER", "K3S");
     } else {


### PR DESCRIPTION
Drop k3s on helm test as newer k3s v1.35.x is not supported on SLES 15-SP4 & 15-SP5:
https://www.suse.com/suse-k3s/support-matrix/all-supported-versions/k3s-v1-35/

Also drop dead code for 15-SP3 EOL.

Failed jobs:
- SLES 15-SP4: https://openqa.suse.de/tests/22088904
- SLES 15-SP5: https://openqa.suse.de/tests/22088909