### PR TITLE
Rename image_checks to a distinct name

### DIFF
--- a/schedule/jeos/sle/minimalvm-main.yaml
+++ b/schedule/jeos/sle/minimalvm-main.yaml
@@ -64,7 +64,7 @@ schedule:
     - '{{bootloader}}'
     - '{{wizard}}'
     - jeos/image_info
-    - jeos/image_checks
+    - jeos/minimalvm_image_checks
     - jeos/record_machine_id
     - console/force_scheduled_tasks
     - jeos/diskusage

--- a/tests/jeos/minimalvm_image_checks.pm
+++ b/tests/jeos/minimalvm_image_checks.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Small tests for MinimalVM that do not require a whole module for
+#          themselves.
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use version_utils "is_sle";
+
+sub check_pcr_oracle_absent {
+    die "pcr-oracle must not be present on Encrypted images (bsc#1261611)" if (script_run("rpm -q pcr-oracle") == 0);
+}
+
+sub run {
+    # PCR oracle must not be present on Encrypted Images from 16.1 onwards, see bsc#1261611
+    check_pcr_oracle_absent() if (is_sle('>=16.1') && get_var('FLAVOR') =~ m/-encrypt/i);
+}
+
+1;


### PR DESCRIPTION
Rename the image_checks module to minimalvm_image_checks to avoid a name collision with microos/image_checks.

- Related ticket: https://progress.opensuse.org/issues/200853
- Verification run: https://openqa.suse.de/tests/22268908