### PR TITLE
Add workaround for bsc#1264714

### DIFF
--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -31,6 +31,12 @@ sub run {
 
     assert_script_run("ps aux | nl");
 
+    # Workaround for missing iproute2 package in 15-SP4 CHOST images (bsc#1264714)
+    if (get_required_var('FLAVOR') =~ 'GCE-CHOST-BYOS' && (is_sle("=15-SP4") || is_sle("=15-SP5")) && script_run("ip l") != 0) {
+        record_soft_failure("bsc#1264714 Missing iproute2 package");
+        script_retry("zypper -n in iproute2", retry => 3, timeout => 300);
+    }
+
     my $ip_color = (is_sle('>=15-SP3')) ? '-c=never' : '';
     assert_script_run("ip $ip_color a s");
     assert_script_run("ip $ip_color r s");


### PR DESCRIPTION
Manually install the `iproute2` tools as a workaround for bsc#1264714.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1264714

### Verification run

- 15-SP4 GCE-CHOST: https://openqa.suse.de/tests/22246188#step/instance_overview/16
- 15-SP4 EC2-CHOST: https://openqa.suse.de/tests/22246194#step/instance_overview/72
- 15-SP5 GCE-CHOST: https://openqa.suse.de/tests/22246196#step/instance_overview/16
