### PR TITLE
Fix moving registries.conf to /etc

### DIFF
--- a/lib/containers/podman.pm
+++ b/lib/containers/podman.pm
@@ -26,7 +26,7 @@ sub configure_insecure_registries {
 
     my $containers_registries = "/etc/containers/registries.conf";
     assert_script_run "curl " . data_url('containers/registries.conf') . " -o /tmp/containers_registries.conf";
-    assert_script_run "mv -Z /tmp/containers_registries.conf $containers_registries";
+    assert_script_run "mv -f -Z /tmp/containers_registries.conf $containers_registries";
     assert_script_run "chmod 644 /etc/containers/registries.conf";
     # Add custom registry only if set by the REGISTRY variable
     assert_script_run('echo -e \'[[registry]]\nlocation = "' . registry_url() . '"\ninsecure = true\' >> /etc/containers/registries.conf') if get_var('REGISTRY');


### PR DESCRIPTION
After AppArmor introduced a profile for cURL which no longer permits writing directly to /etc, the test code was changed to download the file to /tmp, then move it from there to /etc

In case the file already existed, curl would have overwritten it silently, but move asks for interactive confirmation unless called as mv -f

- Related ticket: https://progress.opensuse.org/issues/201129
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/5962646

openqa: clone https://openqa.opensuse.org/tests/5961840
