### PR TITLE
Skip JUnit result parsing when Ansible successfully recovers via rescue blocks

### DIFF
--- a/tests/sles4sap/publiccloud/qesap_ansible.pm
+++ b/tests/sles4sap/publiccloud/qesap_ansible.pm
@@ -130,8 +130,10 @@ sub run {
             '[', '$?', '-ne', '124', ']',
             '||', 'echo', '"Command find timed out"');
 
-        for my $log (split(/\n/, script_output($find_cmd))) {
-            parse_extra_log("XUnit", $log);
+        if ($ret[0]) {
+            for my $log (split(/\n/, script_output($find_cmd))) {
+                parse_extra_log("XUnit", $log);
+            }
         }
         qesap_ansible_softfail(logfile => $ret[1]);
 

--- a/tests/sles4sap/qesapdeployment/deploy.pm
+++ b/tests/sles4sap/qesapdeployment/deploy.pm
@@ -103,9 +103,11 @@ sub run {
         '/tmp/results/',
         '-type', 'f',
         '-iname', "*.xml");
-    for my $log (split(/\n/, script_output($find_cmd))) {
-        parse_extra_log("XUnit", $log);
-        enter_cmd("rm $log");
+    if ($ret[0]) {
+        for my $log (split(/\n/, script_output($find_cmd))) {
+            parse_extra_log("XUnit", $log);
+            enter_cmd("rm $log");
+        }
     }
     qesap_ansible_softfail(logfile => $ret[1]);
     if ($ret[0]) {


### PR DESCRIPTION
When qe-sap-deployment Ansible playbooks use block/rescue to handle transient failures, the command returns exit code 0 if recovery is successful. However, the JUnit reporter still records the initial task failures in the generated XML reports.

Previously, parse_extra_log("XUnit", ...) was called unconditionally on all generated reports. This caused openQA to mark the job as failed by reading those recorded failures, even when the deployment was ultimately successful.

This change restricts JUnit report parsing to cases where the Ansible command actually fails (non-zero exit code), preventing false openQA failures for successfully recovered deployments.


- Related ticket: https://jira.suse.com/browse/TEAM-11211

# Verifications

 ## Group qesap regression (Verifying deploy.pm)
  These jobs test the logic that handles Ansible rescue blocks during Azure deployments.

   * Job #366043 (http://openqaworker15.qe.prg2.suse.org/tests/366043): qesap_azure_angi_test (15-SP6)
   * Job #366044 (http://openqaworker15.qe.prg2.suse.org/tests/366044): qesap_azure_saptune_test_spn (15-SP6)
   * sle-16.0-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE16_0-qesap_gcp_angi_test -> http://openqaworker15.qe.prg2.suse.org/tests/366127

 ## Group HanaSR regression (Verifying qesap_ansible.pm)
  These jobs test the same logic within the qesap_ansible module across AWS and GCP.

   * Job #366045 (http://openqaworker15.qe.prg2.suse.org/tests/366045): hanasr_aws_test_fencing_native_stop_kill (15-SP6) :green_circle: 
   * Job #366046 (http://openqaworker15.qe.prg2.suse.org/tests/366046): hanasr_aws_test_fencing_native_stop_kill (16.0) :green_circle: 
   * Job #366047 (http://openqaworker15.qe.prg2.suse.org/tests/366047): hanasr_gcp_test_fencing_native_stop_kill (15-SP6) :green_circle: 
   *  - sle-15-SP6-HanaSr-Gcp-Byos-x86_64-Build15-SP6_2026-05-05T02:03:23Z-hanasr_gcp_test_fencing_native_stop_kill gce_n1_highmem_32 artificial ansible failure using an invalid registration code -> http://openqaworker15.qe.prg2.suse.org/tests/366134
