### PR TITLE
tests: Simplify mocking and make it more reliable

### DIFF
--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -29,8 +29,7 @@ sub create_qesap_prepare_env_mocks_noret {
 }
 
 sub create_qesap_prepare_env_mocks_with_calls {
-    my $called_functions = shift;
-    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
+    my ($qesap, $called_functions) = @_;
 
     # then mock functions with some more complex return value
     $called_functions->{qesap_get_file_paths} = 0;
@@ -962,7 +961,7 @@ subtest '[qesap_prepare_env]' => sub {
       qesap_pip_install
       qesap_galaxy_install);
     my $qesap = create_qesap_prepare_env_mocks_noret(\%called_functions, \@mock_func);
-    $qesap = create_qesap_prepare_env_mocks_with_calls(\%called_functions);
+    create_qesap_prepare_env_mocks_with_calls($qesap, \%called_functions);
     my @calls;
     $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
     $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
@@ -992,7 +991,7 @@ subtest '[qesap_prepare_env] openqa_variables' => sub {
       qesap_pip_install
       qesap_galaxy_install);
     my $qesap = create_qesap_prepare_env_mocks_noret(\%called_functions, \@mock_func);
-    $qesap = create_qesap_prepare_env_mocks_with_calls(\%called_functions);
+    create_qesap_prepare_env_mocks_with_calls($qesap, \%called_functions);
     my @calls;
     $qesap->redefine(script_run => sub { push @calls, $_[0]; return 0; });
     $qesap->redefine(assert_script_run => sub { push @calls, $_[0]; });
@@ -1016,7 +1015,7 @@ subtest '[qesap_prepare_env] only_configure' => sub {
       qesap_pip_install
       qesap_galaxy_install);
     my $qesap = create_qesap_prepare_env_mocks_noret(\%called_functions, \@mock_func);
-    $qesap = create_qesap_prepare_env_mocks_with_calls(\%called_functions);
+    create_qesap_prepare_env_mocks_with_calls($qesap, \%called_functions);
     my @calls;
     $qesap->redefine(script_run => sub { push @calls, $_[0]; });
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
@@ -1035,7 +1034,7 @@ subtest '[qesap_prepare_env] qesap_yaml_replace' => sub {
     my %called_functions;
     my @mock_func = qw(qesap_get_variables);
     my $qesap = create_qesap_prepare_env_mocks_noret(\%called_functions, \@mock_func);
-    $qesap = create_qesap_prepare_env_mocks_with_calls(\%called_functions);
+    create_qesap_prepare_env_mocks_with_calls($qesap, \%called_functions);
     my @calls;
     $qesap->redefine(script_run => sub { push @calls, $_[0]; });
     $called_functions{file_content_replace} = 0;


### PR DESCRIPTION
This test failed for me with the latest Test::MockModule *and* perl 5.42,
while in CI we have 5.32, and it didn't fail there, but it seems to be
caused by this fix:
* https://github.com/geofffranks/test-mockmodule/issues/48

What was happening here in short:

    sub create_mocked_module_1 {
        my $qesap = Test::MockModule->new('class');
        # mock something
        return $qesap;
    }
    sub create_mocked_module_2 {
        my $qesap = Test::MockModule->new('class');
        # mock something else
        return $qesap;
    }
    my $qesap = create_mocked_module_1();
    $qesap = create_mocked_module_2();

This was somehow working, but it's not a good design, because the second function is creating another MockModule instance for the same class, and then when it's returned, it will overwrite the previous `$qesap` variable, which would then remove the previous mocks.

Instead we are now reusing the already created `$qesap` instance and just passing it to the second function.

