### PR TITLE
Fix get_online_string calling pacemaker_version via method dispatch

### DIFF
--- a/lib/sles4sap/publiccloud.pm
+++ b/lib/sles4sap/publiccloud.pm
@@ -1413,7 +1413,7 @@ sub pacemaker_version {
 
 sub get_online_string {
     my ($self) = @_;
-    return check_version('>=2.1.7', $self->pacemaker_version(retries => 6, sleep_time => 10)) ? '4' : 'online';
+    return check_version('>=2.1.7', pacemaker_version($self, retries => 6, sleep_time => 10)) ? '4' : 'online';
 }
 
 =head2 saphanasr_showAttr_version

--- a/tests/sles4sap/publiccloud/hana_sr_takeover.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_takeover.pm
@@ -88,7 +88,7 @@ sub run {
     }
 
     # Cache the online_string to avoid repeated SSH calls to pacemaker_version()
-    my $online_string = $self->get_online_string();
+    my $online_string = get_online_string($self);
 
     # Stop/kill/crash HANA DB and wait till SSH is again available with pacemaker running.
     $self->stop_hana(method => $takeover_action, online_string => $online_string);

--- a/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
+++ b/tests/sles4sap/publiccloud/hana_sr_test_secondary.pm
@@ -94,7 +94,7 @@ sub run {
     $sbd_delay = $self->sbd_delay_formula if $db_action eq 'crash';
 
     # Cache the online_string to avoid repeated SSH calls to pacemaker_version()
-    my $online_string = $self->get_online_string();
+    my $online_string = get_online_string($self);
 
     $self->stop_hana(method => $db_action, online_string => $online_string);
 

--- a/tests/sles4sap/publiccloud/qesap_prevalidate.pm
+++ b/tests/sles4sap/publiccloud/qesap_prevalidate.pm
@@ -81,7 +81,7 @@ sub run {
         # Output the version of tool 'SAPHanaSR-showAttr'
         record_info('SAPHanaSR version number', $self->saphanasr_showAttr_version());
 
-        $online_string //= $self->get_online_string();
+        $online_string //= get_online_string($self);
         $self->wait_for_sync(online_string => $online_string);
 
         # Define initial state for both sites


### PR DESCRIPTION
Use direct function call instead of method dispatch for pacemaker_version inside get_online_string. Since sles4sap::publiccloud is used as a functional library (exported functions), calling $self->pacemaker_version() fails when $self is not of type sles4sap::publiccloud (e.g. qesap_prevalidate which inherits from sles4sap::publiccloud_basetest). pacemaker_version was removed from @EXPORT in commit 1d9ef99a7045d2ed6e522be123790de185e75ff5, making it unreachable via method resolution for consumer test modules.

Fix regression introduced by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25483

Related ticket: https://jira.suse.com/browse/TEAM-11212

# Verification
sle-15-SP4-Azure-SAP-PAYG-Incidents-x86_64-Build:smelt:40094:cloud-init-SAPHanaSR-ScaleUp-PerfOpt-spn az_Standard_E4s_v3
 - first commit http://openqa.suse.de/tests/22196480 :green_circle: 
 - both commits http://openqa.suse.de/tests/22200843