### PR TITLE
apptainer: Regenerate certificate store right after image build

### DIFF
--- a/data/containers/apptainer_container.def
+++ b/data/containers/apptainer_container.def
@@ -3,6 +3,7 @@ MirrorURL: http://download.opensuse.org/distribution/openSUSE-stable/repo/oss/
 Include: zypper
 
 %post
+    update-ca-certificates
     zypper ref
     zypper -n in cowsay
 


### PR DESCRIPTION
A recent Leap 16.0 update[1] changed the protocol for openh264 to https
leading to failures in openQA, looking at SLE .def files [2] this is
done right after post too.

[1]: https://src.opensuse.org/openSUSE/Leap/pulls/84/files#issuecomment-169800
[2]: https://build.opensuse.org/projects/openSUSE:Factory/packages/apptainer/files/SLE-16.def?expand=1

openqa: clone https://openqa.opensuse.org/tests/5923267


#### Results from cloned jobs:
- [![https://openqa.opensuse.org/tests/5923878](https://openqa.opensuse.org/tests/5923878/badge)](https://openqa.opensuse.org/tests/5923878)

<sub>The above list is generated with a script with information from the "clone_mentioned_job" workflow.</sub>
