### PR TITLE
Refactor regionsrv-enabler-azure.timer check

### DIFF
--- a/tests/publiccloud/registercloudguest.pm
+++ b/tests/publiccloud/registercloudguest.pm
@@ -80,36 +80,19 @@ sub run {
                 die('guestregister.service is not disabled');
             }
 
-            # Temporary transition check:
-            # Azure & GCE images are migrating from regionsrv-enabler-azure.timer to guestregister-lic-watcher.timer.
-            # During the transition, exactly one of these timers must be active (running), but not both.
-            if (is_azure() || is_gce()) {
-                my $legacy_t = 'regionsrv-enabler-azure.timer';
-                my $guestregister_lic_watcher_t = 'guestregister-lic-watcher.timer';
-
-                my $legacy_active = $instance->ssh_script_output(
-                    cmd => "systemctl is-active $legacy_t 2>/dev/null || echo not-found",
-                    proceed_on_failure => 1
-                );
-                my $guestregister_lic_watcher_active = $instance->ssh_script_output(
-                    cmd => "systemctl is-active $guestregister_lic_watcher_t 2>/dev/null || echo not-found",
-                    proceed_on_failure => 1
-                );
-
-                my $is_legacy_active = ($legacy_active =~ /^(active)$/m);
-                my $is_guestregister_lic_watcher_active = ($guestregister_lic_watcher_active =~ /^(active)$/m);
-
-                if (is_gce()) {
-                    record_info("gce-timers", "$legacy_t is $legacy_active; $guestregister_lic_watcher_t is $guestregister_lic_watcher_active");
-                    die("$legacy_t should not be active on GCE images") if ($is_legacy_active);
-                } elsif ($is_legacy_active && $is_guestregister_lic_watcher_active) {
-                    die("Both $legacy_t and $guestregister_lic_watcher_t are active; expected exactly one during transition");
-                } elsif (!$is_legacy_active && !$is_guestregister_lic_watcher_active) {
-                    die("Neither $legacy_t nor $guestregister_lic_watcher_t is active; expected exactly one during transition");
+            # guestregister-lic-watcher.timer replaces regionsrv-enabler-azure.timer on all images except Azure 12-SP5.
+            if ($instance->ssh_script_run('systemctl is-active guestregister-lic-watcher.timer') != 0) {
+                # The legacy service is still in use on 12-SP5 Azure.
+                if (is_sle("=12-SP5") && is_azure) {
+                    $instance->ssh_assert_script_run('systemctl is-active regionsrv-enabler-azure.timer', fail_message => "neither guestregister-lic-watcher.timer nor regionsrv-enabler-azure.timer is not present");
+                    $instance->ssh_assert_script_run('systemctl show guestregister-lic-watcher.timer | grep LoadState=not-found', fail_message => "guestregister-lic-watcher.timer must not be present when regionsrv-enabler-azure.timer is there");
                 } else {
-                    my $active = $is_legacy_active ? $legacy_t : $guestregister_lic_watcher_t;
-                    record_info('timer-ok', "Exactly one timer active: $active");
+                    die "guestregister-lic-watcher.timer is not active";
                 }
+            } else {
+                record_soft_failure('poo#190068 - The legacy check for regionsrv-enabler-azure.timer should be removed') if (is_sle("=12-SP5") && is_azure);
+                # Ensure the legacy timer is not present
+                $instance->ssh_assert_script_run('systemctl show regionsrv-enabler-azure.timer | grep LoadState=not-found', fail_message => "regionsrv-enabler-azure.timer must not be present");
             }
 
             if ($instance->ssh_script_run(cmd => 'sudo test -s /var/log/cloudregister') == 0) {


### PR DESCRIPTION
Refactor the `regionsrv-enabler-azure.timer` transition check to the new state where the legacy service is only present on SLES 12-SP5 images anymore.

- Related ticket: https://progress.opensuse.org/issues/190068

## Verification runs

The registration failures are unrelated

* [12-SP5](https://duck-norris.qe.suse.de/tests/138#step/registercloudguest/18)
* [15-SP5](https://duck-norris.qe.suse.de/tests/139#step/registercloudguest/15)
* [15-SP7](https://duck-norris.qe.suse.de/tests/137#step/registercloudguest/15)