### PR TITLE
bats/netavark: Drop tests from SLES < 16.0

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -41,7 +41,6 @@ our @EXPORT = qw(
   go_arch
   install_docker_compose
   install_gotestsum
-  install_ncat
   numeric_version
   patch_junit
   patch_sources
@@ -332,18 +331,6 @@ sub install_gotestsum {
     run_command 'export GOPATH=$HOME/go';
     run_command 'export PATH=$GOPATH/bin:$PATH';
     run_command 'go install gotest.tools/gotestsum@v1.13.0';
-}
-
-sub install_ncat {
-    if (is_sle('<16')) {
-        # This repo has ncat 7.94
-        run_command "zypper addrepo https://download.opensuse.org/repositories/network:/utilities/15.6/network:utilities.repo";
-    }
-    run_command "zypper --gpg-auto-import-keys -n install ncat";
-
-    # Some tests use nc instead of ncat but expect ncat behaviour instead of netcat-openbsd
-    run_command "ln -sf /usr/bin/ncat /usr/bin/nc";
-    record_info("nc", script_output("nc --version"));
 }
 
 sub install_bats {

--- a/tests/containers/bats/netavark.pm
+++ b/tests/containers/bats/netavark.pm
@@ -37,8 +37,7 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    my @pkgs = qw(aardvark-dns cargo firewalld iproute2 iptables make netavark protobuf-devel);
-    push @pkgs, is_sle("<16") ? qw(dbus-1) : qw(dbus-1-daemon);
+    my @pkgs = qw(aardvark-dns cargo dbus-1-daemon firewalld iproute2 iptables make netavark protobuf-devel);
 
     $self->setup_pkgs(@pkgs);
 
@@ -48,7 +47,11 @@ sub run {
 
     $version = script_output "$netavark --version | awk '{ print \$2 }'";
 
-    install_ncat if (version->parse(numeric_version($version)) < version->parse("1.16.0"));
+    if (version->parse(numeric_version($version)) < version->parse("1.16.0")) {
+        run_command "zypper --gpg-auto-import-keys -n install ncat";
+        # Some tests use "nc" instead of "ncat" expecting ncat behaviour instead of netcat-openbsd
+        run_command "ln -sf /usr/bin/ncat /usr/bin/nc";
+    }
 
     # Download netavark sources
     patch_sources "netavark", "v$version", "test";


### PR DESCRIPTION
The repo we were using to get the right version of nmap-ncat is gone. Forever.

Related MR: 

Failed job: https://openqa.suse.de/tests/22520731#step/netavark/202