### PR TITLE
blktests: Add known issues

### DIFF
--- a/lib/LTP/WhiteList.pm
+++ b/lib/LTP/WhiteList.pm
@@ -183,7 +183,7 @@ sub list_skipped_tests {
 sub _whitelist_entry_match
 {
     my ($entry, $env) = @_;
-    my @attributes = qw(product ltp_version revision arch kernel backend retval flavor machine);
+    my @attributes = qw(product ltp_version revision arch kernel backend retval flavor machine test_variant);
 
     foreach my $attr (@attributes) {
         next unless defined $entry->{$attr};

--- a/t/07_ltp_whitelist.t
+++ b/t/07_ltp_whitelist.t
@@ -34,7 +34,7 @@ subtest 'whitelist_entry_match' => sub {
     $env->{flavor} = 'EC2-HVM';
     is_deeply(LTP::WhiteList::_whitelist_entry_match($entry, $env), $entry, "Entry match with less attributes");
 
-    for my $attr (qw(product ltp_version revision arch kernel backend retval flavor)) {
+    for my $attr (qw(product ltp_version revision arch kernel backend retval flavor test_variant)) {
         $entry = {$attr => '^incredible_value$'};
         $env = {$attr => "incredible_value"};
         is_deeply(LTP::WhiteList::_whitelist_entry_match($entry, $env), $entry, "Check match attribute $attr");

--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -12,6 +12,8 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use repo_tools 'add_qa_head_repo';
+use LTP::WhiteList;
+use LTP::utils 'prepare_whitelist_environment';
 use package_utils 'install_package';
 use Utils::Logging qw(export_logs_basic save_and_upload_log);
 
@@ -32,10 +34,11 @@ sub run {
     #below variable exposes blktests options to the openQA testsuite
     #definition, so that it allows flexible ways of re-runing the tests
     my $tests = get_required_var('BLKTESTS');
+    my $devices = get_required_var('BLKTESTS_TEST_DEVS');
     my $quick = get_var('BLKTESTS_QUICK', 60);
     my $exclude = get_var('BLKTESTS_EXCLUDE');
-    my $devices = get_required_var('BLKTESTS_DEVICE_ONLY');
     my $trtypes = get_var('BLKTESTS_TRTYPES');
+    my $issues = get_var('BLKTESTS_KNOWN_ISSUES');
 
     record_info('KERNEL', script_output('rpm -qi kernel-default'));
     save_and_upload_log('rpm -qi kernel-default', 'kernel_bug_report.txt');
@@ -56,8 +59,25 @@ sub run {
     my @tests = split(',', $tests);
     assert_script_run('cd /usr/lib/blktests');
 
-    $exclude = join(' ', map { "--exclude=$_" } split(/,/, $exclude // ''));
+    # BLKTESTS_EXCLUDE provides the initial list; known-issue entries are appended below
+    my @exclude = split(/,/, $exclude // '');
+    if ($issues) {
+        my $whitelist = LTP::WhiteList->new($issues);
+        my $environment = prepare_whitelist_environment();
+        $environment->{test_variant} = $trtypes // '';
+        $environment->{kernel} = script_output('uname -r');
+
+        for my $test ($whitelist->list_skipped_tests($environment, 'blktests')) {
+            my $entry = $whitelist->find_whitelist_entry($environment, 'blktests', $test);
+            my $message = $entry->{message} // '';
+            record_info('Known issue', "Skipping $test" . ($message ? ": $message" : ''));
+            push @exclude, $test;
+        }
+    }
+
+    $exclude = join(' ', map { "--exclude=$_" } @exclude);
     $trtypes = "NVMET_TRTYPES=\"$trtypes\" " if $trtypes;
+
     foreach my $i (@tests) {
         my $config = $devices eq 'none' ? '' : '-c /etc/blktests/config';
         script_run("${trtypes} ./check $config -o ${log_dir}/results --quick=$quick $exclude $i", 1200);

--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -110,3 +110,78 @@ sub post_fail_hook {
 }
 
 1;
+
+=head1 Description
+
+Run the upstream blktests suite from the C<blktests> package.
+
+The test groups to execute are selected with C<BLKTESTS>. Individual tests can
+be skipped either directly with C<BLKTESTS_EXCLUDE> (mostly for debugging purposes)
+or through known-issues metadata referenced by C<BLKTESTS_KNOWN_ISSUES>.
+Most native C<blktests> variables are exposed as C<BLKTESTS_NAME>, where C<NAME>
+matches the upstream C<blktests> variable name, for example C<BLKTESTS_TRTYPES>
+for C<TRTYPES>.
+
+=head1 Configuration
+
+=head2 BLKTESTS
+
+Required. Comma-separated list of blktests groups or individual tests passed to
+C<./check>. Examples:
+
+  BLKTESTS=block
+  BLKTESTS=dm,throtl,scsi,loop
+  BLKTESTS=nvme/001
+
+=head2 BLKTESTS_TEST_DEVS
+
+Required. Device list written to F</etc/blktests/config> as C<TEST_DEVS>.
+Set to C<none> to skip writing a device list.
+
+=head2 BLKTESTS_EXCLUDE
+
+Optional. Comma-separated list of tests to exclude directly from this job. The
+value is converted to C<./check --exclude=...> arguments.
+
+This remains useful for temporary debugging overrides. Persistent product or
+transport specific skips should be represented in C<BLKTESTS_KNOWN_ISSUES>
+instead.
+
+=head2 BLKTESTS_KNOWN_ISSUES
+
+Optional. URL or local path to a known-issues YAML file parsed with
+C<LTP::WhiteList>. Entries under the C<blktests> suite with C<skip: 1> are
+added to the C<./check --exclude=...> arguments when they match the current
+openQA environment.
+
+Known-issues keys must use the full upstream blktests test ID format
+C<group/number>. Matching C<skip: 1> entries are passed directly to
+C<./check --exclude=...>.
+
+Example:
+
+  blktests:
+      block/033:
+      - product: sle:16\.1$
+        skip: 1
+        message: miniublk uses legacy ublk command opcodes
+      nvme/041:
+      - test_variant: ^fc$
+        skip: 1
+        message: skipped only for NVMe Fibre Channel transport
+
+The common C<LTP::WhiteList> fields such as C<product>, C<revision>, C<flavor>,
+C<arch>, C<backend>, C<machine>, C<kernel>, and C<test_variant> are supported.
+For blktests, C<test_variant> matches C<BLKTESTS_TRTYPES>.
+
+=head2 BLKTESTS_QUICK
+
+Optional. Value passed to C<./check --quick>. Defaults to C<60>.
+
+=head2 BLKTESTS_TRTYPES
+
+Optional. NVMe transport type passed to blktests through C<NVMET_TRTYPES>.
+This value is also available to C<BLKTESTS_KNOWN_ISSUES> entries through the
+C<test_variant> matcher.
+
+=cut

--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -12,6 +12,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use repo_tools 'add_qa_head_repo';
+use LTP::WhiteList;
 use package_utils 'install_package';
 use Utils::Logging qw(export_logs_basic save_and_upload_log);
 
@@ -26,42 +27,65 @@ sub prepare_blktests_config {
     }
 }
 
-sub run {
-    select_serial_terminal;
+sub blktests_entry_match {
+    my ($entry, $environment) = @_;
 
-    #below variable exposes blktests options to the openQA testsuite
-    #definition, so that it allows flexible ways of re-runing the tests
-    my $tests = get_required_var('BLKTESTS');
-    my $quick = get_var('BLKTESTS_QUICK', 60);
-    my $exclude = get_var('BLKTESTS_EXCLUDE');
-    my $devices = get_required_var('BLKTESTS_DEVICE_ONLY');
-    my $trtypes = get_var('BLKTESTS_TRTYPES');
+    return unless LTP::WhiteList::_whitelist_entry_match($entry, $environment);
 
-    record_info('KERNEL', script_output('rpm -qi kernel-default'));
-    save_and_upload_log('rpm -qi kernel-default', 'kernel_bug_report.txt');
-
-    #QA repo is added with lower prio in order to avoid possible problems
-    #with some packages provided in both, tested product and qa repo; example: fio
-    add_qa_head_repo(priority => 100);
-    install_package('blktests fio', trup_apply => 1);
-
-    #Prepare configuration, log/results directories
-    assert_script_run("mkdir -p /etc/blktests");
-
-    my $log_dir = '/var/log/blktests';
-    assert_script_run("mkdir -p ${log_dir}/results");
-
-    prepare_blktests_config($devices);
-
-    my @tests = split(',', $tests);
-    assert_script_run('cd /usr/lib/blktests');
-
-    $exclude = join(' ', map { "--exclude=$_" } split(/,/, $exclude // ''));
-    $trtypes = "NVMET_TRTYPES=\"$trtypes\" " if $trtypes;
-    foreach my $i (@tests) {
-        my $config = $devices eq 'none' ? '' : '-c /etc/blktests/config';
-        script_run("${trtypes} ./check $config -o ${log_dir}/results --quick=$quick $exclude $i", 1200);
+    if (defined $entry->{trtypes}) {
+        return unless defined $environment->{trtypes};
+        return unless $environment->{trtypes} =~ m/$entry->{trtypes}/;
     }
+
+    return 1;
+}
+
+sub list_skipped_blktests {
+    my ($whitelist, $environment) = @_;
+    my %skipped_tests;
+
+    my $suite = $whitelist->{whitelist}->{blktests};
+    return %skipped_tests unless ($suite);
+    return %skipped_tests if (ref($suite) eq 'ARRAY');
+
+    for my $test (keys(%$suite)) {
+        next if $test eq '*';
+        my @entries = grep { $_->{skip} && blktests_entry_match($_, $environment) } @{$suite->{$test}};
+        $skipped_tests{$test} = $entries[0]->{message} // '' if @entries;
+    }
+
+    return %skipped_tests;
+}
+
+sub prepare_whitelist_environment {
+    my ($trtypes) = @_;
+
+    return {
+        product => get_var('DISTRI') . ':' . get_var('VERSION'),
+        revision => get_var('BUILD'),
+        flavor => get_var('FLAVOR'),
+        arch => get_var('ARCH'),
+        backend => get_var('BACKEND'),
+        machine => get_var('MACHINE'),
+        trtypes => $trtypes // '',
+        kernel => script_output('uname -r')
+    };
+}
+
+sub get_known_excludes {
+    my (%args) = @_;
+    my $issues = $args{issues};
+
+    return unless $issues;
+
+    my $whitelist = LTP::WhiteList->new($issues);
+    my $environment = prepare_whitelist_environment($args{trtypes});
+
+    return list_skipped_blktests($whitelist, $environment);
+}
+
+sub process_blktests_results {
+    my ($log_dir) = @_;
 
     script_run("cd ${log_dir}");
     script_run('wget --quiet ' . data_url('kernel/post_process') . ' -O post_process');
@@ -79,6 +103,56 @@ sub run {
     }
 }
 
+sub run {
+    select_serial_terminal;
+
+    #below variable exposes blktests options to the openQA testsuite
+    #definition, so that it allows flexible ways of re-runing the tests
+    my $tests = get_required_var('BLKTESTS');
+    my $devices = get_required_var('BLKTESTS_TEST_DEVS');
+    my $quick = get_var('BLKTESTS_QUICK', 60);
+    my $exclude = get_var('BLKTESTS_EXCLUDE');
+    my $trtypes = get_var('BLKTESTS_TRTYPES');
+    my $issues = get_var('BLKTESTS_KNOWN_ISSUES');
+
+    record_info('KERNEL', script_output('rpm -qi kernel-default'));
+    save_and_upload_log('rpm -qi kernel-default', 'kernel_bug_report.txt');
+
+    #QA repo is added with lower prio in order to avoid possible problems
+    #with some packages provided in both, tested product and qa repo; example: fio
+    add_qa_head_repo(priority => 100);
+    install_package('blktests fio', trup_apply => 1);
+
+    #Prepare configuration, log/results directories
+    assert_script_run('mkdir -p /etc/blktests');
+
+    my $log_dir = '/var/log/blktests';
+    assert_script_run("mkdir -p ${log_dir}/results");
+
+    prepare_blktests_config($devices);
+
+    my @tests = map { s/^\s+|\s+$//gr } split(',', $tests);
+    assert_script_run('cd /usr/lib/blktests');
+
+    my @exclude = split(/,/, $exclude // '');
+    my %known_exclude = get_known_excludes(issues => $issues, trtypes => $trtypes);
+    push @exclude, sort keys(%known_exclude);
+    for my $test (sort keys(%known_exclude)) {
+        my $message = $known_exclude{$test} ? ": $known_exclude{$test}" : '';
+        record_info('Known issue', "Skipping $test$message");
+    }
+
+    $exclude = join(' ', map { "--exclude=$_" } grep { $_ ne '' } @exclude);
+    $trtypes = "NVMET_TRTYPES=\"$trtypes\" " if $trtypes;
+
+    foreach my $i (@tests) {
+        my $config = $devices eq 'none' ? '' : '-c /etc/blktests/config';
+        script_run("${trtypes} ./check $config -o ${log_dir}/results --quick=$quick $exclude $i", 1200);
+    }
+
+    process_blktests_results($log_dir);
+}
+
 sub test_flags {
     return {fatal => 1};
 }
@@ -90,3 +164,77 @@ sub post_fail_hook {
 }
 
 1;
+
+=head1 Description
+
+Run the upstream blktests suite from the C<blktests> package.
+
+The test groups to execute are selected with C<BLKTESTS>. Individual tests can
+be skipped either directly with C<BLKTESTS_EXCLUDE> (mostly for debugging purposes)
+or through known-issues metadata referenced by C<BLKTESTS_KNOWN_ISSUES>.
+Most native C<blktests> variables are exposed as C<BLKTESTS_NAME>, where C<NAME>
+matches the upstream C<blktests> variable name, for example C<BLKTESTS_TRTYPES>
+for C<TRTYPES>.
+
+=head1 Configuration
+
+=head2 BLKTESTS
+
+Required. Comma-separated list of blktests groups or individual tests passed to
+C<./check>. Examples:
+
+  BLKTESTS=block
+  BLKTESTS=dm,throtl,scsi,loop
+  BLKTESTS=nvme/001
+
+=head2 BLKTESTS_TEST_DEVS
+
+Required. Device list written to F</etc/blktests/config> as C<TEST_DEVS>.
+Set to C<none> to skip writing a device list.
+
+=head2 BLKTESTS_EXCLUDE
+
+Optional. Comma-separated list of tests to exclude directly from this job. The
+value is converted to C<./check --exclude=...> arguments.
+
+This remains useful for temporary debugging overrides. Persistent product or
+transport specific skips should be represented in C<BLKTESTS_KNOWN_ISSUES>
+instead.
+
+=head2 BLKTESTS_KNOWN_ISSUES
+
+Optional. URL or local path to a known-issues YAML file parsed with
+C<LTP::WhiteList>. Entries under the C<blktests> suite with C<skip: 1> are
+added to the C<./check --exclude=...> arguments when they match the current
+openQA environment.
+
+Known-issues keys must use the full upstream blktests test ID format
+C<group/number>. Matching C<skip: 1> entries are passed directly to
+C<./check --exclude=...>.
+
+Example:
+
+  blktests:
+      block/033:
+      - product: sle:16\.1$
+        skip: 1
+        message: miniublk uses legacy ublk command opcodes
+      nvme/041:
+      - trtypes: ^fc$
+        skip: 1
+        message: skipped only for NVMe Fibre Channel transport
+
+The common C<LTP::WhiteList> fields such as C<product>, C<revision>, C<flavor>,
+C<arch>, C<backend>, C<machine>, and C<kernel> are supported.
+The C<trtypes> field is handled locally by this module and matches
+C<BLKTESTS_TRTYPES>.
+
+=head2 BLKTESTS_QUICK
+
+Optional. Value passed to C<./check --quick>. Defaults to C<60>.
+
+=head2 BLKTESTS_TRTYPES
+
+Optional. NVMe transport type passed to blktests through C<NVMET_TRTYPES>.
+This value is also available to C<BLKTESTS_KNOWN_ISSUES> entries through the
+blktests-local C<trtypes> matcher.


### PR DESCRIPTION
Test like block/033 are failing specifically on a single codestream and for such cases it makes sense to have WhiteList being used in blktests runner, so that the kernel-qe yamls exclude tests which are not to be run against SLES and openSuse at all.

- Related ticket: https://progress.opensuse.org/issues/200787

- Verification run:
  - no `BLKTESTS_KNOWN_ISSUES` set:  https://openqa.suse.de/tests/22599830 (test block/033 is run and failed)
  - `BLKTESTS_KNOWN_ISSUES` set:  https://openqa.suse.de/tests/22599828 (no failures, test block/033 is excluded)

  - immutable system: `BLKTESTS_KNOWN_ISSUES` set:  https://openqa.suse.de/tests/22599836 (no failures, test block/033 is excluded)

[v1]
- Verification run:
  - no `BLKTESTS_KNOWN_ISSUES` set: https://openqa.suse.de/tests/22312387  (test block/033 is run and failed)
  - `BLKTESTS_KNOWN_ISSUES` set: https://openqa.suse.de/tests/22312386 (no failures, test block/033 is excluded)
  - quick regression VRs: https://openqa.suse.de/tests/22312389, https://openqa.suse.de/tests/22312415
  - quick regression VRs on immutable: https://openqa.suse.de/tests/22312388
