### PR TITLE
AppArmor: Don't use curl to read/write files directly on /etc

### DIFF
--- a/lib/containers/podman.pm
+++ b/lib/containers/podman.pm
@@ -24,7 +24,9 @@ sub init {
 sub configure_insecure_registries {
     my ($self) = shift;
 
-    assert_script_run "curl " . data_url('containers/registries.conf') . " -o /etc/containers/registries.conf";
+    my $containers_registries = "/etc/containers/registries.conf";
+    assert_script_run "curl " . data_url('containers/registries.conf') . " -o /tmp/containers_registries.conf";
+    assert_script_run "mv /tmp/containers_registries.conf $containers_registries";
     assert_script_run "chmod 644 /etc/containers/registries.conf";
     # Add custom registry only if set by the REGISTRY variable
     assert_script_run('echo -e \'[[registry]]\nlocation = "' . registry_url() . '"\ninsecure = true\' >> /etc/containers/registries.conf') if get_var('REGISTRY');

--- a/lib/services/nginx.pm
+++ b/lib/services/nginx.pm
@@ -99,7 +99,8 @@ sub config_service {
     my $nginx_conf = "/etc/nginx/vhosts.d/nginx_vhost.conf";
 
     # Add new virtual host and check the configuration files
-    assert_script_run("curl -fv " . data_url("console/nginx_vhost.conf") . " -o $nginx_conf");
+    assert_script_run("curl -fv " . data_url("console/nginx_vhost.conf") . " -o /tmp/nginx_vhost.conf");
+    assert_script_run("mv /tmp/nginx_vhost.conf $nginx_conf");
 
     # Add custom ports to SELinux
     add_custom_ports_to_selinux(nginx_conf => $nginx_conf) if $selinux_enabled;

--- a/tests/console/apache.pm
+++ b/tests/console/apache.pm
@@ -183,10 +183,14 @@ sub run {
     assert_script_run 'htpasswd -s -b /srv/www/vhosts/localhost/authtest/.htpasswd joe secret';
 
     # Paste the .htaccess file
-    assert_script_run('curl -o /srv/www/vhosts/localhost/authtest/.htaccess ' . data_url('console/apache_.htaccess'));
+    my $apache_htaccess = "/srv/www/vhosts/localhost/authtest/.htaccess";
+    assert_script_run('curl -o /tmp/apache_.htaccess ' . data_url('console/apache_.htaccess'));
+    assert_script_run("mv /tmp/apache_.htaccess $apache_htaccess");
 
     # Paste the config file
-    assert_script_run('curl -o /etc/apache2/conf.d/authtest.conf ' . data_url('console/apache_authtest.conf'));
+    my $apache_authtest = "/etc/apache2/conf.d/authtest.conf";
+    assert_script_run('curl -o /tmp/apache_authtest.conf ' . data_url('console/apache_authtest.conf'));
+    assert_script_run("mv /tmp/apache_authtest.conf $apache_authtest");
 
     # Start the webserver and test the password access
     record_info('poo#179678', 'Job for apache2.service may fail because start of the service was attempted too often');
@@ -208,4 +212,3 @@ sub run {
 }
 
 1;
-

--- a/tests/console/mariadb_srv.pm
+++ b/tests/console/mariadb_srv.pm
@@ -63,9 +63,10 @@ sub run {
     # Test multiple instance configuration
     # It is not supported in sle12sp2 and sle12sp3
     if (!is_sle('<=12-SP3')) {
-        assert_script_run "touch /etc/mynode{1,2}.cnf";
-        assert_script_run "curl " . data_url('console/mariadb/mynode1.cnf') . " -o /etc/mynode1.cnf";
-        assert_script_run "curl " . data_url('console/mariadb/mynode2.cnf') . " -o /etc/mynode2.cnf";
+        assert_script_run "curl " . data_url('console/mariadb/mynode1.cnf') . " -o /tmp/mariadb_mynode1.cnf";
+        assert_script_run "curl " . data_url('console/mariadb/mynode2.cnf') . " -o /tmp/mariadb_mynode2.cnf";
+        assert_script_run "mv /tmp/mariadb_mynode1.cnf /etc/mynode1.cnf";
+        assert_script_run "mv /tmp/mariadb_mynode2.cnf /etc/mynode2.cnf";
         assert_script_run "mkdir -p /var/lib/mysql/node{1,2}";
         assert_script_run "chown mysql:root /var/lib/mysql/node{1,2}";
 

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -90,8 +90,9 @@ sub test_cryptographic_policies {
     }
 
     record_info("Restart sshd", "Restart sshd.service");
+    assert_script_run("cp /etc/ssh/sshd_config /tmp/sshd_config");
     # Bsc#1239976 Curl is not installed by default in minimal system role on aarch64
-    upload_logs("/etc/ssh/sshd_config") if (script_run("which curl") == 0);
+    upload_logs("/tmp/sshd_config") if (script_run("which curl") == 0);
     systemctl("restart sshd");
 
     # Add all the ssh public key hashes as known hosts


### PR DESCRIPTION
A curl profile has been added to AppArmor 5.0+ which only allows writing only to $HOME or any of the tmp directories in the system

openqa: clone https://openqa.opensuse.org/tests/5928153
openqa: clone https://openqa.opensuse.org/tests/5927831
