### PR TITLE
fix(k3s): add missing kubectl install before k3s setup in helm test

### DIFF
--- a/tests/containers/k3s_helm_install.pm
+++ b/tests/containers/k3s_helm_install.pm
@@ -13,14 +13,15 @@ use Mojo::Base 'containers::basetest';
 use testapi;
 use utils;
 use serial_terminal qw(select_serial_terminal);
-use containers::k8s qw(install_helm install_k3s);
+use containers::k8s qw(install_kubectl install_helm install_k3s);
 
 # Expected to work only on x86_64 and aarch64 due to k3s restrictions and only on Suse hosts due to the usage of zypper
 sub run {
     select_serial_terminal;
 
-    install_k3s();
     systemctl 'disable --now firewalld';
+    install_kubectl();
+    install_k3s();
     install_helm() if get_var("INSTALL_HELM");
 }
 


### PR DESCRIPTION
## Summary

- Add `install_kubectl()` call before `install_k3s()` so the kubectl binary is present when helm chart operations need it
- Move `systemctl disable --now firewalld` ahead of `install_k3s()` to ensure firewall is down before k3s networking initialises
- Import `install_kubectl` from `containers::k8s` module

## Problem solved

Helm chart tests in `k3s_helm_install` were failing due to a missing kubectl binary. Execution order now matches the pattern established by the rmt helm test module (c003d355e2).