### PR TITLE
Install migrate-sles-to-sles4sap before cleaning up registration

### DIFF
--- a/tests/sles4sap/migrate_sles_to_sles4sap.pm
+++ b/tests/sles4sap/migrate_sles_to_sles4sap.pm
@@ -23,6 +23,9 @@ sub run {
 
     select_serial_terminal;
 
+    # Install migration tool
+    zypper_call 'in -y migrate-sles-to-sles4sap';
+
     # Clean up and re-register not to affect other job which are sharing same qcow2
     if (is_sle('15+')) {
         cleanup_registration();
@@ -32,9 +35,6 @@ sub run {
     # Check the build number, can useful for debugging!
     my $build_version = script_output('cat /etc/YaST2/build', proceed_on_failure => 1);
     record_info("Build version", "Build version installed: $build_version");
-
-    # Install migration tool
-    zypper_call 'in -y migrate-sles-to-sles4sap';
 
     # Do the migration!
     enter_cmd "$cmd && touch /tmp/OK";


### PR DESCRIPTION
I moved the lines `installing migrate-sles-to-sles4sap` package before `cleanup_registration`, this avoids the problem that `migrate-sles-to-sles4sap` is from LTSS repository or test repository.

- Related ticket: https://jira.suse.com/browse/TEAM-11236
- Needles: None
- Verification run:
    https://openqa.suse.de/tests/22283098 (15-SP4 LTSS)
    https://openqa.suse.de/tests/22283230 (12-SP5 LTSS)
    https://openqa.suse.de/tests/22283309 (15-SP7)