### PR TITLE
Add softfailure for bsc1261908

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -318,6 +318,10 @@ sub wait_for_guestregister {
             # we have some cases where it is known that guestregister service will fail
             # ( e.g. when we testing images not published on Market hence w/o product codes)
             return 1 if (get_var('PUBLIC_CLOUD_IGNORE_UNREGISTERED'));
+            if (is_sle("=16.0") && is_gce) {
+                record_soft_failure("bsc#1261908 guestregister.service fails on SLES 16");
+                return 1;
+            }
             die('guestregister failed');
         }
         elsif ($out =~ m/active$/) {


### PR DESCRIPTION
Do not fail the test when guestregister.service fails on startup. This is filed as [bsc#1261908](https://bugzilla.suse.com/show_bug.cgi?id=1261908) for SLES16.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1261908
- Related failure: https://openqa.suse.de/tests/22282605#step/prepare_instance/164
- Verification run: https://openqa.suse.de/tests/22283168#step/prepare_instance/163
