### PR TITLE
Refactor test for SLE15-SP7

### DIFF
--- a/data/security/openqa_agnostic/testPostQuantumCrypto/openssl_pqc_test.py
+++ b/data/security/openqa_agnostic/testPostQuantumCrypto/openssl_pqc_test.py
@@ -137,7 +137,7 @@ def openssl():
 @pytest.mark.parametrize("algo", ML_DSA_ALGOS)
 def test_ml_dsa_explicit_dgst_compatibility(tmp_path: Path, algo, openssl):
     if not openssl.is_supported(algo):
-        pytest.skip(f"Algorithm {algo} not supported.")
+        pytest.fail(f"Error: Algorithm {algo} not supported.")
 
     priv_key_path = tmp_path / "dgst_key.der"
     pub_key_path = tmp_path / "dgst_pub.der"
@@ -170,7 +170,7 @@ def test_tls_handshake(tmp_path: Path, algo, openssl):
     """
     # STRICT CHECK: Only attempt handshake if OpenSSL explicitly lists it as a TLS group.
     if not openssl.is_tls_group(algo):
-        pytest.skip(f"Algorithm {algo} is not listed in 'openssl list -tls-groups'.")
+        pytest.fail(f"Error: Algorithm {algo} is not listed in 'openssl list -tls-groups'.")
 
     # 1. Prepare Server Certs
     server_key = tmp_path / "server.key"
@@ -254,10 +254,10 @@ def test_kem_lifecycle(tmp_path: Path, algo, openssl):
     Tests Key Encapsulation Mechanism (File-based).
     """
     if not openssl.is_supported(algo):
-        pytest.skip(f"Algorithm {algo} not supported.")
+        pytest.fail(f"Error: Algorithm {algo} not supported.")
     
     if not openssl.can_generate_key(algo):
-        pytest.skip(f"Algorithm {algo} appears to be a TLS Group only (no CLI KeyGen support).")
+        pytest.fail(f"Error: Algorithm {algo} appears to be a TLS Group only (no CLI KeyGen support).")
 
     priv_key_path = tmp_path / "key.der"
     openssl.run(["genpkey", "-algorithm", algo, "-outform", "DER", "-out", str(priv_key_path)])
@@ -297,7 +297,7 @@ def test_kem_lifecycle(tmp_path: Path, algo, openssl):
 @pytest.mark.parametrize("algo", ML_DSA_ALGOS + SLH_DSA_ALGOS)
 def test_post_quantum_signatures(tmp_path: Path, algo, openssl):
     if not openssl.is_supported(algo):
-        pytest.skip(f"Algorithm {algo} not supported.")
+        pytest.fail(f"Error: Algorithm {algo} not supported.")
 
     priv_key_path = tmp_path / "sign_key.der"
     openssl.run(["genpkey", "-algorithm", algo, "-outform", "DER", "-out", str(priv_key_path)])

--- a/tests/security/oqa_agnostic/openssl_pqc.pm
+++ b/tests/security/oqa_agnostic/openssl_pqc.pm
@@ -24,7 +24,14 @@ sub run {
             name => 'testPostQuantumCrypto',
         }
     );
-    $test->setup()->run_test()->parse_results()->cleanup();
+    if (is_sle('=15-SP7')) {
+        eval { $test->setup()->run_test()->parse_results()->cleanup() };
+        if ($@) {
+            record_soft_failure("poo#200579 OpenSSL PQ not yet ready for SLE15-SP7: $@");
+        }
+    } else {
+        $test->setup()->run_test()->parse_results()->cleanup();
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
Refactor test the openssl PQ test for SLE15-SP7, fail when missing cipher, softfail for 15-SP7

- Related ticket: https://progress.opensuse.org/issues/200579?
- Verification run: 
  - 15-SP7: https://openqa.suse.de/tests/22471123
  - 16.1: https://openqa.suse.de/tests/22471164 (failing due to product bug)