### PR TITLE
fix(cloud-init): fix error management in cloud-init check

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -715,7 +715,7 @@ sub check_cloudinit() {
 
     # cloud-init status
     my $rc = $self->ssh_script_run(cmd => "sudo cloud-init status --wait", timeout => 300);
-    record_info("cloud-init", $self->ssh_script_output("sudo cloud-init status --long", timeout => 300));
+    record_info("cloud-init", $self->ssh_script_output("sudo cloud-init status --long", proceed_on_failure => 1, timeout => 300));
     die "cloud-init failed with return code $rc" if ($rc != 0);
 
     # cloud-id


### PR DESCRIPTION
- Fix the failure triggered in script_output, preventing to reach the `die` command
- Proceed on failure for the --long cloud-init status check, being the error managed by the next command.

- Ref. tkt: https://progress.opensuse.org/issues/201480

- Verification run: https://openqa.suse.de/tests/22473787
