### PR TITLE
Ipaddr2 add retry and timeout support for SCC registration

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -1639,6 +1639,10 @@ ipaddr2_infra_deploy by adding couple of lines to cloud-init configuration file.
                       Providing it as an argument is recommended
                       to avoid having to query Azure to get it.
 
+=item B<timeout> - Execution timeout for the registration command in seconds. Default 360.
+
+=item B<retry> - Number of attempts for the registration command. Default 3.
+
 =back
 =cut
 
@@ -1647,6 +1651,8 @@ sub ipaddr2_scc_register(%args) {
         croak("Argument < $_ > missing") unless $args{$_}; }
     $args{bastion_ip} //= ipaddr2_bastion_pubip();
     $args{scc_endpoint} //= 'registercloudguest';
+    $args{timeout} //= 360;
+    $args{retry} //= 3;
     croak("SCC endpoint $args{scc_endpoint} is not supported.") unless ($args{scc_endpoint} eq 'SUSEConnect' || $args{scc_endpoint} eq 'registercloudguest');
 
     ipaddr2_ssh_internal(id => $args{id},
@@ -1656,7 +1662,8 @@ sub ipaddr2_scc_register(%args) {
     my $forcenew = ($args{scc_endpoint} eq 'registercloudguest') ? '--force-new' : '';
     ipaddr2_ssh_internal(id => $args{id},
         cmd => "sudo $args{scc_endpoint} $forcenew -r \"$args{scc_code}\"",
-        timeout => 360,
+        timeout => $args{timeout},
+        retry => $args{retry},
         bastion_ip => $args{bastion_ip});
 }
 

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -904,6 +904,45 @@ subtest '[ipaddr2_scc_register] scc_endpoint' => sub {
     ok((none { /SUSEConnect.*force.*1234567890/ } @calls), 'SUSEConnect register does not have force-new');
 };
 
+subtest '[ipaddr2_scc_register] retry and timeout defaults' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    my @calls;
+
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub {
+            my (%args) = @_;
+            push @calls, {cmd => $args{cmd}, retry => $args{retry}, timeout => $args{timeout}};
+            return;
+    });
+
+    ipaddr2_scc_register(id => 42, scc_code => '1234567890');
+
+    # The registration command (not the --clean) should have retry and timeout
+    my @reg_calls = grep { $_->{cmd} =~ /force-new/ } @calls;
+    ok((scalar @reg_calls == 1), 'Exactly one registration command');
+    ok(($reg_calls[0]->{retry} == 3), "Default retry is 3, got $reg_calls[0]->{retry}");
+    ok(($reg_calls[0]->{timeout} == 360), "Default timeout is 360, got $reg_calls[0]->{timeout}");
+};
+
+subtest '[ipaddr2_scc_register] custom retry and timeout' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    my @calls;
+
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub {
+            my (%args) = @_;
+            push @calls, {cmd => $args{cmd}, retry => $args{retry}, timeout => $args{timeout}};
+            return;
+    });
+
+    ipaddr2_scc_register(id => 42, scc_code => '1234567890', retry => 5, timeout => 600);
+
+    my @reg_calls = grep { $_->{cmd} =~ /force-new/ } @calls;
+    ok((scalar @reg_calls == 1), 'Exactly one registration command');
+    ok(($reg_calls[0]->{retry} == 5), "Custom retry is 5, got $reg_calls[0]->{retry}");
+    ok(($reg_calls[0]->{timeout} == 600), "Custom timeout is 600, got $reg_calls[0]->{timeout}");
+};
+
 subtest '[ipaddr2_logs_cloudinit]' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });


### PR DESCRIPTION
The `ipaddr2_scc_register` function now supports configurable `retry` and `timeout` parameters, which are passed down to the underlying SSH command execution. This improvement addresses transient failures when interacting with SCC infrastructure.
Default values are set to 3 retries and a 360-second timeout. The documentation has been updated accordingly, and new unit tests have been added to verify both default and custom configurations in `t/22_ipaddr2.t`.

- Related ticket: https://jira.suse.com/browse/TEAM-11098

# Verification:
 - sle-15-SP6-Azure-SAP-BYOS-Incidents-x86_64-Build:smelt:44136:perl-Crypt-URandom-ipaddr2  -> http://openqaworker15.qe.prg2.suse.org/tests/366487

 - sle-15-SP6-Azure-SAP-BYOS-Incidents-x86_64-Build:smelt:44136:perl-Crypt-URandom-ipaddr2 -> http://openqaworker15.qe.prg2.suse.org/tests/366488 :green_circle:  intentionally wrong reg code. The retry is visible here http://openqaworker15.qe.prg2.suse.org/tests/366488#step/registration/29
