### PR TITLE
Replace csync2 with crm cluster copy in NetWeaver tests

### DIFF
--- a/tests/sles4sap/netweaver_network.pm
+++ b/tests/sles4sap/netweaver_network.pm
@@ -45,7 +45,7 @@ sub run {
         assert_script_run 'mv /tmp/hosts.nw /etc/hosts';
 
         # Synchronize the hosts file
-        add_file_in_csync(value => '/etc/hosts');
+        sync_path('/etc/hosts');
     }
 }
 


### PR DESCRIPTION
In SLES 16 codestream, `crmsh` cluster bootstrap does not initialize `csync` service, so it's recommended to instead use `crm cluster copy` to keep files in sync between cluster nodes.

This commit replaces the call to `add_file_in_csync` in the test module `sles4sap/netweaver_network` used to synchronize `/etc/hosts` to all nodes with `sync_file` which will call `crm cluster copy` if running on 16.0 or newer, or `add_file_in_csync` if running in older service packs.

- Related Ticket: https://jira.suse.com/browse/TEAM-11093
- Needles: N/A
- Verification run: [16.1](http://mango.qe.nue2.suse.org/tests/overview?build=41.4&distri=sle&version=16.1) :green_circle: , [16.0](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=TEAM11093&distri=sle&version=16.0) :green_circle: , [15-SP7](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=TEAM11093&distri=sle&version=15-SP7) :green_circle: , [15-SP6](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=TEAM11093&distri=sle&version=15-SP6) :green_circle: , [15-SP5](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=TEAM11093&distri=sle&version=15-SP5) :green_circle: , [15-SP4](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=TEAM11093&distri=sle&version=15-SP4) :green_circle: , [12-SP5](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=TEAM11093&distri=sle&version=12-SP5) :green_circle: 
