### PR TITLE
fix: correct overly broad failure detection in script_run_interactive

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -2292,14 +2292,15 @@ sub script_run_interactive {
     }
 
     # Hack: '$' doesn't match '\r\n' line endings, so use '\s' instead
-    push(@words, qr/${endmark}\d+\s/m);
+    my $exitre = qr/${endmark}\d+\s/m;
+    push(@words, $exitre);
 
     {
         do {
             $output = wait_serial(\@words, $timeout) || die "No message matched!";
 
             last if ($output =~ /${endmark}0\s/m);    # return value is 0
-            die if ($output =~ /${endmark}/m);    # other return values
+            die if ($output =~ $exitre);    # other return values
 
             for my $i (@$scan) {
                 next if ($output !~ $i->{prompt});


### PR DESCRIPTION
Motivation:
When PRETTY_SERIAL_MARKER=1 is enabled, the bash history hook echoes the literal
command string back into the serial buffer. This includes the EOS~~~ marker
used by script_run_interactive to detect script completion and exit status.
The previous regex /EOS~~~/m was too broad and caught this reflection,
causing the test to die prematurely even though the script was still running.

Design Choices:
Refine the failure detection regex to strictly match the expected output format
of the exit code marker (EOS~~~<digits><whitespace>). This matches the actual
output of "echo EOS~~~$?" while ignoring the string reflection in the history
hook.

Benefits:
Allows script_run_interactive to work correctly with advanced serial markers,
enabling more efficient synchronization without breaking existing interactive
tests.

Verification run:
```
MARKDOWN=1 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25500 https://openqa.opensuse.org/tests/5896070
```

* [opensuse-Tumbleweed-DVD-x86_64-Build20260430-okurz-pretty-apparmor-okurz-pretty@uefi](https://openqa.opensuse.org/tests/5901179) -> ![[opensuse-Tumbleweed-DVD-x86_64-Build20260430-okurz-pretty-apparmor-okurz-pretty@uefi](https://openqa.opensuse.org/tests/5901179)](https://openqa.opensuse.org/tests/5901179/badge)

Related issue: https://progress.opensuse.org/issues/183761