### PR TITLE
Adapt sssd_389ds_functional to run on Tumbleweed again

### DIFF
--- a/tests/console/sssd_389ds_functional.pm
+++ b/tests/console/sssd_389ds_functional.pm
@@ -38,7 +38,7 @@ sub install_dependencies($container_engine) {
 
 sub setup_389ds_container ($container_engine) {
 
-    my $pkgs = "awk systemd systemd-sysvinit 389-ds openssl";
+    my $pkgs = "awk systemd 389-ds openssl";
     my $tag = "";
     if (is_opensuse) {
         $tag = (is_tumbleweed) ? "registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed" : "registry.opensuse.org/opensuse/leap";

--- a/tests/console/sssd_389ds_functional.pm
+++ b/tests/console/sssd_389ds_functional.pm
@@ -41,7 +41,7 @@ sub setup_389ds_container ($container_engine) {
     my $pkgs = "awk systemd systemd-sysvinit 389-ds openssl";
     my $tag = "";
     if (is_opensuse) {
-        $tag = (is_tumbleweed) ? "registry.opensuse.org/opensuse/tumbleweed" : "registry.opensuse.org/opensuse/leap";
+        $tag = (is_tumbleweed) ? "registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed" : "registry.opensuse.org/opensuse/leap";
     }
     else {
         $tag = 'registry.suse.com/suse/sle15:15.7';


### PR DESCRIPTION
This test has two issues for running in TW:

- It used the wrong container image
- Has a dependency with systemd-sysvinit which is nolonger shipped on TW as a result of new systemd v260+ which is either a leftover or was never really needed

VR:
- https://openqa.opensuse.org/tests/5895168
- SLE https://openqa.suse.de/tests/22152243
