### PR TITLE
Install required package 'openssl'

### DIFF
--- a/tests/console/rsyslog_ossl_client.pm
+++ b/tests/console/rsyslog_ossl_client.pm
@@ -34,7 +34,7 @@ use package_utils 'install_package';
 
 sub run {
     select_serial_terminal;
-    install_package('rsyslog-module-ossl', trup_reboot => 1);
+    install_package('rsyslog-module-ossl openssl', trup_reboot => 1);
     mutex_wait 'server_is_ready';
     assert_script_run 'mkdir -p /etc/rsyslog-certs';
     assert_script_run 'curl -o /etc/rsyslog.d/10-tls-client.conf ' . data_url('rsyslog/10-tls-client.conf');

--- a/tests/console/rsyslog_ossl_server.pm
+++ b/tests/console/rsyslog_ossl_server.pm
@@ -34,7 +34,7 @@ use package_utils 'install_package';
 
 sub run {
     select_serial_terminal;
-    install_package('rsyslog-module-ossl', trup_reboot => 1);
+    install_package('rsyslog-module-ossl openssl', trup_reboot => 1);
     assert_script_run 'mkdir -p /etc/rsyslog-certs;cd /etc/rsyslog-certs';
     assert_script_run 'curl -o /etc/rsyslog.d/10-tls-server.conf ' . data_url('rsyslog/10-tls-server.conf');
     assert_script_run 'openssl req -new -x509 -extensions v3_ca -keyout ca-key.pem -out ca.pem -days 365 -nodes -subj "/CN=TestCA"';


### PR DESCRIPTION
On ppc64le, openssl is not installed by default,
[Bug](https://bugzilla.suse.com/show_bug.cgi?id=1265926)
Failed job: https://openqa.suse.de/tests/22455058

VR: https://openqa.suse.de/tests/22455067#dependencies
