### PR TITLE
agama: Skip desktop selection for textmode

### DIFF
--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -213,7 +213,7 @@ sub run {
     back_to_overview;
 
     # Agama 20+ has a new desktop selection screen
-    if (!is_leap) {
+    if (!is_leap && !check_var('DESKTOP', "textmode")) {
         software_select_desktop;
         back_to_overview;
     }


### PR DESCRIPTION
There is no "textmode" desktop pattern or anything as such, so there is no
point trying to select one

openqa: clone https://openqa.opensuse.org/tests/5922408
