### PR TITLE
Add schedule for selinux on SLE16 transactional with prebuilt qcow2

### DIFF
--- a/schedule/security/sle16_transactional/selinux_qcow.yaml
+++ b/schedule/security/sle16_transactional/selinux_qcow.yaml
@@ -1,0 +1,24 @@
+name: selinux-transactional-qcow
+description: >
+  Test selinux using preinstalled qcow2 images in immutable mode
+schedule:
+  - '{{boot}}'
+  - transactional/host_config
+  - console/suseconnect_scc
+  - microos/services_enabled
+  - transactional/disable_timers
+  - microos/verify_setup
+  - security/selinux/selinux_setup
+  - security/selinux/selinux_smoke
+  - security/selinux/container_selinux
+  - shutdown/shutdown
+conditional_schedule:
+  boot:
+    ARCH:
+      s390x:
+        - installation/bootloader_start
+        - boot/boot_to_desktop
+      aarch64:
+        - microos/disk_boot
+      x86_64:
+        - microos/disk_boot


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/197477
- Verification runs:
  - x86_64: https://openqa.suse.de/tests/22187767
  - aarch64: https://openqa.suse.de/tests/22187835
  - s390x: https://openqa.suse.de/tests/22188173
