### PR TITLE
Remove SUPER::post_fail_hook from ipaddr2 tests

### DIFF
--- a/tests/sles4sap/ipaddr2/cluster_create.pm
+++ b/tests/sles4sap/ipaddr2/cluster_create.pm
@@ -107,7 +107,6 @@ sub post_fail_hook {
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1),
         ibsm_rg => get_var('IBSM_RG'));
-    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/sles4sap/ipaddr2/configure.pm
+++ b/tests/sles4sap/ipaddr2/configure.pm
@@ -94,7 +94,6 @@ sub post_fail_hook {
     ipaddr2_cleanup(
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1));
-    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/sles4sap/ipaddr2/deploy.pm
+++ b/tests/sles4sap/ipaddr2/deploy.pm
@@ -144,7 +144,6 @@ sub post_fail_hook {
     ipaddr2_logs_collect();
     ipaddr2_cleanup(diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1));
-    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/sles4sap/ipaddr2/destroy.pm
+++ b/tests/sles4sap/ipaddr2/destroy.pm
@@ -96,7 +96,6 @@ sub post_fail_hook {
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1),
         ibsm_rg => get_var('IBSM_RG'));
-    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/sles4sap/ipaddr2/network_peering.pm
+++ b/tests/sles4sap/ipaddr2/network_peering.pm
@@ -87,7 +87,6 @@ sub post_fail_hook {
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1),
         ibsm_rg => get_var('IBSM_RG'));
-    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/sles4sap/ipaddr2/patch_system.pm
+++ b/tests/sles4sap/ipaddr2/patch_system.pm
@@ -76,7 +76,6 @@ sub post_fail_hook {
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1),
         ibsm_rg => get_var('IBSM_RG'));
-    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/sles4sap/ipaddr2/registration.pm
+++ b/tests/sles4sap/ipaddr2/registration.pm
@@ -144,7 +144,6 @@ sub post_fail_hook {
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1),
         ibsm_rg => get_var('IBSM_RG'));
-    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/sles4sap/ipaddr2/sanity_cluster.pm
+++ b/tests/sles4sap/ipaddr2/sanity_cluster.pm
@@ -85,7 +85,6 @@ sub post_fail_hook {
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1),
         ibsm_rg => get_var('IBSM_RG'));
-    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/sles4sap/ipaddr2/sanity_os.pm
+++ b/tests/sles4sap/ipaddr2/sanity_os.pm
@@ -96,7 +96,6 @@ sub post_fail_hook {
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1),
         ibsm_rg => get_var('IBSM_RG'));
-    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/sles4sap/ipaddr2/test_move_resource.pm
+++ b/tests/sles4sap/ipaddr2/test_move_resource.pm
@@ -131,7 +131,6 @@ sub post_fail_hook {
         diagnostic => get_var('IPADDR2_DIAGNOSTIC', 0),
         cloudinit => get_var('IPADDR2_CLOUDINIT', 1),
         ibsm_rg => get_var('IBSM_RG'));
-    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
ipaddr2 tests have their own self-contained cleanup via ipaddr2_logs_collect() and ipaddr2_cleanup(). Calling SUPER::post_fail_hook chains into publiccloud::basetest which invokes sles4sap::publiccloud::deployment_cleanup, a function designed for Terraform/Ansible-based deployments that is incompatible with ipaddr2's direct Azure CLI infrastructure. When PUBLIC_CLOUD_SLES4SAP is set, this causes 'Undefined subroutine' crashes during post_fail_hook.

- Related ticket: [TEAM-11216](https://jira.suse.com/browse/TEAM-11216)

# Verification
sle-15-SP6-Azure-SAP-BYOS-Incidents ipaddr2
 - http://openqaworker15.qe.prg2.suse.org/tests/366505

sle-15-SP6-Azure-SAP-BYOS-Incidents ipaddr2 with wrong reg code
- http://openqaworker15.qe.prg2.suse.org/tests/366506

sle-15-SP6-Azure-SAP-BYOS-Incidents ipaddr2 with wrong OS image name
- http://openqaworker15.qe.prg2.suse.org/tests/366507