### PR TITLE
Add Tumbleweed for bsc#1126272

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -118,6 +118,9 @@
                 "5.4",
                 "5.5"
             ],
+            "opensuse": [
+                "Tumbleweed"
+            ],
             "microos": [
                 "Tumbleweed"
             ],


### PR DESCRIPTION
It happens on openSUSE Tumblewwed aarch64 as well: `zdup_twjeos2twnext_aarch64@aarch64-HD20G` https://openqa.opensuse.org/tests/5949811#step/journal_check/10