### PR TITLE
Add missing LibreOffice Math to list of applications in launch wrapper

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -1028,12 +1028,13 @@ sub libreoffice_start_program {
     my %start_program_args;
 
     my %libreoffice_applications = (
+        "libreoffice" => "libreoffice",
         "oobase" => "base",
         "oocalc" => "calc",
         "oodraw" => "draw",
         "ooimpress" => "impress",
-        "oowriter" => "writer",
-        "libreoffice" => "libreoffice"
+        "oomath" => "math",
+        "oowriter" => "writer"
     );
 
     die "Unrecognized LibreOffice application: $program" unless $libreoffice_applications{$program};

--- a/tests/x11/oocalc.pm
+++ b/tests/x11/oocalc.pm
@@ -27,11 +27,4 @@ sub run {
     assert_and_click 'dont-save-libreoffice-btn';    # _Don't save
 }
 
-sub ocr_checklist {
-    [
-
-        #                {screenshot=>2, x=>104, y=>201, xs=>380, ys=>150, pattern=>"H ?ello", result=>"OK"}
-    ];
-}
-
 1;


### PR DESCRIPTION
Failure: https://openqa.opensuse.org/tests/5908798#step/oomath/2
Follows: #25487

29615a7272e1669ff73b5581dab9437463deb746 missed oomath in the list of applications

openqa: clone https://openqa.opensuse.org/tests/5908798
