### PR TITLE
Fix sed -i<letters> creating spurious backup files

### DIFF
--- a/data/virt_autotest/setup_dns_service.sh
+++ b/data/virt_autotest/setup_dns_service.sh
@@ -67,10 +67,10 @@ if [ $? -eq 0 ];then
         mv ${dhcpd_config_file}.orig ${dhcpd_config_file} #Restore ${dhcpd_config_file} if it was previously modified by this script
 fi
 cp $dhcpd_config_file $dhcpd_config_file.orig
-sed -irn "s/^.*default-lease-time.*$/default-lease-time 28800;/g; s/^.*max-lease-time.*$/max-lease-time 28800;/g; s/^.*option domain-name .*$/option domain-name \"$dns_domain_forward\";/g" ${qa_standalone_file}
+sed -i "s/^.*default-lease-time.*$/default-lease-time 28800;/g; s/^.*max-lease-time.*$/max-lease-time 28800;/g; s/^.*option domain-name .*$/option domain-name \"$dns_domain_forward\";/g" ${qa_standalone_file}
 get_dhcp_ipaddr_range=`echo -e ${dns_domain_reverse} | awk -F"." 'BEGIN {OFS=".";} {print $3,$2,$1}'`
 dhcp_ipaddr_range=$(echo -e ${get_dhcp_ipaddr_range})
-sed -irn "s/^IP=.*$/IP=\'${bridgeip}\'/g; s/^NET=.*$/NET=\'${dhcp_ipaddr_range}\.0\'/g; s/^NETREV=.*$/NETREV=\'${dns_domain_reverse}\'/g; s/^NET_DHCP_RANGE_START=.*$/NET_DHCP_RANGE_START=\'${dhcp_ipaddr_range}\.10\'/g; s/^NET_DHCP_RANGE_END=.*$/NET_DHCP_RANGE_END=\'${dhcp_ipaddr_range}\.100\'/g; s/^NET_STATIC_RANGE_START=.*$/NET_STATIC_RANGE_START=\'${dhcp_ipaddr_range}\.101\'/g; s/^NET_STATIC_RANGE_END=.*$/NET_STATIC_RANGE_END=\'${dhcp_ipaddr_range}\.115\'/g" ${qa_standalone_file}
+sed -i "s/^IP=.*$/IP=\'${bridgeip}\'/g; s/^NET=.*$/NET=\'${dhcp_ipaddr_range}\.0\'/g; s/^NETREV=.*$/NETREV=\'${dns_domain_reverse}\'/g; s/^NET_DHCP_RANGE_START=.*$/NET_DHCP_RANGE_START=\'${dhcp_ipaddr_range}\.10\'/g; s/^NET_DHCP_RANGE_END=.*$/NET_DHCP_RANGE_END=\'${dhcp_ipaddr_range}\.100\'/g; s/^NET_STATIC_RANGE_START=.*$/NET_STATIC_RANGE_START=\'${dhcp_ipaddr_range}\.101\'/g; s/^NET_STATIC_RANGE_END=.*$/NET_STATIC_RANGE_END=\'${dhcp_ipaddr_range}\.115\'/g" ${qa_standalone_file}
 source ${qa_standalone_file}
 
 #Insert script signature to the end of ${dhcpd_config_file}
@@ -269,7 +269,7 @@ cp ${dns_resolv_file} ${dns_resolv_file}.orig
 awk -v dnsvar=${bridgeip} 'done != 1 && /^nameserver.*$/ { print "nameserver "dnsvar"\n"; done=1 } 1' ${dns_resolv_file} > ${dns_config_file_tmp}
 mv ${dns_config_file_tmp} ${dns_resolv_file}
 #Add testvirt.net as domain suffix
-sed -irn "s/^search/search ${dns_domain_forward}/" ${dns_resolv_file}
+sed -i "s/^search/search ${dns_domain_forward}/" ${dns_resolv_file}
 #Add 192.168.123.1 as forwarder
 get_nameservers=`cat ${dns_resolv_file} | grep -iE "^nameserver" | awk '{print $NF}'`
 nameservers_array=$(echo -e ${get_nameservers})
@@ -278,7 +278,7 @@ declare -a forwarders_array=""
 for single_nameserver in ${nameservers_array[@]};do
 	forwarders_array+=(${single_nameserver}\;)
 done	
-sed -irn "/^ *forwarders/s/forwarders.*$/forwarders { `echo -e ${forwarders_array[@]}` };/" ${dns_config_file}
+sed -i "/^ *forwarders/s/forwarders.*$/forwarders { `echo -e ${forwarders_array[@]}` };/" ${dns_config_file}
 #Insert script signature to the end of ${dns_config_file} and ${dns_resolv_file}
 echo -e "#$0" >> ${dns_config_file}
 echo -e "#$0" >> ${dns_resolv_file}

--- a/data/wicked/scripts/test-ext-firewall.sh
+++ b/data/wicked/scripts/test-ext-firewall.sh
@@ -34,7 +34,7 @@ function ifcfg_set_zone {
     local ifc=${1:? Function need interface as parameter}
     local zone=${2:? Function need zone as parameter}
 
-    sed -iE '/\s*ZONE=/d' "$ifcfg"
+    sed -i -E '/\s*ZONE=/d' "$ifcfg"
     echo "ZONE=$zone" >> "$ifcfg"
 }
 
@@ -186,7 +186,7 @@ function test6 {
     logex wicked ifreload "$ifc"
     check_ifc_in_zone "$ifc" "$zone1"
     
-    logex sed -iE '/\s*ZONE=/d' "$ifcfg"
+    logex sed -i -E '/\s*ZONE=/d' "$ifcfg"
     logex wicked ifreload "$ifc"
     check_ifc_in_zone "$ifc" "$default_zone"
 }

--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -271,7 +271,7 @@ sub set_ssh_console_timeout {
     $sshd_timeout //= 28800;
     my $client_count_max = $sshd_timeout / 60;
     if (script_run("ls $sshd_config_file") == 0) {
-        script_run("sed -irnE 's/^.*TCPKeepAlive.*\$/TCPKeepAlive yes/g; s/^.*ClientAliveInterval.*\$/ClientAliveInterval 60/g; s/^.*ClientAliveCountMax.*\$/ClientAliveCountMax $client_count_max/g' $sshd_config_file");
+        script_run("sed -i -E 's/^.*TCPKeepAlive.*\$/TCPKeepAlive yes/g; s/^.*ClientAliveInterval.*\$/ClientAliveInterval 60/g; s/^.*ClientAliveCountMax.*\$/ClientAliveCountMax $client_count_max/g' $sshd_config_file");
         if (script_run("grep -i Alive $sshd_config_file") != 0) {
             script_run("echo -e \"\nTCPKeepAlive yes\n\" >> $sshd_config_file");
             script_run("echo -e \"ClientAliveInterval 60\n\" >> $sshd_config_file");

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1468,9 +1468,9 @@ sub change_grub_config {
 
     if (is_bootloader_sdboot || is_bootloader_grub2_bls) {
         die "Unsupported option $search on BLS" unless $search == "GRUB_CMDLINE_LINUX_DEFAULT";
-        assert_script_run("sed -ie 's/${old}/${new}/${modifiers}' " . BLS_DEFAULT_FILE);
+        assert_script_run("sed -i -e 's/${old}/${new}/${modifiers}' " . BLS_DEFAULT_FILE);
     } else {
-        assert_script_run("sed -ie '${search}s/${old}/${new}/${modifiers}' " . GRUB_DEFAULT_FILE);
+        assert_script_run("sed -i -e '${search}s/${old}/${new}/${modifiers}' " . GRUB_DEFAULT_FILE);
     }
 
     if ($update_grub && is_bootloader_grub2) {

--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -2370,7 +2370,7 @@ sub start_guest_installation {
     #The -Logfile option is only supported by more recent operating systems.
     $self->{guest_installation_session_config} = script_output("cd ~;pwd") . '/' . $self->{guest_name} . '_installation_screen_config';
     script_run("rm -f -r $self->{guest_installation_session_config};touch $self->{guest_installation_session_config};chmod 777 $self->{guest_installation_session_config}");
-    script_run("cat /etc/screenrc > $self->{guest_installation_session_config};sed -in \'/^logfile .*\$/d\' $self->{guest_installation_session_config}");
+    script_run("cat /etc/screenrc > $self->{guest_installation_session_config};sed -i \'/^logfile .*\$/d\' $self->{guest_installation_session_config}");
     script_run("echo \"logfile $_guest_installation_log\" >> $self->{guest_installation_session_config}");
     if ($self->{guest_os_name} eq 'windows') {
         # Windows guests need running on background
@@ -3054,7 +3054,7 @@ sub do_attach_guest_installation_screen_without_session {
             $_attach_timestamp =~ s/ |:/_/g;
             my $_guest_installation_log = "$_host_params{common_log_folder}/$self->{guest_name}/$self->{guest_name}" . "_installation_log_" . $_attach_timestamp;
             $self->{guest_installation_session_config} = script_output("cd ~;pwd") . '/' . $self->{guest_name} . '_installation_screen_config' if ($self->{guest_installation_session_config} eq '');
-            script_run("> $self->{guest_installation_session_config};cat /etc/screenrc > $self->{guest_installation_session_config};sed -in \'/^logfile .*\$/d\' $self->{guest_installation_session_config}");
+            script_run("> $self->{guest_installation_session_config};cat /etc/screenrc > $self->{guest_installation_session_config};sed -i \'/^logfile .*\$/d\' $self->{guest_installation_session_config}");
             script_run("echo \"logfile $_guest_installation_log\" >> $self->{guest_installation_session_config}");
          #Use "screen" in the most compatible way, screen -t "title (window's name)" -c "screen configuration file" -L(turn on output logging) "command to run".
             #The -Logfile option is only supported by more recent operating systems.

--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -661,7 +661,7 @@ sub lvm_add_filter {
     my ($type, $filter) = @_;
     my $lvm_conf = '/etc/lvm/lvm.conf';
 
-    assert_script_run "sed -ie '/^[[:blank:]][[:blank:]]*filter/s;\\[[[:blank:]]*;\\[ \"$type|$filter|\", ;' $lvm_conf";
+    assert_script_run "sed -i -e '/^[[:blank:]][[:blank:]]*filter/s;\\[[[:blank:]]*;\\[ \"$type|$filter|\", ;' $lvm_conf";
 }
 
 =head2 lvm_remove_filter
@@ -676,7 +676,7 @@ sub lvm_remove_filter {
     my $filter = shift;
     my $lvm_conf = '/etc/lvm/lvm.conf';
 
-    assert_script_run "sed -ie '/^[[:blank:]][[:blank:]]*filter/s;$filter;;' $lvm_conf";
+    assert_script_run "sed -i -e '/^[[:blank:]][[:blank:]]*filter/s;$filter;;' $lvm_conf";
 }
 
 =head2 rsc_cleanup
@@ -1139,7 +1139,7 @@ sub set_lvm_config {
     my $cmd;
 
     foreach my $param (keys %args) {
-        $cmd = sprintf("sed -ie 's/^\\([[:blank:]]*%s[[:blank:]]*=\\).*/\\1 %s/' %s", $param, $args{$param}, $lvm_conf);
+        $cmd = sprintf("sed -i -e 's/^\\([[:blank:]]*%s[[:blank:]]*=\\).*/\\1 %s/' %s", $param, $args{$param}, $lvm_conf);
         assert_script_run $cmd;
     }
 
@@ -1164,8 +1164,8 @@ sub add_lock_mgr {
     $args{force} //= 0;
     my $cmd = join(' ', 'crm', ($args{force} ? '--force' : ''), 'configure', 'edit');
 
-    assert_script_run "EDITOR=\"sed -ie '\$ a primitive $lock_mgr ocf:heartbeat:$lock_mgr'\" $cmd";
-    assert_script_run "EDITOR=\"sed -ie 's/^\\(group base-group.*\\)/\\1 $lock_mgr/'\" $cmd";
+    assert_script_run "EDITOR=\"sed -i -e '\$ a primitive $lock_mgr ocf:heartbeat:$lock_mgr'\" $cmd";
+    assert_script_run "EDITOR=\"sed -i -e 's/^\\(group base-group.*\\)/\\1 $lock_mgr/'\" $cmd";
 
     # Wait to get clvmd/lvmlockd running on all nodes
     sleep 5;

--- a/lib/selinuxtest.pm
+++ b/lib/selinuxtest.pm
@@ -155,7 +155,7 @@ sub set_sestatus {
     # workaround for 'selinux-auto-relabel' in case: auto relabel then trigger reboot
     my $results = script_run("zypper --non-interactive se selinux-autorelabel");
     if (!$results) {
-        assert_script_run("sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=8/\' /etc/default/grub");
+        assert_script_run("sed -i -e \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=8/\' /etc/default/grub");
     }
 
     # enable SELinux in grub

--- a/tests/console/apache.pm
+++ b/tests/console/apache.pm
@@ -32,7 +32,7 @@ sub run {
     # enable full package installation, and clean up previous apache2 deployment
     if (is_jeos) {
         my $command = $zypp_econf ? qq@echo -e "$config_snippet" > "$config_drop_in"@ :
-          'sed -ie \'s/rpm.install.excludedocs = yes/rpm.install.excludedocs = no/\' /etc/zypp/zypp.conf';
+          'sed -i -e \'s/rpm.install.excludedocs = yes/rpm.install.excludedocs = no/\' /etc/zypp/zypp.conf';
 
         assert_script_run($command);
         zypper_call('rm apache2', exitcode => [0, 104]);
@@ -141,8 +141,8 @@ sub run {
             assert_script_run "sed 's_\(/var/log/apache2\|/var/run\)_/tmp/prefork_; s/80/8080/' $apache2_default_configuration > /tmp/prefork/httpd.conf";
 
             # httpd.default.conf contains wrong service userid and groupid
-            assert_script_run q{sed -ie 's/^User daemon$/User wwwrun/' /tmp/prefork/httpd.conf};
-            assert_script_run q{sed -ie 's/^Group daemon$/Group www/' /tmp/prefork/httpd.conf};
+            assert_script_run q{sed -i -e 's/^User daemon$/User wwwrun/' /tmp/prefork/httpd.conf};
+            assert_script_run q{sed -i -e 's/^Group daemon$/Group www/' /tmp/prefork/httpd.conf};
 
             # Run and test this new environment
             assert_script_run 'httpd-prefork -f /tmp/prefork/httpd.conf';
@@ -205,7 +205,7 @@ sub run {
     # Revert zypp.conf changes on JeOS
     if (is_jeos) {
         my $command = $zypp_econf ? "rm $config_drop_in" :
-          'sed -ie \'s/rpm.install.excludedocs = no/rpm.install.excludedocs = yes/\' /etc/zypp/zypp.conf';
+          'sed -i -e \'s/rpm.install.excludedocs = no/rpm.install.excludedocs = yes/\' /etc/zypp/zypp.conf';
 
         assert_script_run($command);
     }

--- a/tests/console/verify_efi_mok.pm
+++ b/tests/console/verify_efi_mok.pm
@@ -257,7 +257,7 @@ sub sign_kernel_module {
 sub disable_secureboot {
     my ($self, $exp_data, $esp_details) = @_;
     $self->verification('After grub2-install', $exp_data, sub {
-            assert_script_run('sed -ie s/SECURE_BOOT=.*/SECURE_BOOT=no/ ' . SYSCONFIG_BOOTLADER);
+            assert_script_run('sed -i -e s/SECURE_BOOT=.*/SECURE_BOOT=no/ ' . SYSCONFIG_BOOTLADER);
             assert_script_run "grub2-install --efi-directory=$esp_details->{mount} $esp_details->{drive}";
             assert_script_run('grub2-mkconfig -o ' . GRUB_CFG);
         }

--- a/tests/ha/cluster_md.pm
+++ b/tests/ha/cluster_md.pm
@@ -60,8 +60,8 @@ sub run {
     if (is_node(1)) {
         # Create cluster-md resource
         assert_script_run
-"EDITOR=\"sed -ie '\$ a primitive $clustermd_rsc ocf:heartbeat:Raid1 params raiddev=auto force_clones=true raidconf=$mdadm_conf'\" crm configure edit", $default_timeout;
-        assert_script_run "EDITOR=\"sed -ie 's/^\\(group base-group.*\\)/\\1 $clustermd_rsc/'\" crm configure edit", $default_timeout;
+"EDITOR=\"sed -i -e '\$ a primitive $clustermd_rsc ocf:heartbeat:Raid1 params raiddev=auto force_clones=true raidconf=$mdadm_conf'\" crm configure edit", $default_timeout;
+        assert_script_run "EDITOR=\"sed -i -e 's/^\\(group base-group.*\\)/\\1 $clustermd_rsc/'\" crm configure edit", $default_timeout;
     }
     else {
         diag 'Wait until cluster-md resource is created...';

--- a/tests/ha/ctdb.pm
+++ b/tests/ha/ctdb.pm
@@ -72,18 +72,18 @@ sub run {
             assert_script_run "crm configure property maintenance-mode=true";
 
             # Create vip resource
-            assert_script_run "EDITOR=\"sed -ie '\$ a primitive $ip_rsc IPaddr2 params ip='$vip_ip' nic='$iface' cidr_netmask='24' broadcast='10.0.2.255''\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -i -e '\$ a primitive $ip_rsc IPaddr2 params ip='$vip_ip' nic='$iface' cidr_netmask='24' broadcast='10.0.2.255''\" crm configure edit";
 
             # Add ctdb, nmb, smb, group, clone and order resources
-            assert_script_run "EDITOR=\"sed -ie '\$ a primitive $ctdb_rsc CTDB params ctdb_manages_winbind=false ctdb_manages_samba=false ctdb_recovery_lock='$ctdb_folder/ctdb.lock' ctdb_socket='$ctdb_socket''\" crm configure edit";
-            assert_script_run "EDITOR=\"sed -ie '\$ a primitive $nmb_rsc systemd:nmb'\" crm configure edit";
-            assert_script_run "EDITOR=\"sed -ie '\$ a primitive $smb_rsc systemd:smb'\" crm configure edit";
-            assert_script_run "EDITOR=\"sed -ie '\$ a group ctdb-group $ctdb_rsc $nmb_rsc $smb_rsc'\" crm configure edit";
-            assert_script_run "EDITOR=\"sed -ie '\$ a clone ctdb-clone ctdb-group meta interleave=true'\" crm configure edit";
-            assert_script_run "EDITOR=\"sed -ie '\$ a colocation col-ctdb-with-clusterfs inf: ctdb-clone base-clone'\" crm configure edit";
-            assert_script_run "EDITOR=\"sed -ie '\$ a colocation col-ip-with-ctdb Mandatory: $ip_rsc ctdb-clone'\" crm configure edit";
-            assert_script_run "EDITOR=\"sed -ie '\$ a order o-clusterfs-then-ctdb Mandatory: base-clone ctdb-clone'\" crm configure edit";
-            assert_script_run "EDITOR=\"sed -ie '\$ a order o-ip-then-ctdb Mandatory: $ip_rsc ctdb-clone'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -i -e '\$ a primitive $ctdb_rsc CTDB params ctdb_manages_winbind=false ctdb_manages_samba=false ctdb_recovery_lock='$ctdb_folder/ctdb.lock' ctdb_socket='$ctdb_socket''\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -i -e '\$ a primitive $nmb_rsc systemd:nmb'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -i -e '\$ a primitive $smb_rsc systemd:smb'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -i -e '\$ a group ctdb-group $ctdb_rsc $nmb_rsc $smb_rsc'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -i -e '\$ a clone ctdb-clone ctdb-group meta interleave=true'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -i -e '\$ a colocation col-ctdb-with-clusterfs inf: ctdb-clone base-clone'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -i -e '\$ a colocation col-ip-with-ctdb Mandatory: $ip_rsc ctdb-clone'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -i -e '\$ a order o-clusterfs-then-ctdb Mandatory: base-clone ctdb-clone'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -i -e '\$ a order o-ip-then-ctdb Mandatory: $ip_rsc ctdb-clone'\" crm configure edit";
 
             # Remove maintenance mode and wait for resources start
             assert_script_run "crm configure property maintenance-mode=false";

--- a/tests/ha/dlm.pm
+++ b/tests/ha/dlm.pm
@@ -26,9 +26,9 @@ sub run {
 
     if (is_node(1)) {
         # Create DLM resource
-        assert_script_run 'EDITOR="sed -ie \'$ a primitive dlm ocf:pacemaker:controld\'" crm configure edit', $default_timeout;
-        assert_script_run 'EDITOR="sed -ie \'$ a group base-group dlm\'" crm configure edit', $default_timeout;
-        assert_script_run 'EDITOR="sed -ie \'$ a clone base-clone base-group\'" crm configure edit', $default_timeout;
+        assert_script_run 'EDITOR="sed -i -e \'$ a primitive dlm ocf:pacemaker:controld\'" crm configure edit', $default_timeout;
+        assert_script_run 'EDITOR="sed -i -e \'$ a group base-group dlm\'" crm configure edit', $default_timeout;
+        assert_script_run 'EDITOR="sed -i -e \'$ a clone base-clone base-group\'" crm configure edit', $default_timeout;
     }
     else {
         diag 'Wait until DLM resource is created...';

--- a/tests/ha/drbd_passive.pm
+++ b/tests/ha/drbd_passive.pm
@@ -254,15 +254,15 @@ sub run {
 
     # Create the HA resource
     if (is_node(1)) {
-        assert_script_run "EDITOR=\"sed -ie '\$ a primitive $drbd_rsc ocf:linbit:drbd params drbd_resource=$drbd_rsc'\" crm configure edit";
+        assert_script_run "EDITOR=\"sed -i -e '\$ a primitive $drbd_rsc ocf:linbit:drbd params drbd_resource=$drbd_rsc'\" crm configure edit";
 
         if (is_sle('>=15-SP4')) {
             assert_script_run
-              "EDITOR=\"sed -ie '\$ a clone ms_$drbd_rsc $drbd_rsc meta clone-max=2 clone-node-max=1 promotable=true notify=true'\" crm configure edit";
+              "EDITOR=\"sed -i -e '\$ a clone ms_$drbd_rsc $drbd_rsc meta clone-max=2 clone-node-max=1 promotable=true notify=true'\" crm configure edit";
         }
         else {
             assert_script_run
-"EDITOR=\"sed -ie '\$ a ms ms_$drbd_rsc $drbd_rsc meta master-max=1 master-node-max=1 clone-max=2 clone-node-max=1 notify=true'\" crm configure edit";
+"EDITOR=\"sed -i -e '\$ a ms ms_$drbd_rsc $drbd_rsc meta master-max=1 master-node-max=1 clone-max=2 clone-node-max=1 notify=true'\" crm configure edit";
         }
         # Sometimes we need to cleanup the resource
         rsc_cleanup $drbd_rsc;

--- a/tests/ha/filesystem.pm
+++ b/tests/ha/filesystem.pm
@@ -111,26 +111,26 @@ sub run {
         # Create the Filesystem resource
         my $clean_flag = undef;
         my $edit_crm_config_script = "#!/bin/sh
-EDITOR='sed -ie \"\$ a primitive $fs_rsc ocf:heartbeat:Filesystem params device=\'$fs_lun\' directory=\'/srv/$fs_rsc\' fstype=\'$fs_type\'\"' crm configure edit
+EDITOR='sed -i -e \"\$ a primitive $fs_rsc ocf:heartbeat:Filesystem params device=\'$fs_lun\' directory=\'/srv/$fs_rsc\' fstype=\'$fs_type\'\"' crm configure edit
 ";
         # Only OCFS2 and GFS can be cloned
         if ($fs_type eq 'ocfs2' || $fs_type eq 'gfs2') {
             $edit_crm_config_script .= "
-EDITOR='sed -ie \"s/^\\(group base-group.*\\)/\\1 $fs_rsc/\"' crm configure edit
+EDITOR='sed -i -e \"s/^\\(group base-group.*\\)/\\1 $fs_rsc/\"' crm configure edit
 ";
         }
         else {
             if ($resource eq 'drbd_passive') {
                 my $role = is_sle('>=15-SP4') ? "Promoted" : "Master";
                 $edit_crm_config_script .= "
-EDITOR='sed -ie \"\$ a colocation colocation_$fs_rsc inf: $fs_rsc ms_$resource:$role\"' crm configure edit
-EDITOR='sed -ie \"\$ a order order_$fs_rsc Mandatory: ms_$resource:promote $fs_rsc:start\"' crm configure edit
+EDITOR='sed -i -e \"\$ a colocation colocation_$fs_rsc inf: $fs_rsc ms_$resource:$role\"' crm configure edit
+EDITOR='sed -i -e \"\$ a order order_$fs_rsc Mandatory: ms_$resource:promote $fs_rsc:start\"' crm configure edit
 ";
             }
             else {
                 $edit_crm_config_script .= "
-EDITOR='sed -ie \"\$ a colocation colocation_$fs_rsc inf: $fs_rsc vg_$resource\"' crm configure edit
-EDITOR='sed -ie \"\$ a order order_$fs_rsc Mandatory: vg_$resource $fs_rsc\"\' crm configure edit
+EDITOR='sed -i -e \"\$ a colocation colocation_$fs_rsc inf: $fs_rsc vg_$resource\"' crm configure edit
+EDITOR='sed -i -e \"\$ a order order_$fs_rsc Mandatory: vg_$resource $fs_rsc\"\' crm configure edit
 ";
             }
             $clean_flag = "cleanup";

--- a/tests/ha/haproxy.pm
+++ b/tests/ha/haproxy.pm
@@ -72,20 +72,20 @@ sub run {
 
     if (is_node(1)) {
         # Create vip resource
-        assert_script_run "EDITOR=\"sed -ie '\$ a primitive $vip_rsc IPaddr2 params ip='$vip_ip' nic='$iface' cidr_netmask='24' broadcast='10.0.2.255''\" crm configure edit";
+        assert_script_run "EDITOR=\"sed -i -e '\$ a primitive $vip_rsc IPaddr2 params ip='$vip_ip' nic='$iface' cidr_netmask='24' broadcast='10.0.2.255''\" crm configure edit";
 
         # Just to be sure that vip resource is started
         sleep 5;
         save_state;
 
         # Create haproxy resource
-        assert_script_run "EDITOR=\"sed -ie '\$ a primitive $haproxy_rsc systemd:haproxy'\" crm configure edit";
+        assert_script_run "EDITOR=\"sed -i -e '\$ a primitive $haproxy_rsc systemd:haproxy'\" crm configure edit";
 
         # Vip must be started before haproxy
-        assert_script_run "EDITOR=\"sed -ie '\$ a order order_vip_haproxy Mandatory: $vip_rsc $haproxy_rsc'\" crm configure edit";
+        assert_script_run "EDITOR=\"sed -i -e '\$ a order order_vip_haproxy Mandatory: $vip_rsc $haproxy_rsc'\" crm configure edit";
 
         # Vip must be started where haproxy is live
-        assert_script_run "EDITOR=\"sed -ie '\$ a colocation colocation_vip_haproxy inf: $haproxy_rsc $vip_rsc'\" crm configure edit";
+        assert_script_run "EDITOR=\"sed -i -e '\$ a colocation colocation_vip_haproxy inf: $haproxy_rsc $vip_rsc'\" crm configure edit";
 
         # Sometimes we need to cleanup the resource
         rsc_cleanup $haproxy_rsc;

--- a/tests/ha/qnetd.pm
+++ b/tests/ha/qnetd.pm
@@ -113,8 +113,8 @@ sub run {
         # Add a promotable resource to check if the current node is hosting
         # master instance of the resource. If so, this cluster partition
         # is preferred to be given the vote from qnetd.
-        assert_script_run q|EDITOR="sed -ie '$ a primitive stateful-1 ocf:pacemaker:Stateful'" crm configure edit|;
-        assert_script_run q|EDITOR="sed -ie '$ a clone promotable-1 stateful-1 meta promotable=true'" crm configure edit|;
+        assert_script_run q|EDITOR="sed -i -e '$ a primitive stateful-1 ocf:pacemaker:Stateful'" crm configure edit|;
+        assert_script_run q|EDITOR="sed -i -e '$ a clone promotable-1 stateful-1 meta promotable=true'" crm configure edit|;
         save_state;
 
         # Qdevice should be started

--- a/tests/ha/vg.pm
+++ b/tests/ha/vg.pm
@@ -93,7 +93,7 @@ sub run {
     # DRBD passive test need some specific LVM configuration *after* PV/VG/LV creation
     if ($resource eq 'drbd_passive') {
         my $vol_list = script_output "for I in \$(vgs -o vg_name --noheadings | grep -v $vg_name); do echo -e '\"\$I\", \\c'; done | sed 's/, \$//'";
-        assert_script_run "sed -ie '/\\<volume_list\\>[[:blank:]][[:blank:]]*=/ a volume_list = [ $vol_list ]' $lvm_conf";
+        assert_script_run "sed -i -e '/\\<volume_list\\>[[:blank:]][[:blank:]]*=/ a volume_list = [ $vol_list ]' $lvm_conf";
     }
 
     # Wait until PV-VG-LV is created
@@ -107,20 +107,20 @@ sub run {
         if (get_var("USE_LVMLOCKD")) {
             $activation_mode = undef if ($vg_exclusive eq 'true');
             assert_script_run
-"EDITOR=\"sed -ie '\$ a primitive $vg_name ocf:heartbeat:LVM-activate params vgname=$vg_name vg_access_mode=lvmlockd $activation_mode'\" crm configure edit";
+"EDITOR=\"sed -i -e '\$ a primitive $vg_name ocf:heartbeat:LVM-activate params vgname=$vg_name vg_access_mode=lvmlockd $activation_mode'\" crm configure edit";
         }
         else {
             assert_script_run
-              "EDITOR=\"sed -ie '\$ a primitive $vg_name ocf:heartbeat:LVM params volgrpname=$vg_name exclusive=$vg_exclusive'\" crm configure edit";
+              "EDITOR=\"sed -i -e '\$ a primitive $vg_name ocf:heartbeat:LVM params volgrpname=$vg_name exclusive=$vg_exclusive'\" crm configure edit";
         }
 
         if ($resource eq 'drbd_passive') {
             # DRBD passive test need some specific HA configuration
-            assert_script_run "EDITOR=\"sed -ie '\$ a colocation colocation_$vg_name inf: $vg_name ms_$resource:Master'\" crm configure edit";
-            assert_script_run "EDITOR=\"sed -ie '\$ a order order_$vg_name inf: ms_$resource:promote $vg_name:start'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -i -e '\$ a colocation colocation_$vg_name inf: $vg_name ms_$resource:Master'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -i -e '\$ a order order_$vg_name inf: ms_$resource:promote $vg_name:start'\" crm configure edit";
         }
         else {
-            assert_script_run "EDITOR=\"sed -ie 's/^\\(group base-group.*\\)/\\1 $vg_name/'\" crm configure edit";
+            assert_script_run "EDITOR=\"sed -i -e 's/^\\(group base-group.*\\)/\\1 $vg_name/'\" crm configure edit";
         }
 
         # Wait to get VG active on all nodes

--- a/tests/installation/add_serial_console.pm
+++ b/tests/installation/add_serial_console.pm
@@ -28,13 +28,13 @@ sub run {
     # Mount Btrfs sub-volumes
     assert_script_run('mount -a');
     # Configure GRUB with serial terminal (in addition to gfxterm)
-    assert_script_run('sed -ie \'s/GRUB_TERMINAL.*//\' /etc/default/grub');
+    assert_script_run('sed -i -e \'s/GRUB_TERMINAL.*//\' /etc/default/grub');
     # VMware needs to always stop in Grub and wait for interaction.
     # Migration seems to reset it.
     if (get_var('GRUB_TIMEOUT')) {
-        assert_script_run('sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=' . get_var('GRUB_TIMEOUT') . '/\' /etc/default/grub');
+        assert_script_run('sed -i -e \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=' . get_var('GRUB_TIMEOUT') . '/\' /etc/default/grub');
     } else {
-        assert_script_run('sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=-1/\' /etc/default/grub');
+        assert_script_run('sed -i -e \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=-1/\' /etc/default/grub');
     }
     assert_script_run('echo GRUB_TERMINAL_OUTPUT=\"serial gfxterm\" >> /etc/default/grub');
     # Specify the serial unit to workaround bsc#1219463
@@ -44,7 +44,7 @@ sub run {
         assert_script_run('echo GRUB_SERIAL_COMMAND=\"serial\" >> /etc/default/grub');
     }
     # Set expected resolution for GRUB and kernel
-    assert_script_run('sed -ie \'s/GRUB_GFXMODE.*/GRUB_GFXMODE=\"1024x768x32\"/\' /etc/default/grub');
+    assert_script_run('sed -i -e \'s/GRUB_GFXMODE.*/GRUB_GFXMODE=\"1024x768x32\"/\' /etc/default/grub');
     assert_script_run('echo GRUB_GFXPAYLOAD_LINUX=\"1024x768x32\" >> /etc/default/grub');
     assert_script_run('grep ^[[:alpha:]] /etc/default/grub');
     # Update GRUB

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -468,7 +468,7 @@ sub run {
 
     select_console 'root-console';
     if ($lang ne 'en_US') {
-        assert_script_run("sed -ie '/KEYMAP=/s/=.*/=us/' /etc/vconsole.conf");
+        assert_script_run("sed -i -e '/KEYMAP=/s/=.*/=us/' /etc/vconsole.conf");
     }
 
     # openSUSE JeOS has SWAP mounted as LABEL instead of UUID until kiwi 9.19.0, so tw and Leap 15.2+ are fine

--- a/tests/jeos/glibc_locale.pm
+++ b/tests/jeos/glibc_locale.pm
@@ -64,7 +64,7 @@ sub change_locale {
         $rc_lc_modified{LC_MESSAGES} = $rc_lc_modified{LANG};
 
         for (qw(LANG LC_MESSAGES)) {
-            assert_script_run("sed -ie \'s/$_=\"$rc_lc_setup_const->{$_}\"/$_=\"$rc_lc_modified{$_}\"/\' $suse_lang_conf",
+            assert_script_run("sed -i -e \'s/$_=\"$rc_lc_setup_const->{$_}\"/$_=\"$rc_lc_modified{$_}\"/\' $suse_lang_conf",
                 fail_message => "Update of $suse_lang_conf failed!");
         }
     } else {

--- a/tests/kiwi_images_test/kiwi_build_image.pm
+++ b/tests/kiwi_images_test/kiwi_build_image.pm
@@ -30,8 +30,8 @@ sub run {
     my $kiwi_file = is_sle('=15-SP7') ? 'appliance_sle15sp7.kiwi' : 'appliance.kiwi';
     assert_script_run("curl -v -o $testdir/appliance.kiwi " . data_url("kiwi/$kiwi_file"));
     assert_script_run("curl -v -o $testdir/config.sh " . data_url("kiwi/config.sh"));
-    assert_script_run("sed -ie 's/SLE-version/$version/' $testdir/appliance.kiwi");
-    assert_script_run("sed -ie 's/USER_PASSWORD/$testapi::password/' $testdir/appliance.kiwi");
+    assert_script_run("sed -i -e 's/SLE-version/$version/' $testdir/appliance.kiwi");
+    assert_script_run("sed -i -e 's/USER_PASSWORD/$testapi::password/' $testdir/appliance.kiwi");
     # Execute the Kiwi-ng command to build the KVM and Xen system image
     assert_script_run("kiwi-ng --profile kvm-and-xen  system build  --description $testdir  --target-dir /tmp/", timeout => 1200);
     # Verify the built qcow2 image filename in the /tmp folder and rename the file with the proper build number,

--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -49,7 +49,7 @@ sub run {
         zypper_call('up -l', timeout => 600);
         if (is_aarch64) {
             # Disable grub timeout for aarch64 cases so that the test doesn't stall
-            assert_script_run("sed -ie \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=-1/\' /etc/default/grub");
+            assert_script_run("sed -i -e \'s/GRUB_TIMEOUT.*/GRUB_TIMEOUT=-1/\' /etc/default/grub");
             assert_script_run('grub2-mkconfig -o /boot/grub2/grub.cfg');
             record_info('GRUB', script_output('cat /etc/default/grub'));
         }

--- a/tests/virt_autotest/cleanup_service.pm
+++ b/tests/virt_autotest/cleanup_service.pm
@@ -15,7 +15,7 @@ sub run {
     #revert dns setting
     if (script_run('ls /etc/resolv.conf.orig') == 0) {
         script_run("mv /etc/resolv.conf.orig /etc/resolv.conf; mv /etc/named.conf.orig /etc/named.conf; mv /etc/ssh/ssh_config.orig /etc/ssh/ssh_config; mv /etc/dhcpd.conf.orig /etc/dhcpd.conf");
-        script_run("sed -irn '/^nameserver 192\\.168\\.123\\.1/d' /etc/resolv.conf");
+        script_run("sed -i '/^nameserver 192\\.168\\.123\\.1/d' /etc/resolv.conf");
         script_run("rm /var/lib/named/testvirt.net.zone; rm /var/lib/named/123.168.192.zone");
     }
 

--- a/tests/virt_autotest/setup_dns_service.pm
+++ b/tests/virt_autotest/setup_dns_service.pm
@@ -37,7 +37,7 @@ sub post_fail_hook {
     script_run("cat /var/lib/named/123.168.192.zone");
     save_screenshot;
     script_run("mv /etc/resolv.conf.orig /etc/resolv.conf; mv /etc/named.conf.orig /etc/named.conf; mv /etc/ssh/ssh_config.orig /etc/ssh/ssh_config; mv /etc/dhcpd.conf.orig /etc/dhcpd.conf");
-    script_run("sed -irn '/^nameserver 192\\.168\\.123\\.1/d' /etc/resolv.conf");
+    script_run("sed -i '/^nameserver 192\\.168\\.123\\.1/d' /etc/resolv.conf");
     script_run("rm /var/lib/named/testvirt.net.zone; rm /var/lib/named/123.168.192.zone");
 
     script_run("systemctl stop named.service");


### PR DESCRIPTION
## Problem

Across ~60 invocations in this repository, `sed` is called with the
in-place flag bundled together with other letters, like:

* `sed -ie 's/.../.../' /etc/default/grub`
* `sed -irn '/^nameserver .../d' /etc/resolv.conf`
* `sed -irnE 's/.../.../' /etc/ssh/sshd_config`
* `sed -iE '/\s*ZONE=/d' "$ifcfg"`
* `sed -in '/^logfile .*$/d' "$cfg"`

These look like `-i` combined with `-e`, `-r`, `-E`, `-n`, but GNU sed
treats the argument to `-i` as an optional backup-file extension when
no whitespace separates them. So `-ie` is `-i` with backup extension
`e`, `-irnE` is `-i` with backup extension `rnE`, and so on. The
trailing letters are **not** interpreted as flags.

Consequences:

1. Every such invocation leaves a backup copy of the original file
   on disk:

   ```
   $ cp /etc/ssh/sshd_config /tmp/cfg
   $ sed -irnE 's/^.*TCPKeepAlive.*$/TCPKeepAlive yes/g' /tmp/cfg
   $ ls /tmp/cfg*
   /tmp/cfg  /tmp/cfgrnE       # <-- spurious backup
   ```

   On the SUT this pollutes paths like `/etc/default/grube`,
   `/etc/resolv.confrn`, `/etc/ssh/sshd_configrnE`,
   `/etc/sysconfig/network/ifcfg-<dev>E`, `/etc/lvm/lvm.confe`,
   `/etc/zypp/zypp.confe`, plus the cluster-CIB temp files for the
   `EDITOR="sed -ie ..." crm configure edit` sites.

2. The flags the author intended (`-r`/`-E` for ERE, `-n` for
   `--quiet`) never actually take effect. The current behavior only
   works because the substitution and delete patterns happen to be
   BRE-compatible. Any future caller relying on those flags would
   silently misbehave.

3. `-n` is especially dangerous to leave latent: if a later change
   re-spaces the flag without re-thinking the command, `sed -i -n`
   on a `s/.../.../` (no `p` flag) or `/.../d` would suppress
   auto-print and wipe the target file.

## Fix

Insert a space between `-i` and the following flag so GNU sed
parses the in-place flag with no backup extension. `-n` is dropped
wherever it was attached to `-i`, because it was never actually
applied and enabling it now would change behavior. `-r` is dropped
in cases that combined `-r` with `-n` and used BRE-compatible
patterns, matching the actual current behavior; `-E` is kept where
the author wrote it.

After the fix, the substitution behavior is exactly the same as
before, but no backup files are left behind.

```
$ cp /etc/ssh/sshd_config /tmp/cfg
$ sed -i -E 's/^.*TCPKeepAlive.*$/TCPKeepAlive yes/g' /tmp/cfg
$ ls /tmp/cfg*
/tmp/cfg                    # <-- clean
```

The change is mechanical and confined to the flag portion of the
`sed` command; no Perl logic, no surrounding code, no other commands
are touched. Diff stats:

```
 24 files changed, 69 insertions(+), 69 deletions(-)
```

Every changed line is a `sed` invocation, one-to-one.

## Verification

End-to-end smoke test of each fix variant on a local GNU sed 4.9
(matches the version on current openSUSE/SLE), confirming the
expected output and no leftover backup file:

| Variant | Source                                  | Result      |
|---------|-----------------------------------------|-------------|
| `-i -e` | `tests/installation/add_serial_console.pm` | clean, content updated |
| `-i -E` | `lib/Utils/Backends.pm` (sshd_config)   | clean, content updated |
| `-i`    | `tests/virt_autotest/cleanup_service.pm` | clean, line deleted |
| `-i -E` | `data/wicked/scripts/test-ext-firewall.sh` | clean, ZONE= removed |
| `-i -e` | `lib/hacluster.pm` (lvm filter)          | clean, filter inserted |

## Test plan

- [ ] CI green
- [ ] Existing openQA tests touching the affected code paths
      (jeos-firstrun, ha/dlm, ha/filesystem, ha/ctdb, ha/haproxy,
      ha/vg, ha/qnetd, ha/cluster_md, ha/drbd_passive,
      add_serial_console, selinux_setup, virt_autotest dns
      setup/cleanup, console/apache, console/verify_efi_mok,
      kiwi_images_test/kiwi_build_image, qa_automation/patch_and_reboot)
      continue to behave the same on a clean run

## Notes

* GitHub Issues are disabled on this repository (Redmine is the
  issue tracker), so this problem is described in full above rather
  than linked to a ticket.
* `sed -i_bk '...' file` calls in `lib/autofs_utils.pm` are
  intentional backups (`_bk` extension is explicit) and are not
  touched by this change.