### PR TITLE
Adapt zypper lr output without colon

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -580,7 +580,7 @@ Returns Hash reference with all the parsed properties and their values, for exam
 
 sub parse_repo_data {
     my ($repo_identifier) = @_;
-    my @lines = split(/\n/, script_output("zypper lr $repo_identifier"));
+    my @lines = split(/\n/, script_output("zypper -q lr $repo_identifier"));
     my %repo_data = map { split(/\s*:\s*/, $_, 2) } @lines;
     return \%repo_data;
 }


### PR DESCRIPTION
## 
#### Description:
We need to adapt `parse_repo_data` for sometimes we have kind of output that has no `:`
```log
Refreshing service 'SUSE_Linux_Enterprise_Server_16.1_x86_64'
Alias          : SUSE_Linux_Enterprise_Server_for_SAP_applications_16.1_x86_64:SLE-Product-SLES_SAP-16.1
Name           : SLE-Product-SLES_SAP-16.1
```
- Related ticket:
  - Quick PR to fix [zypper lr output](https://openqa.suse.de/tests/22282859#step/validate_repos/7) issue.
- Needles: 
  - N/A
- Verification run:
  - [**validate_repos**](https://openqa.suse.de/tests/overview?build=hjluo%2Fos-autoinst-distri-opensuse%23fix_validate_repos&distri=sle&version=16.1)

<div align="Center">

 $`- ~by~e^{i\pi }~`$
</div>

##
