### PR TITLE
fix(cont): manually create /var/log/apache2 as a temp workaround

### DIFF
--- a/data/containers/Dockerfile
+++ b/data/containers/Dockerfile
@@ -5,6 +5,8 @@ FROM baseimage_var
 RUN zypper --gpg-auto-import-keys ref
 RUN zypper -n in apache2 && zypper clean -a
 RUN echo 'ServerName AppacheInContainer' >> /etc/apache2/httpd.conf
+# apache fails to start without its log folder --> bsc#1264186
+RUN mkdir -p /var/log/apache2
 
 # set a directory for the app
 WORKDIR /srv/www/htdocs/


### PR DESCRIPTION
The recent apache2 update in Tumbleweed shifted directory creation to systemd-tmpfiles. Since this container environment lacks systemd, Apache fails to start due to the missing log directory.

This is a temporary fix.

Related to: bsc#1264186

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1264186
- Verification run: https://openqa.suse.de/tests/22185506