### PR TITLE
Disable rollbacks in journal scans

### DIFF
--- a/tests/console/journal_check.pm
+++ b/tests/console/journal_check.pm
@@ -118,7 +118,7 @@ sub run {
 }
 
 sub test_flags {
-    return {fatal => 0};
+    return {fatal => 0, no_rollback => 1};
 }
 
 1;


### PR DESCRIPTION
The journal scans does not need to trigger rollback.

- Verification run: https://openqa.suse.de/tests/22443395#
