### PR TITLE
services::users::restore_passwd: Close terminal after use 

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -131,6 +131,7 @@ sub restore_passwd {
     assert_screen "pwd4user-confirm-terminal";
     type_password "$password\n";
     assert_screen "password-changed-terminal";
+    close_gui_terminal;
 }
 
 # remove test user


### PR DESCRIPTION
Failure: https://openqa.opensuse.org/tests/5903484#step/change_password/97

This avoids the need to handle it in `gnomecase/change_password` when
the test ends

openqa: clone https://openqa.opensuse.org/tests/5903484 EXCLUDE_MODULES=nautilus_permission 
