### PR TITLE
Allow pq openssl3 test to run on SLE 15-SP7

### DIFF
--- a/lib/security/agnosticTestRunner.pm
+++ b/lib/security/agnosticTestRunner.pm
@@ -41,6 +41,9 @@ sub setup {
     my ($self) = @_;
     my $url = data_url($self->{data_url_path});
 
+    # SLE15 needs phub for that packages
+    add_suseconnect_product(get_addon_fullname('phub')) if is_sle('<16.0');
+
     zypper_call 'in go gotestsum' if $self->{language} eq 'go';
     zypper_call 'in python3-pytest' if $self->{language} eq 'python';
 

--- a/tests/security/oqa_agnostic/openssl_pqc.pm
+++ b/tests/security/oqa_agnostic/openssl_pqc.pm
@@ -14,10 +14,11 @@ use version_utils 'is_sle';
 
 sub run {
     select_serial_terminal;
-    if (is_sle('<16')) {
-        record_info('SKIP', 'OpenSSL post quantum crypto tests are only available on SLE 16 and later');
+    if (is_sle('<15-SP7')) {
+        record_info('SKIP', 'OpenSSL post quantum crypto tests are only available on SLE 15-SP7 and later');
         return;
     }
+    record_info('openssl version:', script_output('rpm -q openssl'));
     my $test = security::agnosticTestRunner->new({
             language => 'python',
             name => 'testPostQuantumCrypto',


### PR DESCRIPTION
Enable openSSL 3 post-quantum testing on SLE 15-SP7

- Related ticket: https://progress.opensuse.org/issues/200579
- Verification runs: https://openqa.suse.de/tests/overview?groupid=611&distri=sle&version=15-SP7&build=20260510-1 
