### PR TITLE
xfstests: Add two parameters for tumbleweed

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -178,7 +178,10 @@ sub setup_env {
         set_var('INSTLANG', 'en_US');
     }
 
-    set_var('LTP_KNOWN_ISSUES', 'https://raw.githubusercontent.com/openSUSE/kernel-qe/main/ltp_known_issues.yaml') if is_opensuse and !get_var('LTP_KNOWN_ISSUES');
+    my $kernel_qe_opensuse_repo_base = 'https://raw.githubusercontent.com/openSUSE/kernel-qe/main';
+    set_var('LTP_KNOWN_ISSUES', "$kernel_qe_opensuse_repo_base/ltp_known_issues.yaml") if is_opensuse and !get_var('LTP_KNOWN_ISSUES');
+    set_var('XFSTESTS_AI_KB', "$kernel_qe_opensuse_repo_base/ai_knowledge_base.yaml") if is_opensuse and get_var('XFSTESTS') and !get_var('XFSTESTS_AI_KB');
+    set_var('XFSTESTS_QE_KB', "$kernel_qe_opensuse_repo_base/qe_knowledge_base.yaml") if is_opensuse and get_var('XFSTESTS') and !get_var('XFSTESTS_QE_KB');
 
     # By default format DASD devices before installation
     if (is_backend_s390x) {


### PR DESCRIPTION
Set XFSTESTS_AI_KB and XFSTESTS_QE_KB in o3 xfstests.
Make sure to merge it after https://github.com/openSUSE/kernel-qe/pull/49

- Related ticket: https://progress.opensuse.org/issues/198452
- Verification run: https://openqa.opensuse.org/tests/5888257#step/xfs-073/114  (knowledge-base review suggestion works)