### PR TITLE
Do not run dig in ipaddr2 for 16.0

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -862,6 +862,8 @@ Tests are independent by the cluster status.
 =item B<user> - user expected to be able to ssh connect password-less from one internal VM to the other.
                 Default is cloudadmin.
 
+=item B<enable_dig> - optionally enable dig command execution in the connectivity sanity checks.
+
 =back
 =cut
 
@@ -870,7 +872,7 @@ sub ipaddr2_os_sanity(%args) {
     $args{user} //= USER;
 
     ipaddr2_os_network_sanity(bastion_ip => $args{bastion_ip});
-    ipaddr2_os_connectivity_sanity(bastion_ip => $args{bastion_ip});
+    ipaddr2_os_connectivity_sanity(bastion_ip => $args{bastion_ip}, enable_dig => $args{enable_dig});
     ipaddr2_os_ssh_sanity(user => $args{user}, bastion_ip => $args{bastion_ip});
 
     foreach (1 .. 2) {
@@ -944,6 +946,8 @@ die in case of failure
                       Providing it as an argument is recommended
                       to avoid having to query Azure to get it.
 
+=item B<enable_dig> - optionally enable dig command execution.
+
 =back
 =cut
 
@@ -963,8 +967,10 @@ sub ipaddr2_os_connectivity_sanity(%args) {
             ipaddr2_get_internal_vm_private_ip(id => $i),
             ipaddr2_get_internal_vm_name(id => $i)) {
             # tracepath is not available by default in 12sp5
-            # so only use ping and dig
-            foreach my $cmd (PING_CMD, 'dig') {
+            # so only use ping and optionally dig
+            my @cmds = (PING_CMD);
+            push @cmds, 'dig' if $args{enable_dig};
+            foreach my $cmd (@cmds) {
                 ipaddr2_ssh_bastion_assert_script_run(
                     cmd => "$cmd $addr",
                     bastion_ip => $args{bastion_ip});

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -385,6 +385,9 @@ subtest '[ipaddr2_os_sanity]' => sub {
         note($calls[$call_idx][0] . " C-->  $calls[$call_idx][1]");
     }
     ok((scalar @calls > 0), "Some calls to ipaddr2_ssh_internal");
+    # extract just the command strings
+    my @cmds = map { $_->[1] } @calls;
+    ok((none { /dig/ } @cmds), 'No dig command when enable_dig is not set');
 };
 
 subtest '[ipaddr2_os_sanity] root' => sub {
@@ -415,6 +418,39 @@ subtest '[ipaddr2_os_sanity] root' => sub {
         note($calls[$call_idx][0] . " C-->  $calls[$call_idx][1]");
     }
     ok((scalar @calls > 0), "Some calls to ipaddr2_ssh_internal");
+};
+
+subtest '[ipaddr2_os_sanity] enable_dig' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $ipaddr2->redefine(ipaddr2_get_internal_vm_name => sub { return 'Galileo'; });
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return 'Invalid_IP_Galileo'; });
+    my @calls;
+    $ipaddr2->redefine(script_run => sub {
+            push @calls, ['local', $_[0]]; });
+    $ipaddr2->redefine(assert_script_run => sub {
+            push @calls, ['local', $_[0]]; });
+    $ipaddr2->redefine(ipaddr2_ssh_bastion_assert_script_run => sub {
+            my (%args) = @_;
+            push @calls, ['bastion', $args{cmd}]; });
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub {
+            my (%args) = @_;
+            push @calls, ["VM$args{id}", $args{cmd}]; });
+    $ipaddr2->redefine(ipaddr2_ssh_internal_output => sub {
+            my (%args) = @_;
+            push @calls, ["VM$args{id}", $args{cmd}];
+            # return exactly what ipaddr2_os_ssh_sanity needs
+            return 3; });
+
+    ipaddr2_os_sanity(enable_dig => 1);
+
+    for my $call_idx (0 .. $#calls) {
+        note($calls[$call_idx][0] . " C-->  $calls[$call_idx][1]");
+    }
+    ok((scalar @calls > 0), "Some calls to ipaddr2_ssh_internal");
+    # extract just the command strings
+    my @cmds = map { $_->[1] } @calls;
+    ok((any { /dig/ } @cmds), 'dig command present when enable_dig is set');
 };
 
 subtest '[ipaddr2_bastion_pubip]' => sub {
@@ -1029,6 +1065,22 @@ subtest '[ipaddr2_os_connectivity_sanity]' => sub {
 
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok((any { /ping/ } @calls), 'Connectivity sanity has some ping');
+    ok((none { /dig/ } @calls), 'Connectivity sanity has no dig by default');
+};
+
+subtest '[ipaddr2_os_connectivity_sanity] enable_dig' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    my @calls;
+    $ipaddr2->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    ipaddr2_os_connectivity_sanity(enable_dig => 1);
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /ping/ } @calls), 'Connectivity sanity has some ping');
+    ok((any { /dig/ } @calls), 'Connectivity sanity has dig when enable_dig is set');
 };
 
 subtest '[ipaddr2_test_other_vm]' => sub {

--- a/tests/sles4sap/ipaddr2/sanity_os.pm
+++ b/tests/sles4sap/ipaddr2/sanity_os.pm
@@ -62,6 +62,7 @@ QE-SAP <qe-sap@suse.de>
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal qw( select_serial_terminal );
+use version_utils qw( is_sle );
 use sles4sap::ipaddr2 qw(
   ipaddr2_bastion_pubip
   ipaddr2_os_sanity
@@ -82,6 +83,7 @@ sub run {
     # It has to know about it to decide which ssh are expected in internal VMs
     my %sanity_args = (bastion_ip => $bastion_ip);
     $sanity_args{user} = 'root' unless check_var('IPADDR2_ROOTLESS', '1');
+    $sanity_args{enable_dig} = 1 unless is_sle('16+');
     ipaddr2_os_sanity(%sanity_args);
 }
 


### PR DESCRIPTION
Introduce 'enable_dig' parameter to 'ipaddr2_os_sanity' and 'ipaddr2_os_connectivity_sanity' to control the execution of the dig command during network checks.
By default, 'dig' is now disabled in 'ipaddr2_os_connectivity_sanity' unless explicitly requested. In the 'sanity_os' test module, it is enabled only for SLE versions older than 16.
This change also removes 'ipaddr2_os_connectivity_sanity' from the default exported symbols of 'sles4sap::ipaddr2' to promote the use of the high-level 'ipaddr2_os_sanity' interface.
Updated unit tests in t/22_ipaddr2.t to verify the new flag behavior.

- Related ticket: https://jira.suse.com/browse/TEAM-11080

# Verification run:

sle-16.0-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE16.0-ipaddr2_azure_test az_Standard_B1s
 - http://openqaworker15.qe.prg2.suse.org/tests/366729 :green_circle: deployment is ok, failure is later in timeout during supportconfig 
 - https://openqaworker15.qe.prg2.suse.org/tests/367284#live