### PR TITLE
Fix flaky sysctl check in disable_unprivileged_ebpf on aarch64

### DIFF
--- a/tests/security/ebpf/disable_unprivileged_ebpf.pm
+++ b/tests/security/ebpf/disable_unprivileged_ebpf.pm
@@ -51,8 +51,11 @@ sub run {
     # Verify the eBPF status: OS should be disabled unprivileged eBPF by default
     validate_script_output("cat $f_unpriv_bpf_disabled", sub { m/2/ });
 
-    # Re-enable unprivileged eBPF temporarily using 'sysctl'
-    validate_script_output('sysctl kernel.unprivileged_bpf_disabled=0', sub { m/kernel.unprivileged_bpf_disabled = 0/ });
+    # Re-enable unprivileged eBPF temporarily using 'sysctl'.
+    # Use assert_script_run instead of validate_script_output: the 2->0 transition
+    # triggers a kernel printk WARNING on ttyAMA0 that races with the script marker
+    # echoed via 'tee', breaking script_output's marker-newline regex on slow aarch64.
+    assert_script_run('sysctl kernel.unprivileged_bpf_disabled=0');
     # Verify the eBPF status: should be enabled unprivileged eBPF
     validate_script_output("cat $f_unpriv_bpf_disabled", sub { m/0/ });
 


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/201687
VR: https://openqa.suse.de/tests/overview?build=20260526-1&groupid=431&distri=sle&version=15-SP6