### PR TITLE
Skip year_2038_detection on sle16.1 immutable image

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -251,7 +251,8 @@ sub load_common_tests {
     # With sd-boot, host_config does not perform a reboot and a snapshot is made while the serial terminal
     # is logged in. year_2038_detection does a forced rollback to this snapshot and triggers poo#109929,
     # breaking most later modules.
-    loadtest 'console/year_2038_detection' unless (is_s390x || is_sle_micro || is_leap_micro || is_bootloader_sdboot);
+    # Skip the test on sle16.1+ immutable images due to bsc#1266277
+    loadtest 'console/year_2038_detection' unless (is_s390x || is_sle_micro || is_leap_micro || is_bootloader_sdboot || (is_transactional && is_sle('>=16.1')));
 }
 
 


### PR DESCRIPTION
Change the system time to year 2038 will cause issue: SUSEConnect error: Put "https://scc.suse.com/connect/systems": tls: failed to verify certificate: x509: certificate has expired

https://bugzilla.suse.com/show_bug.cgi?id=1266277
https://progress.opensuse.org/issues/201633


- Verification run: https://openqa.suse.de/tests/22511788
**Please ignore the failed module, it is caused by another issue**