### PR TITLE
kernel: Add update_kernel to baremetal agama schedules

### DIFF
--- a/schedule/kernel/agama_gfx_drivers.yaml
+++ b/schedule/kernel/agama_gfx_drivers.yaml
@@ -2,11 +2,13 @@
 name: agama-gfx-usb-drivers
 vars:
     INST_AUTO: agama_auto/sle_default_ipmi.jsonnet
+    LTP_BAREMETAL: '1'
 schedule:
 - installation/bootloader_start
 - installation/agama_reboot
 - installation/grub_test
 - installation/first_boot
+- kernel/update_kernel
 - console/system_prepare
 - console/consoletest_setup
 - console/hostname

--- a/schedule/kernel/agama_ibtest-master.yaml
+++ b/schedule/kernel/agama_ibtest-master.yaml
@@ -6,6 +6,7 @@ vars:
     DESKTOP: textmode
     IBTESTS: 1
     IBTEST_ROLE: IBTEST_MASTER
+    LTP_BAREMETAL: '1'
     MLX_PROTOCOL: 1
 schedule:
     - kernel/ibtests_barriers
@@ -13,6 +14,7 @@ schedule:
     - installation/agama_reboot
     - installation/grub_test
     - installation/first_boot
+    - kernel/update_kernel
     - kernel/ibtests_prepare
     - installation/handle_reboot
     - kernel/ibtests

--- a/schedule/kernel/agama_ibtest-slave.yaml
+++ b/schedule/kernel/agama_ibtest-slave.yaml
@@ -6,6 +6,7 @@ vars:
     DESKTOP: textmode
     IBTESTS: 1
     IBTEST_ROLE: IBTEST_SLAVE
+    LTP_BAREMETAL: '1'
     MLX_PROTOCOL: 1
     PARALLEL_WITH: ibtest-master
 schedule:
@@ -13,6 +14,7 @@ schedule:
     - installation/agama_reboot
     - installation/grub_test
     - installation/first_boot
+    - kernel/update_kernel
     - kernel/ibtests_prepare
     - installation/handle_reboot
     - kernel/ibtests

--- a/schedule/kernel/agama_install_kdump.yaml
+++ b/schedule/kernel/agama_install_kdump.yaml
@@ -2,11 +2,15 @@ name: agama_install_kdump
 description:    >
     Install the system and proceed with kdump using the IPXE setup or PowerVM HMC backend.
 
+vars:
+    LTP_BAREMETAL: '1'
+
 schedule:
     - '{{boot}}'
     - installation/agama_reboot
     - installation/grub_test
     - installation/first_boot
+    - kernel/update_kernel
     - console/system_prepare
     - kernel/kdump
 


### PR DESCRIPTION
The agama_gfx_drivers, agama_ibtest-master, agama_ibtest-slave, and agama_install_kdump schedules running on baremetal machines were missing the `update_kernel`. The addition of this module will allow us to use these schedules in maintenance or to switch kernels if needed.

Although tests are not LTP related, they must have `LTP_BAREMETAL=1` for `update_kernel` to select the correct console during system boot.


- Related ticket: none
- Needles: none
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&build=czerw%2Fos-autoinst-distri-opensuse%2325477&version=16.1  (usb failure is not related).
