### PR TITLE
Elemental3: bump systemd checking timeout

### DIFF
--- a/tests/elemental3/elemental_boot.pm
+++ b/tests/elemental3/elemental_boot.pm
@@ -60,7 +60,7 @@ sub run {
 
     # Wait for system to be in running state
     unless (get_var('PARALLEL_WITH')) {
-        my $sys_state = script_output('systemctl is-system-running --wait', timeout => 240, proceed_on_failure => 1);
+        my $sys_state = script_output('systemctl is-system-running --wait', timeout => 600, proceed_on_failure => 1);
         die("Wrong OS state: $sys_state") unless ($sys_state =~ m/running/);
     }
 


### PR DESCRIPTION
This should avoid sporadic issue when RKE2 takes more time to come up.

- Related ticket: N/A
- Needles: N/A
- Failing tests: [test_raw on aarch64](https://openqa.suse.de/tests/22472080#step/elemental_boot/1), [test_raw on x86_64](https://openqa.suse.de/tests/22472081#step/elemental_boot/1)
- Verification runs: [test_raw on aarch64](https://openqa.suse.de/tests/22472569), [test_raw on x86_64](https://openqa.suse.de/tests/22472546)
