### PR TITLE
Move host config due to vmware

### DIFF
--- a/schedule/jeos/sle/minimalvm-extratest.yaml
+++ b/schedule/jeos/sle/minimalvm-extratest.yaml
@@ -31,11 +31,11 @@ conditional_schedule:
 schedule:
     - '{{bootloader}}'
     - jeos/firstrun
+    - jeos/host_config
     - console/consoletest_setup
     - jeos/record_machine_id
     - console/system_prepare
     - console/force_scheduled_tasks
-    - jeos/host_config
     - jeos/diskusage
     - jeos/build_key
     - console/suseconnect_scc

--- a/schedule/jeos/sle/minimalvm-main.yaml
+++ b/schedule/jeos/sle/minimalvm-main.yaml
@@ -50,8 +50,10 @@ conditional_schedule:
         FIRST_BOOT_CONFIG:
             'wizard':
                 - jeos/firstrun
+                - jeos/host_config
             'cloud-init':
                 - installation/first_boot
+                - jeos/host_config
                 - console/system_prepare
             'combustion':
                 - installation/first_boot


### PR DESCRIPTION
We need to ensure that all vmware MinimalVM tests are not going to remove the grub2's timeout

- Verification run: https://openqa.suse.de/tests/22187722#details
