### PR TITLE
Install sap_server pattern on SLE16+

### DIFF
--- a/tests/sles4sap/migrate_sles_to_sles4sap.pm
+++ b/tests/sles4sap/migrate_sles_to_sles4sap.pm
@@ -53,7 +53,7 @@ sub run {
         assert_script_run "! test -f /tmp/OK";
     } else {
         assert_script_run "ls /tmp/OK";
-        zypper_call "in -y -t pattern sap_server";
+        zypper_call 'in -y -t pattern ' . (is_sle('>=16') ? 'sles_sap_base_sap_server' : 'sap_server');
         # We have now a SLES4SAP product, so we need to notify the test(s)
         set_var('SLE_PRODUCT', 'sles4sap');
     }


### PR DESCRIPTION
the name of the **sap_server** pattern changed to **sles_sap_base_sap_server** on SLE 16+, this update fixed the issue.

- Related ticket: https://jira.suse.com/browse/TEAM-11235
- Needles: None
- Verification run:
    https://openqa.suse.de/tests/22355148
    https://openqa.suse.de/tests/22355149
    https://openqa.suse.de/tests/22355150 (failure because of bsc#1265271)
