### PR TITLE
xfstests: Universally applicable kernel-default-extra version

### DIFF
--- a/lib/rdma.pm
+++ b/lib/rdma.pm
@@ -40,12 +40,10 @@ sub install_rdma_dependency {
       libibverbs-utils
     );
     my $kernel_version = get_var('KERNEL_VERSION');
-    if ($kernel_version) {
-        my $kver = script_output("rpm -q kernel-default --queryformat '%{VERSION}-%{RELEASE}\\n' | grep '$kernel_version'");
-        push @deps, "kernel-default-extra=$kver";
-    } else {
-        push @deps, 'kernel-default-extra';
-    }
+    my $match = $kernel_version || script_output("uname -r | sed 's/-[^0-9]*\$//'");
+    my $rpm_output = script_output("rpm -q kernel-default --queryformat '%{VERSION}-%{RELEASE}\\n'");
+    my $kver = (grep { /^\Q$match\E/ } split(/\n/, $rpm_output))[-1] // '';
+    push @deps, "kernel-default-extra=$kver";
     my $packages = join(' ', @deps);
     script_run('zypper --gpg-auto-import-keys ref');
     install_package($packages, trup_reboot => 1);


### PR DESCRIPTION
xfstests 16.0 staging test didn't set with KERNEL_VERSION then the match will fail, this commit to make it more general.

- Related ticket: https://progress.opensuse.org/issues/200606
- Verification run: https://openqa.suse.de/tests/22183903#step/partition/56 (The VR is in a developing product, because the klp staging can't retrigger, and this test also not configured with KERNEL_VERSION)