### PR TITLE
Extend ha_2nodes scenario for transactional systems

### DIFF
--- a/tests/ha/drbd_passive.pm
+++ b/tests/ha/drbd_passive.pm
@@ -9,7 +9,6 @@
 
 use Mojo::Base 'haclusterbasetest';
 use version_utils 'is_sle';
-use utils 'zypper_call';
 use testapi;
 use lockapi;
 use hacluster;
@@ -162,8 +161,6 @@ sub run {
 
     # Wait until DRBD test is initialized
     barrier_wait("DRBD_INIT_$cluster_name");
-
-    zypper_call '-n up';
 
     # Do the DRBD configuration only on the first node
     if (is_node(1)) {

--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -14,6 +14,7 @@ use serial_terminal qw(select_serial_terminal);
 use hacluster;
 use utils qw(zypper_call clear_console file_content_replace);
 use version_utils qw(is_sle package_version_cmp);
+use package_utils qw(install_package);
 
 sub type_qnetd_pwd {
     if (wait_serial(qr/Password:\s*$/i)) {
@@ -62,7 +63,8 @@ sub run {
 
     # HA test modules use packages from ClusterTools2. Attempt to install it here and in
     # ha_cluster_join, but continue if it's not possible (retval 104)
-    zypper_call('in ClusterTools2', exitcode => [0, 104]);
+    my $search_rc = zypper_call('se ClusterTools2', exitcode => [0, 104]);
+    install_package("ClusterTools2", trup_reboot => 1) if ($search_rc == 0);
 
     # Qdevice configuration
     if (get_var('QDEVICE')) {

--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -13,6 +13,7 @@ use lockapi;
 use serial_terminal qw(select_serial_terminal);
 use hacluster;
 use utils qw(zypper_call);
+use package_utils qw(install_package);
 
 sub wait_for_password_prompt {
     my %args = @_;
@@ -31,7 +32,8 @@ sub run {
 
     # HA test modules use packages from ClusterTools2. Attempt to install it here and in
     # ha_cluster_init, but continue if it's not possible (retval 104)
-    zypper_call('in ClusterTools2', exitcode => [0, 104]);
+    my $search_rc = zypper_call('se ClusterTools2', exitcode => [0, 104]);
+    install_package("ClusterTools2", trup_reboot => 1) if ($search_rc == 0);
 
     # Qdevice configuration
     if (get_var('QDEVICE')) {

--- a/tests/ha/iscsi_client_setup.pm
+++ b/tests/ha/iscsi_client_setup.pm
@@ -15,6 +15,7 @@ use hacluster;
 use mmapi qw(get_parents get_current_job_id);
 use serial_terminal qw(select_serial_terminal);
 use version_utils qw(is_sle package_version_cmp);
+use package_utils qw(install_package);
 
 =head1 NAME
 
@@ -85,7 +86,6 @@ iSCSI target and LUNs.
 sub request_luns {
     my (%args) = @_;
     foreach (qw(instance jobid numluns)) { die "request_luns: missing [$_] argument" unless $args{$_} }
-    zypper_call 'in nfs-client';    # Make sure nfs-client is installed
     assert_script_run 'mount -t nfs ' . get_required_var('NFS_SUPPORT_SHARE') . ' /mnt';
     assert_script_run "mkdir /mnt/ondemand/$args{instance}_$args{jobid}_$args{numluns}";
     assert_script_run 'umount /mnt';
@@ -113,8 +113,9 @@ sub run {
     record_info 'iscsi initiator pre configuration', script_output('cat /etc/iscsi/initiatorname.iscsi', proceed_on_failure => 1);
     record_info 'rpm-qf', script_output('rpm -qf /etc/iscsi/initiatorname.iscsi', proceed_on_failure => 1);
 
-    # open-iscsi & iscsiuio
-    zypper_call 'in open-iscsi' if (script_run('rpm -q open-iscsi'));
+    # Install dependencies
+    install_package("open-iscsi nfs-client", trup_reboot => 1);
+
     record_info 'iscsi initiator configuration', script_output('cat /etc/iscsi/initiatorname.iscsi');
     record_info 'rpm-qf', script_output('rpm -qf /etc/iscsi/initiatorname.iscsi');
     record_info('open-iscsi version', script_output('rpm -q open-iscsi'));


### PR DESCRIPTION
HA now supports transactional systems and the tests need to be extended. This
commit:
* Uses package_utils::install_package instead of zypper directly. That way the
correct way to install packages will be chosen whether the SUT is transactional
or not.
* Turns the check for the installability of ClusterTools2 to a `zypper se`, as
that is available to all systems.
* Removes an unnecessary `zypper up` in the begining of `drbd_passive.pm`, as
the system needs to be fully patched by the time that point is reached.

- Related ticket: TEAM-11014
- Verification run: [SLE 16.1 (transactional)](https://openqaworker15.qe.prg2.suse.org/tests/366159#dependencies), [SLE 15SP7 (classic-no drbd)](https://openqaworker15.qe.prg2.suse.org/tests/366165#dependencies) [SLE 15SP7 (classic with drbd)](https://openqaworker15.qe.prg2.suse.org/tests/366161#dependencies