### PR TITLE
coredump_collect: Add missing import for script_retry

### DIFF
--- a/tests/console/coredump_collect.pm
+++ b/tests/console/coredump_collect.pm
@@ -12,6 +12,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use Utils::Logging qw(upload_coredumps cleanup_known_coredumps);
 use version_utils qw(is_tumbleweed);
+use utils qw(script_retry);
 
 sub run {
     my $self = shift;


### PR DESCRIPTION
Failed job: https://openqa.suse.de/tests/22404122#step/coredump_collect/2