### PR TITLE
Refactor PC LTP invocation

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -119,6 +119,8 @@ sub load_latest_publiccloud_tests {
     }
 
     if (get_var('PUBLIC_CLOUD_LTP')) {
+        loadtest "publiccloud/prepare_instance", run_args => $args;
+        loadtest("publiccloud/registration", run_args => $args);
         loadtest 'publiccloud/run_ltp', run_args => $args;
     }
     elsif (get_var('PUBLIC_CLOUD_ACCNET')) {

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -412,13 +412,10 @@ sub run {
 
     select_host_console();
 
-    ($args->{my_provider}, $args->{my_instance}) = $self->prepare_instance($args);
-
     my $instance = $args->{my_instance};
     my $provider = $args->{my_provider};
 
     prepare_scripts();
-    register_instance($instance, $qam);
 
     my $ltp_dir = '/tmp/ltp';
     my $ltp_prefix = '/opt/ltp';
@@ -458,28 +455,12 @@ sub run {
 }
 
 
-sub prepare_instance {
-    my ($self, $args) = @_;
-    unless ($args->{my_provider} && $args->{my_instance}) {
-        $args->{my_provider} = $self->provider_factory();
-        $args->{my_instance} = $args->{my_provider}->create_instance();
-        $args->{my_instance}->wait_for_guestregister() if (is_ondemand());
-    }
-
-    return ($args->{my_provider}, $args->{my_instance});
-}
-
 sub prepare_scripts {
     assert_script_run("cd $root_dir");
     assert_script_run('curl ' . data_url('publiccloud/restart_instance.sh') . ' -o restart_instance.sh');
     assert_script_run('curl ' . data_url('publiccloud/log_instance.sh') . ' -o log_instance.sh');
     assert_script_run('chmod +x restart_instance.sh');
     assert_script_run('chmod +x log_instance.sh');
-}
-
-sub register_instance {
-    my ($instance, $qam) = @_;
-    registercloudguest($instance) if (is_byos() && !$qam);
 }
 
 sub install_ltp {


### PR DESCRIPTION
We have a workflow divergence when running LTP between maintenance test runs and Latest Test runs.

This commit is intended to fix workflow divergence and unify the workflow.

- Related ticket: https://progress.opensuse.org/issues/198170?
- Verification run: [Azure-BYOS](https://openqa.suse.de/tests/22166890)
-  sle-16.0-Azure-BYOS-aarch64-Build0870-publiccloud_ltp@64bit -> https://openqa.suse.de/tests/22171610
- sle-16.0-Azure-Standard-x86_64-Build0870-publiccloud_ltp@az_Standard_B2s -> https://openqa.suse.de/tests/22171611
- sle-16.0-Azure-Basic-x86_64-Build0870-publiccloud_ltp@az_Standard_B2s -> https://openqa.suse.de/tests/22171612
- sle-16.0-EC2-aarch64-Build0871-publiccloud_ltp@ec2_m7g.large -> https://openqa.suse.de/tests/22171613
- sle-16.0-EC2-BYOS-aarch64-Build0871-publiccloud_ltp@ec2_m7g.large -> https://openqa.suse.de/tests/22216742
- sle-16.0-GCE-BYOS-aarch64-Build0826-publiccloud_ltp@64bit -> https://openqa.suse.de/tests/22171615
- sle-16.0-GCE-aarch64-Build0826-publiccloud_ltp@64bit -> https://openqa.suse.de/tests/22171616

---

- sle-12-SP5-Azure-Incidents-x86_64-Build:smelt:44184:kernel-ec2-publiccloud_ltp@az_Standard_B2s -> https://openqa.suse.de/tests/22268951
- sle-12-SP5-Azure-BYOS-Incidents-x86_64-Build:smelt:44184:kernel-ec2-publiccloud_ltp@az_Standard_B2s -> https://openqa.suse.de/tests/22268955
- sle-12-SP5-EC2-BYOS-Incidents-x86_64-Build:smelt:44184:kernel-ec2-publiccloud_ltp@ec2_t3a.large -> https://openqa.suse.de/tests/22268958
- sle-12-SP5-EC2-Incidents-x86_64-Build:smelt:44184:kernel-ec2-publiccloud_ltp@ec2_t3a.large -> https://openqa.suse.de/tests/22268959
- sle-12-SP5-GCE-BYOS-Incidents-kernel-x86_64-Build:smelt:44184:kernel-ec2-publiccloud_ltp@gce_t2d_standard_60 -> https://openqa.suse.de/tests/22268960
 - sle-12-SP5-GCE-Incidents-x86_64-Build:smelt:44184:kernel-ec2-publiccloud_ltp@gce_n1_standard_2 -> https://openqa.suse.de/tests/22268961
