### PR TITLE
Remove BOOTFROM=d on verify_iscsi_initiator schedule and ...

### DIFF
--- a/schedule/ha/bv/verify_iscsi_initiator.yaml
+++ b/schedule/ha/bv/verify_iscsi_initiator.yaml
@@ -14,8 +14,6 @@ description: >
   to pollute the second installation.
   This schedule relies on BOOTFROM=d setting, so the VM always
   boots first from the ISO.
-vars:
-  BOOTFROM: 'd'
 schedule:
   - '{{agama_install}}'
   - installation/first_boot

--- a/tests/ha/check_iscsi_initiator.py
+++ b/tests/ha/check_iscsi_initiator.py
@@ -11,6 +11,7 @@ from mmapi import get_current_job_id
 
 perl.require("serial_terminal")
 perl.require("power_action_utils")
+perl.require("version_utils")
 
 def run(self):
     """
@@ -75,11 +76,40 @@ def run(self):
         # are different. How reinstallation is performed, depends on the
         # backend. Below is code for qemu and svirt/s390x where this was tested
         if (check_var("BACKEND", "qemu")):
+            #### Workaround for ppc64le jobs on qemu:
+            # In SLES 16.1, grub menu from the ppc64le ISO does not include the
+            # 'Boot from Hard Disk' entry; this prevents tests from booting into
+            # the installed system when using the setting BOOTFROM=d, and causing it to
+            # always attempt to boot from the 'Install SUSE SLE 16.1' entry; it means that
+            # the first module after OS installation would fail to boot into the installed
+            # OS. This can be prevented by using BOOTFROM=c, but then job will always
+            # attempt to boot from the hard disk (except right at the start), which breaks
+            # the test as it requires to perform more than one installation to confirm that
+            # the iSCSI initiators are different on different installations.
+            # As a workaround, only on BACKEND=qemu and ARCH=ppc64le and VERSION>=16.1,
+            # the following commands wipe the installed OS from the hard disk, which in turn
+            # will prevent the SUT from booting into the installed OS and instead fail to
+            # to boot and remain on the Open FirmWare menu. Once there, a command can be
+            # issued to make the SUT boot from the ISO again.
+            # WARNING: if using this module right before a module that expects an installed
+            # SUT, then it will be destroyed and test will fail.
+            need_workaround = (check_var("ARCH", "ppc64le") and perl.version_utils.is_sle(">=16.1"))
+            if (need_workaround):
+                # Assume HDDMODEL is virtio-blk by default
+                lsblk_opt = "v"
+                if (check_var("HDDMODEL", "scsi-hd")):
+                    lsblk_opt = "S"
+                assert_script_run(f"dd if=/dev/zero of=\"/dev/$(lsblk -{lsblk_opt} -o NAME -e 11 | grep -vw NAME)\" count=10000 bs=512")
             # On qemu, reboot the SUT to re-install. As next module expects the
             # SUT to be in a grub menu, assert the grub screen here first,
             # and move the highlighted option down and up to disable the
             # timeout
             perl.power_action_utils.power_action("reboot", "textmode", 1)
+            if (need_workaround):
+                assert_screen("ofw-failed-prompt-zero")
+                enter_cmd("boot-menu-start")
+                assert_screen("ofw-prompt-boot-menu-start")
+                send_key("1")
             assert_screen("grub-menu-first-entry-highlighted")
             send_key("down")
             send_key("up")


### PR DESCRIPTION
add workaround for jobs on ppc64le.

The SLES 16.1 ppc64le ISO lacks a `Boot from Hard Disk` entry in grub by design, which prevents jobs running with `BACKEND=qemu` and `ARCH=ppc64le` from successfully booting into the installed system if jobs also have the setting `BOOTFROM=d`. More details in bug https://bugzilla.suse.com/show_bug.cgi?id=1265899#c1

This commit drops `BOOTFROM=d` from the schedule (setting will need to be added to jobs in x86_64 and s390x in the test definition in the job group). This will cause jobs on PowerKVM (ppc64le @ qemu) to attempt to boot always from the hard disk after installation.

But this introduces an issue on the test module
`ha/check_iscsi_initiator.py` as it expects to leave the SUT in the grub menu from the ISO so the modules that follow perform a second installation. Without `BOOTFROM=d`, the SUT will always attempt to boot from the Hard Disk, and thus prevent the second installation. As a workaround, code has been added on `ha/check_iscsi_initiator.py` to wipe the installed OS, which in turn will cause the SUT to fail to reboot and instead to enter on the Open FirmWare prompt. Once there, commands can be issued to make the SUT boot from the ISO even without `BOOTFROM=d` set.

- Related Ticket: https://jira.suse.com/browse/TEAM-11092
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/commit/4b3cbe4757b2b2cc506a236c4ea06c791fd31433 & https://gitlab.suse.de/openqa/os-autoinst-needles-sles/-/commit/51fa9dc2c883e248b06e7fc6500069084720b653
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&build=team11092&version=16.1 :green_circle: 
