### PR TITLE
Add soft-failures for aws-cli & azure-cli on helm tests

### DIFF
--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -45,7 +45,8 @@ sub init {
         assert_script_run('mkdir -p ~/.aws');
         # CAVEAT: Use the bash environment variables to prevent credential leaks.
         assert_script_run('printf "[default]\naws_access_key_id=$AWS_ACCESS_KEY_ID\naws_secret_access_key=$AWS_SECRET_ACCESS_KEY\nregion=$AWS_DEFAULT_REGION\n" > ~/.aws/credentials');
-        script_run("PILOT_DEBUG=1 aws %silent --help");
+        my $rc = script_run("PILOT_DEBUG=1 aws %silent --help");
+        die("bsc#1263669 - openQA test fails in azure_cli") if ($rc && check_var("CONTAINER_RUNTIMES", "helm"));
     }
 
     # Disable pager (see poo#133226 - EC2: WARNING: terminal is not fully functional)

--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -42,7 +42,10 @@ sub init {
           . '"galleryEndpointUrl": "https://gallery.azure.com/", ' . $/
           . '"managementEndpointUrl": "https://management.core.windows.net/" ' . $/
           . '}');
-    script_run("PILOT_DEBUG=1 az %silent --help") if is_sle(">=16");
+    if (is_sle(">=16")) {
+        my $rc = script_run("PILOT_DEBUG=1 az %silent --help");
+        die("bsc#1263669 - openQA test fails in azure_cli") if ($rc && check_var("CONTAINER_RUNTIMES", "helm"));
+    }
 
     $self->az_login();
     assert_script_run("az account set --subscription \$ARM_SUBSCRIPTION_ID");

--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -113,8 +113,11 @@ sub run {
             if ($k8s_backend eq "EC2") {
                 record_soft_failure("bsc#1263667 - openQA test fails in aws_cli");
                 return;
+            } elsif ($k8s_backend eq "AZURE") {
+                record_soft_failure("bsc#1263669 - openQA test fails in azure_cli");
+                return;
             } else {
-                die "Provider init failed";
+                die "Provider init failed: $err";
             }
         }
 

--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -107,7 +107,17 @@ sub run {
             die('Unknown service given');
         }
 
-        $provider->init();
+        eval { $provider->init(); };
+        my $err = $@;
+        if ($err) {
+            if ($k8s_backend eq "EC2") {
+                record_soft_failure("bsc#1263667 - openQA test fails in aws_cli");
+                return;
+            } else {
+                die "Provider init failed";
+            }
+        }
+
     }
 
     install_helm();


### PR DESCRIPTION
The helm tests are failing due to the regressions in [aws-cli-cmd](https://bugzilla.suse.com/show_bug.cgi?id=1263667) & [azure-cli-cmd](https://bugzilla.suse.com/show_bug.cgi?id=1263669).  These failures block updates in SLES 16.0 Staging and we also have to test the [helm update :git:4636:helm](https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=%3Agit%3A4636%3Ahelm&groupid=678)

These should be removed when the above issues are fixed (the jobs no longer soft-fail).

Verification run: https://openqa.suse.de/tests/22434875