### PR TITLE
Add optional SSH resilience features to SLES4SAP Public Cloud library

### DIFF
--- a/lib/sles4sap/publiccloud.pm
+++ b/lib/sles4sap/publiccloud.pm
@@ -97,6 +97,8 @@ our @EXPORT = qw(
 
 =item B<runas> - pre-pend the command with su to execute it as specific user
 
+=item B<ssh_keepalive> - optional: enable SSH keepalive options to detect hung connections faster
+
 =item B<...> - pass through all other arguments supported by ssh_script_run
 
 =back
@@ -111,11 +113,19 @@ sub run_cmd {
     my $title = $args{title} // $args{cmd};
     $title =~ s/[[:blank:]].+// unless defined $args{title};
     my $cmd = defined($args{runas}) ? "su - $args{runas} -c '$args{cmd}'" : "$args{cmd}";
+
+    # Ensure SSH keepalives to detect hung connections faster
+    if ($args{ssh_keepalive}) {
+        $args{ssh_opts} //= '';
+        $args{ssh_opts} .= ' -o ServerAliveInterval=15 -o ServerAliveCountMax=3' unless $args{ssh_opts} =~ /ServerAliveInterval/;
+    }
+
     # Without cleaning up variables SSH commands get executed under wrong user
     delete($args{cmd});
     delete($args{title});
     delete($args{timeout});
     delete($args{runas});
+    delete($args{ssh_keepalive});
 
     $self->{my_instance}->update_instance_ip();
     $self->{my_instance}->wait_for_ssh(timeout => $timeout);
@@ -147,6 +157,8 @@ sub run_cmd {
 
 =item B<delay> - idle time between retry attempts
 
+=item B<ssh_keepalive> - optional: enable SSH keepalive options and send ETX on failure
+
 =item B<...> - pass through all other arguments supported by run_cmd
 
 =back
@@ -162,6 +174,10 @@ sub run_cmd_retry {
     for (1 .. $retry) {
         my $ret = eval { $self->run_cmd(timeout => $timeout, proceed_on_failure => 0, %args); };
         return $ret if (defined $ret);
+
+        # Unblock console in case the previous command hung and timed out
+        type_string('', terminate_with => 'ETX') if $args{ssh_keepalive};
+
         sleep $delay;
         record_soft_failure('jsc#TEAM-10485 SSH timeout or failure, retrying');
     }
@@ -367,8 +383,8 @@ sub is_hana_resource_running {
     }
 }
 
-=head2 is_hana_node_up
-    is_hana_node_up($my_instance, [timeout => 900]);
+=head2 wait_hana_node_up
+    wait_hana_node_up($my_instance, [timeout => 900, ssh_keepalive => 1]);
 
     Waits until 'is-system-running' returns successfully on the target instance.
 
@@ -378,7 +394,9 @@ sub is_hana_resource_running {
 
 =item B<timeout> - how much time to wait for before aborting
 
-=back  
+=item B<ssh_keepalive> - optional: enable SSH keepalive options
+
+=back
 =cut
 
 sub wait_hana_node_up {
@@ -396,13 +414,16 @@ sub wait_hana_node_up {
         sleep $delay;
     }
 
+    my $ssh_opts = '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ControlPath=none -o ConnectTimeout=10';
+    $ssh_opts .= ' -o ServerAliveInterval=15 -o ServerAliveCountMax=3' if $args{ssh_keepalive};
+
     $start_time = time();
     while ((time() - $start_time) < $args{timeout}) {
         $out = $instance->ssh_script_output(
             cmd => 'sudo systemctl is-system-running',
             # timeout must be enough for ssh handshake to not kill the test
             timeout => 30,
-            ssh_opts => '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ControlPath=none -o ConnectTimeout=10',
+            ssh_opts => $ssh_opts,
             proceed_on_failure => 1);
         return if ($out =~ m/running/);
         if ($out =~ m/degraded/) {
@@ -501,7 +522,7 @@ sub stop_hana {
         record_info('Wait ssh disappear', $end_msg);
 
         # wait for node to be ready
-        wait_hana_node_up($self->{my_instance}, timeout => 900);
+        wait_hana_node_up($self->{my_instance}, timeout => 900, ssh_keepalive => 1);
         record_info('Wait ssh is back again');
     }
     else {
@@ -547,7 +568,7 @@ sub cleanup_resource {
 
     # Retry when running crm command with issue, refer to TEAM-10483
     while ($retry) {
-        $out = $self->run_cmd(cmd => 'crm resource cleanup', proceed_on_failure => 1);
+        $out = $self->run_cmd(cmd => 'crm resource cleanup', proceed_on_failure => 1, ssh_keepalive => 1);
         last if (!grep { $out =~ /$_/ } @errors);
         $retry--;
         sleep 5;

--- a/t/12_sles4sap_publiccloud.t
+++ b/t/12_sles4sap_publiccloud.t
@@ -38,6 +38,63 @@ subtest "[run_cmd]" => sub {
     ok $ret eq 'BABUUUUUUUUM';
 };
 
+subtest "[run_cmd] with ssh_keepalive" => sub {
+    my $self = sles4sap::publiccloud->new();
+
+    my $mock_pc = Test::MockObject->new();
+    $mock_pc->set_true('wait_for_ssh');
+    $mock_pc->set_true('update_instance_ip');
+    my @captured_opts;
+    $mock_pc->mock('ssh_script_output', sub {
+            my ($self, %args) = @_;
+            push @captured_opts, $args{ssh_opts};
+            return 'OK' });
+    $self->{my_instance} = $mock_pc;
+    $self->{my_instance}->{instance_id} = 'Yondu';
+
+    my $sles4sap_publiccloud = Test::MockModule->new('sles4sap::publiccloud', no_auto => 1);
+    $sles4sap_publiccloud->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    # Case 1: ssh_keepalive enabled
+    $self->run_cmd(cmd => 'dummy', ssh_keepalive => 1);
+    like($captured_opts[0], qr/ServerAliveInterval=15/, "ServerAliveInterval is set");
+    like($captured_opts[0], qr/ServerAliveCountMax=3/, "ServerAliveCountMax is set");
+
+    # Case 2: ssh_keepalive disabled (default)
+    @captured_opts = ();
+    $self->run_cmd(cmd => 'dummy');
+    ok(!defined($captured_opts[0]) || $captured_opts[0] !~ /ServerAliveInterval/, "Keepalive options not injected by default");
+};
+
+subtest "[run_cmd_retry] with ssh_keepalive" => sub {
+    my $self = sles4sap::publiccloud->new();
+    my $sles4sap_pc_mock = Test::MockModule->new('sles4sap::publiccloud', no_auto => 1);
+
+    my $etx_called = 0;
+    $sles4sap_pc_mock->redefine(type_string => sub {
+            my ($string, %args) = @_;
+            $etx_called++ if $args{terminate_with} && $args{terminate_with} eq 'ETX';
+    });
+    $sles4sap_pc_mock->redefine(record_soft_failure => sub { note(join(' ', 'SOFT_FAILURE -->', @_)); });
+
+    # Mock run_cmd to fail twice and then succeed
+    my $calls = 0;
+    $sles4sap_pc_mock->redefine(run_cmd => sub {
+            return 'OK' if ++$calls > 2;
+            die "Command failed";
+    });
+
+    # Case 1: ssh_keepalive enabled -> ETX should be called
+    $self->run_cmd_retry(cmd => 'dummy', ssh_keepalive => 1, retry => 3, delay => 0);
+    is($etx_called, 2, "ETX called twice (once for each failed attempt before success)");
+
+    # Case 2: ssh_keepalive disabled -> ETX should NOT be called
+    $etx_called = 0;
+    $calls = 0;
+    $self->run_cmd_retry(cmd => 'dummy', retry => 3, delay => 0);
+    is($etx_called, 0, "ETX not called when ssh_keepalive is disabled");
+};
+
 subtest "[deployment_cleanup] no args and all pass" => sub {
     # deployment_cleanup is called with no args
     # it result in only to perform terraform destroy
@@ -373,6 +430,29 @@ subtest "[stop_hana] crash wait_hana_node_up degradated" => sub {
     dies_ok { $self->stop_hana(method => 'crash', online_string => 'online') } 'Test expected to die within wait_hana_node_up';
     note("\n  C -->  " . join("\n  C -->  ", @calls));
     ok((any { qr/systemctl --failed/ } @calls), 'function calls systemctl --failed to figure out which service is failed');
+};
+
+subtest "[wait_hana_node_up] with ssh_keepalive" => sub {
+    my $mock_instance = Test::MockObject->new();
+    $mock_instance->{public_ip} = '1.2.3.4';
+    my @captured_opts;
+    $mock_instance->mock('ssh_script_output', sub {
+            my ($self, %args) = @_;
+            push @captured_opts, $args{ssh_opts};
+            return 'running' });
+
+    my $sles4sap_pc_mock = Test::MockModule->new('sles4sap::publiccloud', no_auto => 1);
+    $sles4sap_pc_mock->redefine(script_run => sub { return 0; });
+    $sles4sap_pc_mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    # Case 1: ssh_keepalive enabled
+    sles4sap::publiccloud::wait_hana_node_up($mock_instance, timeout => 10, ssh_keepalive => 1);
+    like($captured_opts[0], qr/ServerAliveInterval=15/, "ServerAliveInterval is set in wait_hana_node_up");
+
+    # Case 2: ssh_keepalive disabled
+    @captured_opts = ();
+    sles4sap::publiccloud::wait_hana_node_up($mock_instance, timeout => 10);
+    ok($captured_opts[0] !~ /ServerAliveInterval/, "Keepalive options not injected in wait_hana_node_up by default");
 };
 
 subtest "[stop_hana] missing online_string croaks" => sub {


### PR DESCRIPTION
Introduced a 'ssh_keepalive' parameter to 'run_cmd', 'run_cmd_retry', and 'wait_hana_node_up' to allow opting into enhanced SSH robustness. When 'ssh_keepalive' is enabled, SSH keepalive options (ServerAliveInterval and ServerAliveCountMax) are automatically injected into the SSH command line.
In 'run_cmd_retry', if 'ssh_keepalive' is active, an ETX (Ctrl+C) signal is sent to the console after a failure to ensure it is cleared for the next retry attempt.
Fixed a documentation bug where 'wait_hana_node_up' was incorrectly labeled as 'is_hana_node_up' in its POD header.


- Related ticket: https://jira.suse.com/browse/TEAM-10982
 
# Verification run: 

 - sle-15-SP7-HanaSr-Azure-Payg-x86_64-Build15-SP7_2026-05-21T02:03:20Z-hanasr_azure_test_msi@az_Standard_E4s_v3 -> http://openqaworker15.qe.prg2.suse.org/tests/368887

 - sle-15-SP7-HanaSr-Aws-Byos-x86_64-Build15-SP7_2026-05-21T02:03:20Z-hanasr_aws_test_fencing_native_baremetal@ec2_r5b.metal -> http://openqaworker15.qe.prg2.suse.org/tests/368894
