### PR TITLE
xfstests: Add dumpe2fs collection and fix fsxops missing issue

### DIFF
--- a/data/xfstests/wrapper.sh
+++ b/data/xfstests/wrapper.sh
@@ -166,10 +166,10 @@ if [[ $? -ne 0 ]]; then
     sed -i -e "s/::1.*/& $(hostname)/g" /etc/hosts
 fi
 
-# Load xfstests settings from ~/.xfstests
-if [[ -f "$HOME/.xfstests" ]]; then
+# Load xfstests settings from local.config
+if [[ -f "$XFSTESTS_DIR/local.config" ]]; then
     unset_vars
-    source "$HOME/.xfstests"
+    source "$XFSTESTS_DIR/local.config"
 fi
 
 smart_clean "$1"
@@ -190,7 +190,4 @@ parse_result "$1" "$output"
 ret=$?
 
 popd &> /dev/null
-if [[ -f "$HOME/.xfstests" ]]; then
-    unset_vars
-fi
 exit $ret

--- a/lib/xfstests_utils.pm
+++ b/lib/xfstests_utils.pm
@@ -491,7 +491,14 @@ END_CMD
         $cmd = "find /sys/fs/$fstype/*/allocation/ -type f -exec tail -n +1 {} + >> $LOG_DIR/$category/$num.fs_stat";
     }
     elsif ($fstype eq 'ext4') {
-        $cmd = "find /sys/fs/$fstype/ -type f -exec tail -n +1 {} + >> $LOG_DIR/$category/$num.fs_stat";
+        $cmd = <<END_CMD;
+find /sys/fs/$fstype/ -type f -exec tail -n +1 {} + >> $LOG_DIR/$category/$num.fs_stat
+. $INST_DIR/local.config
+echo "==> dumpe2fs SCRATCH_DEV (\$SCRATCH_DEV) <==" >> $LOG_DIR/$category/$num.fs_stat
+dumpe2fs -h \$SCRATCH_DEV >> $LOG_DIR/$category/$num.fs_stat 2>&1
+echo "==> dumpe2fs TEST_DEV (\$TEST_DEV) <==" >> $LOG_DIR/$category/$num.fs_stat
+dumpe2fs -h \$TEST_DEV >> $LOG_DIR/$category/$num.fs_stat 2>&1
+END_CMD
     }
     elsif ($fstype eq 'nfs') {
         enter_cmd("$cmd");
@@ -522,6 +529,7 @@ sub copy_all_log {
         upload_logs("$LOG_DIR/$num.dump.tar");
     }
     collect_fs_status($category, $num, $fstype, $is_crash);
+    script_run("cp $INST_DIR/results/$category/$num.e2image $LOG_DIR/$category/$num.e2image 2>/dev/null");
     if ($raw_dump) { raw_dump($category, $num, $scratch_dev, $scratch_dev_pool); }
 }
 

--- a/lib/xfstests_utils.pm
+++ b/lib/xfstests_utils.pm
@@ -116,7 +116,7 @@ Start heartbeat, setup environment variables (Call it everytime SUT reboots)
 =cut
 
 sub heartbeat_start {
-    enter_cmd(". ~/.xfstests; nohup sh $HB_SCRIPT &");
+    enter_cmd(". $INST_DIR/local.config; nohup sh $HB_SCRIPT &");
 }
 
 =head2 heartbeat_stop

--- a/lib/xfstests_utils.pm
+++ b/lib/xfstests_utils.pm
@@ -450,8 +450,11 @@ Log: Copy junk.fsxops for fails fsx tests included in subtests
 
 sub copy_fsxops {
     my ($category, $num) = @_;
-    my $cmd = "if [ -e $TEST_FOLDER/junk.fsxops ]; then cp $TEST_FOLDER/junk.fsxops $LOG_DIR/$category/$num.junk.fsxops; fi";
-    script_run($cmd);
+    script_run(". $INST_DIR/local.config && mount \$TEST_DEV $TEST_FOLDER 2>/dev/null");
+    if (script_run("test -f $TEST_FOLDER/junk.fsxops") == 0) {
+        my $fsxops = script_output("cat $TEST_FOLDER/junk.fsxops 2>/dev/null", 30, proceed_on_failure => 1);
+        record_info('fsxops', $fsxops) if $fsxops;
+    }
 }
 
 =head2 raw_dump

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -330,7 +330,6 @@ elsif (get_var('XFSTESTS')) {
     else {
         loadtest 'xfstests/partition';
         loadtest 'xfstests/run';
-        loadtest 'xfstests/generate_report';
     }
 }
 else {


### PR DESCRIPTION
1. Add e2image and dumpe2fs collection for ext4 on test failure
2. Save junk.fsxops in wrapper.sh and record via record_info to survive snapshot rollbacks
3. Fix config loading: source local.config instead of nonexistent ~/.xfstests so TEST_DEV/TEST_DIR are available for smart_clean, heartbeat_start, and fsxops/dumpe2fs collection
4. Skip existing tar archives in upload_subdirs to avoid nested tarballs
5. Remove duplicate generate_report scheduling from opensuse/main.pm


- Related ticket: https://progress.opensuse.org/issues/200970
- Verification run: 
- fsxops will not be missing by loading a new snapshot, it will show in https://openqa.suse.de/tests/22491502#step/generic-263/56
- ext4 test fail to save dumpe2fs: https://openqa.opensuse.org/tests/5964037 (dumpe2fs info is include generate_report-generic.tar.xz under 347.fs_stat)