### PR TITLE
feat: ensure serial marker hook is persistent across become_root

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -409,7 +409,9 @@ Log in as root in the current console
 sub become_root {
     my ($self) = @_;
 
+    $self->_detect_serial_marker_capability() if get_var('PRETTY_SERIAL_MARKER');
     $self->script_sudo('bash', 1);
+    $self->invalidate_serial_marker_hook();
     # No need to apply on more recent kernels
     if (is_sle('<=15-SP2') || is_leap('<=15.2')) {
         disable_serial_getty() unless $self->script_run("systemctl is-enabled serial-getty\@$testapi::serialdev");

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -345,6 +345,7 @@ sub ensure_installed {
     zypper_call "in $pkglist";
     wait_still_screen 1;
     close_gui_terminal;
+    $self->invalidate_serial_marker_hook();
 }
 
 =head2 script_sudo


### PR DESCRIPTION
Motivation:
When switching from an unprivileged user to root via become_root, the
PRETTY_SERIAL_MARKER hook might not have been installed for the original
user if no script_run calls occurred yet. This leads to timeouts if the
root shell is closed and a new unprivileged shell is opened.

Design Choices:
Updated the openSUSE-specific become_root implementation to proactively
trigger capability detection before the sudo switch. Invalidate the hook
status immediately after the switch to ensure re-installation for root.

Benefits:
Consistent serial marker synchronization across multiple terminal windows
and user privilege transitions.

Related issue: https://openqa.opensuse.org/tests/5935252