### PR TITLE
Tidy test module

### DIFF
--- a/tests/jeos/image_checks.pm
+++ b/tests/jeos/image_checks.pm
@@ -11,41 +11,13 @@ use Mojo::Base 'opensusebasetest';
 use testapi;
 use version_utils "is_sle";
 
-my @failed_checks;
-
-sub check_pcr_oracle_disabled {
-    record_info(
-        "check_pcr_oracle_disabled test",
-        "pcr-oracle should not be installed on Encrypted images from SLES 16.1 onwards"
-    );
-    if (script_run("! rpm -q pcr-oracle")) {
-        record_info(
-            "pcr-oracle present",
-            "pcr-oracle found but should not be installed",
-            result => 'fail'
-        );
-        push @failed_checks, "check_pcr_oracle_disabled";
-    }
+sub check_pcr_oracle_absent {
+    die "pcr-oracle must not be present on Encrypted images (bsc#1261611)" if (script_run("rpm -q pcr-oracle") == 0);
 }
 
 sub run {
-    my $checks_run = 0;
-
-    # The pcr-oracle module must not be enabled in encrypted images 16.1+
-    if (is_sle('>=16.1') && get_var('FLAVOR') =~ m/-encrypt/i) {
-        check_pcr_oracle_disabled();
-        $checks_run++;
-    }
-
-    if ($checks_run == 0) {
-        record_info(
-            "No checks",
-            "Current image does not meet requirements for any small checks."
-        );
-    }
-    elsif (@failed_checks) {
-        die "The following checks failed: " . join(", ", @failed_checks);
-    }
+    # PCR oracle must not be present on Encrypted Images from 16.1 onwards, see bsc#1261611
+    check_pcr_oracle_absent() if (is_sle('>=16.1') && get_var('FLAVOR') =~ m/-encrypt/i);
 }
 
 1;


### PR DESCRIPTION
Tidy the test module code.

- Related failure: https://openqa.suse.de/tests/22249119 and [this Slack thread](https://suse.slack.com/archives/C02CANHLANP/p1778497253887899)
- Verification run: https://openqa.suse.de/tests/22251688#step/image_checks/1
