### PR TITLE
Increase timeout for remote zypper update on SLE 15-SP5

### DIFF
--- a/tests/publiccloud/registration.pm
+++ b/tests/publiccloud/registration.pm
@@ -29,7 +29,7 @@ sub run {
 
     # https://progress.opensuse.org/issues/196370 workaround for a known issue on 15-SP5
     if (is_sle('=15-SP5')) {
-        $args->{my_instance}->zypper_call_remote("update -y", retry => 10, delay => 60);
+        $args->{my_instance}->zypper_call_remote("update -y", retry => 10, delay => 60, timeout => 1800);
         $args->{my_instance}->softreboot(timeout => 3600);
     }
 


### PR DESCRIPTION
A known issue on SLE 15-SP5 requires a full system update before registration. The previous implementation used the default timeout of 700 seconds in `zypper_call_remote`, which was insufficient for systems with many maintenance updates.
Analysis of failing jobs showed that `zypper update` sometimes exceeds the 700-second threshold, causing the test to die immediately and bypassing the retry logic.
This change increases the timeout to 1800 seconds (30 minutes) to ensure sufficient headroom for downloading and installing updates on Azure instances, based on observed maximums of nearly 700 seconds.

- Related ticket: https://jira.suse.com/browse/TEAM-11213

# Verification run:
 - sle-15-SP5-Azure-SAP-BYOS-Updates-saptune-x86_64-Build20260503-1-sles4sap_gnome_saptune_delete_rename@az_Standard_E4s_v3 -> http://openqaworker15.qe.prg2.suse.org/tests/365794