### PR TITLE
Refactor LibreOffice tests

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -1010,10 +1010,30 @@ sub open_overview {
 
 # Start one of the libreoffice components, close any first-run dialogs
 sub libreoffice_start_program {
-    my ($self, $program) = @_;
+    my ($self, $program, %args) = @_;
     my %start_program_args;
-    $start_program_args{timeout} = 100 if get_var('LIVECD') && check_var('MACHINE', 'uefi-usb');
-    x11_start_program($program, %start_program_args);
+
+    my %libreoffice_applications = (
+        "oobase" => "base",
+        "oocalc" => "calc",
+        "oodraw" => "draw",
+        "ooimpress" => "impress",
+        "oowriter" => "writer",
+        "libreoffice" => "libreoffice"
+    );
+
+    die "Unrecognized LibreOffice application: $program" unless $libreoffice_applications{$program};
+
+    if ($args{from_overview}) {
+        $self->open_overview;
+        type_string $libreoffice_applications{$program};
+        assert_and_click "overview-office-" . $libreoffice_applications{$program};
+        assert_screen $program;
+    } else {
+        $start_program_args{timeout} = 100 if get_var('LIVECD') && check_var('MACHINE', 'uefi-usb');
+        x11_start_program($program, %start_program_args);
+    }
+
     if (check_screen('popup-welcome-to-libreoffice')) {
         send_key "alt-f4";
     }

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -1002,6 +1002,12 @@ sub disable_key_repeat {
     x11_start_program('xset -r', target_match => 'generic-desktop', no_wait => 1);
 }
 
+sub open_overview {
+    wait_still_screen 3;
+    send_key "super";
+    assert_screen 'tracker-mainmenu-launched';
+}
+
 # Start one of the libreoffice components, close any first-run dialogs
 sub libreoffice_start_program {
     my ($self, $program) = @_;

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -1008,6 +1008,20 @@ sub open_overview {
     assert_screen 'tracker-mainmenu-launched';
 }
 
+sub libreoffice_handle_welcome_popup {
+    if (check_screen('popup-welcome-to-libreoffice')) {
+        send_key "alt-f4";
+    }
+}
+
+sub libreoffice_handle_tip_of_the_day {
+    if (check_screen([qw(ooffice-tip-of-the-day oomath-tip-of-the-day)], 5)) {
+        # Unselect "_S_how tips on startup", select "_O_k"
+        send_key "alt-s";
+        send_key "alt-o";
+    }
+}
+
 # Start one of the libreoffice components, close any first-run dialogs
 sub libreoffice_start_program {
     my ($self, $program, %args) = @_;
@@ -1034,14 +1048,8 @@ sub libreoffice_start_program {
         x11_start_program($program, %start_program_args);
     }
 
-    if (check_screen('popup-welcome-to-libreoffice')) {
-        send_key "alt-f4";
-    }
-    if (check_screen([qw(ooffice-tip-of-the-day oomath-tip-of-the-day)], 5)) {
-        # Unselect "_S_how tips on startup", select "_O_k"
-        send_key "alt-s";
-        send_key "alt-o";
-    }
+    libreoffice_handle_welcome_popup;
+    libreoffice_handle_tip_of_the_day;
 }
 
 sub start_gnome_tweak_tool {

--- a/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
@@ -1,50 +1,13 @@
 # LibreOffice tests
 #
-# Copyright 2016-2019 SUSE LLC
+# Copyright 2016-2026 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: libreoffice libreoffice-base libreoffice-calc libreoffice-draw
 # libreoffice-impress libreoffice-writer
 # Summary: Case 1503827 - LibreOffice: Launch application components from system menu
-# - Open menu button -> office menu
-#   - Launch libreoffice and check
-#   - Quit libreoffice
-# - Open menu button -> office menu
-#   - Launch office base and check
-#   - Save a database named "testdatabase"
-#   - Cleanup created database
-#   - Quit libreoffice
-# - Open menu button -> office menu
-#   - Launch office calc and check
-#   - Quit libreoffice
-# - Open menu button -> office menu
-#   - Launch office draw and check
-#   - Quit libreoffice
-# - Open menu button -> office menu
-#   - Launch office impress and check
-#   - Quit libreoffice
-# - Open menu button -> office menu
-#   - Launch office writer and check
-#   - Quit libreoffice
-# - Install libreoffice-base if necessary
-# - Open gnome activities overview
-#   - Type "base", send <ENTER> and check
-#   - Save a database named "testdatabase"
-#   - Cleanup created database
-# - Open gnome activities overview
-#   - Type "calc", send <ENTER> and check
-#   - Uncheck "show tips on startup"
-#   - Quit libreoffice
-# - Open gnome activities overview
-#   - Type "draw", send <ENTER> and check
-#   - Quit libreoffice
-# - Open gnome activities overview
-#   - Type "impress", send <ENTER> and check
-#   - Quit libreoffice
-# - Open gnome activities overview
-#   - Type "writer", send <ENTER> and check
-#   - Click on writing area
-#   - Quit libreoffice
+# - Use Gnome Activities to launch LibreOffice Base, Calc, Draw, Impress and Writer
+#   by clicking on the Icons
 # Maintainer: Zhaocong Jia <zcjia@suse.com>
 
 use Mojo::Base 'x11test';
@@ -52,17 +15,6 @@ use testapi;
 use utils;
 use version_utils qw(is_sle is_tumbleweed);
 use x11utils qw(default_gui_terminal close_gui_terminal);
-
-# open desktop mainmenu and click office
-sub open_mainmenu {
-    my $self = shift;
-
-    wait_still_screen 3;
-    send_key "alt-f1";
-    assert_screen 'test-desktop_mainmenu-1';
-    assert_and_click 'mainmenu-office';
-    assert_screen 'mainmenu-office-components';
-}
 
 sub select_base_and_cleanup {
     assert_screen 'oobase-select-database', 45;
@@ -90,48 +42,6 @@ sub select_base_and_cleanup {
 sub run {
     my $self = shift;
 
-    if (!is_tumbleweed && is_sle('<15')) {
-        # launch components from mainmenu
-        $self->open_mainmenu();
-        assert_and_click 'mainmenu-office-lo';    #open lo
-        assert_screen 'welcome-to-libreoffice';
-        send_key "ctrl-q";    #close lo
-
-        $self->open_mainmenu();
-        assert_and_click 'mainmenu-office-base';    #open base
-        select_base_and_cleanup;
-
-        $self->open_mainmenu();
-        assert_and_click 'mainmenu-office-calc';    #open calc
-        assert_screen 'test-oocalc-1';
-        send_key "ctrl-q";    #close calc
-
-        $self->open_mainmenu();
-        assert_and_click 'mainmenu-office-draw';    #open draw
-        assert_screen 'oodraw-launched';
-        send_key "ctrl-q";    #close draw
-
-        $self->open_mainmenu();
-        assert_and_click 'mainmenu-office-impress';    #open impress
-        assert_screen [qw(ooimpress-select-a-template ooimpress-select-template-nofocus ooimpress-launched)];
-        if (match_has_tag 'ooimpress-select-template-nofocus') {
-            assert_and_click 'ooimpress-select-template-nofocus';
-            send_key 'alt-f4';
-            assert_screen 'ooimpress-launched';
-        }
-        elsif (match_has_tag 'ooimpress-select-a-template') {
-            send_key 'alt-f4';    # close impress template window
-            assert_screen 'ooimpress-launched';
-        }
-        send_key "ctrl-q";    #close impress
-
-        $self->open_mainmenu();
-        assert_and_click 'mainmenu-office-writer';    #open writer
-        assert_screen 'test-ooffice-1';
-        send_key "ctrl-q";    #close writer
-    }
-
-    # launch components from Activities overview
     $self->libreoffice_start_program("oobase", from_overview => 1);
     select_base_and_cleanup;
 
@@ -144,7 +54,7 @@ sub run {
     $self->libreoffice_start_program("ooimpress", from_overview => 1);
 
     assert_screen [qw(ooimpress-select-a-template ooimpress-select-template-nofocus ooimpress-launched)];
-    elsif (match_has_tag 'ooimpress-select-a-template') {
+    if (match_has_tag 'ooimpress-select-a-template') {
         send_key 'alt-f4';    # close impress template window
         assert_screen 'ooimpress-launched';
     }

--- a/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
@@ -64,13 +64,6 @@ sub open_mainmenu {
     assert_screen 'mainmenu-office-components';
 }
 
-# enter 'Activities overview'
-sub open_overview {
-    wait_still_screen 3;
-    send_key "super";
-    assert_screen 'tracker-mainmenu-launched';
-}
-
 sub select_base_and_cleanup {
     assert_screen 'oobase-select-database', 45;
     if (check_screen 'oobase-database-empty') {

--- a/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
@@ -132,74 +132,25 @@ sub run {
     }
 
     # launch components from Activities overview
-    $self->open_overview();
-    type_string "base";
-    assert_screen([qw(base-install overview-office-base)]);
-    # tag is base-install means libreoffice-base not installed
-    if (match_has_tag 'base-install') {
-        send_key 'esc';
-        send_key 'esc';
-        x11_start_program(default_gui_terminal());
-        script_run("gsettings set org.gnome.desktop.session idle-delay 0", 0);    #value=0 means never blank screen
-        become_root;
-        zypper_call("in libreoffice-base", timeout => 900);
-        script_run("gsettings set org.gnome.desktop.session idle-delay 900", 0);    #default value=900
-        close_gui_terminal;
-        $self->open_overview();
-        type_string "base";
-    }
-    assert_screen 'overview-office-base';
-    send_key "ret";
+    $self->libreoffice_start_program("oobase", from_overview => 1);
     select_base_and_cleanup;
 
-    $self->open_overview();
-    type_string "calc";    #open calc
-    assert_and_click 'overview-office-calc';
-    assert_screen 'test-oocalc-1', 60;
-    if (!match_has_tag('ooffice-tip-of-the-day')) {
-        # Sometimes the dialog does not appear immediately but after a short delay,
-        # or is fading in slowly - poo#56510
-        wait_still_screen 2;
-        assert_screen 'test-oocalc-1';
-    }
-    if (match_has_tag('ooffice-tip-of-the-day')) {
-        # Unselect "_S_how tips on startup", select "_O_k"
-        send_key "alt-s";
-        send_key "alt-o";
-        while (match_has_tag('ooffice-tip-of-the-day')) {
-            assert_screen 'test-oocalc-1';
-        }
-    }
+    $self->libreoffice_start_program("oocalc", from_overview => 1);
     send_key "ctrl-q";    #close calc
 
-    $self->open_overview();
-    type_string "draw";    #open draw
-    assert_screen 'overview-office-draw';
-    send_key "ret";
-    assert_screen 'oodraw-launched';
+    $self->libreoffice_start_program("oodraw", from_overview => 1);
     send_key "ctrl-q";    #close draw
 
-    $self->open_overview();
-    type_string "impress";    #open impress
-    assert_screen 'overview-office-impress';
-    send_key "ret";
+    $self->libreoffice_start_program("ooimpress", from_overview => 1);
+
     assert_screen [qw(ooimpress-select-a-template ooimpress-select-template-nofocus ooimpress-launched)];
-    if (match_has_tag 'ooimpress-select-template-nofocus') {
-        assert_and_click 'ooimpress-select-template-nofocus';
-        send_key 'alt-f4';
-        assert_screen 'ooimpress-launched';
-    }
     elsif (match_has_tag 'ooimpress-select-a-template') {
         send_key 'alt-f4';    # close impress template window
         assert_screen 'ooimpress-launched';
     }
     send_key "ctrl-q";    #close impress
 
-    $self->open_overview();
-    type_string "writer";    #open writer
-    assert_screen 'overview-office-writer';
-    send_key "ret";
-    assert_screen 'test-ooffice-1';
+    $self->libreoffice_start_program("oowriter", from_overview => 1);
     assert_and_click('ooffice-writing-area', timeout => 10);
     send_key "ctrl-q";    #close writer
 }

--- a/tests/x11/libreoffice/libreoffice_open_specified_file.pm
+++ b/tests/x11/libreoffice/libreoffice_open_specified_file.pm
@@ -35,12 +35,9 @@ sub run {
         save_screenshot;
         type_string_slow "test.$tag\n";
         wait_still_screen 3, 7;
+        $self->libreoffice_handle_welcome_popup;
+        $self->libreoffice_handle_tip_of_the_day;
         assert_screen("libreoffice-test-$tag", 120);
-        if (match_has_tag('ooffice-tip-of-the-day')) {
-            # Unselect "_S_how tips on startup", select "_O_k"
-            send_key "alt-s";
-            send_key "alt-o";
-        }
         # close document
         send_key "ctrl-f4";
         wait_still_screen(2);

--- a/tests/x11/libreoffice/libreoffice_recent_documents.pm
+++ b/tests/x11/libreoffice/libreoffice_recent_documents.pm
@@ -51,18 +51,17 @@ sub run {
         assert_screen 'oowriter-menus-file';
     }
 
-    if (is_tumbleweed || is_sle('15+')) {
-        send_key 'down';
-        wait_still_screen 3;
-        send_key 'u';
-    }
-    else {
-        send_key "ctrl-u";
-    }
+    send_key 'down', wait_screen_change => 1;
+    send_key 'u';
+
     assert_screen 'oowriter-menus-file-recentDocuments';
     send_key_until_needlematch("libreoffice-clear-list", "down");
-    send_key "ret";
-    assert_screen 'test-ooffice-1';
+    send_key "ret", wait_screen_change => 1;
+    assert_screen [qw(test-ooffice-1 oowriter clear-recent-documents)];
+
+    if (match_has_tag('clear-recent-documents')) {
+        send_key "alt-f4", wait_screen_change => 1;
+    }
 
     # Quit oowriter
     assert_and_click('ooffice-writing-area', timeout => 10);

--- a/tests/x11/libreoffice/libreoffice_recent_documents.pm
+++ b/tests/x11/libreoffice/libreoffice_recent_documents.pm
@@ -1,6 +1,6 @@
 # LibreOffice tests
 #
-# Copyright 2016-2019 SUSE LLC
+# Copyright 2016-2026 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Package: libreoffice-writer
@@ -39,7 +39,7 @@ sub run {
 
     # Check Recent Documents
     wait_still_screen;
-    x11_start_program('oowriter');
+    $self->libreoffice_start_program('oowriter');
 
     send_key "alt-f";
     # The menu may disappear due to boo#1156745, so we wait here


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/199187

This PR mostly makes common parts reusable and standarirzes application launching, along with some fixes for the tests to pass on TW.

- Changed `libreoffice_start_program` into a generic wrapper for launching LibreOffice applications from either GNOME Activities or the application runner, making handling of pop-ups to happen in a single place at application start.
- Moved the checks for "Tip of the Day" and "LibreOffice Welcome" dialogs to their own functions so they can be reused in other modules (like `libreoffice_open_specified_file`)
- Added logic to handle a new confirmation popup in recent LibreOffice versions that appears when clearing recent documents.
- Removed obsolete code paths, as all currently supported platforms (SLE, Leap, Tumbleweed) have migrated to GNOME Activities, and SLE 12 is EOL.


VR:
- SLE-15-SP7: https://openqa.suse.de/tests/22166185
- Tumbleweed: https://openqa.opensuse.org/tests/5897001
