### PR TITLE
Improve handling of known coredumps

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -179,13 +179,13 @@ sub cleanup_known_coredumps {
         'https://gitlab.isc.org/isc-projects/bind9/-/work_items/2983' => q(9.18.33/bin/named/.libs/named -D doth),
     );
 
-    for my $pid (split(/\n/, script_output(q(coredumpctl -q --no-pager --no-legend | awk '$9 == "present" { print $5 }'), proceed_on_failure => 1))) {
+    for my $pid (split(/\n/, script_output(q(coredumpctl -q --no-pager --no-legend | awk '$9 ~ /^(present|truncated)$/ { print $5 }'), proceed_on_failure => 1))) {
         my $coredump_info = script_output("time coredumpctl info --no-pager $pid", proceed_on_failure => 1);
         my ($cmdline) = $coredump_info =~ /^\s+Command Line: (.*)$/m;
         for my $known (keys %known_coredumps) {
             if (index($cmdline, $known_coredumps{$known}) >= 0) {
                 record_info('Known dump', $coredump_info);
-                my ($coredump) = $coredump_info =~ /^\s+Storage: (.+?) \(present\)$/m;
+                my ($coredump) = $coredump_info =~ /^\s+Storage: (.+?) \(present|truncated\)$/m;
                 script_output("rm -vf $coredump");
                 last;
             }
@@ -207,7 +207,7 @@ remove them from /var/lib/systemd/coredump/ to avoid processing them here.
 sub upload_coredumps {
     my $res = script_run('coredumpctl --no-pager');
     return if $res;
-    my @pids = split(/\n/, script_output(q(coredumpctl --no-pager --no-legend | awk '$9 == "present" { print $5 }'), proceed_on_failure => 1));
+    my @pids = split(/\n/, script_output(q(coredumpctl --no-pager --no-legend | awk '$9 ~ /^(present|truncated)$/ { print $5 }'), proceed_on_failure => 1));
     return unless @pids;
     record_info("COREDUMPS found", "we found coredumps on SUT, attempt to upload");
     my $get_backtrace = get_var("COREDUMP_WITH_BACKTRACE") && !is_transactional;

--- a/tests/console/coredump_collect.pm
+++ b/tests/console/coredump_collect.pm
@@ -17,6 +17,12 @@ sub run {
     my $self = shift;
     select_serial_terminal;
 
+    # Avoid tiny races where systemd-coredump is still busy compressing.
+    # Otherwise we may get this on coredumpctl info:
+    #   Timestamp: Sun 2026-05-17 23:34:06 CEST (684ms ago)
+    # Note: We can't use systemd-coredump in pgrep because we'd get:
+    #   pgrep: pattern that searches for process name longer than 15 characters will result in zero matches
+    script_retry("pgrep systemd-cored >/dev/null", retry => 5, delay => 60);
     cleanup_known_coredumps unless is_tumbleweed;
     upload_coredumps;
 }


### PR DESCRIPTION
- Coredumps may also be truncated and we should handle them.
- Fix a tiny race where a coredump is still being compressed by systemd-coredump:
 https://openqa.suse.de/tests/22394490/file/core.ovs-vswitchd.472.dc23148f59bd43959c0c67c0be4ef952.8960.1779053646000000.zst.txt
`     Timestamp: Sun 2026-05-17 23:34:06 CEST (684ms ago)`

Related ticket: https://progress.opensuse.org/issues/197969
Verification run: https://openqa.suse.de/tests/22405664