### PR TITLE
Improve `check_cluster_state` regex

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -838,25 +838,23 @@ sub check_cluster_state {
         script_run $verify_cmd;
     }
     else {
-        if (is_sle('>16')) {
-            # Need both retval and output, so use utils::cmd_run
-            # Also redirect stderr to stdout to get the actual command output
-            my ($ret, $out) = cmd_run("$verify_cmd 2>&1");
-            return if (defined $ret && $ret == 0);
-            if ($ret == 78) {
-                my $errors = 0;
-                foreach my $line (split(/\n/, $out)) {
-                    record_soft_failure "jsc#PED-14519 - $verify_cmd shows deprecation warnings"
-                      if ($line =~ /Support for legacy name .stonith.+is deprecated/);
-                    next if ($line =~ /^warning:/);
-                    next if ($line =~ /^Configuration may need attention/);
-                    ++$errors;
-                }
-                return unless ($errors);
+        # Need both retval and output, so use utils::cmd_run
+        # Also redirect stderr to stdout to get the actual command output
+        my ($ret, $out) = cmd_run("$verify_cmd 2>&1");
+        return if (defined $ret && $ret == 0);
+        if ($ret == 78) {
+            my $errors = 0;
+            foreach my $line (split(/\n/, $out)) {
+                record_soft_failure "jsc#PED-14519 - $verify_cmd shows deprecation warnings"
+                  if ($line =~ /Support for legacy name .stonith.+is deprecated/);
+                next if ($line =~ /^[Ww]arning/);
+                next if ($line =~ /^Configuration may need attention/);
+                ++$errors;
             }
-            die "$verify_cmd failed. return value=[$ret]; output=[$out]";
+            return unless ($errors);
         }
-        $cmd_sub->($verify_cmd);
+        die "$verify_cmd failed. return value=[$ret]; output=[$out]"
+          unless ($args{proceed_on_failure});
     }
 }
 

--- a/t/11_hacluster.t
+++ b/t/11_hacluster.t
@@ -465,6 +465,8 @@ subtest '[check_cluster_state]' => sub {
     my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
     my @calls;
     $hacluster->redefine(script_run => sub { push @calls, $_[0]; });
+    $hacluster->redefine(cmd_run => sub { push @calls, $_[0];
+            return 'cmd_run'; });
     $hacluster->redefine(assert_script_run => sub { push @calls, $_[0]; });
     $hacluster->redefine(check_online_nodes => sub { push @calls, 'check_online_nodes'; });
     $hacluster->redefine(script_output => sub { return 'crmshver=4.4.2'; });
@@ -484,11 +486,27 @@ subtest '[check_cluster_state] assert calls normally' => sub {
     $hacluster->redefine(assert_script_run => sub { push @calls, 'assert_script_run'; });
     $hacluster->redefine(check_online_nodes => sub { return; });
     $hacluster->redefine(script_output => sub { return 'crmshver=4.4.2'; });
+    $hacluster->redefine(cmd_run => sub { push @calls, 'cmd_run';
+            return 'all good' });
 
     check_cluster_state();
     note("\n  -->  " . join("\n  -->  ", @calls));
 
-    ok((all { /assert_script_run/ } @calls), 'check_cluster_state used assert_script_run');
+    ok((all { /(assert_script_run|cmd_run)/ } @calls), 'check_cluster_state
+    used assert_script_run');
+};
+
+subtest '[check_cluster_state] Cluster state errors' => sub {
+    my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
+    my @calls;
+    $hacluster->redefine(script_run => sub { push @calls, 'script_run'; });
+    $hacluster->redefine(assert_script_run => sub { push @calls, 'assert_script_run'; });
+    $hacluster->redefine(check_online_nodes => sub { return; });
+    $hacluster->redefine(script_output => sub { return 'crmshver=4.4.2'; });
+    $hacluster->redefine(cmd_run => sub { push @calls, 'cmd_run';
+            return (42, 'Cluster is not happy') });
+
+    dies_ok { check_cluster_state() } 'Fail with unhealthy cluster';
 };
 
 subtest '[check_cluster_state] proceed_on_failure' => sub {
@@ -498,11 +516,14 @@ subtest '[check_cluster_state] proceed_on_failure' => sub {
     $hacluster->redefine(assert_script_run => sub { push @calls, 'assert_script_run'; });
     $hacluster->redefine(check_online_nodes => sub { return; });
     $hacluster->redefine(script_output => sub { return 'crmshver=4.4.2'; });
+    $hacluster->redefine(cmd_run => sub { push @calls, 'cmd_run';
+            return (78, 'Warnings only') });
 
     check_cluster_state(proceed_on_failure => 1);
     note("\n  -->  " . join("\n  -->  ", @calls));
 
-    ok((all { /^script_run$/ } @calls), 'check_cluster_state used script_run');
+    ok((all { /^(script_run|cmd_run)$/ } @calls), 'check_cluster_state used
+    script_run');
 };
 
 subtest '[check_cluster_state] migration scenario' => sub {
@@ -529,6 +550,8 @@ subtest '[check_cluster_state] old crmsh' => sub {
     $hacluster->redefine(assert_script_run => sub { push @calls, $_[0]; });
     $hacluster->redefine(check_online_nodes => sub { push @calls, 'check_online_nodes'; });
     $hacluster->redefine(script_output => sub { return 'crmshver=3.6.0'; });
+    $hacluster->redefine(cmd_run => sub { push @calls, $_[0];
+            return (0, 'Cluster happy') });
 
     check_cluster_state();
     note("\n  -->  " . join("\n  -->  ", @calls));


### PR DESCRIPTION
Command `crm_verify -LV` returns RC78 in case of warnings which makes tests fail.
This PR improves existing regex to capture broader range of warning messages.

Ticket: https://jira.suse.com/browse/TEAM-11087
VR:
On prem: https://openqaworker15.qe.prg2.suse.org/tests/366489#live
SDAF: https://openqaworker15.qe.prg2.suse.org/tests/366492#live