### PR TITLE
Enhance lpar_cmd to capture and log command output

### DIFF
--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -330,21 +330,31 @@ sub lpar_cmd {
 
     die 'Command not provided' unless $cmd;
 
-    my $ret = console('svirt')->run_cmd($cmd, timeout => $timeout);
-    $ret //= 1;
+    # Append 2>&1 to capture standard error (stderr) into standard output (stdout),
+    # unless the command already includes it.
+    $cmd .= ' 2>&1' unless $cmd =~ /2>&1/;
 
+    # Execute the command with wantarray => 1 to capture both RC and combined output
+    my ($ret, $output) = console('svirt')->run_cmd($cmd, timeout => $timeout, wantarray => 1);
+
+    # Fallbacks in case run_cmd returns undefined values
+    $ret = 1 unless defined $ret;
+    $output = '' unless defined $output;
+
+    # Record the result and the captured output/errors to openQA Web UI
     if ($ret == 0) {
-        record_info('LPAR_CMD_PASS', "Command finished with RC 0: $cmd");
+        record_info('LPAR_CMD_PASS', "Command finished with RC 0: $cmd\n\nOutput:\n$output");
     }
     else {
-        record_info('LPAR_CMD_FAIL', "Command failed with RC $ret: $cmd");
+        record_info('LPAR_CMD_FAIL', "Command failed with RC $ret: $cmd\n\nOutput:\n$output");
     }
 
-    die "Find new failure (RC $ret), please check manually for command: $cmd"
+    # Die with the output string if the command failed and we are not ignoring the RC
+    die "Find new failure (RC $ret), please check manually for command: $cmd\nOutput:\n$output"
       unless ($ignore_return_code || $ret == 0);
 
-    # Return the captured return code
-    return $ret;
+    # Return context-aware results: list of (RC, output) or just RC
+    return wantarray ? ($ret, $output) : $ret;
 }
 
 # Guest xml will be uploaded with name format [generated_name_by_this_func].xml


### PR DESCRIPTION
Previously, `lpar_cmd` only captured and evaluated the return code of the executed command, making it difficult to debug failures without manual intervention.

```
This commit introduces the following improvements:
- Added `wantarray => 1` to `run_cmd` to capture both the return code (RC) and the standard output of the command.
- Added console print statements to display the command output in real-time.
- Appended the captured output to `record_info` logs and `die` exception messages for better visibility in test reports and Web UI.
- Updated the return statement to be context-aware, allowing callers to optionally retrieve both the RC and output `($rc, $out)` if needed, while maintaining backward compatibility for scalar calls.
```

- Related ticket: https://progress.opensuse.org/issues/196127
- Verification run:
[gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/22391238/#) PASS 
[gi-online-guest_developing-on-host_sles16.0-kvm](https://openqa.suse.de/tests/22435805#) PASS 
[gi-online-guest_developing-on-host_sles15sp7-kvm](https://openqa.suse.de/tests/22435804#) PASS
[gi-guest_sles15sp7-on-host_developing-kvm](https://openqa.suse.de/tests/22435970#) PASS
[gi-online-guest_sles16.0-on-host_developing-kvm](https://openqa.suse.de/tests/22435811#) PASS
