### PR TITLE
y2_installbase: Collect y2logs before calling parent's post_fail_hook

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -685,15 +685,17 @@ sub post_fail_hook {
         wait_for_children;
     }
     else {
-        # In case of autoyast, actions in parent post fail hook might close
-        # error pop-up and system will reboot, so log collection will fail (see poo#61052)
-        $self->SUPER::post_fail_hook unless get_var('AUTOYAST');
         get_to_console;
         detect_bsc_1063638;
         $self->get_ip_address;
         remount_tmp_if_ro;
-        # Avoid collectin logs twice when investigate_yast2_failure() is inteded to hard-fail
+        # Avoid collecting logs twice when investigate_yast2_failure() is inteded to hard-fail
         $self->save_upload_y2logs unless get_var('ASSERT_Y2LOGS');
+
+        # In case of AutoYaST, actions in parent post fail hook might close
+        # error pop-up and system will reboot, so log collection will fail (see poo#61052)
+        $self->SUPER::post_fail_hook unless get_var('AUTOYAST');
+
         return if is_microos;
         $self->save_system_logs;
 


### PR DESCRIPTION
By the time a test fails [during installation](https://openqa.opensuse.org/tests/5910265#step/partitioning/6), the SUT may have not yet
have a serial terminal setup, which can cause log collection to fail
completely, by ensuring the y2logs are collected in console, we
guarantee at least that these would be present for further analysis

Failure: https://openqa.opensuse.org/tests/5910265#step/partitioning/6
VR: https://openqa.opensuse.org/tests/5917519#step/partitioning/44 (expected to fail, but y2log is uploaded)



