### PR TITLE
SLES4SAP: reorder cloud saptune test order

### DIFF
--- a/schedule/sles4sap/sles4sap_gnome_saptune_maintenance.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune_maintenance.yaml
@@ -25,9 +25,9 @@ conditional_schedule:
         - sles4sap/publiccloud/qesap_terraform
         - sles4sap/publiccloud/qesap_instances_preparation
         - sles4sap/publiccloud/add_server_to_hosts
-        - sles4sap/publiccloud/cluster_add_repos
         - sles4sap/publiccloud/mr_test_setup_env
         - publiccloud/registration
+        - sles4sap/publiccloud/cluster_add_repos
         - publiccloud/patch_and_reboot
         - publiccloud/ssh_interactive_start
         - publiccloud/instance_overview


### PR DESCRIPTION
The root cause is https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/f0bdbc5b8d670be541e0caea0e51ac418bb83b57/tests/publiccloud/registration.pm#L30-L34 , for 15SP5 we are doing update in "registration", but test repo is added before that.

So we should move  "cluster_add_repo" between "registration" and "patch_and_reboot".  For public cloud tests, they also have "transfer_repos" in between.

- Related ticket: https://jira.suse.com/browse/TEAM-11253 https://progress.opensuse.org/issues/201060
- Needles: none
- Verification run:
15SP7: https://openqa.suse.de/tests/22390788
15SP6: https://openqa.suse.de/tests/22390790
15SP5: https://openqa.suse.de/tests/22390654
15SP4: https://openqa.suse.de/tests/22390791
12SP5: https://openqa.suse.de/tests/22390792