### PR TITLE
Disable obsolete repo before continue zypper migration

### DIFF
--- a/tests/yam/migration/zypper_migration.pm
+++ b/tests/yam/migration/zypper_migration.pm
@@ -21,6 +21,7 @@ sub run {
     my $zypper_prompts = {
         migration_target => qr/(\d+)\s+\|\s?SUSE Linux Enterprise Server.*?$target_version\s+$arch/m,
         select_id => qr/\[num\/q\]:/m,
+        disable_repo => qr/^Disable obsolete repository.*?\[y\/n\]\s*\(y\):/m,
         continue => qr/^Continue\? \[y/m,
     };
 
@@ -42,6 +43,8 @@ sub run {
     wait_serial($zypper_prompts->{select_id}, 60) || die "ID selection prompt not found";
     enter_cmd $target_id;
     save_screenshot;
+
+    wait_serial($zypper_prompts->{disable_repo}, 30) && enter_cmd "y";
 
     wait_serial($zypper_prompts->{continue}, 120) || die "Continue prompt was not found";
     enter_cmd "y";


### PR DESCRIPTION
##
In zypper migration, sometimes it need us to disable the obsoleted repo before continue the migration.
- Related error:
  - [zypper_migaration](https://openqa.suse.de/tests/22347844#step/zypper_migration/10)
- Disable obsolete repo before zypper migration
- Related ticket: Quick PR
- VR:
  - [**zypper_migration**](https://openqa.suse.de/tests/overview?version=16.1&distri=sle&build=hjluo%2Fos-autoinst-distri-opensuse%23disable_mig_repos)

##
