### PR TITLE
pc: Avoid testing kernel-ec2 on Azure & GCE

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -24,6 +24,8 @@ sub load_maintenance_publiccloud_tests {
 
     # Avoid running jobs for ARM-only packages on x86_64. poo#201303
     return if (is_x86_64 && get_var("BUILD") =~ /:\d+:dtb-(?:aarch64|armv7l)/);
+    # Avoid testing kernel-ec2 on Azure & GCE
+    return if (!is_ec2() && get_var("BUILD") =~ /:\d+:kernel-ec2/);
 
     loadtest "publiccloud/download_repos" unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
     loadtest "publiccloud/prepare_instance", run_args => $args;


### PR DESCRIPTION
Avoid testing kernel-ec2 on Azure & GCE.

This will improve our budget, bring down our carbon footprint and improve the review experience.

See https://openqa.suse.de/tests/overview?distri=sle&version=12-SP5&build=%3Asmelt%3A44373%3Akernel-ec2&groupid=430