### PR TITLE
Don't gather logs on console with undefined state

### DIFF
--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -44,8 +44,8 @@ Method executed when run() finishes and the module has result => 'fail'
 sub post_fail_hook {
     my ($self) = @_;
     return if get_var('NOLOGS');
-    $self->record_avc_selinux_alerts();
     $self->SUPER::post_fail_hook;
+    $self->record_avc_selinux_alerts();
     # at this point the instance is shutdown
     return if is_public_cloud();
     # Remaining log functions are executed in Utils::Logging::export_logs()


### PR DESCRIPTION
Always use a log-console in post_fail_hook as the active console might not be usable.

Ticket: https://progress.opensuse.org/issues/201543
VR (forcing the cmd timeout by setting it to 4s): http://10.149.244.62/tests/131