### PR TITLE
Add an extra xen option on briza for MU tests

### DIFF
--- a/data/virtualization/autoyast/host_15.xml.ep
+++ b/data/virtualization/autoyast/host_15.xml.ep
@@ -122,7 +122,11 @@
       <terminal>console</terminal>
       % if ($check_var->('SYSTEM_ROLE', 'xen')) {
       <xen_append>splash=silent quiet console=<%= $get_var->('SERIALDEV') %>,115200</xen_append>
+      % if ($check_var->('VERSION', '15-SP6')) {
+      <xen_kernel_append><%= $check_var->('IPMI_HW', 'AMD') ? "" : "dom0_max_vcpus=4 dom0_mem=8192M,max:8192M" %> vga=gfx-1024x768x16 loglvl=all guest_loglvl=all <%= $get_var->('XEN_EXTRA_HYPERVISOR_PARAMS', '') %></xen_kernel_append>
+      % } else {
       <xen_kernel_append><%= $check_var->('IPMI_HW', 'AMD') ? "" : "dom0_max_vcpus=4 dom0_mem=8192M,max:8192M" %> vga=gfx-1024x768x16 loglvl=all guest_loglvl=all</xen_kernel_append>
+      % }
       % } elsif ($check_var->('ENABLE_SEV_ES', '1')) {
       <append>splash=silent amd_iommu=on mem_encrypt=on kvm_amd.sev=1</append>
       % } else {


### PR DESCRIPTION
https://progress.opensuse.org/issues/201189

- Make MU test installation go the same way developing tests do to allow them to support `IPXE_SET_HDD_BOOTSCRIPT`, and it make host installation more visible and reliable.
- Add `reboot=pci,force` as Xen hypervisor boot options to avoid the boot loop, eg. https://openqa.suse.de/tests/22541623#step/installation/24

Verification run: 
[sriov tests on sle15sp6 xen host on `briza`](https://openqa.suse.de/tests/22559426)
[feature tests on sle15sp6 xen host on `briza`](https://openqa.suse.de/tests/22587158)
[sle15sp7 xen host on `briza`](https://openqa.suse.de/tests/22559434)
[sle15sp6 xen host on other machines](https://openqa.suse.de/tests/22559428)
