### PR TITLE
himmelblau: Fix nsswitch modification on Tumbleweed

### DIFF
--- a/tests/publiccloud/himmelblau.pm
+++ b/tests/publiccloud/himmelblau.pm
@@ -13,7 +13,7 @@
 use Mojo::Base 'opensusebasetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use version_utils qw(is_sle);
+use version_utils qw(is_sle is_tumbleweed);
 use utils qw(zypper_call);
 
 sub configure_himmelblau {
@@ -32,7 +32,7 @@ sub configure_himmelblau {
 
 sub configure_nss {
     my $NSSWITCH_CONF_PATH = "/etc/nsswitch.conf";
-    if (is_sle(">=16")) {
+    if (is_sle(">=16") || is_tumbleweed) {
         assert_script_run("cp /usr/etc/nsswitch.conf $NSSWITCH_CONF_PATH");
     }
 


### PR DESCRIPTION
Tumbleweed, just like SLE 16 (or rather the other way around) uses /usr/etc/nsswitch.conf by default. If the admin attempts to modify the file, they are first supposed to copy the file to /etc


- Related ticket: https://progress.opensuse.org/issues/201156
- Verification run: https://openqa.opensuse.org/tests/5935842

openqa: clone https://openqa.opensuse.org/tests/5933877