### PR TITLE
Remove record_soft_failure in rpm difference checker in `patch_and_reboot.pm`

### DIFF
--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -70,11 +70,12 @@ sub run {
     my $rc = $instance->ssh_script_run(cmd => "test -s $rpm_list_diff");
     unless ($rc == 0) {
         if ($ignore_empty_updates) {
-            record_info('No packages were updated during patching');
+            record_info(
+                'PUBLIC_CLOUD_IGNORE_EMPTY_UPDATES',
+                'No packages were updated during patching'
+            );
         } else {
-            # Uncomment the line below and remove record_soft_failure line once we are confident we don't run into empty updates
-            # die 'No packages were updated during patching';
-            record_soft_failure('poo#197723 - No packages were updated during patching');
+            die 'No packages were updated during patching';
         }
     }
 }


### PR DESCRIPTION
As we are not sure if there are cases of empty updates, we came to conclusion to use record_soft_failure for a while instead of blocking updates (we aren't introducing regression as we are not loosing up existing rules, rather introducing NEW loose rules which we will tight after are are sure we can)

- Related ticket: https://progress.opensuse.org/issues/198245
- Verification run: [fails now](https://openqa.suse.de/tests/22283706)