### PR TITLE
Remove unnecessary variables in kubevirt schedule yaml

### DIFF
--- a/schedule/virt_autotest/kubevirt-tests-slem-pxe.yaml
+++ b/schedule/virt_autotest/kubevirt-tests-slem-pxe.yaml
@@ -3,15 +3,6 @@ description:    >
     Maintainer: Nan Zhang <nan.zhang@suse.com> qe-virt@suse.de
     Kubevirt server & agent node installation and test modules
 vars:
-  IPXE: 1
-  IPXE_UEFI: 1
-  USB_BOOT: 0
-  BOOT_HDD_IMAGE: 1
-  VIRT_AUTOTEST: 1
-  DO_NOT_INSTALL_HOST: 0
-  SYSTEM_ROLE: kvm
-  HOST_HYPERVISOR: kvm
-  PATTERNS: default,kvm
   MAX_JOB_TIME: 10800
 schedule:
   - '{{install_preparation}}'


### PR DESCRIPTION
Most kubevirt job variables already exist in job group yaml file, so cleaned up unnecessary variables in schedule yaml file.

- Related ticket: https://progress.opensuse.org/issues/199613
- Related PR: https://gitlab.suse.de/qa-testsuites/openqa-job-group-yaml/-/merge_requests/396
