### PR TITLE
Skip scp and log upload if remote log generation fails

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -17,6 +17,7 @@ use Mojo::JSON qw( decode_json );
 # a Fully Qualified Domain Name which returns an ipV4 address or an ipV6 address
 # embodied in that order. This feature can be disabled with:
 use NetAddr::IP::Lite ':nofqdn';
+use File::Basename qw(basename);
 use testapi;
 use mmapi qw( get_current_job_id );
 use utils qw( write_sut_file ssh_fully_patch_system);
@@ -2553,6 +2554,7 @@ sub ipaddr2_logs_collect(%args) {
     my %log_data;
     my $remote_file;
     my $timeout;
+    my $scp_cmd;
 
     # Iterate over all the logs
     foreach my $log (ipaddr2_logs_collect_cmds()) {
@@ -2569,29 +2571,31 @@ sub ipaddr2_logs_collect(%args) {
                 $remote_file = $log_data{file};
 
                 # Execute command on the remote VM to generate the log file, if there is a command to run.
-                ipaddr2_ssh_internal(
-                    id => $id,
-                    bastion_ip => $args{bastion_ip},
-                    no_assert => 1,
-                    timeout => $timeout,
-                    cmd => $log_data{cmd}) if (defined $log_data{cmd});
+                my $cmd_ret = 0;
+                if (defined $log_data{cmd}) {
+                    $cmd_ret = ipaddr2_ssh_internal(
+                        id => $id,
+                        bastion_ip => $args{bastion_ip},
+                        no_assert => 1,
+                        timeout => $timeout,
+                        cmd => $log_data{cmd});
+                }
 
-                # Download the generated file from the remote VM to the local worker.
-                my ($filename) = $remote_file =~ m|/([^/]+)$|;
-                $filename //= $remote_file;    # Fallback
-                $local_file = "$worker_tmp_dir/$filename";
-                record_info("bastion_ssh_addr:$bastion_ssh_addr vm_addr:$vm_addr ", join(' ',
+                # Download the generated file from the remote VM to the local worker
+                # only if the previous command was successful.
+                if (defined $cmd_ret && $cmd_ret == 0) {
+                    $local_file = join('/', $worker_tmp_dir, basename($remote_file));
+
+                    $scp_cmd = join(' ',
                         'scp',
                         '-J', $bastion_ssh_addr,
-                        "$vm_addr:$remote_file", $local_file));
+                        "$vm_addr:$remote_file", $local_file);
+                    record_info("bastion_ssh_addr:$bastion_ssh_addr vm_addr:$vm_addr ", $scp_cmd);
+                    $scp_ret = script_run($scp_cmd);
 
-                $scp_ret = script_run(join(' ',
-                        'scp',
-                        '-J', $bastion_ssh_addr,
-                        "$vm_addr:$remote_file", $local_file));
-
-                # If download was successful or file is local, upload the local file to openQA.
-                upload_logs($local_file) if ($scp_ret == 0);
+                    # If download was successful, upload the local file to openQA.
+                    upload_logs($local_file) if ($scp_ret == 0);
+                }
             }
         } else {
             # call it without id

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -1349,6 +1349,7 @@ subtest '[ipaddr2_logs_collect]' => sub {
     $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
     $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
 
+    note("Testing log collection with successful SSH commands...");
     ipaddr2_logs_collect();
 
     note("\n  SSH CALLS -->  " . join("\n  SSH CALLS -->  ", @ssh_calls));
@@ -1368,47 +1369,38 @@ subtest '[ipaddr2_logs_collect]' => sub {
     ok((any { /supportconfig.*/ } @upload_calls), "supportconfig uploaded");
 };
 
-subtest '[ipaddr2_logs_collect] fail' => sub {
+subtest '[ipaddr2_logs_collect] skip scp on failure' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     my @upload_calls;
     $ipaddr2->redefine(upload_logs => sub {
             push @upload_calls, $_[0];
             return;
     });
-    my @records;
-    $ipaddr2->redefine(record_info => sub { push @records, \@_; note(join(' ', 'RECORD_INFO -->', @_)); });
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    my @ssh_calls;
+    my @scp_calls;
+    # Redefine ipaddr2_ssh_internal to return 1 (failure) and track calls
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub {
+            my (%args) = @_;
+            push @ssh_calls, $args{cmd};
+            return 1;
+    });
     $ipaddr2->redefine(script_run => sub {
-            return 1 if $_[0] =~ /^ssh /;
+            push @scp_calls, $_[0] if $_[0] =~ /^scp /;
             return 0;
     });
     $ipaddr2->redefine(assert_script_run => sub { return; });
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
 
-    lives_ok { ipaddr2_logs_collect(bastion_ip => '1.2.3.4') } 'survives failing script_run';
+    note("Testing log collection with failing SSH commands (skip scp)...");
+    ipaddr2_logs_collect();
 
-    is(scalar @upload_calls, 10, "upload_logs called 10 times even if commands fail");
-    ok((any { $_->[0] =~ /Failed.*time/ } @records), "failure was recorded");
+    is(scalar @ssh_calls, 8, "ipaddr2_ssh_internal still called 8 times for log generation");
+    is(scalar @scp_calls, 0, "scp is NOT called because all log generation failed");
+    is(scalar @upload_calls, 2, "upload_logs called only 2 times for local logs");
 };
 
-subtest '[ipaddr2_logs_collect] timeout' => sub {
-    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
-    my @upload_calls;
-    $ipaddr2->redefine(upload_logs => sub {
-            push @upload_calls, $_[0];
-            return;
-    });
-    my @records;
-    $ipaddr2->redefine(record_info => sub { push @records, \@_; note(join(' ', 'RECORD_INFO -->', @_)); });
-    $ipaddr2->redefine(script_run => sub {
-            die "command '$_[0]' timed out" if $_[0] =~ /^ssh /;
-            return 0;
-    });
-    $ipaddr2->redefine(assert_script_run => sub { return; });
-
-    lives_ok { ipaddr2_logs_collect(bastion_ip => '1.2.3.4') } 'survives timeout from script_run';
-
-    is(scalar @upload_calls, 10, "upload_logs called 10 times even if commands timeout");
-    ok((any { $_->[0] =~ /SSH timeout/ } @records), "timeout was recorded");
-};
 
 subtest '[ipaddr2_ssh_intrusion_detection]' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2');


### PR DESCRIPTION
In `ipaddr2_logs_collect`, if the remote `ssh` command to generate a log file fails, the test previously continued to attempt downloading the non-existent file via `scp`. 
This commit updates the log collection loop to evaluate the return code of the log generation command. The `scp` download and subsequent `upload_logs` are now correctly skipped when the remote generation fails. The unit tests in `t/22_ipaddr2.t` have been updated to assert this new conditional logic.

- Related ticket: https://jira.suse.com/browse/TEAM-11080

# Verification run:
 - sle-16.0-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE16.0-ipaddr2_azure_test@az_Standard_B1s -> http://openqaworker15.qe.prg2.suse.org/tests/368389 :green_circle: 

- sle-16.0-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE16.0-ipaddr2_azure_test@az_Standard_B1s -> http://openqaworker15.qe.prg2.suse.org/tests/368455

## Example of :green_circle:  log collect cmd
   * call `crm report` https://openqaworker15.qe.prg2.suse.org/tests/368389/logfile?filename=autoinst-log.txt#line-11471
   * get a 0 exit code https://openqaworker15.qe.prg2.suse.org/tests/368389/logfile?filename=autoinst-log.txt#line-11492
   * call the associated scp https://openqaworker15.qe.prg2.suse.org/tests/368389/logfile?filename=autoinst-log.txt#line-11497

## Example of :red_circle:  log collect cmd
   * call `save_y2logs`  https://openqaworker15.qe.prg2.suse.org/tests/368389/logfile?filename=autoinst-log.txt#line-11671
   * exit code 1 https://openqaworker15.qe.prg2.suse.org/tests/368389/logfile?filename=autoinst-log.txt#line-11692
   * no scp