### PR TITLE
upload_coredumps: Remove all coredumps for ovs-vswitchd

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -207,6 +207,8 @@ remove them from /var/lib/systemd/coredump/ to avoid processing them here.
 sub upload_coredumps {
     my $res = script_run('coredumpctl --no-pager');
     return if $res;
+    # XXX https://progress.opensuse.org/issues/201375
+    script_run("rm -f /var/lib/systemd/coredump/core.ovs-vswitchd.*");
     my @pids = split(/\n/, script_output(q(coredumpctl --no-pager --no-legend | awk '$9 ~ /^(present|truncated)$/ { print $5 }'), proceed_on_failure => 1));
     return unless @pids;
     my $get_backtrace = get_var("COREDUMP_WITH_BACKTRACE") && !is_transactional;


### PR DESCRIPTION
The ovs-vswitchd generates a lot of coredumps because they abuse the abort(3) call which generates a coredump by default.  We still have a race where the systemd-coredump@.service unit is running.

Remove all coredumps for now until we fix the race and also be more selective in cleanup_known_coredumps to remove only SIGABRT coredumps in the case of ovs-vswitchd.

Related ticket: https://progress.opensuse.org/issues/201375

Failed job: https://openqa.suse.de/tests/22455426/logfile?filename=serial_terminal.txt#line-21813