### PR TITLE
SDAF pcw_cleanup tagging

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -75,6 +75,7 @@ our @EXPORT = qw(
   az_disk_create
   az_resource_delete
   az_resource_list
+  az_resource_tag
   az_validate_uuid_pattern
   az_keyvault_list
   az_keyvault_secret_list
@@ -1796,8 +1797,43 @@ sub az_resource_list(%args) {
     push(@az_command, "--resource-group $args{resource_group}") if $args{resource_group};
     push(@az_command, "--query \"$args{query}\"") if $args{query};
     push(@az_command, '--output json');
+    push(@az_command, $SDAF_Azure_podman_flake_filter);
 
     return (decode_json(script_output(join(' ', @az_command))));
+}
+
+=head2 az_resource_tag
+
+    az_resource_tag(resource_ids=>['/id/a', '/id/b'], tags=>['pcw_ignore=1']);
+
+Tags list of resource IDs with list of tags
+
+=over
+
+=item B<resource_ids> List of existing resource id that will be tagged
+
+=item B<tags> List of tags
+
+=back
+=cut
+
+sub az_resource_tag(%args) {
+
+    for my $argument ('resource_ids', 'tags') {
+        croak "Mandatory argument '$argument' missing" unless $args{$argument};
+        croak "Argument '$argument' must be an array reference" unless
+          (ref($args{$argument}) eq 'ARRAY');
+    }
+
+    my $resources = join(' ', map("\"$_\"", @{$args{resource_ids}}));
+    my $tags = join(' ', map("\"$_\"", @{$args{tags}}));
+
+    my @az_command = ('az resource tag');
+    push(@az_command, "--ids $resources");
+    push(@az_command, "--tags $tags");
+    push(@az_command, '--output json');
+
+    return (assert_script_run(join(' ', @az_command)));
 }
 
 =head2 az_validate_uuid_pattern
@@ -2471,7 +2507,7 @@ sub az_account_show {
     return decode_json(script_output($az_cmd));
 }
 
-=head2
+=head2 az_role_definition_list
 
 List and return id about named role
 

--- a/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
@@ -159,7 +159,7 @@ sub sdaf_ibsm_teardown {
         record_info('DELETE PASS', 'Deleting peerings successful');
     }
 
-    my $workload_resource_group = get_workload_resource_group(deployment_id => find_deployment_id());
+    my $workload_resource_group = get_sdaf_resource_group(deployment_id => find_deployment_id(), resource_group_type => 'workload_zone');
     az_network_dns_links_cleanup(resource_group => $workload_resource_group);
     az_network_dns_zones_cleanup(resource_group => $workload_resource_group);
 }

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -54,7 +54,8 @@ our @EXPORT = qw(
   validate_components
   get_fencing_mechanism
   sdaf_upload_logs
-  get_workload_resource_group
+  get_sdaf_resource_group
+  apply_no_cleanup_tag
 );
 
 our $output_log_file = '';
@@ -1045,26 +1046,31 @@ sub get_fencing_mechanism {
     return ($supported_fencing_values{$fencing_type});
 }
 
-=head2 get_workload_resource_group
+=head2 get_sdaf_resource_group
 
-    get_workload_resource_group(deployment_id=>'1234');
+    get_sdaf_resource_group(deployment_id=>'1234', resource_group_type=>'workload_zone');
 
-Finds and returns resource group belonging to the tests workload zone.
+Finds and returns resource group belonging to the test according to deployment type.
 
 B<Value conversion:>
 
 =over
 
-=item * B<deployment_id> =>  Test/deployment ID
+=item * B<deployment_id>: Test/deployment ID
+
+=item * B<resource_group_type>: Type of resource group.
+    Supported values: workload_zone, sap_system
 
 =back
 
 =cut
 
-sub get_workload_resource_group {
+sub get_sdaf_resource_group {
     my (%args) = @_;
     croak 'Missing mandatory argument "$args{deployment_id}"' unless $args{deployment_id};
-    my $query = "[?contains(name, 'workload') && contains(name, '$args{deployment_id}')].name";
+    croak 'Missing mandatory argument "$args{resource_group_type}"' unless $args{resource_group_type};
+
+    my $query = "[?contains(name, '$args{resource_group_type}') && contains(name, '$args{deployment_id}')].name";
     my $groups = az_group_name_get(query => $query);
     die "Zero or more than one resource groups found:\n" . join("\n", @$groups) unless (@$groups == 1);
     return $groups->[0];
@@ -1136,6 +1142,40 @@ sub sdaf_upload_logs {
 
     # need to return positive value for unit test to work properly
     return 1;
+}
+
+=head2 apply_no_cleanup_tag
+
+    apply_no_cleanup_tag(resource_group=>'workload_zone', no_cleanup_tag=>'pc_ignore');
+
+Checks resources inside B<resource_group> for B<SDAF_NO_CLEANUP_TAG> and applies one if missing.
+
+=over
+
+=item * B<resource_group>: Resource group name
+
+=item * B<no_cleanup_tag>: Tag name
+
+=back
+
+=cut
+
+sub apply_no_cleanup_tag {
+    my (%args) = @_;
+    for my $argument ('resource_group', 'no_cleanup_tag') {
+        croak "Missing mandatory argument '\$args{$argument}'" unless $args{$argument};
+    }
+    my $query = "[?tags.$args{no_cleanup_tag} == null].id";
+    my @untagged_resources = @{
+        az_resource_list(resource_group => $args{resource_group},
+            query => $query)};
+    record_info('Retain deployment',
+        "Adding missing tag '$args{no_cleanup_tag}' on following resources:\n" .
+          join("\n", @untagged_resources)) if @untagged_resources;
+    az_resource_tag(
+        resource_ids => \@untagged_resources,
+        tags => ["$args{no_cleanup_tag}=1"]
+    ) if @untagged_resources;
 }
 
 1;

--- a/t/20_sdaf_deployment_library.t
+++ b/t/20_sdaf_deployment_library.t
@@ -470,22 +470,23 @@ subtest '[sdaf_upload_logs]' => sub {
     ok sdaf_upload_logs(hostname => $arguments{hostname}, sap_sid => $arguments{sap_sid});
 };
 
-subtest '[get_workload_resource_group]' => sub {
+subtest '[get_sdaf_resource_group]' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
     $ms_sdaf->noop('record_info');
     $ms_sdaf->redefine(az_group_name_get => sub { return ['Resource_group']; });
 
-    is get_workload_resource_group(deployment_id => '123'), 'Resource_group', 'Return exactly one RG';
+    is get_sdaf_resource_group(deployment_id => '123',
+        resource_group_type => 'workload_zone'), 'Resource_group', 'Return exactly one RG';
 };
 
-subtest '[get_workload_resource_group]' => sub {
+subtest '[get_sdaf_resource_group]' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
     $ms_sdaf->noop('record_info');
     $ms_sdaf->redefine(az_group_name_get => sub { return []; });
-    dies_ok { get_workload_resource_group(deployment_id => '123') } 'Fail with empty result';
+    dies_ok { get_sdaf_resource_group(deployment_id => '123', resource_group_type => 'workload_zone') } 'Fail with empty result';
 
     $ms_sdaf->redefine(az_group_name_get => sub { return ['First_result', 'Oh_no-second_one']; });
-    dies_ok { get_workload_resource_group(deployment_id => '123') } 'Fail with more than one results';
+    dies_ok { get_sdaf_resource_group(deployment_id => '123', resource_group_type => 'workload_zone') } 'Fail with more than one results';
 };
 
 subtest '[Check credentials] Long name regex ' => sub {
@@ -560,6 +561,23 @@ subtest '[Check credentials] Short name regex ' => sub {
         ok(grep($secret, @expected_result), "Short secret '$secret' found in keyvault");
     }
     undef_variables;
+};
+
+subtest '[apply_no_cleanup_tag]' => sub {
+    my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
+    my $tag_called;
+    $ms_sdaf->redefine(az_resource_tag => sub { $tag_called = '1' });
+    $ms_sdaf->redefine(az_resource_list => sub { return []; });
+    $ms_sdaf->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    set_var('SDAF_NO_CLEANUP_TAG', '1');
+    apply_no_cleanup_tag(resource_group => 'firepenguindiscopanda', no_cleanup_tag => 'justaboringwhale');
+    is $tag_called, undef, '"az_resource_tag" is not called if no resource is found';
+
+    $ms_sdaf->redefine(az_resource_list => sub { return ['fire', 'penguin', 'disco', 'panda']; });
+    apply_no_cleanup_tag(resource_group => 'firepenguindiscopanda', no_cleanup_tag => 'justaboringwhale');
+    is $tag_called, '1', '"az_resource_tag" is called if resource is found';
+
+    set_var('SDAF_NO_CLEANUP_TAG', undef);
 };
 
 done_testing;

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -1611,4 +1611,26 @@ subtest '[az_role_definition_list]' => sub {
     ok(($ret eq 'Pantalone'), 'Ret is the expected value, of type string');
 };
 
+subtest '[az_resource_tag] Check command composition' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+    $azcli->redefine(assert_script_run => sub { @calls = $_[0]; return; });
+    my $resource_ids = ['/sub/A', '/sub/B'];
+    my $tags = ['pcw_ignore=1'];
+
+    az_resource_tag(resource_ids => $resource_ids, tags => $tags);
+
+    note("\n --> " . join("\n --> ", @calls));
+    ok((any { /az resource tag/ } @calls), 'Correct composition of the main command');
+    ok((any { /--ids "\/sub\/A" "\/sub\/B"/ } @calls), 'Check for --ids option.');
+    ok((any { /--tags "pcw_ignore=1"/ } @calls), 'Check for --tags');
+};
+
+subtest '[az_resource_tag] Test exceptions' => sub {
+    dies_ok { az_resource_tag(resource_ids => ['A', 'B']) } 'Fail with missing "tags" argument';
+    dies_ok { az_resource_tag(tags => ['pcw_ignore=1']) } 'Fail with missing "resource_ids" argument';
+    dies_ok { az_resource_tag(resource_ids => 'string', tags => ['pcw_ignore=1']) } 'Fail with non arrayref argument - resource_ids';
+    dies_ok { az_resource_tag(resource_ids => ['A', 'B'], tags => 'string') } 'Fail with non arrayref argument - tags';
+};
+
 done_testing;

--- a/tests/sles4sap/sap_deployment_automation_framework/deploy_sap_systems.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/deploy_sap_systems.pm
@@ -7,9 +7,9 @@
 
 use Mojo::Base qw(sles4sap::sap_deployment_automation_framework::basetest publiccloud::basetest);
 
-use sles4sap::sap_deployment_automation_framework::deployment
-  qw(serial_console_diag_banner load_os_env_variables sdaf_execute_deployment az_login sdaf_deployment_reused);
+use sles4sap::sap_deployment_automation_framework::deployment;
 use sles4sap::sap_deployment_automation_framework::configure_sap_systems_tfvars qw(create_sap_systems_tfvars);
+use sles4sap::sap_deployment_automation_framework::deployment_connector qw(no_cleanup_tag find_deployment_id);
 use sles4sap::sap_deployment_automation_framework::naming_conventions;
 use sles4sap::console_redirection;
 use serial_terminal qw(select_serial_terminal);
@@ -107,6 +107,13 @@ sub run {
     create_sap_systems_tfvars(workload_vnet_code => $workload_vnet_code, os_image => $os);
     sdaf_execute_deployment(deployment_type => 'sap_system', timeout => 3600);
 
+    if (get_var('SDAF_RETAIN_DEPLOYMENT')) {
+        my $workload_rg = get_sdaf_resource_group(
+            deployment_id => find_deployment_id(), resource_group_type => 'sap_system'
+        );
+        apply_no_cleanup_tag(resource_group => $workload_rg, no_cleanup_tag => no_cleanup_tag());
+    }
+
     my @check_files = (
         "$config_root_path/sap-parameters.yaml",
         get_sdaf_inventory_path(sap_sid => $sap_sid, config_root_path => $config_root_path));
@@ -117,7 +124,6 @@ sub run {
 
     # disconnect the console
     disconnect_target_from_serial();
-
     # reset temporary variables
     set_var('SDAF_VNET_CODE', undef);
     serial_console_diag_banner('Module sdaf_deploy_sap_systems.pm : end');

--- a/tests/sles4sap/sap_deployment_automation_framework/deploy_workload_zone.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/deploy_workload_zone.pm
@@ -9,10 +9,11 @@ use Mojo::Base 'sles4sap::sap_deployment_automation_framework::basetest';
 
 use sles4sap::sap_deployment_automation_framework::deployment;
 use sles4sap::sap_deployment_automation_framework::naming_conventions;
-use sles4sap::sap_deployment_automation_framework::deployment_connector qw(no_cleanup_tag);
+use sles4sap::sap_deployment_automation_framework::deployment_connector qw(no_cleanup_tag find_deployment_id);
 use sles4sap::sap_deployment_automation_framework::networking qw(assign_address_space calculate_subnets);
 use sles4sap::sap_deployment_automation_framework::configure_workload_tfvars qw(create_workload_tfvars);
 use sles4sap::console_redirection;
+use sles4sap::azure_cli qw(az_resource_list az_resource_tag);
 use serial_terminal qw(select_serial_terminal);
 use testapi;
 
@@ -67,9 +68,15 @@ sub run {
         retries => $terraform_retries,
         timeout => $terraform_timeout);
 
+    if (get_var('SDAF_RETAIN_DEPLOYMENT')) {
+        my $workload_rg = get_sdaf_resource_group(
+            deployment_id => find_deployment_id(), resource_group_type => 'workload_zone'
+        );
+        apply_no_cleanup_tag(resource_group => $workload_rg, no_cleanup_tag => no_cleanup_tag());
+    }
+
     # disconnect the console
     disconnect_target_from_serial();
-
     # reset temporary variables
     set_var('SDAF_VNET_CODE', undef);
     serial_console_diag_banner('Module sdaf_deploy_workload_zone.pm : end');

--- a/tests/sles4sap/sap_deployment_automation_framework/patch_and_reboot.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/patch_and_reboot.pm
@@ -66,7 +66,7 @@ use sles4sap::azure_cli;
 use sles4sap::sap_deployment_automation_framework::naming_conventions;
 use sles4sap::console_redirection;
 use sles4sap::console_redirection::redirection_data_tools;
-use sles4sap::sap_deployment_automation_framework::deployment qw(get_workload_resource_group sdaf_ssh_key_from_keyvault);
+use sles4sap::sap_deployment_automation_framework::deployment qw(get_sdaf_resource_group sdaf_ssh_key_from_keyvault);
 use sles4sap::sap_deployment_automation_framework::deployment_connector qw(find_deployment_id);
 use sles4sap::sap_deployment_automation_framework::basetest qw(sdaf_ibsm_teardown);
 
@@ -152,7 +152,7 @@ file_content
     assert_script_run('pip install -r requirements.txt');
 
     # Fetch SUT SSH key from keyvault
-    my $workload_rg = get_workload_resource_group(deployment_id => find_deployment_id());
+    my $workload_rg = get_sdaf_resource_group(deployment_id => find_deployment_id(), resource_group_type => 'workload_zone');
     my $workload_key_vault = ${az_keyvault_list(resource_group => $workload_rg)}[0];
     sdaf_ssh_key_from_keyvault(key_vault => $workload_key_vault, target_file => $sut_ssh_key_path);
 

--- a/tests/sles4sap/sap_deployment_automation_framework/prepare_ssh_config.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/prepare_ssh_config.pm
@@ -13,7 +13,7 @@ use serial_terminal qw(select_serial_terminal);
 use sles4sap::console_redirection;
 use sles4sap::azure_cli qw(az_keyvault_list);
 use sles4sap::sap_deployment_automation_framework::inventory_tools;
-use sles4sap::sap_deployment_automation_framework::deployment qw(sdaf_ssh_key_from_keyvault get_workload_resource_group);
+use sles4sap::sap_deployment_automation_framework::deployment qw(sdaf_ssh_key_from_keyvault get_sdaf_resource_group);
 use sles4sap::sap_deployment_automation_framework::naming_conventions;
 use sles4sap::sap_deployment_automation_framework::deployment_connector qw(find_deployment_id);
 
@@ -24,7 +24,7 @@ sub run {
     my $sdaf_region_code = convert_region_to_short(get_required_var('PUBLIC_CLOUD_REGION'));
     my $sap_sid = get_required_var('SAP_SID');
     my $workload_vnet_code = get_workload_vnet_code();
-    my $workload_rg = get_workload_resource_group(deployment_id => find_deployment_id());
+    my $workload_rg = get_sdaf_resource_group(deployment_id => find_deployment_id(), resource_group_type => 'workload_zone');
     my $workload_key_vault = ${az_keyvault_list(resource_group => $workload_rg)}[0];
 
     my $jump_host_user = get_required_var('REDIRECT_DESTINATION_USER');


### PR DESCRIPTION
With switch to Cloud custodian, there is a need to tag all resources 
with `pcw_ignore=1` instead of resource group only. This PR adds a step 
which lists untagged resources and applies tag to each one individually. 

Ticket: https://jira.suse.com/browse/TEAM-10916
VR: 
Workload zone: https://openqaworker15.qe.prg2.suse.org/tests/369957#step/deploy_workload_zone/459
SAP systems: https://openqaworker15.qe.prg2.suse.org/tests/369957#step/deploy_sap_systems/104  (All resources were tagged by SDAF deployment)
