### PR TITLE
Fix serial console timeout during ReaR recovery and backup

### DIFF
--- a/tests/ha/rear_backup.pm
+++ b/tests/ha/rear_backup.pm
@@ -47,11 +47,11 @@ sub run {
         my $local_conf = '/etc/rear/local.conf';
         assert_script_run("curl -f -v " . data_url('ha/rear_local.conf') . " -o $local_conf");
         file_content_replace("$local_conf", q(%BACKUP_URL%) => $backup_url);
-        my $rear_cmd = 'rear -d -D mkbackup |& tee -a ' . $self->rear_cmd_log();
-        assert_script_run('set -o pipefail');
+        my $rear_cmd = 'rear -d -D mkbackup > ' . $self->rear_cmd_log() . ' 2>&1';
         my $backup_rc = script_run($rear_cmd, timeout => $timeout);
         die 'Unexpected error in mkbackup command' unless defined $backup_rc;
         unless ($backup_rc == 0) {
+            script_run('cat ' . $self->rear_cmd_log());
             # Check for bsc#1245306
             if (is_sle('>=16') && (zypper_call('se -i dhcpcd', exitcode => [0, 104]) == 104)) {
                 record_soft_failure('bsc#1245306 - Rear29a: DHCP is enabled but no DHCP client binary was found');
@@ -66,7 +66,12 @@ sub run {
                 assert_script_run("echo \"MODULES=( 'all_modules' )\" >> $local_conf");
             }
             # Retry the mkbackup command
-            assert_script_run($rear_cmd, timeout => $timeout);
+            $backup_rc = script_run($rear_cmd, timeout => $timeout);
+            if (!defined $backup_rc || $backup_rc != 0) {
+                script_run('cat ' . $self->rear_cmd_log());
+                die "mkbackup failed after retry" if defined $backup_rc;
+                die "mkbackup retry timed out";
+            }
         }
     }
 

--- a/tests/ha/rear_restore.pm
+++ b/tests/ha/rear_restore.pm
@@ -39,8 +39,13 @@ sub run {
     set_var('LIVETEST', 1);    # Because there is no password in ReaR miniOS
     select_console('root-console', skip_setterm => 1);    # Serial console is not configured in ReaR miniOS
     $self->upload_fs_blk_info(prefix => 'before');
-    assert_script_run('set -o pipefail');
-    assert_script_run('export USER_INPUT_TIMEOUT=5; rear -d -D recover |& tee -a ' . $self->rear_cmd_log(), timeout => $timeout);
+    my $rear_cmd = 'export USER_INPUT_TIMEOUT=5; rear -d -D recover > ' . $self->rear_cmd_log() . ' 2>&1';
+    my $rc = script_run($rear_cmd, timeout => $timeout);
+    if (!defined $rc || $rc != 0) {
+        script_run('cat ' . $self->rear_cmd_log());
+        die "ReaR recovery failed (rc: $rc)" if defined $rc;
+        die "ReaR recovery timed out";
+    }
     $self->upload_rear_logs;
     set_var('LIVETEST', 0);
 


### PR DESCRIPTION
Replace the `|& tee` pipeline with direct redirection to prevent `tee` from hanging when background daemons inherit its file descriptors.

On SLES 16, ReaR starts services like `rpcbind` which can keep the redirection pipe open indefinitely, causing openQA to time out waiting for the command completion marker.

Switch to a Perl-native approach for log visibility:
- Logs are redirected directly to a file.
- The file is `cat`ed to the terminal only if the command fails.
- This ensures debug visibility without the risk of pipeline hangs.
- Removed unnecessary `set -o pipefail` calls.

Related Ticket: https://jira.suse.com/browse/TEAM-11240

# Verification run:

 - sle-16.1-Online-x86_64-Build43.1-rear_generate_backup_textmode  -> http://openqa.suse.de/tests/22414569 :green_circle: 
 - sle-16.1-Online-x86_64-Build43.1-rear_restore_backup_textmode  -> http://openqa.suse.de/tests/22414567 :green_circle: 
 - sle-16.1-Online-x86_64-Build43.1-rear_restore_backup_textmode  -> http://openqa.suse.de/tests/22414568