### PR TITLE
podman_e2e: Remove 00-suse-registries.conf

### DIFF
--- a/tests/containers/podman_e2e.pm
+++ b/tests/containers/podman_e2e.pm
@@ -38,6 +38,9 @@ sub setup {
     run_command "usermod --add-subgids 100000-165535 containers";
     # Make /run/secrets directory available on containers
     run_command "echo /var/lib/empty:/run/secrets >> /etc/containers/mounts.conf";
+    # The tests expect an exact list of unqualified-search-registries containing "quay.io" and we ship:
+    # unqualified-search-registries = ["registry.opensuse.org", "registry.suse.com", "docker.io"]
+    run_command "rm -f /etc/containers/registries.conf.d/00-suse-registries.conf";
 
     enable_docker;
 


### PR DESCRIPTION
The tests expect an exact list of unqualified-search-registries containing "quay.io" and we now ship:
`unqualified-search-registries = ["registry.opensuse.org", "registry.suse.com", "docker.io"]` in /etc/containers/registries.conf.d/00-suse-registries.conf

Same as https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25492 but for podman_e2e test.

Failed jobs:
- root: https://openqa.suse.de/tests/22262952
- rootless: https://openqa.suse.de/tests/22262954

Verification runs:
- root: https://openqa.suse.de/tests/22264074
- rootless: https://openqa.suse.de/tests/22264075