### PR TITLE
Fix SDAF crm delete meta + crm_mon Errors

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -815,11 +815,16 @@ sub check_cluster_state {
     my $cmd_sub = (defined $args{proceed_on_failure} && $args{proceed_on_failure} == 1) ? \&script_run : \&assert_script_run;
 
     $cmd_sub->("$crm_mon_cmd", 180);
-    if (is_sle '12-sp3+') {
-        # Add sleep as command 'crm_mon' outputs 'Inactive resources:' instead of 'no inactive resources' on 12-sp5
+    # Add retry mechanism as command 'crm_mon' outputs 'Inactive resources:' instead of 'no inactive resources' sometime
+    my $retry = 10;
+    while ($retry--) {
+        last if (!script_run("$crm_mon_cmd | grep -i 'no inactive resources'"));
         sleep 5;
-        $cmd_sub->("$crm_mon_cmd | grep -i 'no inactive resources'");
+        if ($retry == 1) {
+            $cmd_sub->("$crm_mon_cmd | grep -i 'no inactive resources'");
+        }
     }
+
     $cmd_sub->('crm_mon -1 | grep \'partition with quorum\'');
 
     # If running with versions of crmsh older than 4.4.2, do not use check_online_nodes (see POD below)

--- a/t/11_hacluster.t
+++ b/t/11_hacluster.t
@@ -482,7 +482,7 @@ subtest '[check_cluster_state]' => sub {
 subtest '[check_cluster_state] assert calls normally' => sub {
     my $hacluster = Test::MockModule->new('hacluster', no_auto => 1);
     my @calls;
-    $hacluster->redefine(script_run => sub { push @calls, 'script_run'; });
+    $hacluster->redefine(script_run => sub { push @calls, 'retry_script_run'; });
     $hacluster->redefine(assert_script_run => sub { push @calls, 'assert_script_run'; });
     $hacluster->redefine(check_online_nodes => sub { return; });
     $hacluster->redefine(script_output => sub { return 'crmshver=4.4.2'; });
@@ -492,7 +492,7 @@ subtest '[check_cluster_state] assert calls normally' => sub {
     check_cluster_state();
     note("\n  -->  " . join("\n  -->  ", @calls));
 
-    ok((all { /(assert_script_run|cmd_run)/ } @calls), 'check_cluster_state
+    ok((all { /(retry_script_run|assert_script_run|cmd_run)/ } @calls), 'check_cluster_state
     used assert_script_run');
 };
 
@@ -538,8 +538,8 @@ subtest '[check_cluster_state] migration scenario' => sub {
     check_cluster_state();
     note("\n  -->  " . join("\n  -->  ", @calls));
 
-    ok((scalar(grep { /^script_run$/ } @calls)) == 1, 'One call with script_run');
-    ok((scalar(grep { /assert_script_run/ } @calls) == (scalar(@calls) - 1)), 'Remaining calls with assert_script_run');
+    ok((scalar(grep { /^script_run$/ } @calls)) == 11, 'Eleven calls with script_run');
+    ok((scalar(grep { /assert_script_run/ } @calls) == (scalar(@calls) - 11)), 'Remaining calls with assert_script_run');
     set_var('HDDVERSION', undef);
 };
 

--- a/tests/sles4sap/redirection_tests/ensa2_kill_sapinstance.pm
+++ b/tests/sles4sap/redirection_tests/ensa2_kill_sapinstance.pm
@@ -88,6 +88,14 @@ sub run {
     wait_until_resources_started();
     wait_for_idle_cluster();
 
+    # Setup 'meta' 'migration-threshold' for resource as it's missing for 'meta' part
+    # Resource also inherits 'migration-threshold' from resource 'group' ('3' by default)
+    # So use '4' to distinguish here
+    crm_resource_meta_set(
+        resource => $resource_name,
+        meta_argument => 'migration-threshold',
+        argument_value => '4');
+
     # Store original 'migration-threshold' to restore it at the end of the test
     my $migration_threshold_original_value =
       crm_resource_meta_show(resource => $resource_name, meta_argument => 'migration-threshold');


### PR DESCRIPTION
Fix SDAF `crm delete meta` Error: No such object
* There is no `'migration-threshold'` for resource's  `'meta'` attribute so setup it before delete it.

Fix SDAF `crm_mon` Error: no inactive resources
* Add retry mechanism 

  
Related ticket: 
[TEAM-11221](https://jira.suse.com/browse/TEAM-11221) - [SDAF] test "ensa2_scenarios_sbd" failed on module  "Kill_sapinstance_ASCS": "crm_resource: Error performing operation: No such object
[TEAM-11219](https://jira.suse.com/browse/TEAM-11219) - [SDAF] test "ensa2_scenarios" failed on module "ensa2_hanadb_refresh_sapinstances": 'crm_mon -R -r -n -1 | grep -i 'no inactive resources'' failed

- Verification run:

sle-15-SP7 SDAF_LAB_ensa2_scenarios_sbd:
  https://openqaworker15.qe.prg2.suse.org/tests/367698#step/Kill_sapinstance_ASCS-takeover/337 (test step passed)
  https://openqaworker15.qe.prg2.suse.org/tests/367698#step/Kill_sapinstance_ASCS-takeover/377 (this failure is a new issue, I will open a new ticket to track)  

sle-15-SP5 SDAF_LAB_ensa2_scenarios:
  https://openqaworker15.qe.prg2.suse.org/tests/367873#dependencies (all jobs passed)

sle-15-SP6 SDAF_LAB_ensa2_scenarios_sbd  
  http://openqaworker15.qe.prg2.suse.org/tests/367878#dependencies (all jobs passed)

On-prem VRs:
sle-15-SP7 sles4sap_ensa_ascs_node
http://openqa.suse.de/tests/22397469#dependencies (passed)

sle-15-SP4 SAPHanaSR_angi_ScaleUp_PerfOpt_WMP_node01
http://openqa.suse.de/tests/22397479#dependencies  (passed)

sle-12-SP5 qam_alpha_cluster_01
http://openqa.suse.de/tests/22397494#dependencies  (passed)