### PR TITLE
Adapt pattern selection to new agama version on Tumbleweed

### DIFF
--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -172,6 +172,8 @@ sub select_software {
 
     # Futher manually selected patterns should go here
 
+    send_key "ctrl-down";
+
     assert_and_click('agama-software-selection-close');
 
 }


### PR DESCRIPTION
The close button is now gone and has been replaced with an Accept/Cancel
option

openqa: clone https://openqa.opensuse.org/tests/5883751
openqa: clone https://openqa.opensuse.org/tests/5908612
