### PR TITLE
Reduce wait_for_idle timeout for SAPHanaSR-showAttr

### DIFF
--- a/lib/sles4sap/publiccloud.pm
+++ b/lib/sles4sap/publiccloud.pm
@@ -295,7 +295,7 @@ sub deployment_cleanup {
 sub get_hana_topology {
     my ($self) = @_;
     my $output_format = get_var('USE_SAP_HANA_SR_ANGI') ? 'json' : 'script';
-    $self->wait_for_idle(timeout => 240);
+    $self->wait_for_idle(timeout => 60);
     my $cmd_out = $self->run_cmd_retry(cmd => "SAPHanaSR-showAttr --format=$output_format", quiet => 1);
     return calculate_hana_topology(input_format => $output_format, input => $cmd_out);
 }
@@ -1589,7 +1589,7 @@ sub check_zypper_ref {
 
 sub wait_for_idle {
     my ($self, %args) = @_;
-    my $timeout = $args{timeout} // 240;
+    my $timeout = $args{timeout} // 60;
 
     my $rc = $self->run_cmd_retry(cmd => 'cs_wait_for_idle --sleep 5', timeout => $timeout, rc_only => 1);
     if ($rc == 124) {


### PR DESCRIPTION
The SAPHanaSR-showAttr command and the corresponding cs_wait_for_idle checks are expected to be short operations. A 240-second (4-minute) timeout is excessive for these tasks.

Reducing the default timeout in wait_for_idle and the explicit call in get_hana_topology to 60 seconds. This avoids unnecessary waiting in case of issues and better reflects the expected execution time of these commands.

- Related ticket: https://jira.suse.com/browse/TEAM-10982

# Verification run:
sle-15-SP7-HanaSr-Aws-Byos-x86_64-Build15-SP7 hanasr_aws_test_fencing_native_baremetal ec2_r5b.metal
 - http://openqaworker15.qe.prg2.suse.org/tests/367527