### PR TITLE
Fix ReaR layout recreation loop and snapper script syntax in local.conf

### DIFF
--- a/data/ha/rear_local.conf
+++ b/data/ha/rear_local.conf
@@ -17,6 +17,6 @@ NETFS_KEEP_OLD_BACKUP_COPY=
 USE_DHCLIENT=
 MODULES_LOAD=( )
 BACKUP_PROG_INCLUDE=(/boot/grub2/i386-pc/* /boot/grub2/x86_64-efi/* /opt/* /root/* /srv/* /tmp/* /usr/local/* /var/*)
-POST_RECOVERY_SCRIPT=(if\ snapper\ --no-dbus\ -r\ $TARGET_FS_ROOT\ get-config\ |\ grep\ -q\ "^QGROUP.*[0-9]/[0-9]"\ ;\ then\ snapper\ --no-dbus\ -r\ $TARGET_FS_ROOT\ set-config\ QGROUP=\ ;\ snapper\ --no-dbus\ -r\ $TARGET_FS_ROOT\ setup-quota\ &&\ echo\ snapper\ setup-quota\ done\ ||\ echo\ snapper\ setup-quota\ failed\ ;\ else\ echo\ snapper\ setup-quota\ not\ used\ ;\ fi)
+POST_RECOVERY_SCRIPT=( 'if snapper --no-dbus -r $TARGET_FS_ROOT get-config | grep -q "^QGROUP.*[0-9]/[0-9]" ; then snapper --no-dbus -r $TARGET_FS_ROOT set-config QGROUP= ; snapper --no-dbus -r $TARGET_FS_ROOT setup-quota && echo snapper setup-quota done || echo snapper setup-quota failed ; else echo snapper setup-quota not used ; fi' )
 REQUIRED_PROGS=(snapper chattr lsattr ${REQUIRED_PROGS[@]})
-COPY_AS_IS=(/usr/lib/snapper/installation-helper /etc/snapper/config-templates/default ${COPY_AS_IS[@]})
+COPY_AS_IS=(/usr/lib/snapper/installation-helper /etc/snapper/config-templates /usr/share/snapper/config-templates ${COPY_AS_IS[@]})


### PR DESCRIPTION
Add /usr/share/snapper/config-templates to COPY_AS_IS to support SLES 16. On SLES 16, snapper templates moved from /etc to /usr/share. Missing these templates in the rescue ISO causes installation-helper to fail, leading to an infinite loop in ReaR's layout recreation. (ReaR issue https://github.com/rear/rear/issues/3566 )

Fix bash syntax error in POST_RECOVERY_SCRIPT.
The previous unquoted array literal contained unescaped shell metacharacters (|, ;, &&), causing the script to be silently ignored. Using single quotes ensures the script is correctly assigned and executed post-recovery.


- Related ticket: https://jira.suse.com/browse/TEAM-11240

# Verification run:


 - sle-16.0-Online-x86_64-BuildwjVR-rear_generate_backup_textmode@64bit-4gbram -> http://openqa.suse.de/tests/22277450
 - sle-16.0-Online-x86_64-BuildwjVR-rear_restore_backup_textmode@64bit-4gbram -> http://openqa.suse.de/tests/22277452
 - sle-16.0-Online-x86_64-BuildwjVR-rear_restore_backup_textmode@64bit-4gbram -> http://openqa.suse.de/tests/22277448
 - sle-16.0-Online-x86_64-BuildwjVR-rear_restore_backup_textmode@64bit-4gbram -> http://openqa.suse.de/tests/22277453
 - sle-16.0-Online-x86_64-BuildwjVR-rear_restore_backup_textmode@64bit-4gbram -> http://openqa.suse.de/tests/22277449
 - sle-16.0-Online-x86_64-BuildwjVR-rear_restore_backup_textmode@64bit-4gbram -> http://openqa.suse.de/tests/22277451