### PR TITLE
Introduce FIREWALL_BACKEND variable to test nftables integration

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -165,6 +165,13 @@ sub configure_docker {
         $docker_opts .= configure_docker_tls;
     }
     $docker_opts .= " -H tcp://0.0.0.0:$port";
+    my $firewall_backend = get_var("FIREWALL_BACKEND");
+    $docker_opts .= " --firewall-backend $firewall_backend" if $firewall_backend;
+    # https://docs.docker.com/engine/network/firewall-nftables/#ip-forwarding
+    if ($firewall_backend eq "nftables") {
+        run_command "echo 1 > /proc/sys/net/ipv4/ip_forward";
+        run_command "echo net.ipv4.ip_forward = 1 > /etc/sysctl.d/ip_forward.conf";
+    }
     run_command "mv -f /etc/sysconfig/docker{,.bak} || true";
     run_command "mv -f /etc/docker/daemon.json{,.bak} || true";
     if (script_output(q(docker --version | awk -F'[. ]' '{ print $3 }')) > 28) {
@@ -223,12 +230,14 @@ sub enable_docker {
     script_run 'systemctl enable --now docker';
     script_run "usermod -aG docker $testapi::username";
 
+    my $firewall_backend = script_output "docker info -f '{{ .FirewallBackend.Driver }}' | awk -F+ '{ print \$1 }'";
+
     # Running podman as root with docker installed may be problematic as netavark uses nftables
     # while docker still uses iptables.
     # Use workaround suggested in:
     # - https://fedoraproject.org/wiki/Changes/NetavarkNftablesDefault#Known_Issue_with_docker
     # - https://docs.docker.com/engine/network/packet-filtering-firewalls/#docker-on-a-router
-    if (script_run("iptables -L -v | grep -q DOCKER") == 0) {
+    if ($firewall_backend eq "iptables" && script_run("iptables -L -v | grep -q DOCKER") == 0) {
         script_run "iptables -I DOCKER-USER -j ACCEPT";
         script_run "ip6tables -I DOCKER-USER -j ACCEPT";
     }

--- a/tests/containers/docker_cli.pm
+++ b/tests/containers/docker_cli.pm
@@ -16,6 +16,7 @@ use utils;
 use Utils::Architectures;
 use containers::bats;
 
+my $firewall_backend;
 my $version;
 my $port = 2375;
 
@@ -56,9 +57,11 @@ sub setup {
 
     # Fetch needed images
     run_command "./scripts/test/e2e/load-image";
+
+    $firewall_backend = script_output "docker info -f '{{ .FirewallBackend.Driver }}' | awk -F+ '{ print \$1 }'";
     # Init Docker Swarm
     my $ip_addr = script_output("ip -j route get 8.8.8.8 | jq -Mr '.[0].prefsrc'");
-    run_command "docker swarm init --advertise-addr $ip_addr";
+    run_command "docker swarm init --advertise-addr $ip_addr" unless ($firewall_backend eq "nftables");
     # Init Docker Compose
     run_command "COMPOSE_PROJECT_NAME=clie2e COMPOSE_FILE=./e2e/compose-env.yaml docker compose up --build -d registry";
 }
@@ -109,6 +112,11 @@ sub run {
         "github.com/docker/cli/e2e/container::TestProcessTermination",
         "github.com/docker/cli/e2e/plugin::TestInstall",
     ) unless (is_x86_64);
+    # Docker Swarm is not compatible with nftables
+    push @xfails, (
+        "github.com/docker/cli/e2e/stack::TestDeployWithNamedResources",
+        "github.com/docker/cli/e2e/stack::TestRemove",
+    ) if ($firewall_backend eq "nftables");
 
     run_timeout_command "$env gotestsum --junitfile cli.xml ./e2e/... -- &> cli.txt", no_assert => 1, timeout => 3000;
     upload_logs "cli.txt";
@@ -120,7 +128,7 @@ sub run {
 sub cleanup {
     script_run "docker rm -vf registry";
     script_run "COMPOSE_PROJECT_NAME=clie2e COMPOSE_FILE=./e2e/compose-env.yaml docker compose down -v --rmi all";
-    script_run "docker swarm leave -f";
+    script_run "docker swarm leave -f" unless ($firewall_backend eq "nftables");
     cleanup_docker;
 }
 

--- a/tests/containers/docker_engine.pm
+++ b/tests/containers/docker_engine.pm
@@ -95,7 +95,7 @@ sub run {
     select_serial_terminal;
     $self->setup;
 
-    my $firewall_backend = script_output "docker info -f '{{ .FirewallBackend.Driver }}' | awk -F+ '{ print \$1 }'";
+    my $firewall_backend = get_var("FIREWALL_BACKEND", script_output "docker info -f '{{ .FirewallBackend.Driver }}' | awk -F+ '{ print \$1 }'");
     record_info "firewall backend", $firewall_backend;
     my $test_no_firewalld = ($firewall_backend eq "iptables") ? "true" : "";
 

--- a/tests/containers/multi_runtime.pm
+++ b/tests/containers/multi_runtime.pm
@@ -94,7 +94,20 @@ sub run {
     # https://docs.docker.com/engine/daemon/ipv6/
     assert_script_run "sed -i 's%^{%&\"ipv6\":true,\"fixed-cidr-v6\":\"2001:db8:1::/64\",%' /etc/docker/daemon.json";
     record_info("docker daemon.json", script_output("cat /etc/docker/daemon.json"));
+    my $firewall_backend = get_var("FIREWALL_BACKEND");
+    assert_script_run q(sed -ri 's/^(DOCKER_OPTS)="(.*?)"/\1="\2 --firewall-backend nftables"/' /etc/sysconfig/docker) if $firewall_backend;
+    # https://docs.docker.com/engine/network/firewall-nftables/#ip-forwarding
+    if ($firewall_backend eq "nftables") {
+        assert_script_run "echo 1 > /proc/sys/net/ipv4/ip_forward";
+        assert_script_run "echo 1 > /proc/sys/net/ipv6/conf/all/forwarding";
+        assert_script_run "echo 1 > /proc/sys/net/ipv6/conf/default/forwarding";
+        assert_script_run "echo net.ipv4.ip_forward = 1 > /etc/sysctl.d/ip_forward.conf";
+        assert_script_run "echo net.ipv6.conf.all.forwarding = 1 >> /etc/sysctl.d/ip_forward.conf";
+        assert_script_run "echo net.ipv6.conf.default.forwarding = 1 >> /etc/sysctl.d/ip_forward.conf";
+    }
     systemctl "enable --now docker";
+
+    record_info "firewall backend", script_output "docker info -f '{{ .FirewallBackend.Driver }}' | awk -F+ '{ print \$1 }'";
 
     record_info("docker root", script_output("docker info"));
     my $warnings = script_output("docker info -f '{{ range .Warnings }}{{ println . }}{{ end }}'");

--- a/tests/containers/multi_runtime.pm
+++ b/tests/containers/multi_runtime.pm
@@ -14,6 +14,7 @@ use serial_terminal qw(select_serial_terminal select_user_serial_terminal);
 use utils;
 use containers::common qw(install_packages);
 use Utils::Logging 'save_and_upload_log';
+use containers::bats qw(bats_post_hook);
 
 my $port = 8000;
 my $test_image = "registry.opensuse.org/opensuse/nginx";
@@ -167,17 +168,12 @@ sub cleanup {
 }
 
 sub post_run_hook {
+    bats_post_hook;
     cleanup;
 }
 
 sub post_fail_hook {
-    for my $ip_version (4, 6) {
-        save_and_upload_log("ip -$ip_version addr", "/tmp/ip${ip_version}addr.txt");
-        save_and_upload_log("ip -$ip_version route", "/tmp/ip${ip_version}route.txt");
-    }
-    save_and_upload_log("sudo nft list ruleset", "/tmp/nft.txt");
-    save_and_upload_log("sudo ss -tnlp", "/tmp/tcp_services.txt");
-    save_and_upload_log("sudo sysctl -a | grep ^net", "/tmp/net_sysctl.txt");
+    bats_post_hook;
 
     for my $runtime ("docker", "podman") {
         for my $sudo ("", "sudo") {
@@ -192,10 +188,6 @@ sub post_fail_hook {
     }
 
     cleanup;
-}
-
-sub test_flags () {
-    return {always_rollback => 1};
 }
 
 1;

--- a/variables.md
+++ b/variables.md
@@ -87,6 +87,7 @@ EXTRABOOTPARAMS_DELETE_CHARACTERS | string | | Characters to delete from boot pr
 EXTRABOOTPARAMS_DELETE_NEEDLE_TARGET | string | | If specified, go back with the cursor until this needle is matched to delete characters from there. Needs EXTRABOOTPARAMS_BOOT_LOCAL and should be combined with EXTRABOOTPARAMS_DELETE_CHARACTERS.
 EXTRATEST | boolean | false | Enables execution of extra tests, see `load_extra_tests`
 FDE_ENROLLMENT | string | | Type of authentication to use when configuring FDE during installation, current values are `TPM2`, `TPM2 and PIN`, `Only Password` and `FIDO2`. 
+FIREWALL_BACKEND | strings | | Firewall backend (iptables or nftables)
 FIRST_BOOT_CONFIG | string | combustion+ignition | The method used for initial configuration of MicroOS images. Possible values are: `combustion`, `ignition`, `combustion+ignition` and `wizard`. For ignition/combustion, the job needs to have a matching HDD attached.
 FLAVOR | string | | Defines flavor of the product under test, e.g. `staging-.-DVD`, `Krypton`, `Argon`, `Gnome-Live`, `DVD`, `Rescue-CD`, etc.
 FULLURL | string | | Full url to the factory repo. Is relevant for openSUSE only.


### PR DESCRIPTION
With Docker v29 it's now possible to use nftables, but it must be manually enabled. 

Introduce the `FIREWALL_BACKEND` variable to test nftables integration

Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1255069

Verification runs:
- Tumbleweed: https://openqa.opensuse.org/tests/5956410
- SLES 16.1: https://openqa.suse.de/tests/22485768
- docker upstream tests: https://openqa.opensuse.org/tests/5956432

Related PR: https://github.com/os-autoinst/opensuse-jobgroups/pull/857