### PR TITLE
Update Puppeteer code to reflect UI changes in latest ISO development Build

### DIFF
--- a/lib/Yam/Agama/LiveIso.pm
+++ b/lib/Yam/Agama/LiveIso.pm
@@ -36,7 +36,13 @@ sub parse_agama_packages {
     my @packages = qw(agama agama-autoinstall agama-cli agama-web-ui);
     my %versions = map { $_ => get_package_version($_) } @packages;
     die "Error getting Agama packages info from ISO image" if ($? != 0);
-    join("\n", map { $_ . " => " . $versions{$_} } keys %versions);
+
+    # Set each package version as environment variable
+    set_var('AGAMA_PACKAGE_VERSION', $versions{'agama'} || '17+0');
+    set_var('AGAMA_AUTOINSTALL_PACKAGE_VERSION', $versions{'agama-autoinstall'} || '17+0');
+    set_var('AGAMA_CLI_PACKAGE_VERSION', $versions{'agama-cli'} || '17+0');
+    set_var('AGAMA_WEBUI_PACKAGE_VERSION', $versions{'agama-web-ui'} || '17+0');
+    join("\n", map { $_ . " => " . ($versions{$_} || '17+0') } keys %versions);
 }
 
 sub record_agama_info {
@@ -58,7 +64,7 @@ sub read_live_iso {
     $info =~ /^Image.version:\s+(?<major_version>\d+\.\w+)\./m;
     # Agama version was not available yet on GM medium, so we inject the default value
     set_var("AGAMA_VERSION", $+{'major_version'} // '17.0');
-    record_agama_info($info, $pkgs, $+{'major_version'});
+    record_agama_info($info, $pkgs, ($+{'major_version'} || '17.0'));
 }
 
 1;

--- a/tests/yam/agama/agama.pm
+++ b/tests/yam/agama/agama.pm
@@ -44,7 +44,7 @@ sub run {
       " --test-reporter-destination=/tmp/$tap" .
       " /usr/share/agama/system-tests/${test}.js" .
       " --product-version " . get_required_var('VERSION') .
-      " --agama-version " . get_required_var('AGAMA_VERSION') .
+      " --agama-web-ui-package-version " . get_var('AGAMA_WEBUI_PACKAGE_VERSION') .
       " $test_options";
 
     record_info("node cmd", $node_cmd);


### PR DESCRIPTION
Added Web UI parameter into integration tests.

- Related ticket: https://progress.opensuse.org/issues/200669
- Needles: N/A
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/797
- Related PR: https://github.com/qe-installation-and-migration/agama-integration-test-webpack/pull/247
- Related PR: https://github.com/qe-installation-and-migration/agama-integration-test-webpack/pull/250
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/806
- Verification runs:
  - QU: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=227.1&groupid=583
  - Prod: https://openqa.suse.de/tests/overview?distri=sle&version=16.1&build=42.1&groupid=583 (Failed due to new UI changes)
  - Dev: https://openqa.suse.de/tests/overview?distri=sle&version=16.1&build=12.8&groupid=583
  - https://openqa.suse.de/tests/22489490
  - https://openqa.suse.de/tests/22489422#
