### PR TITLE
boot_agama: Increase Agama timeout on ppc64le

### DIFF
--- a/lib/Distribution/Opensuse/AgamaDevel.pm
+++ b/lib/Distribution/Opensuse/AgamaDevel.pm
@@ -48,7 +48,7 @@ sub get_grub_entry_edition {
 
 sub get_agama_up_an_running {
     return is_ppc64le() ? Yam::Agama::Pom::AgamaUpAndRunningPage->new({
-            timeout_expect_is_shown => 300})
+            timeout_expect_is_shown => 400})
       : Yam::Agama::Pom::AgamaUpAndRunningPage->new();
 }
 


### PR DESCRIPTION
Does time out often on ppc64le with timeout 300

- Related ticket:
https://openqa.suse.de/tests/22328471#step/boot_agama/1
https://openqa.suse.de/tests/22291351#step/boot_agama/1
https://openqa.suse.de/tests/22291338#step/boot_agama/1
https://openqa.suse.de/tests/22291315#step/boot_agama/1
https://openqa.suse.de/tests/22291313#step/boot_agama/1
- Verification run: https://openqa.suse.de/tests/22331533
https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=jpupava_agama
