### PR TITLE
Containers: Create directories needed by Apache2 after recent package update

### DIFF
--- a/data/containers/Dockerfile
+++ b/data/containers/Dockerfile
@@ -6,6 +6,9 @@ RUN zypper --gpg-auto-import-keys ref
 RUN zypper -n in apache2 && zypper clean -a
 RUN echo 'ServerName AppacheInContainer' >> /etc/apache2/httpd.conf
 
+# /var/log/apache2 and /srv/www/htdocs are now created via systemd-tmpfiles: https://build.opensuse.org/requests/1350419
+RUN mkdir -p /var/log/apache2 /srv/www/htdocs
+
 # set a directory for the app
 WORKDIR /srv/www/htdocs/
 


### PR DESCRIPTION
This is blocking TW Staging

Failure: https://openqa.opensuse.org/tests/5899948#step/image_podman/177
Ticket: https://progress.opensuse.org/issues/200666

After https://build.opensuse.org/requests/1350419 `/var/log/apache2` and `/srv/www/htdocs` among others are now created via systemd-tmpfiles[1] and are needed for apache to be able to run inside the container

openqa: clone https://openqa.opensuse.org/tests/5899950
openqa: clone https://openqa.opensuse.org/tests/5899949
