### PR TITLE
Lower the metric of br0 to make sure its default route

### DIFF
--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -121,10 +121,9 @@ sub create_host_bridge_nm {
         reset_consoles;
         select_console('root-ssh');
         # Set metric the lowest to make br0 always be the default route
-        script_run("nmcli con modify br0 ipv4.route-metric 100");
+        script_run("nmcli con modify br0 ipv4.route-metric 50");
         script_run("nmcli con up br0");
-        script_run("ip r");
-        record_info("Create a Host Bridge Network Interface - $host_bridge for sles16", script_output("ip a", proceed_on_failure => 1, timeout => 60));
+        record_info("Create a Host Bridge Network Interface - $host_bridge for sles16", script_output("ip a; echo ''; ip r;", proceed_on_failure => 1, timeout => 60));
     }
 }
 


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/200877

Tests failed on a few machines with multiple network connections from time to time because the non-primary card was considered the default route as it might have lower or equal metric, eg. https://openqa.suse.de/tests/22268358#step/prepare_non_transactional_server/61

This PR is to lower the metric of primary card(br0) to 50 which is far safer than original 100.

- Verification run: 
[sle16.1 host/guest on blackbauhinia](https://openqa.suse.de/tests/22282607)
[sle16.0 host](https://openqa.suse.de/tests/22283383)
[sle16.0 guest](https://openqa.suse.de/tests/22283398)
[sle15sp7 guest on sle16.1 host](https://openqa.suse.de/tests/22355463)
[an MU test](https://openqa.suse.de/tests/22358346)
