### PR TITLE
fix(tests): install kubectl/helm in rmt test and add fatal flag to k3s_helm_install

### DIFF
--- a/tests/containers/charts/rmt.pm
+++ b/tests/containers/charts/rmt.pm
@@ -26,6 +26,10 @@ sub run {
     my ($self) = @_;
 
     select_serial_terminal;
+
+    install_kubectl;
+    install_helm;
+
     my $helm_chart = get_required_var('HELM_CHART');
     my $helm_values = get_var('HELM_CONFIG');
 

--- a/tests/containers/k3s_helm_install.pm
+++ b/tests/containers/k3s_helm_install.pm
@@ -24,4 +24,7 @@ sub run {
     install_helm() if get_var("INSTALL_HELM");
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
 1;


### PR DESCRIPTION
## Summary

- Install kubectl and helm before running RMT helm chart tests
- Add fatal flag to k3s_helm_install module for proper error handling

## Changes

- **tests/containers/charts/rmt.pm**: Added `install_kubectl()` and `install_helm()` calls before accessing HELM_CHART and HELM_CONFIG variables
- **tests/containers/k3s_helm_install.pm**: Added `test_flags()` subroutine with `fatal => 1` to ensure errors properly fail the test

## Problem solved

RMT helm chart tests now have required tools (kubectl, helm) available before execution. The k3s_helm_install module now properly fails on errors instead of silently continuing, making test failures visible and actionable.

## Related

- https://progress.opensuse.org/issues/200699