### PR TITLE
Introduce CONTAINERS_K8S_TEST switch

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -415,7 +415,7 @@ sub load_container_tests {
                 # Common openQA image tests
                 load_image_tests_podman($run_args) if (/podman/i);
                 load_image_tests_docker($run_args) if (/docker/i);
-                load_image_tests_in_k8s($run_args) if (/k8s/i);
+                load_image_tests_in_k8s($run_args) if ((get_var('CONTAINERS_K8S_TEST', '1')) && /k8s/i);
             }
         } else {
             # Container Host tests

--- a/variables.md
+++ b/variables.md
@@ -47,6 +47,7 @@ CHECKSUM_FAILED | string | | Variable is set if checksum of installation medium 
 CONTAINER_RUNTIMES | string | | Container runtime to be used, e.g.  `docker`, `podman`, or both `podman,docker`. In addition, it is also used for other container tests, like  `kubectl`, `helm`, etc.
 CONTAINERS_CGROUP_VERSION | string | | If defined, cgroups version to switch to
 CONTAINERS_K3S_VERSION | string |  | If defined, install the provided version of k3s
+CONTAINERS_K8S_TEST | boolean | true | Schedule k8s tests if the runtime is k8s. This is used as a opt-out flag for special tests that should not run on k8s while sharing default settings within the BCI job groups.
 CONTAINERS_NO_SUSE_OS | boolean | false | Used by main_containers to see if the host is different than SLE or openSUSE.
 CONTAINERS_UNTESTED_IMAGES | boolean | false | Whether to use `untested_images` or `released_images` from `lib/containers/urls.pm`.
 CONTAINERS_CRICTL_VERSION | string | v1.23.0 | The version of CriCtl tool.


### PR DESCRIPTION
Add the `CONTAINERS_K8S_TEST` switch that allows specific BCI containers to opt out from the k8s test runs, while still sharing the same job group with the rest of the BCI containers.

- Related ticket: https://progress.opensuse.org/issues/201174
## Verification runs

- [Unchanged schedule with default settings](https://openqa.suse.de/tests/22401573)
- [Disabled test runs](https://openqa.suse.de/tests/22401574)
