### PR TITLE
Install openssh-server-config-rootlogin to enable root login

### DIFF
--- a/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_aarch64.jsonnet
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_aarch64.jsonnet
@@ -47,6 +47,9 @@
       }
     ]
   },
+  software: {
+    packages: ['openssh-server-config-rootlogin'],
+  },
   "network": {
     "connections": [
       {
@@ -79,7 +82,7 @@
         chroot: true,
         content: |||
           #!/usr/bin/env bash
-          echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes\nPermitEmptyPasswords no\nTCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 60" > /etc/ssh/sshd_config.d/01-qe-virtualization-functional.conf
+          echo -e "PubkeyAuthentication yes\nPasswordAuthentication yes\nPermitEmptyPasswords no\nTCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 60" > /etc/ssh/sshd_config.d/01-qe-virtualization-functional.conf
         |||
       },
       {
@@ -95,14 +98,6 @@
         content: |||
           #!/usr/bin/env bash
           echo -e "[Journal]\\nStorage=persistent" > /etc/systemd/journald.conf.d/01-qe-virtualization-functional.conf
-        |||
-      },
-      {
-        name: "enable_sshd",
-        chroot: true,
-        content: |||
-          #!/usr/bin/env bash
-          systemctl enable sshd.service
         |||
       }
     ]

--- a/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet
+++ b/data/virt_autotest/guest_unattended_installation_files/sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet
@@ -48,6 +48,9 @@
       }
     ]
   },
+  software: {
+    packages: ['openssh-server-config-rootlogin'],
+  },
   "network": {
     "connections": [
       {
@@ -80,7 +83,7 @@
         chroot: true,
         content: |||
           #!/usr/bin/env bash
-          echo -e "PermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication yes\nPermitEmptyPasswords no\nTCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 60" > /etc/ssh/sshd_config.d/01-qe-virtualization-functional.conf
+          echo -e "PubkeyAuthentication yes\nPasswordAuthentication yes\nPermitEmptyPasswords no\nTCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 60" > /etc/ssh/sshd_config.d/01-qe-virtualization-functional.conf
         |||
       },
       {
@@ -96,14 +99,6 @@
         content: |||
           #!/usr/bin/env bash
           echo -e "[Journal]\\nStorage=persistent" > /etc/systemd/journald.conf.d/01-qe-virtualization-functional.conf
-        |||
-      },
-      {
-        name: "enable_sshd",
-        chroot: true,
-        content: |||
-          #!/usr/bin/env bash
-          systemctl enable sshd.service
         |||
       }
     ]

--- a/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
+++ b/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
@@ -48,6 +48,7 @@ local agama_product_mode = if transactional == '1' then 'immutable' else 'standa
         ],
       },
       packages: [
+        'openssh-server-config-rootlogin',
         'virt-bridge-setup',
         // Workaround for bsc#1260073
         'curl'
@@ -73,7 +74,6 @@ local agama_product_mode = if transactional == '1' then 'immutable' else 'standa
         chroot: true,
         content: |||
           #!/usr/bin/env bash
-          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
           sshd_config_file="/etc/ssh/sshd_config.d/01-virt-test.conf"
           echo -e "TCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 60" > $sshd_config_file
         |||
@@ -119,14 +119,6 @@ local agama_product_mode = if transactional == '1' then 'immutable' else 'standa
             sed -i "/^[# ]*log_outputs *=/{h;s%^[# ]*log_outputs *=.*[0-9].*\$%log_outputs = \"1:file:${log_file}\"%};\${x;/^\$/{s%%log_outputs = \"1:file:${log_file}\"%;H};x}" $config_file
             sed -i "/^[# ]*log_filters *=/{h;s%^[# ]*log_filters *=.*[0-9].*\$%log_filters = \"1:qemu 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci\"%};\${x;/^\$/{s%%log_filters = \"1:qemu 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci\"%;H};x}" $config_file
           done
-        |||
-      },
-      {
-        name: "enable_sshd",
-        chroot: true,
-        content: |||
-          #!/usr/bin/env bash
-          systemctl enable sshd.service
         |||
       },
       {

--- a/data/virtualization/agama_virt_auto/sle_virt_default_staging.jsonnet
+++ b/data/virtualization/agama_virt_auto/sle_virt_default_staging.jsonnet
@@ -22,6 +22,7 @@ local urls = if repo != '' then std.split(repo, ',') else [];
   },
   software: {
     packages: [
+      'openssh-server-config-rootlogin',
       'xauth',
       'xmlstarlet',
       'virt-viewer'
@@ -83,8 +84,6 @@ local urls = if repo != '' then std.split(repo, ',') else [];
           # Note: authorized_keys is already configured by Agama via root.sshPublicKey
           
           # 1. Setup SSH server (sshd) - configure server first
-          systemctl enable sshd
-          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
           sshd_config_file="/etc/ssh/sshd_config.d/01-virt-test.conf"
           echo -e "TCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 120" > $sshd_config_file
           

--- a/data/virtualization/agama_virt_auto/sle_virt_guest_staging.jsonnet
+++ b/data/virtualization/agama_virt_auto/sle_virt_guest_staging.jsonnet
@@ -22,7 +22,7 @@ local urls = if repo != '' then std.split(repo, ',') else [];
     sshPublicKey: '{{_SECRET_ED25519_PUB_KEY}}'
   },
   software: {
-    packages: [],
+    packages: ['openssh-server-config-rootlogin'],
     patterns: [
       'base'
     ],
@@ -64,8 +64,6 @@ local urls = if repo != '' then std.split(repo, ',') else [];
         chroot: true,
         content: |||
           #!/usr/bin/env bash
-          systemctl enable sshd
-          echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/root.conf
           sshd_config_file="/etc/ssh/sshd_config.d/01-virt-test.conf"
           echo -e "TCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 120" > $sshd_config_file
         |||


### PR DESCRIPTION
`openssh-server-config-rootlogin` package is provided to allow root login over ssh. The PR is to install the package and remove its previous post script.

related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25405/changes
Related ticket: https://progress.opensuse.org/issues/200168

Verification run: 
[sle16.1 guest on sle16.1 host](https://openqa.suse.de/tests/22236727)    //guest installation passed, test failure is nothing to do with this PR
[sle16.1 sriov test](https://openqa.suse.de/tests/22236915)
[sle16.1 guest on sle16.0 host on aarch64](https://openqa.suse.de/tests/22236913)
[sle15 on sle16.1 host on aarch64](https://openqa.suse.de/tests/22235278)
[sle16 QU2 snapshot test](https://openqa.suse.de/tests/22235279)
[MU 16.0 sriov test](https://openqa.suse.de/tests/22235281)

