### PR TITLE
Add softfailure for bsc#1261908 in preparation

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -534,6 +534,15 @@ sub wait_for_ssh {
 
     # OK
     return $duration if (!$exit_code && !$args{wait_stop} || $exit_code && $args{wait_stop});
+    # softfailure for 1261908, remove this after resolved.
+    # On SLES 16 GCE this is really coarse, but the guestregister.service is really stubburn.
+    # Sometimes it fails, sometimes it keeps running and tries to register but we run into the timeout (10mins)
+    # where the system is still booting.
+    if (is_sle("=16.0") && is_gce) {
+        record_soft_failure("bsc#1261908 guestregister.service fails on SLES 16");
+        return 1;
+    }
+
     # FAIL
     croak(" results summary:\n" . $sshout . $sysout) unless ($args{proceed_on_failure});
     return;    # proceed_on_failure true


### PR DESCRIPTION
Do not fail if the `guestregister.service` fails to start or is still starting after the 10 minutes timeout. This is rather coarse, but we don't really have better options, as the service could either fail or stubburnly run for more than 10 minutes without success.

We know about the registration issue and to increase the chance that at least some tests will eventually run, this is a trade-off that we likely should make.

- Related failure: https://openqa.suse.de/tests/22283647#step/prepare_instance/142
- Verification run: https://openqa.suse.de/tests/22310102#step/prepare_instance/163
