### PR TITLE
Add Perldoc documentation for sles4sap crash test modules

### DIFF
--- a/tests/sles4sap/crash/configure.pm
+++ b/tests/sles4sap/crash/configure.pm
@@ -2,16 +2,66 @@
 #
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
-# Maintainer: QE-SAP <qe-sap@suse.de>
 # Summary: Public Cloud - VM Configuration and Registration
-# This module connects to the VM via SSH and performs:
-# - SSH availability check
-# - Host key scan and trust
-# - (Optional) IBSM repo addition for maintenance update testing
-# - SUSEConnect registration using SCC_REGCODE
-# - System patching using zypper
-# - System reboot
-# This prepares the system for crash testing.
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+=head1 NAME
+
+sles4sap/crash/configure.pm - VM Configuration and Registration
+
+=head1 DESCRIPTION
+
+C<configure.pm> performs initial setup on the SUT cloud VM for subsequent crash testing.
+
+Its primary tasks are:
+
+=over
+
+=item * Connect to the VM via SSH and verify its availability.
+
+=item * Scan and trust the host key.
+
+=item * Register the system using C<SCC_REGCODE_SLES4SAP> and optional C<SCC_ADDONS>.
+
+=item * Prepare the system by patching and rebooting using C<crash_system_ready>.
+
+=back
+
+=head1 SETTINGS
+
+=over
+
+=item B<PUBLIC_CLOUD_PROVIDER>
+
+Type of the public cloud provider (e.g., AWS, AZURE, GCE). Required.
+
+=item B<PUBLIC_CLOUD_REGION>
+
+Region of the public cloud provider.
+
+=item B<PUBLIC_CLOUD_AVAILABILITY_ZONE>
+
+Availability zone for the public cloud provider (Required for GCE).
+
+=item B<SCC_REGCODE_SLES4SAP>
+
+Registration code for SLES for SAP.
+
+=item B<PUBLIC_CLOUD_SCC_ENDPOINT>
+
+Custom SCC endpoint URL. Optional. Defaults to 'registercloudguest' inside C<crash_system_ready>.
+
+=item B<SCC_ADDONS>
+
+Comma-separated list of addons to register. Optional.
+
+=back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=cut
 
 use Mojo::Base 'publiccloud::basetest';
 use serial_terminal 'select_serial_terminal';

--- a/tests/sles4sap/crash/deploy.pm
+++ b/tests/sles4sap/crash/deploy.pm
@@ -2,36 +2,76 @@
 #
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
-# Maintainer: QE-SAP <qe-sap@suse.de>
 # Summary: Deploy a VM in the cloud (Azure, AWS, GCP) for crash testing.
+# Maintainer: QE-SAP <qe-sap@suse.de>
 
-=head1 SYNOPSIS
+=head1 NAME
 
-Creates and configures Public Cloud infrastructure for crash testing.
-This test module supports AWS (EC2), Azure (AZURE), and GCP (GCE).
-It sets up the necessary networking, security groups, and launches a VM instance.
+sles4sap/crash/deploy.pm - Cloud Infrastructure Deployment for Crash Testing
 
-B<Required OpenQA variables:>
+=head1 DESCRIPTION
+
+C<deploy.pm> creates and configures the necessary Public Cloud infrastructure (AWS, Azure, or GCP) to support crash testing.
+
+Its primary tasks are:
 
 =over
 
-=item * B<PUBLIC_CLOUD_PROVIDER> - 'EC2', 'AZURE' or 'GCE'
+=item * Initialize the cloud provider factory and validate configuration.
 
-=item * B<PUBLIC_CLOUD_REGION> - Cloud region where resources will be created
+=item * Calculate unique network address ranges based on C<WORKER_ID> to avoid collisions.
 
-=item * B<PUBLIC_CLOUD_INSTANCE_TYPE> - VM instance type to launch
+=item * Deploy provider-specific infrastructure (VPC/VNet, subnets, security groups, VM).
+
+=item * Verify initial VM connectivity (especially for AWS).
 
 =back
 
-B<Test flow:>
+=head1 SETTINGS
 
-1. Validates the cloud provider and initializes the provider factory.
+=over
 
-2. Cleans up any existing SSH configuration.
+=item B<PUBLIC_CLOUD_PROVIDER>
 
-3. Calls the appropriate deployment function from C<sles4sap::crash> based on the provider.
+The cloud provider to use: 'EC2', 'AZURE', or 'GCE'. Required.
 
-4. For AWS, it performs an additional connectivity check.
+=item B<PUBLIC_CLOUD_REGION>
+
+Cloud region where resources will be created. Required.
+
+=item B<PUBLIC_CLOUD_INSTANCE_TYPE>
+
+VM instance type to launch. Required. Defaults to 'n1-standard-2' for GCE if not specified.
+
+=item B<WORKER_ID>
+
+OpenQA worker ID used to calculate unique network address ranges. Required.
+
+=item B<PUBLIC_CLOUD_EC2_ACCOUNT_ID>
+
+AWS account ID.
+
+=item B<PUBLIC_CLOUD_IMAGE_LOCATION>
+
+Optional image location for Azure.
+
+=item B<PUBLIC_CLOUD_AVAILABILITY_ZONE>
+
+Availability zone for the cloud provider. Required for GCE.
+
+=item B<PUBLIC_CLOUD_GOOGLE_PROJECT_ID>
+
+GCP project ID. Required for GCE.
+
+=item B<PUBLIC_CLOUD_IMAGE_PROJECT>
+
+GCP image project. Required for GCE.
+
+=back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
 
 =cut
 

--- a/tests/sles4sap/crash/destroy.pm
+++ b/tests/sles4sap/crash/destroy.pm
@@ -2,14 +2,61 @@
 #
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
-# Maintainer: QE-SAP <qe-sap@suse.de>
 # Summary: Public Cloud - Resource Cleanup
-# This module deletes resources from cloud:
-# - Free up cloud resources
-# - Avoid additional cost
-# - Clean up the environment
-# It's also implemented as a post_fail_hook to ensure resources
-# are deleted even if a test module fails.
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+=head1 NAME
+
+sles4sap/crash/destroy.pm - Public Cloud Resource Cleanup
+
+=head1 DESCRIPTION
+
+C<destroy.pm> handles the deletion of cloud resources created during the crash test execution
+to ensure the environment is cleaned up and to avoid unnecessary costs.
+
+Its primary tasks are:
+
+=over
+
+=item * Identify the cloud provider and region from the test configuration.
+
+=item * Perform cleanup of VM instances, networking, and security groups via C<crash_cleanup>.
+
+=item * Handle optional cleanup of IBSm-related resources if configured.
+
+=back
+
+=head1 SETTINGS
+
+=over
+
+=item B<PUBLIC_CLOUD_PROVIDER>
+
+The cloud provider used: 'EC2', 'AZURE', or 'GCE'. Required.
+
+=item B<PUBLIC_CLOUD_REGION>
+
+Cloud region where resources were created. Required.
+
+=item B<PUBLIC_CLOUD_AVAILABILITY_ZONE>
+
+Availability zone for the cloud provider. Required for GCE.
+
+=item B<IBSM_RG>
+
+Azure Resource Group of the IBSm server. Optional.
+
+=item B<IBSM_IP>
+
+IP address of the IBSm server. Optional.
+
+=back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=cut
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;

--- a/tests/sles4sap/crash/network_peering.pm
+++ b/tests/sles4sap/crash/network_peering.pm
@@ -1,19 +1,31 @@
+# SUSE's openQA tests
+#
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
-# Maintainer: QE-SAP <qe-sap@suse.de>
 # Summary: Create network peering with IBSm for the crash test environment.
+# Maintainer: QE-SAP <qe-sap@suse.de>
 
 =head1 NAME
 
-crash/network_peering.pm - Create a network peering with an IBSm server
+sles4sap/crash/network_peering.pm - Create a network peering with an IBSm server
 
 =head1 DESCRIPTION
 
-This module establishes a network peering between the crash test SUT and an
-IBSm server, and configures the SUT to use the IBSm for software repositories.
+This module establishes a network peering between the crash test SUT and an IBSm server, and configures the SUT to use the IBSm for software repositories.
 
-Supported cloud providers are Azure (VNet Peering via B<IBSM_RG>),
-GCP (NCC Spoke via B<IBSM_NCC_HUB>) and AWS (Transit Gateway via B<IBSM_IPRANGE>).
+Supported cloud providers are Azure (VNet Peering via B<IBSM_RG>), GCP (NCC Spoke via B<IBSM_NCC_HUB>) and AWS (Transit Gateway via B<IBSM_IPRANGE>).
+
+Its primary tasks are:
+
+=over
+
+=item * Establish network peering between SUT and IBSm using provider-specific mechanisms.
+
+=item * Add the IBSm IP to C</etc/hosts> on the SUT.
+
+=item * Configure optional incident repositories on the SUT to use the peered connection.
+
+=back
 
 =head1 SETTINGS
 
@@ -21,11 +33,15 @@ GCP (NCC Spoke via B<IBSM_NCC_HUB>) and AWS (Transit Gateway via B<IBSM_IPRANGE>
 
 =item B<PUBLIC_CLOUD_PROVIDER>
 
-Cloud provider: C<AZURE>, C<GCE> or C<EC2>.
+Cloud provider: C<AZURE>, C<GCE> or C<EC2>. Required.
+
+=item B<PUBLIC_CLOUD_REGION>
+
+Cloud region where the SUT is deployed. Required.
 
 =item B<IBSM_IP>
 
-The IP address of the IBSm server. Added to C</etc/hosts> on the SUT.
+The IP address of the IBSm server. Added to C</etc/hosts> on the SUT. Required.
 
 =item B<IBSM_RG>
 
@@ -34,6 +50,14 @@ Azure Resource Group of the IBSm environment. Required for Azure.
 =item B<IBSM_NCC_HUB>
 
 Full NCC hub resource URI of the IBSm environment. Required for GCE.
+
+=item B<PUBLIC_CLOUD_GOOGLE_PROJECT_ID>
+
+GCP project ID of the SUT. Required for GCE.
+
+=item B<PUBLIC_CLOUD_AVAILABILITY_ZONE>
+
+GCP availability zone suffix. Required for GCE.
 
 =item B<IBSM_IPRANGE>
 
@@ -52,6 +76,10 @@ An optional, comma-separated list of incident-specific repository URLs.
 The hostname to redirect to the IBSm. Defaults to C<download.suse.de>.
 
 =back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
 
 =cut
 

--- a/tests/sles4sap/crash/patch_system.pm
+++ b/tests/sles4sap/crash/patch_system.pm
@@ -1,21 +1,55 @@
+# SUSE's openQA tests
+#
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
-
 # Summary: Run zypper patch and reboot
 # Maintainer: QE-SAP <qe-sap@suse.de>
 
 =head1 NAME
 
-sles4sap/patch_system.pm - Apply system patches to the SUT
+sles4sap/crash/patch_system.pm - Apply system patches to the SUT
 
 =head1 DESCRIPTION
 
-This module performs a standard system update on the SUT (System Under Test).
+C<patch_system.pm> performs a standard system update on the SUT (System Under Test) by executing C<zypper patch> and then rebooting the system. This ensures that all updates, including kernel updates, are correctly applied and active before subsequent crash testing.
 
-It executes `zypper patch` to install all available patches and then reboots
-the systems to ensure that all updates, including any kernel updates, are
-correctly applied and active. This step helps ensure the SUTs are in a
-consistent and up-to-date state for subsequent tests.
+Its primary tasks are:
+
+=over
+
+=item * Identify the cloud provider and region for the SUT.
+
+=item * Apply system patches and reboot the SUT via C<crash_patch_system>.
+
+=item * Wait for the SUT to come back online after the reboot.
+
+=back
+
+=head1 SETTINGS
+
+=over
+
+=item B<PUBLIC_CLOUD_PROVIDER>
+
+Cloud provider used: 'EC2', 'AZURE', or 'GCE'. Required.
+
+=item B<PUBLIC_CLOUD_REGION>
+
+Cloud region where the SUT is deployed. Required.
+
+=item B<PUBLIC_CLOUD_AVAILABILITY_ZONE>
+
+Availability zone for the cloud provider. Required for GCE.
+
+=item B<IBSM_RG>
+
+Azure Resource Group of the IBSm server. Optional (used in cleanup).
+
+=item B<IBSM_IP>
+
+IP address of the IBSm server. Optional (used in cleanup).
+
+=back
 
 =head1 MAINTAINER
 

--- a/tests/sles4sap/crash/test_crash.pm
+++ b/tests/sles4sap/crash/test_crash.pm
@@ -2,8 +2,62 @@
 #
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
-# Maintainer: QE-SAP <qe-sap@suse.de>
 # Summary: executes a crash scenario on cloud provider.
+# Maintainer: QE-SAP <qe-sap@suse.de>
+
+=head1 NAME
+
+sles4sap/crash/test_crash.pm - Execute System Crash Scenario
+
+=head1 DESCRIPTION
+
+C<test_crash.pm> executes a system crash on a cloud VM instance by triggering a SysRq reboot.
+
+Its primary tasks are:
+
+=over
+
+=item * Retrieve VM instance information based on the cloud provider.
+
+=item * Trigger an immediate reboot (crash) via C<sysrq-trigger> over SSH.
+
+=item * Monitor the VM's network availability to confirm it has gone down.
+
+=item * Wait for the VM to recover and verify that no critical services have failed using C<crash_wait_back>.
+
+=back
+
+=head1 SETTINGS
+
+=over
+
+=item B<PUBLIC_CLOUD_PROVIDER>
+
+The cloud provider used: 'EC2', 'AZURE', or 'GCE'. Required.
+
+=item B<PUBLIC_CLOUD_REGION>
+
+Cloud region where the SUT is deployed. Required.
+
+=item B<PUBLIC_CLOUD_AVAILABILITY_ZONE>
+
+Availability zone for the cloud provider. Required for GCE.
+
+=item B<IBSM_RG>
+
+Azure Resource Group of the IBSm server. Optional (used in cleanup).
+
+=item B<IBSM_IP>
+
+IP address of the IBSm server. Optional (used in cleanup).
+
+=back
+
+=head1 MAINTAINER
+
+QE-SAP <qe-sap@suse.de>
+
+=cut
 
 use Mojo::Base 'publiccloud::basetest';
 use serial_terminal 'select_serial_terminal';


### PR DESCRIPTION
Standardize documentation in tests/sles4sap/crash/ by adding comprehensive Perldoc headers to all modules. Each module now includes:
- Structured NAME and DESCRIPTION sections
- Detailed list of required and optional SETTINGS
- Standard MAINTAINER information

This follows the project's test catalog standard and improves maintainability and discoverability of crash test scenarios in the public cloud.
