### PR TITLE
fix(container-suseconnect): Install a simple package

### DIFF
--- a/tests/containers/container_suseconnect.pm
+++ b/tests/containers/container_suseconnect.pm
@@ -85,9 +85,9 @@ sub run {
         );
     }
 
+    my $pkg = 'socat';
     assert_script_run(
-        "$runtime_name exec $container_name " .
-          "zypper -n --gpg-auto-import-keys in gvim"
+        "$runtime_name exec $container_name zypper -n --gpg-auto-import-keys in $pkg"
     );
 
     validate_script_output(
@@ -100,7 +100,7 @@ sub run {
     );
     validate_script_output(
         "$runtime_name exec $container_name rpm -qa",
-        sub { m/gvim/ }
+        sub { m/$pkg/ }
     );
 
 }


### PR DESCRIPTION
We do not need to test a package with a lot of deps, especially not a
package that pull graphical dependencies

- Test failure: https://openqa.suse.de/tests/22262115#step/docker_suseconnect/102
- Verification run: https://openqa.suse.de/tests/22271822#step/docker_suseconnect/102
