### PR TITLE
Apply ppc64le 3565382 override  only on 16.1+

### DIFF
--- a/tests/sles4sap/saptune/mr_test_run.pm
+++ b/tests/sles4sap/saptune/mr_test_run.pm
@@ -435,7 +435,7 @@ sub test_override {
         $self->wrap_script_run("mr_test dump Pattern/$SLE/testpattern_note_${override}_b > baseline_testpattern_note_${override}_b");
         $self->wrap_script_run("cp Pattern/$SLE/override/$override /etc/saptune/override/$note");
         $self->wrap_script_run("saptune note apply $note");
-        my $override_suffix = ($suffix && $override eq '3565382') ? $suffix : '';
+        my $override_suffix = ($suffix && is_sle('>=16.1') && $override eq '3565382') ? $suffix : '';
         $self->wrap_script_run("mr_test verify Pattern/$SLE/testpattern_note_${override}_a_override${override_suffix}");
         $self->wrap_script_run("mr_test verify baseline_testpattern_note_${override}_b");
         tune_baseline("baseline_testpattern_note_${override}_b");


### PR DESCRIPTION
the line is commented in `/usr/lib/udev/rules.d/60-io-scheduler.rules`  only on 16.1+:
```
# 1. BFQ scheduler for single-queue HDD
# ATTR{queue/rotational}!="0", TEST!="%S%p/mq/1", ATTR{queue/scheduler}!="bfq", ATTR{queue/scheduler}="bfq", GOTO="scheduler_end"
```
so the scheduler is `mq-deadline`, rather than `bfq`. this PR fixed this problem.

- Related ticket: https://jira.suse.com/browse/TEAM-10994
- Needles: None
- Verification run:
    https://openqa.suse.de/tests/22203309 (16.0/ppc64le hmc)
    https://openqa.suse.de/tests/22203361 (16.1/ppc64le hmc)
