### PR TITLE
Drop register_url and allow vendor change for Leap to SLES migration

### DIFF
--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -49,7 +49,16 @@ sub prepare_boot_params {
         set_var('INST_AUTO', $profile_url);
         push @params, "inst.auto=\"$profile_url\"", 'inst.finish=stop';
     }
-    push @params, 'inst.register_url=' . get_var('SCC_URL') if get_var('SCC_URL') && (get_var('FLAVOR') =~ /^(Online.*|agama-installer)$/ || get_var('AGAMA_FORCE_REGISTER'));
+
+    # add register url
+    my $has_scc_url = get_var('SCC_URL');
+    my $is_online_flavor = get_var('FLAVOR') =~ /^(Online.*|agama-installer)$/;
+    my $is_forced_register = get_var('AGAMA_FORCE_REGISTER');
+    my $is_leap = get_var('ISO') =~ /Leap/;
+    my $should_register = ($is_online_flavor || $is_forced_register) && !$is_leap;
+    if ($has_scc_url && $should_register) {
+        push @params, 'inst.register_url=' . get_var('SCC_URL');
+    }
 
     push @params, 'inst.install_url=' . get_var('INST_INSTALL_URL') if get_var('INST_INSTALL_URL');
 

--- a/tests/yam/migration/zypper_migration.pm
+++ b/tests/yam/migration/zypper_migration.pm
@@ -31,7 +31,8 @@ sub run {
 
     assert_script_run("echo 'url: " . get_required_var('SCC_URL') . "' > /etc/SUSEConnect");
 
-    script_run("(zypper migration; echo $zypper_done) |& tee /dev/$serialdev", 0);
+    my $allow_vendor_change = (get_var("ISO") =~ /Leap/) ? '--allow-vendor-change' : '';
+    script_run("(zypper migration $allow_vendor_change; echo $zypper_done) |& tee /dev/$serialdev", 0);
 
     my $match = wait_serial($zypper_prompts->{migration_target}, 120)
       || die "Target version $target_version was not found.";


### PR DESCRIPTION
Update leap to sles migration testing: drop the inst.register_url for Leap installation and allow vendor change during zypper migration. The PackageHub would be added during migration, it happens that some packages would change vendor between SUSE and openSUSE.

- Related ticket: 
  https://progress.opensuse.org/issues/198935
- Verification run:
  [leap_on_aarch64](https://openqa.suse.de/tests/22444623#details) || [leap_on_ppc64le](https://openqa.suse.de/tests/22444622#details) || [register_url_on_sles](https://openqa.suse.de/tests/22445515#step/boot_agama/10) || [zypper_migration_cmd_on_sles](https://openqa.suse.de/tests/22445488#step/zypper_migration/4)
- Related MR: 
  https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/791