### PR TITLE
Bring ReaR log collection in sync with debug recommendations

### DIFF
--- a/lib/rear.pm
+++ b/lib/rear.pm
@@ -6,15 +6,17 @@
 # Summary: Functions for ReaR tests
 
 package rear;
-use base "opensusebasetest";
+use Mojo::Base 'opensusebasetest';
 
 use strict;
 use warnings;
-use testapi;
+use testapi qw(is_serial_terminal :DEFAULT);
+use version_utils qw(is_sle);
 use Utils::Logging 'save_and_upload_log';
 
 our @EXPORT = qw(
   upload_rear_logs
+  upload_fs_blk_info
 );
 
 =head1 SYNOPSIS
@@ -26,6 +28,38 @@ This package inherits from B<opensusebasetest> and should be used as
 a class.
 
 =cut
+
+=head2 rear_cmd_log
+
+ $self->rear_cmd_log();
+ $self->rear_cmd_log('/path/to/log/file.log');
+
+Sets or gets the full path to the ReaR command log.
+=cut
+
+has rear_cmd_log => '/var/log/rear-cmd.log';
+
+=head2 upload_fs_blk_info
+
+ $self->upload_fs_blk_info(prefix => $prefix);
+
+Upload outputs of C<lsblk> and C<findmnt> commands. If supplied with a prefix
+in the named argument B<prefix>, prepend the log file names with it.
+=cut
+
+sub upload_fs_blk_info {
+    my ($self, %args) = @_;
+    my $path_and_prefix = '/tmp/';
+    $path_and_prefix .= $args{prefix} . '-' if ($args{prefix});
+
+    # List of block devices
+    my $lsblk_cmd = 'lsblk -ipo NAME,KNAME,PKNAME,TRAN,TYPE,FSTYPE,SIZE,';
+    $lsblk_cmd .= is_sle('>=16') ? 'MOUNTPOINTS' : 'MOUNTPOINT';
+    save_and_upload_log($lsblk_cmd, "${path_and_prefix}lsblk.log");
+
+    # List of filesystems
+    save_and_upload_log('findmnt -a -o SOURCE,TARGET,FSTYPE -t btrfs,ext2,ext3,ext4,xfs,reiserfs,vfat', "${path_and_prefix}findmnt.log");
+}
 
 =head2 upload_rear_logs
 
@@ -40,19 +74,23 @@ sub upload_rear_logs {
     # Upload config file
     upload_logs('/etc/rear/local.conf', failok => 1);
 
-    # List of block devices
-    save_and_upload_log('lsblk -ipo NAME,KNAME,PKNAME,TRAN,TYPE,FSTYPE,SIZE,MOUNTPOINT', '/tmp/lsblk.log');
+    # Record outputs of lsblk and findmnt
+    $self->upload_fs_blk_info();
 
     # Create tarball with logfiles and upload it
     my $logfile = '/tmp/rear-recover-logs.tar.bz2';
-    script_run("tar cjf $logfile /var/log/rear/rear-*.log /var/lib/rear/layout/* /var/lib/rear/recovery/*");
-    upload_logs("$logfile", failok => 1);
+    script_run("tar cjf $logfile /var/log/rear/* /var/lib/rear/layout/* /var/lib/rear/recovery/*");
+    upload_logs($logfile, failok => 1);
+    upload_logs($self->rear_cmd_log(), failok => 1);
 }
 
 sub post_fail_hook {
     my ($self) = @_;
 
     return if get_var('NOLOGS');
+    # Attempt to clear the current terminal session from any running script
+    is_serial_terminal() ? type_string('', terminate_with => 'ETX') : send_key 'ctrl-c';
+    enter_cmd 'clear';
     # We need to be sure that *ALL* consoles are closed, are SUPER:post_fail_hook
     # does not support virtio/serial console yet
     reset_consoles;

--- a/tests/ha/rear_backup.pm
+++ b/tests/ha/rear_backup.pm
@@ -47,7 +47,8 @@ sub run {
         my $local_conf = '/etc/rear/local.conf';
         assert_script_run("curl -f -v " . data_url('ha/rear_local.conf') . " -o $local_conf");
         file_content_replace("$local_conf", q(%BACKUP_URL%) => $backup_url);
-        my $rear_cmd = 'rear -d -D mkbackup';
+        my $rear_cmd = 'rear -d -D mkbackup |& tee -a ' . $self->rear_cmd_log();
+        assert_script_run('set -o pipefail');
         my $backup_rc = script_run($rear_cmd, timeout => $timeout);
         die 'Unexpected error in mkbackup command' unless defined $backup_rc;
         unless ($backup_rc == 0) {

--- a/tests/ha/rear_restore.pm
+++ b/tests/ha/rear_restore.pm
@@ -38,7 +38,9 @@ sub run {
     # Restore the OS backup
     set_var('LIVETEST', 1);    # Because there is no password in ReaR miniOS
     select_console('root-console', skip_setterm => 1);    # Serial console is not configured in ReaR miniOS
-    assert_script_run('export USER_INPUT_TIMEOUT=5; rear -d -D recover', timeout => $timeout);
+    $self->upload_fs_blk_info(prefix => 'before');
+    assert_script_run('set -o pipefail');
+    assert_script_run('export USER_INPUT_TIMEOUT=5; rear -d -D recover |& tee -a ' . $self->rear_cmd_log(), timeout => $timeout);
     $self->upload_rear_logs;
     set_var('LIVETEST', 0);
 


### PR DESCRIPTION
ReaR has a set of recommended logs and command outputs which are useful to attach when opening bugs to the ReaR packages. These are listed in the openSUSE Disaster Recovery page at:

https://en.opensuse.org/SDB:Disaster_Recovery#Debugging_issues_with_Relax-and-Recover

Some of the required logs and command outputs were already being collected in the `ha/rear_backup` and `ha/rear_restore` test modules (and related libraries), so this commit just adds the missing ones:

- Upload output of `rear -d -D` commands.
- Upload output of `findmnt -a -o SOURCE,TARGET,FSTYPE -t btrfs,ext2,ext3,ext4,xfs,reserfs,vfat`
- Upload outputs of `lsblk` and `findmnt` commands before and after a recovery failure.
- Upload contents of `/var/log/rear/`

Additionally the base class `lib/rear.pm` has been updated to use `Mojo::Base`, and the `post_fail_hook` mehotd has been modified to send a `Ctrl-C` and a `clear` command to the existing terminal session to attempt to unblock it from any running command and thus be able to collect the logs.

- Related Ticket: https://jira.suse.com/browse/TEAM-11240
- Needles: N/A
- Verification run: [backup](http://mango.qe.nue2.suse.org/tests/7765#downloads), [restore](http://mango.qe.nue2.suse.org/tests/7766#downloads) (failure in restore is expected. Described in related [ticket](https://jira.suse.com/browse/TEAM-11240))
