### PR TITLE
Press any key when finish checking installation medium

### DIFF
--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -117,6 +117,12 @@ sub run {
     if (get_var('EXTRABOOTPARAMS', '') =~ /systemd.unit=multi-user.target/) {
         wait_serial('Connect to the Agama installer using these URLs:', 300) || die "Agama installer didn't start";
     } else {
+        if (check_var('AGAMA_GRUB_SELECTION', 'check_medium')) {
+            wait_serial("Medium check succeeded", 600) or die "Medium check failed";
+            if (wait_serial("Press any key to continue...", 60)) {
+                send_key 'ret';
+            }
+        }
         $agama_up_an_running->expect_is_shown();
     }
 }


### PR DESCRIPTION
##
### Press any key when finish checking installation medium
- Related ticket: 
  - https://progress.opensuse.org/issues/201162
- Needles: N/A
- Verification run: 
  - [__sles_check_installation_medium__](https://openqa.suse.de/tests/overview?build=hjluo%2Fos-autoinst-distri-opensuse%23medium_press_key&version=16.1&distri=sle)

##