### PR TITLE
kdump: Check if crash autodetects vmlinux

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -480,6 +480,12 @@ sub check_function {
             $crash_cmd = "podman container run --privileged -v '/:/host' registry.opensuse.org/opensuse/tumbleweed bash -c '$bash_cmd'";
         }
         validate_script_output $crash_cmd, sub { m/PANIC:\s([^\s]+)/ }, is_aarch64 ? 1200 : 800 if $crash_cmd;
+        # also verify crash auto-detects the booted vmlinux when called without arguments
+        if (!is_transactional && !get_var('SKIP_KERNEL_DEBUGINFO')) {
+            my $out = script_output('echo exit | crash 2>&1', is_aarch64 ? 1200 : 800, proceed_on_failure => 1);
+            record_soft_failure 'bsc#1237855 - crash cannot auto-detect booted kernel without arguments'
+              unless $out =~ m/KERNEL:/;
+        }
     }
     else {
         # migration tests need remove core files before migration start


### PR DESCRIPTION
Normally when running without arguments, `crash` is able to detect the
kernel binary if all packages are installed. Therefore add a scenario to
check for this.

- Ticket: https://progress.opensuse.org/issues/188919
- Verification runs:
  - https://openqa.suse.de/tests/22274583 12.5
  - https://openqa.suse.de/tests/22274584 15.4
  - https://openqa.suse.de/tests/22274585 15.5
  - https://openqa.suse.de/tests/22274586 15.6
  - https://openqa.suse.de/tests/22274587 15.7
  - https://openqa.suse.de/tests/22274588 16.0
  - https://openqa.suse.de/tests/22273187 16.1 arm64
  - https://openqa.suse.de/tests/22273188 16.1 ppc64le
  - https://openqa.suse.de/tests/22273190 16.1 x86_64
