### PR TITLE
Reduce number of pacemakerd --version calls

### DIFF
--- a/lib/sles4sap/publiccloud.pm
+++ b/lib/sles4sap/publiccloud.pm
@@ -66,7 +66,7 @@ our @EXPORT = qw(
   is_hana_database_online
   get_hana_database_status
   is_primary_node_online
-  pacemaker_version
+  get_online_string
   saphanasr_showAttr_version
   get_hana_site_names
   wait_for_cluster
@@ -432,11 +432,16 @@ sub wait_hana_node_up {
 
 =item B<timeout> - only used for stop and kill
 
+=item B<online_string> - mandatory string used to match node state in topology output;
+'4' for pacemaker >= 2.1.7 (lss score), 'online' for older versions.
+Use C<$self->get_online_string()> to compute this value.
+
 =back
 =cut
 
 sub stop_hana {
     my ($self, %args) = @_;
+    croak('Argument <online_string> missing') unless defined $args{online_string};
     $args{method} //= 'stop';
     my $timeout = bmwqemu::scale_timeout($args{timeout} // 300);
     my %commands = (
@@ -451,7 +456,7 @@ sub stop_hana {
     my $cmd = $commands{$args{method}};
 
     # Wait for data sync before stopping DB
-    $self->wait_for_sync();
+    $self->wait_for_sync(online_string => $args{online_string});
 
     record_info('Stopping HANA', "CMD:$cmd");
     if ($args{method} eq 'crash') {
@@ -738,25 +743,27 @@ sub get_promoted_instance {
 
 =item B<timeout> - timeout for waiting sync state
 
+=item B<online_string> - mandatory string used to match node state in topology output;
+'4' for pacemaker >= 2.1.7 (lss score), 'online' for older versions.
+Use C<$self->get_online_string()> to compute this value.
+
 =back
 =cut
 
 sub wait_for_sync {
     my ($self, %args) = @_;
+    croak('Argument <online_string> missing') unless defined $args{online_string};
     my $timeout = bmwqemu::scale_timeout($args{timeout} // 900);
-    # If pacemaker >= 2.1.7 then 'online_str' is now based on 'lss' score where 4 means OK
-    # Otherwise it's set to the legacy 'online'
-    my $online_str = check_version('>=2.1.7', $self->pacemaker_version()) ? '4' : 'online';
     my $output_pass = 0;
 
-    record_info('Wait for sync', "Waiting for data sync between nodes. online_str=$online_str timeout=$timeout");
+    record_info('Wait for sync', "Waiting for data sync between nodes. online_str=$args{online_string} timeout=$timeout");
 
     # Check sync status periodically until OK for 5 times in a row or timeout
     my $start_time = time;
     while (time - $start_time < $timeout) {
         # call SAPHanaSR-showAttr to get current topology, validate the output, calculate the score.
         # Not OK cluster result in score reset to zero
-        $output_pass = check_hana_topology(input => $self->get_hana_topology(), node_state_match => $online_str) ? $output_pass + 1 : 0;
+        $output_pass = check_hana_topology(input => $self->get_hana_topology(), node_state_match => $args{online_string}) ? $output_pass + 1 : 0;
         last if $output_pass == 5;
         sleep 30;
     }
@@ -1394,6 +1401,21 @@ sub pacemaker_version {
     return '';
 }
 
+=head2 get_online_string
+
+    $self->get_online_string()
+
+    Returns the string used to match the online/active node state in C<check_hana_topology>.
+    For pacemaker >= 2.1.7 this is C<'4'> (lss score); for older versions it is C<'online'>.
+    Use this helper wherever C<online_string> must be computed from the cluster's pacemaker version.
+
+=cut
+
+sub get_online_string {
+    my ($self) = @_;
+    return check_version('>=2.1.7', $self->pacemaker_version(retries => 6, sleep_time => 10)) ? '4' : 'online';
+}
+
 =head2 saphanasr_showAttr_version
 
     Returns the SAPHanaSR-showattr version
@@ -1424,20 +1446,23 @@ sub saphanasr_showAttr_version {
 
 =item B<max_retries> - maximum number of retries, default 7
 
+=item B<online_string> - mandatory string used to match node state in topology output;
+'4' for pacemaker >= 2.1.7 (lss score), 'online' for older versions.
+Use C<$self->get_online_string()> to compute this value.
+
 =back
 =cut
 
 sub wait_for_cluster {
     my ($self, %args) = @_;
-
+    croak('Argument <online_string> missing') unless defined $args{online_string};
     $args{wait_time} //= 10;
     $args{max_retries} //= 7;
-    my $online_str = check_version('>=2.1.7', $self->pacemaker_version(retries => 6, sleep_time => 10)) ? '4' : 'online';
 
     while ($args{max_retries} > 0) {
         my $crm_output = $self->run_cmd(cmd => $crm_mon_cmd, quiet => 1);
 
-        my $hanasr_ready = check_hana_topology(input => $self->get_hana_topology(), node_state_match => $online_str);
+        my $hanasr_ready = check_hana_topology(input => $self->get_hana_topology(), node_state_match => $args{online_string});
         my $crm_ok = check_crm_output(input => $crm_output);
 
         if ($hanasr_ready && $crm_ok) {

--- a/t/12_sles4sap_publiccloud.t
+++ b/t/12_sles4sap_publiccloud.t
@@ -282,7 +282,7 @@ subtest "[stop_hana]" => sub {
     $self->{my_instance} = $mock_pc;
 
     set_var('INSTANCE_SID', 'INSTANCE_SIDTEST');
-    $self->stop_hana();
+    $self->stop_hana(online_string => 'online');
     set_var('INSTANCE_SID', undef);
     note("\n  C -->  " . join("\n  C -->  ", @calls));
 
@@ -311,7 +311,7 @@ subtest "[stop_hana] crash" => sub {
     $self->{my_instance} = $mock_pc;
     $self->{my_instance}->{public_ip} = '1.2.3.4';
 
-    $self->stop_hana(method => 'crash');
+    $self->stop_hana(method => 'crash', online_string => 'online');
     note("\n  C -->  " . join("\n  C -->  ", @calls));
     ok((any { qr/echo b.*sysrq-trigger/ } @calls), 'function calls HDB stop');
 };
@@ -340,7 +340,7 @@ subtest "[stop_hana] crash wait_hana_node_up running" => sub {
     $self->{my_instance} = $mock_pc;
     $self->{my_instance}->{public_ip} = '1.2.3.4';
 
-    $self->stop_hana(method => 'crash');
+    $self->stop_hana(method => 'crash', online_string => 'online');
     note("\n  C -->  " . join("\n  C -->  ", @calls));
     # Not very important test as we are checking the same within the ssh_script_output mock
     ok((any { qr/systemctl is-system-running/ } @calls), 'function calls systemctl at least one');
@@ -370,9 +370,15 @@ subtest "[stop_hana] crash wait_hana_node_up degradated" => sub {
     $self->{my_instance} = $mock_pc;
     $self->{my_instance}->{public_ip} = '1.2.3.4';
 
-    dies_ok { $self->stop_hana(method => 'crash') } 'Test expected to die within wait_hana_node_up';
+    dies_ok { $self->stop_hana(method => 'crash', online_string => 'online') } 'Test expected to die within wait_hana_node_up';
     note("\n  C -->  " . join("\n  C -->  ", @calls));
     ok((any { qr/systemctl --failed/ } @calls), 'function calls systemctl --failed to figure out which service is failed');
+};
+
+subtest "[stop_hana] missing online_string croaks" => sub {
+    my $sles4sap_publiccloud = Test::MockModule->new('sles4sap::publiccloud', no_auto => 1);
+    my $self = sles4sap::publiccloud->new();
+    dies_ok { $self->stop_hana() } 'Missing online_string argument causes croak';
 };
 
 subtest "[setup_sbd_delay_publiccloud]" => sub {
@@ -1193,12 +1199,11 @@ subtest '[wait_for_sync] all pass' => sub {
     my $sles4sap_publiccloud = Test::MockModule->new('sles4sap::publiccloud', no_auto => 1);
     $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     my $stability_counter = 0;
-    $sles4sap_publiccloud->redefine(pacemaker_version => sub { return '1.2.3'; });
     # return of get_hana_topology does no matter so much as we stub the check_hana_topology
     $sles4sap_publiccloud->redefine(get_hana_topology => sub { return; });
     $sles4sap_publiccloud->redefine(check_hana_topology => sub { $stability_counter++; return 1; });
     my $self = sles4sap::publiccloud->new();
-    $self->wait_for_sync();
+    $self->wait_for_sync(online_string => 'online');
     ok($stability_counter >= 5, "stability_counter : $stability_counter should be greater or equal than 5");
 };
 
@@ -1206,13 +1211,12 @@ subtest '[wait_for_sync] never ok' => sub {
     my $sles4sap_publiccloud = Test::MockModule->new('sles4sap::publiccloud', no_auto => 1);
     $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     my $stability_counter = 0;
-    $sles4sap_publiccloud->redefine(pacemaker_version => sub { return '1.2.3'; });
     # return of get_hana_topology does no matter so much as we stub the check_hana_topology
     $sles4sap_publiccloud->redefine(get_hana_topology => sub { return; });
     $sles4sap_publiccloud->redefine(check_hana_topology => sub { $stability_counter++; return 0; });
     $sles4sap_publiccloud->redefine(run_cmd => sub { return "Marko Ramius"; });
     my $self = sles4sap::publiccloud->new();
-    dies_ok { $self->wait_for_sync() };
+    dies_ok { $self->wait_for_sync(online_string => 'online') };
 };
 
 subtest '[wait_for_sync] one not ok reset the counter' => sub {
@@ -1221,13 +1225,12 @@ subtest '[wait_for_sync] one not ok reset the counter' => sub {
     my $stability_counter = 0;
     # return of get_hana_topology does no matter so much as we stub the check_hana_topology
     $sles4sap_publiccloud->redefine(get_hana_topology => sub { return; });
-    $sles4sap_publiccloud->redefine(pacemaker_version => sub { return '1.2.3'; });
     # The trick here is to return a single cluster failure at run 4, the internal score variable in
     # tested code will start counting back from zero
     # so in total the tested code should look 4 + 5 = 9 times.
     $sles4sap_publiccloud->redefine(check_hana_topology => sub { $stability_counter++; return $stability_counter == 4 ? 0 : 1; });
     my $self = sles4sap::publiccloud->new();
-    $self->wait_for_sync();
+    $self->wait_for_sync(online_string => 'online');
     ok($stability_counter >= 9, "stability_counter : $stability_counter should be more than 9.");
 };
 
@@ -1263,11 +1266,13 @@ subtest '[wait_for_sync] all pass with Pacemaker >= 2.1.7' => sub {
     # Hosts/vmhana01/node_state="1712205541"
     # ...
     # Hosts/vmhana02/node_state="1712205541"
+    #
+    # With Pacemaker >= 2.1.7 the caller computes online_string => '4' and passes it in.
+    # This test verifies that wait_for_sync forwards it correctly to check_hana_topology.
 
     my $sles4sap_publiccloud = Test::MockModule->new('sles4sap::publiccloud', no_auto => 1);
     $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     my $stability_counter = 0;
-    $sles4sap_publiccloud->redefine(pacemaker_version => sub { return '2.1.9'; });
     # return of get_hana_topology does no matter so much as we stub the check_hana_topology
     $sles4sap_publiccloud->redefine(get_hana_topology => sub { return 'Bart Mancuso'; });
     my $node_state_match;
@@ -1279,14 +1284,19 @@ subtest '[wait_for_sync] all pass with Pacemaker >= 2.1.7' => sub {
             $stability_counter++;
             return 1; });
     my $self = sles4sap::publiccloud->new();
-    $self->wait_for_sync();
-    ok($node_state_match =~ /[1-9][0-9]+/ or $node_state_match eq '4', 'node_state_match : ' . $node_state_match . ' is expected to be 4 or an integer');
+    $self->wait_for_sync(online_string => '4');
+    ok($node_state_match eq '4', 'node_state_match : ' . $node_state_match . ' is expected to be 4');
+};
+
+subtest '[wait_for_sync] missing online_string croaks' => sub {
+    my $sles4sap_publiccloud = Test::MockModule->new('sles4sap::publiccloud', no_auto => 1);
+    my $self = sles4sap::publiccloud->new();
+    dies_ok { $self->wait_for_sync() } 'Missing online_string argument causes croak';
 };
 
 subtest '[wait_for_cluster]' => sub {
     my $sles4sap_publiccloud = Test::MockModule->new('sles4sap::publiccloud', no_auto => 1);
     $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
-    $sles4sap_publiccloud->redefine(pacemaker_version => sub { return '1.2.3'; });
     my @calls;
     $sles4sap_publiccloud->redefine(run_cmd => sub {
             my ($self, %args) = @_;
@@ -1307,13 +1317,19 @@ subtest '[wait_for_cluster]' => sub {
 
     my $self = sles4sap::publiccloud->new();
 
-    $self->wait_for_cluster();
+    $self->wait_for_cluster(online_string => 'online');
 
     note("\n  C -->  " . join("\n  C -->  ", @calls));
     note("\n  node_state_matches -->  " . join("\n  -->  ", @node_state_matches));
 
     ok((any { qr/crm_mon -r -R -n -N -1/ } @calls), 'function calls crm_mon -r -R -n -N -1');
     ok((any { qr/online/ } @node_state_matches), 'Pacemaker older than 2.1.7 match with online');
+};
+
+subtest '[wait_for_cluster] missing online_string croaks' => sub {
+    my $sles4sap_publiccloud = Test::MockModule->new('sles4sap::publiccloud', no_auto => 1);
+    my $self = sles4sap::publiccloud->new();
+    dies_ok { $self->wait_for_cluster() } 'Missing online_string argument causes croak';
 };
 
 subtest '[saphanasr_showAttr_version]' => sub {
@@ -1324,6 +1340,22 @@ subtest '[saphanasr_showAttr_version]' => sub {
 
     my $ret = $self->saphanasr_showAttr_version();
     ok $ret eq '1.2.3.4';
+};
+
+subtest '[get_online_string] old pacemaker returns online' => sub {
+    my $sles4sap_publiccloud = Test::MockModule->new('sles4sap::publiccloud', no_auto => 1);
+    $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $sles4sap_publiccloud->redefine(run_cmd => sub { return 'Pacemaker 2.1.6-3.el8'; });
+    my $self = sles4sap::publiccloud->new();
+    is($self->get_online_string(), 'online', 'pacemaker < 2.1.7 returns online');
+};
+
+subtest '[get_online_string] new pacemaker returns 4' => sub {
+    my $sles4sap_publiccloud = Test::MockModule->new('sles4sap::publiccloud', no_auto => 1);
+    $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $sles4sap_publiccloud->redefine(run_cmd => sub { return 'Pacemaker 2.1.7-1.el8'; });
+    my $self = sles4sap::publiccloud->new();
+    is($self->get_online_string(), '4', 'pacemaker >= 2.1.7 returns 4');
 };
 
 subtest '[create_hana_vars_section]' => sub {

--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -87,8 +87,11 @@ sub run {
         $sbd_delay = $self->sbd_delay_formula();
     }
 
+    # Cache the online_string to avoid repeated SSH calls to pacemaker_version()
+    my $online_string = $self->get_online_string();
+
     # Stop/kill/crash HANA DB and wait till SSH is again available with pacemaker running.
-    $self->stop_hana(method => $takeover_action);
+    $self->stop_hana(method => $takeover_action, online_string => $online_string);
 
     # SBD delay is active only after reboot
     if ($takeover_action eq 'crash' || $takeover_action eq 'stop') {
@@ -108,7 +111,7 @@ sub run {
     record_info(ucfirst($site_name) . ' start');
 
     $self->cleanup_resource();
-    $self->wait_for_cluster(wait_time => 60, max_retries => 10);
+    $self->wait_for_cluster(wait_time => 60, max_retries => 10, online_string => $online_string);
     die "Required hana resource is NOT running on $self->{my_instance}, aborting" unless $self->is_hana_resource_running();
     $self->display_full_status();
     if ($self->get_promoted_hostname() eq $target_site->{instance_id}) {

--- a/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
@@ -93,7 +93,10 @@ sub run {
     # Calculate SBD delay sleep time
     $sbd_delay = $self->sbd_delay_formula if $db_action eq 'crash';
 
-    $self->stop_hana(method => $db_action);
+    # Cache the online_string to avoid repeated SSH calls to pacemaker_version()
+    my $online_string = $self->get_online_string();
+
+    $self->stop_hana(method => $db_action, online_string => $online_string);
 
     # SBD delay is active only after reboot
     if ($db_action eq 'crash' || $db_action eq 'stop') {
@@ -117,7 +120,7 @@ sub run {
 
     # Cleanup the resource and check cluster
     $self->cleanup_resource();
-    $self->wait_for_cluster(wait_time => 60, max_retries => 10);
+    $self->wait_for_cluster(wait_time => 60, max_retries => 10, online_string => $online_string);
     $self->display_full_status();
 
     record_info("Done", "Test finished");

--- a/tests/sles4sap/publiccloud/qesap_prevalidate.pm
+++ b/tests/sles4sap/publiccloud/qesap_prevalidate.pm
@@ -63,6 +63,8 @@ sub run {
 
     # Check connectivity to all instances and status of the cluster in case of HA deployment
     my @hana_sites = get_hana_site_names();
+    # Cache the online_string to avoid repeated SSH calls to pacemaker_version() (version is cluster-wide constant)
+    my $online_string;
     foreach my $instance (@{$self->{instances}}) {
         $self->{my_instance} = $instance;
         my $instance_id = $instance->{'instance_id'};
@@ -79,7 +81,8 @@ sub run {
         # Output the version of tool 'SAPHanaSR-showAttr'
         record_info('SAPHanaSR version number', $self->saphanasr_showAttr_version());
 
-        $self->wait_for_sync();
+        $online_string //= $self->get_online_string();
+        $self->wait_for_sync(online_string => $online_string);
 
         # Define initial state for both sites
         # Site A is always PROMOTED (Master node) after deployment
@@ -104,7 +107,7 @@ sub run {
         $self->{my_instance} = $instance;
         last if ($instance->{instance_id} =~ m/vmhana/);
     }
-    $self->wait_for_cluster(wait_time => 60, max_retries => 10);
+    $self->wait_for_cluster(wait_time => 60, max_retries => 10, online_string => $online_string);
 
     record_info(
         'Instances:', "Detected HANA instances:


### PR DESCRIPTION
Refactor online status detection in publiccloud helper Introduces get_online_string() to centralize the logic for determining the "online" status string based on the Pacemaker version. Makes online_string a mandatory parameter for wait_for_sync() and wait_for_cluster() to ensure callers explicitly handle version-dependent states at test module level. This force the test code caching the value with the purpose of avoid repeated SSH calls when checking multiple instances, as implemented in qesap_prevalidate or within wait_for_ functions. Updates relevant test modules and unit tests to align with the new interface and verify the mandatory argument requirement.

- Related ticket: https://jira.suse.com/browse/TEAM-11212

# Verification run:

## 15-SP7

sle-15-SP7-HanaSr-Aws-Byos-x86_64-Build15-SP7_2026-05-05T02:03:23Z-hanasr_aws_test_fencing_native_stop_kill ec2_r4.8xlarge
 -  http://openqaworker15.qe.prg2.suse.org/tests/365717 :green_circle:  but `pacemalerd --version` still called 7 times http://openqaworker15.qe.prg2.suse.org/tests/365717/logfile?filename=serial_terminal.txt&filter=pacemakerd
 - http://openqaworker15.qe.prg2.suse.org/tests/365790

sle-15-SP7-HanaSr-Azure-Payg-x86_64-Build15-SP7_2026-05-05T02:03:23Z-hanasr_azure_test_msi az_Standard_E4s_v3
 - http://openqaworker15.qe.prg2.suse.org/tests/365718
 - https://openqaworker15.qe.prg2.suse.org/tests/365791

Azure (15-SP7): 
- http://openqaworker15.qe.prg2.suse.org/tests/365721 :green_circle:
- https://openqaworker15.qe.prg2.suse.org/tests/365792

## 15-SP6
- AWS (15-SP6): http://openqaworker15.qe.prg2.suse.org/tests/365720 :green_circle:
- GCP (15-SP6): http://openqaworker15.qe.prg2.suse.org/tests/365722 :green_circle:


## 12-SP5
sle-12-SP5-HanaSr-Azure-Byos-x86_64-Build12-SP5_2026-05-04T02:03:28Z-hanasr_azure_test_sbd_ltss_es az_Standard_E4s_v3 
 - http://openqaworker15.qe.prg2.suse.org/tests/365719
 - https://openqaworker15.qe.prg2.suse.org/tests/365793

- Azure (12-SP5): http://openqaworker15.qe.prg2.suse.org/tests/365723
