### PR TITLE
Fix SDAF network lease file

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -1839,7 +1839,7 @@ sub az_validate_uuid_pattern(%args) {
     az_storage_blob_upload(
         container_name=>'somecontainer',
         storage_account_name=>'storageaccount',
-        file=>'somefilename' [, timeout=>42]);
+        file=>'somefilename' [, timeout=>42, name=>'blob_name.txt']);
 
 Uploads file to a storage container.
 
@@ -1850,6 +1850,8 @@ Uploads file to a storage container.
 =item B<storage_account_name> Storage account name.
 
 =item B<file> File to upload.
+
+=item B<name> Target blob filename. (Optional)
 
 =item B<timeout> Timeout for az command. Default: 90s
 
@@ -1862,14 +1864,14 @@ sub az_storage_blob_upload(%args) {
     }
     $args{timeout} //= '90';
 
-    my $az_cmd = join(' ',
-        'az storage blob upload',
+    my @az_cmd = ('az storage blob upload',
         '--only-show-errors',
         "--container-name $args{container_name}",
         "--account-name $args{storage_account_name}",
         "--file $args{file}"
     );
-    assert_script_run(join(' ', $az_cmd), timeout => $args{timeout});
+    push @az_cmd, "--name $args{name}" if $args{name};
+    assert_script_run(join(' ', @az_cmd), timeout => $args{timeout});
 }
 
 =head2 az_storage_blob_lease_acquire

--- a/lib/sles4sap/sap_deployment_automation_framework/networking.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/networking.pm
@@ -370,13 +370,12 @@ sub create_lease_file {
     foreach ('network_space', 'storage_account') {
         croak "Missing mandatory argument: '$_'" unless $args{$_};
     }
-    my $network_lease_filename = $args{network_space};
-    my $lease_file = "/tmp/$network_lease_filename";
-    assert_script_run("touch $lease_file", quiet => 1);
+
     az_storage_blob_upload(
         container_name => 'network-spaces',
         storage_account_name => $args{storage_account},
-        file => $lease_file
+        name => $args{network_space},
+        file => '/dev/null'    # no need to create an empty file
     );
 }
 

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -1170,13 +1170,16 @@ subtest '[az_storage_blob_upload]' => sub {
     az_storage_blob_upload(
         container_name => 'Arlecchino',
         storage_account_name => 'Pantalone',
-        file => 'Colombina');
+        file => 'Colombina',
+        name => 'Smeraldina'
+    );
 
     note("\n --> " . join("\n --> ", @calls));
     ok((any { /az storage blob upload/ } @calls), 'Correct composition of the main command');
     ok(grep(/--only-show-errors/, @calls), 'Check for argument "--only-show-errors"');
     ok(grep(/--container-name Arlecchino/, @calls), 'Check for argument "--container-name"');
     ok(grep(/--account-name Pantalone/, @calls), 'Check for argument "--account-name"');
+    ok(grep(/--name Smeraldina/, @calls), 'Check for argument "--name"');
     ok(grep(/--file Colombina/, @calls), 'Check for argument "--file"');
 };
 


### PR DESCRIPTION
Fix SDAF network lease file

Some nightly runs are failing because of network address space lease
file is failing to being uploaded. Failure is related to a bug in `az 
cli` on sles16: https://bugzilla.suse.com/show_bug.cgi?id=1266045. Since
 the lease file is empty, it is possible to provide /dev/null instead of
  creating separate file. 

**Tickets:** 
https://jira.suse.com/browse/TEAM-11222
https://bugzilla.suse.com/show_bug.cgi?id=1266045  

[Failing test:](https://openqaworker15.qe.prg2.suse.org/tests/368779/logfile?filename=serial_terminal.txt#line-2397)

**VR:** 
https://openqaworker15.qe.prg2.suse.org/tests/368978#step/deploy_workload_zone/68

File was indeed created:
<img width="386" height="116" alt="image" src="https://github.com/user-attachments/assets/f421ea88-60bf-41f9-aa50-71451225cdc1" />
