### PR TITLE
Skip grub2 menu in vmware

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -103,7 +103,7 @@ sub process_reboot {
     my (%args) = @_;
     $args{trigger} //= 0;
     $args{automated_rollback} //= 0;
-    $args{expected_grub} //= (is_sle_micro && is_vmware) ? 0 : 1;
+    $args{expected_grub} //= (is_transactional && is_vmware) ? 0 : 1;
     $args{expected_passphrase} //= 0;
 
     if (is_public_cloud) {


### PR DESCRIPTION
The grub2 timeout should be set for vmware image tests. Handling grub2 menu is instable in this environment and is better to be avoided at all costs.
This has been already introduced in sle micro or minimalVM tests

- Failure: https://openqa.suse.de/tests/22262277#step/rebootmgr/34
- Verification run: https://openqa.suse.de/tests/22307662#
