### PR TITLE
Create new test suite only for checking installation notifications

### DIFF
--- a/schedule/yam/agama_notifications.yaml
+++ b/schedule/yam/agama_notifications.yaml
@@ -1,0 +1,14 @@
+---
+name: agama_notifications
+description: >
+  Perform interactive installation validating notifications functionality:
+    - Validate notifications for incorrect login.
+    - Validate notifications for invalid registration code.
+    - Validate notifications for invalid or weak user password.
+    - Validate notifications for storage disk change.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - installation/grub_test
+  - installation/first_boot


### PR DESCRIPTION
We added a new schedule called agama_notifications.yaml in the schedule/yam/ directory to  create the sles_notifications test.                                                        
                                                                                             
  This schedule performs an interactive Agama installation with the goal of validating notifications functionality in three specific scenarios:                                                                                             
  1. Incorrect login notifications - Validates that appropriate notifications are displayed  when attempting to log in with incorrect credentials
  2. Invalid SCC code notifications - Verifies that notifications appear when an invalid SCC registration code is entered                                                               
  3. Invalid or weak password notifications - Checks notifications when setting user passwords that don't meet requirements

The schedule follows the structure of a standard extended test, but with the following particularities:
- Does not include self-update validation (validate_self_update)                           
- Does not include hostname validation (validate_hostname)                                 
- Focuses specifically on connectivity and bootloader timeout validation after installation

---

- Related ticket: https://progress.opensuse.org/issues/198743
- Related PR (Integration): https://github.com/qe-installation-and-migration/agama-integration-test-webpack/pull/245
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/790
- Needles: N/A
- Verification run: 
  - prod_sles_notifications: https://openqa.suse.de/tests/22733331
  - prod_sles_extended: https://openqa.suse.de/tests/22733332
  - QU_sles_notifications: https://openqa.suse.de/tests/22733333
  - QU_sles_extended: https://openqa.suse.de/tests/22733334
