### PR TITLE
Schedule and execute openjdk vendor affirmation test on SLES, SLE for SAP

### DIFF
--- a/data/security/agama_auto/sles4sap16_gnome.jsonnet
+++ b/data/security/agama_auto/sles4sap16_gnome.jsonnet
@@ -1,0 +1,37 @@
+{
+  product: {
+    id: '{{AGAMA_PRODUCT_ID}}',
+    registrationCode: '{{SCC_REGCODE_SLES4SAP}}',
+  },
+  software: {
+    patterns: {
+      add: ['gnome'],
+    },
+  },
+  bootloader: {
+    stopOnBootMenu: true,
+  },
+  user: {
+    fullName: 'Bernhard M. Wiedemann',
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    userName: 'bernhard',
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+  },
+  scripts: {
+    post: [
+      {
+        name: 'enable sshd',
+        chroot: true,
+        content: |||
+          #!/usr/bin/env bash
+          systemctl enable sshd
+        |||,
+      },
+    ],
+  },
+}
+

--- a/lib/openjdktest.pm
+++ b/lib/openjdktest.pm
@@ -14,6 +14,10 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use serial_terminal qw(select_user_serial_terminal select_serial_terminal);
+use package_utils 'install_package';
+use version_utils 'is_transactional';
+use transactional 'trup_call';
 
 our @EXPORT = qw(
   remove_any_installed_java
@@ -28,20 +32,21 @@ sub remove_any_installed_java {
     my @output = grep /java-\d+-openjdk/, split(/\n/, script_output "rpm -qa 'java-*'");
     return unless scalar @output;    # nothing to remove
     my $pkgs = join ' ', @output;
-    zypper_call("rm ${pkgs}");
+    is_transactional ? trup_call("pkg remove ${pkgs}") : zypper_call("rm ${pkgs}");
 }
 
 sub configure_java_version {
     my ($version) = @_;
-    select_console 'root-console';
+    select_serial_terminal();
 
     remove_any_installed_java();
-    zypper_call("in java-$version-openjdk java-$version-openjdk-devel");
+
+    install_package("java-$version-openjdk java-$version-openjdk-devel", trup_continue => 1);
 
     my $permission = ($version > 15) ? "og+rw" : "og+r";
     assert_script_run("chmod $permission /etc/pki/nssdb/*");
 
-    select_console 'user-console';
+    select_user_serial_terminal();
     my $vers_file = "/tmp/java_versions_$version.txt";
     script_output("java -version &> $vers_file; javac -version &>> $vers_file");
     validate_script_output("cat $vers_file", sub { m/openjdk version "$version\..*/ });
@@ -68,11 +73,11 @@ sub run_crypto_test {
 sub run_ssh_test {
     my ($version) = @_;
 
-    select_console 'root-console';
-    zypper_call('in jsch');
+    select_serial_terminal();
 
-    select_console 'user-console';
+    install_package("jsch xterm", trup_continue => 1);
 
+    select_user_serial_terminal();
     my $java_src = "Shell.java";
     my $url = get_var("TEST_JAVA", data_url("security/openjdk/$java_src"));
     my $cp = script_output('rpm -ql jsch |grep jsch.jar') . ':.';

--- a/tests/fips/openjdk/openjdk_fips.pm
+++ b/tests/fips/openjdk/openjdk_fips.pm
@@ -21,8 +21,9 @@ sub get_java_versions {
     # on newer version we need legacy module for openjdk 11, but is not available
     # on SLERT/SLED, can't test openjdk 11. On 15-SP7 17 is also in legacy module
     return '21' if (is_rt || is_sled) && is_sle('>=15-SP7');
-    return '11 17 21' if (is_sle '>=15-SP6');
+    return '11 17 21' if (is_sle('=15-SP6') || is_sle('=15-SP7'));
     return '17 21' if ((is_rt || is_sled) && is_sle('>=15-SP6'));
+    return '17 21 25' if (is_sle('>=16.0'));
     return '11 17';
 }
 
@@ -32,8 +33,8 @@ sub run {
     my @java_versions = split(' ', get_java_versions);
 
     # SLED and SLERT do not have legacy module; SLE4SAP needs Development tools for jsch
-    add_suseconnect_product 'sle-module-legacy' unless (is_sle('>=15-SP6') && (is_rt || is_sled));
-    add_suseconnect_product 'sle-module-development-tools' if is_sles4sap;
+    add_suseconnect_product 'sle-module-legacy' unless (is_sle('>=16') || is_sle('>=15-SP6') && (is_rt || is_sled));
+    add_suseconnect_product 'sle-module-development-tools' if is_sles4sap && is_sle('<16.0');
 
     foreach my $version (@java_versions) {
         configure_java_version $version;


### PR DESCRIPTION
Schedule and execute openJDK vendor affirmation test on SLES, SLE for SAP

- Related ticket: https://progress.opensuse.org/issues/199238
- Verification runs: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=188.1&groupid=611 (s390x has some issues, other tests fails i believe in product issue, they were passing 2 weeks ago) 
- Related MR: https://gitlab.suse.de/qe-security/openqa-data/-/merge_requests/629