### PR TITLE
feat(boottime): add uptime in publiccloud instance creation check

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -443,6 +443,8 @@ sub wait_for_ssh {
             my $ssh_opts = $self->ssh_opts() . ' -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ControlPath=none -o ConnectTimeout=10';
             while (($duration = time() - $start_time) < $args{timeout}) {
                 # timeout recalculated removing consumed time until now
+                # log time in serial output
+                $self->ssh_script_run(cmd => 'uptime', ssh_opts => $ssh_opts, ignore_timeout_failure => 1);
                 # We don't support password authentication so it would just block the terminal
                 $sysout = $self->ssh_script_output(cmd => 'sudo systemctl is-system-running', ssh_opts => $ssh_opts,
                     timeout => $args{timeout} - $duration, proceed_on_failure => 1, username => $args{username});
@@ -921,6 +923,9 @@ sub do_systemd_analyze_time {
         record_info("WARN", "Unable to get systemd-analyze in ${timeout}s", result => 'fail');
         return (0, 0);
     }
+    # log time
+    $instance->ssh_script_run("uptime");
+
     push @ret, extract_analyze_time($output);
 
     $output = $instance->ssh_script_output(cmd => 'systemd-analyze blame', proceed_on_failure => 1);


### PR DESCRIPTION
\- Add uptime display in instance creation check (wait_for_ssh) and in boottime check to verify the syncronization of the system. 
\- Add time check support, useful in debugging, **visible in serial_terminal log.** 
\- Note about bsc#1262587: in [21829955](https://openqa.suse.de/tests/21829955#step/prepare_instance/217) with irregular overall-boottime=29809.4s, we noticed in first entries of `cloud-init.log` the time started more than 1h before the vm instantiation, against the total duration of the test of 49min. So, having more time references it can help the debugging.

- Ref.tkt.https://progress.opensuse.org/issues/198947

- Verification run, with proper PUBLIC_CLOUD_BOOTTIME_MAX in Azure tests:
  - https://openqa.suse.de/tests/22208793 PASS (MAX=100) [log 1](https://openqa.suse.de/tests/22208793/logfile?filename=serial_terminal.txt#line-496
), [log 2](https://openqa.suse.de/tests/22208793/logfile?filename=serial_terminal.txt#line-550
)
  - https://openqa.suse.de/tests/22209130 SoftF. (MAX=10) [log 1](https://openqa.suse.de/tests/22209130/logfile?filename=serial_terminal.txt#line-498
), [log 2](https://openqa.suse.de/tests/22209130/logfile?filename=serial_terminal.txt#line-552
)