### PR TITLE
[Pending]Set disk boot device via IPMI after iPXE Agama install

### DIFF
--- a/tests/installation/agama_reboot.pm
+++ b/tests/installation/agama_reboot.pm
@@ -27,6 +27,7 @@ use x11utils 'ensure_unlocked_desktop';
 use Utils::Backends qw(is_ipmi is_pvm is_svirt);
 use Utils::Architectures qw(is_aarch64 is_s390x);
 use power_action_utils 'assert_shutdown_and_restore_system';
+use ipmi_backend_utils 'set_disk_boot';
 
 sub upload_agama_logs {
     return if (get_var('NOLOGS'));
@@ -64,6 +65,11 @@ sub run {
         verify_agama_auto_install_done_cmdline();
         upload_agama_logs();
         record_info 'Reboot system to disk boot';
+        # After iPXE-based install, next reboot would PXE-boot again without this
+        if (get_var('SET_DISK_BOOT_AFTER_IPXE') && is_ipmi) {
+            record_info 'Set disk boot', 'Setting IPMI next boot device to disk before reboot';
+            set_disk_boot;
+        }
         enter_cmd 'reboot';
         # Swith back to sol console, then user can monitor the boot log
         select_console 'sol', await_console => 0 if is_ipmi;

--- a/tests/installation/agama_reboot.pm
+++ b/tests/installation/agama_reboot.pm
@@ -27,6 +27,7 @@ use x11utils 'ensure_unlocked_desktop';
 use Utils::Backends qw(is_ipmi is_pvm is_svirt);
 use Utils::Architectures qw(is_aarch64 is_s390x);
 use power_action_utils 'assert_shutdown_and_restore_system';
+use ipmi_backend_utils 'set_disk_boot';
 
 sub upload_agama_logs {
     return if (get_var('NOLOGS'));
@@ -55,6 +56,17 @@ sub verify_agama_auto_install_done_cmdline {
     die "Install phase is not done, please check agama logs";
 }
 
+sub set_disk_boot_after_ipmi_ipxe_aarch64_virt_host_install {
+    return unless is_ipmi;
+    return unless is_aarch64;
+    return unless get_var('INST_AUTO');
+    return unless get_var('VIRT_AUTOTEST');
+    return unless check_var('IPXE', '1') || check_var('IPXE_UEFI', '1');
+
+    record_info 'Set disk boot', 'IPMI+iPXE Agama aarch64 virt host install: switch BMC next boot from PXE/iPXE to disk before rebooting to the installed system';
+    set_disk_boot;
+}
+
 sub run {
     my ($self) = @_;
 
@@ -64,6 +76,7 @@ sub run {
         verify_agama_auto_install_done_cmdline();
         upload_agama_logs();
         record_info 'Reboot system to disk boot';
+        set_disk_boot_after_ipmi_ipxe_aarch64_virt_host_install();
         enter_cmd 'reboot';
         # Swith back to sol console, then user can monitor the boot log
         select_console 'sol', await_console => 0 if is_ipmi;


### PR DESCRIPTION

Without this, the machine PXE-boots again after installation completes.
When SET_DISK_BOOT_AFTER_IPXE is set, use IPMI to switch the next boot
device to disk before rebooting to the installed system.

- Related ticket: https://progress.opensuse.org/issues/201078
- Rleated MR: https://gitlab.suse.de/openqa/salt-pillars-openqa/-/merge_requests/1267
- Needles: na
- Verification run:  
https://openqa.suse.de/tests/22465256#step/agama_reboot/36 squiddlydiddly (Please ignore guest installation issue)
https://openqa.suse.de/tests/22465270#step/prepare_non_transactional_server/24 virt-aarch64-01  Failed job without fix.
https://openqa.suse.de/tests/22469566#step/agama_reboot/36 virt-aarch64-01 (Please ignore guest installation issue)
https://openqa.suse.de/tests/22470498  with IPXE_SET_HDD_BOOTSCRIPT  virt-aarch64-01 passed