### PR TITLE
Fix regex in ignore list

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -729,7 +729,7 @@
         "type": "ignore"
     },
     "update-test-broken": {
-        "description": "Installation of update-test-broken.* failed:|Error: Subprocess failed. Error: RPM failed: Command exited with status 1.|Problem occurred during or after installation or removal of packages:|Installation has been aborted as directed.|Please see the above error message for a hint|ERROR: zypper up on /.snapshots/\\d+/snapshot failed with exit code 8!|Use '--interactive' for manual problem resolution.|Removing snapshot #1\\d",
+        "description": "Installation of update-test-broken.* failed:|Error: Subprocess failed. Error: RPM failed: Command exited with status 1.|Problem occurred during or after installation or removal of packages:|Installation has been aborted as directed.|Please see the above error message for a hint|ERROR: zypper up on /.snapshots/\\d+/snapshot failed with exit code 8!|Use '--interactive' for manual problem resolution.|Removing snapshot #\\d+",
         "products": {
             "microos": [
                 "Tumbleweed"


### PR DESCRIPTION
The `ERROR: zypper up on /.snapshots/9/snapshot failed with exit code 8!` was caught but follow up message was not.
`Removing snapshot #9...`
