### PR TITLE
Fix boot_agama for media check

### DIFF
--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -105,6 +105,7 @@ sub run {
     $grub_entry_edition->boot();
 
     return if check_var('AGAMA_GRUB_SELECTION', 'rescue_system');
+    return if check_var('AGAMA_GRUB_SELECTION', 'check_medium');
     if (get_var('EXTRABOOTPARAMS', '') =~ /systemd.unit=multi-user.target/) {
         wait_serial('Connect to the Agama installer using these URLs:', 300) || die "Agama installer didn't start";
     } else {


### PR DESCRIPTION
- boot_agama failed because when checking medium it expected to see the Agama UI.
- failure: https://openqa.suse.de/tests/22449665
- VR: https://openqa.suse.de/tests/22449716

**Not sure if this really fixes the problem in 16.1** VRs hang in iscsi driver initialization. But if I compare this with [SLE16 QU2]( https://openqa.suse.de/tests/22130923) I see the same driver messages in the video, but the system is not stuck at this point. Product error maybe?