### PR TITLE
Selinux: Fix selinux context when moving files

### DIFF
--- a/lib/containers/podman.pm
+++ b/lib/containers/podman.pm
@@ -26,7 +26,7 @@ sub configure_insecure_registries {
 
     my $containers_registries = "/etc/containers/registries.conf";
     assert_script_run "curl " . data_url('containers/registries.conf') . " -o /tmp/containers_registries.conf";
-    assert_script_run "mv /tmp/containers_registries.conf $containers_registries";
+    assert_script_run "mv -Z /tmp/containers_registries.conf $containers_registries";
     assert_script_run "chmod 644 /etc/containers/registries.conf";
     # Add custom registry only if set by the REGISTRY variable
     assert_script_run('echo -e \'[[registry]]\nlocation = "' . registry_url() . '"\ninsecure = true\' >> /etc/containers/registries.conf') if get_var('REGISTRY');

--- a/lib/services/nginx.pm
+++ b/lib/services/nginx.pm
@@ -100,7 +100,7 @@ sub config_service {
 
     # Add new virtual host and check the configuration files
     assert_script_run("curl -fv " . data_url("console/nginx_vhost.conf") . " -o /tmp/nginx_vhost.conf");
-    assert_script_run("mv /tmp/nginx_vhost.conf $nginx_conf");
+    assert_script_run("mv -Z /tmp/nginx_vhost.conf $nginx_conf");
 
     # Add custom ports to SELinux
     add_custom_ports_to_selinux(nginx_conf => $nginx_conf) if $selinux_enabled;

--- a/tests/console/apache.pm
+++ b/tests/console/apache.pm
@@ -185,12 +185,12 @@ sub run {
     # Paste the .htaccess file
     my $apache_htaccess = "/srv/www/vhosts/localhost/authtest/.htaccess";
     assert_script_run('curl -o /tmp/apache_.htaccess ' . data_url('console/apache_.htaccess'));
-    assert_script_run("mv /tmp/apache_.htaccess $apache_htaccess");
+    assert_script_run("mv -Z /tmp/apache_.htaccess $apache_htaccess");
 
     # Paste the config file
     my $apache_authtest = "/etc/apache2/conf.d/authtest.conf";
     assert_script_run('curl -o /tmp/apache_authtest.conf ' . data_url('console/apache_authtest.conf'));
-    assert_script_run("mv /tmp/apache_authtest.conf $apache_authtest");
+    assert_script_run("mv -Z /tmp/apache_authtest.conf $apache_authtest");
 
     # Start the webserver and test the password access
     record_info('poo#179678', 'Job for apache2.service may fail because start of the service was attempted too often');

--- a/tests/console/mariadb_srv.pm
+++ b/tests/console/mariadb_srv.pm
@@ -65,8 +65,8 @@ sub run {
     if (!is_sle('<=12-SP3')) {
         assert_script_run "curl " . data_url('console/mariadb/mynode1.cnf') . " -o /tmp/mariadb_mynode1.cnf";
         assert_script_run "curl " . data_url('console/mariadb/mynode2.cnf') . " -o /tmp/mariadb_mynode2.cnf";
-        assert_script_run "mv /tmp/mariadb_mynode1.cnf /etc/mynode1.cnf";
-        assert_script_run "mv /tmp/mariadb_mynode2.cnf /etc/mynode2.cnf";
+        assert_script_run "mv -Z /tmp/mariadb_mynode1.cnf /etc/mynode1.cnf";
+        assert_script_run "mv -Z /tmp/mariadb_mynode2.cnf /etc/mynode2.cnf";
         assert_script_run "mkdir -p /var/lib/mysql/node{1,2}";
         assert_script_run "chown mysql:root /var/lib/mysql/node{1,2}";
 


### PR DESCRIPTION
Failure: https://openqa.opensuse.org/tests/5928645#step/apache/184

Fixes the selinux counterpart that #25570 broke

openqa: clone https://openqa.opensuse.org/tests/5927223
openqa: clone https://openqa.opensuse.org/tests/5928515
openqa: clone https://openqa.opensuse.org/tests/5927501
openqa: clone https://openqa.opensuse.org/tests/5927831
