### PR TITLE
Extend libgcrypt test add runtime sign/verify validation

### DIFF
--- a/data/security/libgcrypt-sign-verify.c
+++ b/data/security/libgcrypt-sign-verify.c
@@ -1,0 +1,109 @@
+/*
+ * This utility verifies libgcrypt public-key operations at runtime.
+ * It validates:
+ * 1. KEY GENERATION: Successful creation of cryptographic keypairs.
+ * 2. SIGNING: Ability to generate valid digital signatures.
+ * 3. VERIFICATION: Correct validation of generated signatures.
+ *
+ * Algorithms covered:
+ * - RSA     (baseline, must always work)
+ * - ECDSA   (FIPS-approved, must work in FIPS mode)
+ * - ML-DSA  (post-quantum, optional / may be disabled in FIPS)
+ *
+ * Output format:
+ *   RSA: OK / FAIL
+ *   ECDSA: OK / FAIL
+ *   ML-DSA: OK / FAIL / SKIPPED
+ *
+ * Purpose:
+ * Ensures that libgcrypt correctly performs real cryptographic
+ * operations under current system policy (FIPS or non-FIPS).
+ */
+
+#include <gcrypt.h>
+#include <stdio.h>
+
+/* Helper: generate key, sign data, verify signature */
+static int test_algo(const char *genkey_expr) {
+    gcry_sexp_t key = NULL;
+    gcry_sexp_t parms = NULL;
+    gcry_sexp_t data = NULL;
+    gcry_sexp_t sig = NULL;
+    int rc;
+
+    /* Key generation parameters */
+    rc = gcry_sexp_new(&parms, genkey_expr, 0, 1);
+    if (rc)
+        return -1;
+
+    /* Generate keypair */
+    rc = gcry_pk_genkey(&key, parms);
+    gcry_sexp_release(parms);
+    if (rc)
+        return -1;
+
+    /* Prepare data */
+    rc = gcry_sexp_new(&data,
+        "(data (flags raw) (value \"openqa-test\"))",
+        0, 1);
+    if (rc) {
+        gcry_sexp_release(key);
+        return -1;
+    }
+
+    /* Sign */
+    rc = gcry_pk_sign(&sig, data, key);
+    if (rc) {
+        gcry_sexp_release(data);
+        gcry_sexp_release(key);
+        return -1;
+    }
+
+    /* Verify */
+    rc = gcry_pk_verify(sig, data, key);
+
+    /* Cleanup */
+    gcry_sexp_release(sig);
+    gcry_sexp_release(data);
+    gcry_sexp_release(key);
+
+    return rc ? -1 : 0;
+}
+
+int main(void) {
+    const char *ver;
+
+    ver = gcry_check_version(NULL);
+    if (!ver) {
+        printf("INIT: FAIL\n");
+        return 1;
+    }
+
+    gcry_control(GCRYCTL_INITIALIZATION_FINISHED, 0);
+
+    printf("# libgcrypt: %s\n", ver);
+
+    /* RSA */
+    if (test_algo("(genkey (rsa (nbits 4:2048)))") == 0)
+        printf("RSA: OK\n");
+    else
+        printf("RSA: FAIL\n");
+
+    /* ECDSA */
+    if (test_algo("(genkey (ecdsa (curve \"NIST P-256\")))") == 0)
+        printf("ECDSA: OK\n");
+    else
+        printf("ECDSA: FAIL\n");
+
+#ifdef GCRY_PK_MLDSA
+    /* ML-DSA (PQC) */
+    if (test_algo("(genkey (ml-dsa))") == 0)
+        printf("ML-DSA: OK\n");
+    else
+        printf("ML-DSA: FAIL\n");
+#else
+    printf("ML-DSA: SKIPPED\n");
+#endif
+
+    return 0;
+}

--- a/tests/security/libgcrypt_extended_test.pm
+++ b/tests/security/libgcrypt_extended_test.pm
@@ -48,6 +48,39 @@ sub run {
     die "libgcrypt runtime self-test failed:\n$out" if $out =~ /^not ok\b/m;
 
     record_info('libgcrypt', 'FIPS state and runtime validation successful');
+
+    # SIGN / VERIFY TEST (libgcrypt runtime crypto validation)
+    my $dir_prefix = '/tmp';
+    my $sv_src = 'libgcrypt-sign-verify.c';
+    my $sv_bin = 'libgcrypt-sign-verify';
+
+    assert_script_run("curl -o $dir_prefix/$sv_src " . data_url("security/$sv_src"), 90);
+    assert_script_run("gcc -std=c11 $dir_prefix/$sv_src -lgcrypt -lgpg-error -o $dir_prefix/$sv_bin");
+
+    my $sv_out = script_output("$dir_prefix/$sv_bin", proceed_on_failure => 1);
+    record_info('Sign-Verify Output', $sv_out);
+
+    # RSA must work
+    die "RSA sign/verify failed"
+      unless $sv_out =~ /RSA:\s*OK/;
+
+    # ECDSA must work
+    die "ECDSA sign/verify failed"
+      unless $sv_out =~ /ECDSA:\s*OK/;
+
+    # ML-DSA optional (PQC may not be supported or may be blocked in FIPS)
+    if ($sv_out =~ /ML-DSA:\s*OK/) {
+        record_info('ML-DSA', 'supported and working');
+    } else {
+        if (check_var('FIPS_ENABLED', '1')) {
+            record_info('ML-DSA', 'not available or blocked (expected in FIPS)');
+        } else {
+            # In non-FIPS: this is a regression signal
+            die('ML-DSA sign/verify not working in non-FIPS system');
+        }
+    }
+    # cleanup
+    assert_script_run("rm -rf $dir_prefix/$sv_src $dir_prefix/$sv_bin");
 }
 
 1;


### PR DESCRIPTION


- Related ticket: https://progress.opensuse.org/issues/197588
- Needles:No
- Verification run:  https://openqa.suse.de/tests/overview?version=16.1&distri=sle&build=DeepthiYV%2Fos-autoinst-distri-opensuse%2325541