### PR TITLE
Skip year_2038_detection if snapshot rollback not supported

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -251,8 +251,8 @@ sub load_common_tests {
     # With sd-boot, host_config does not perform a reboot and a snapshot is made while the serial terminal
     # is logged in. year_2038_detection does a forced rollback to this snapshot and triggers poo#109929,
     # breaking most later modules.
-    # Skip the test on sle16.1+ immutable images due to bsc#1266277
-    loadtest 'console/year_2038_detection' unless (is_s390x || is_sle_micro || is_leap_micro || is_bootloader_sdboot || (is_transactional && is_sle('>=16.1')));
+    # Skip the test if setups don't support snapshot rollback due to bsc#1266277
+    loadtest 'console/year_2038_detection' unless (is_s390x || is_bootloader_sdboot || get_var('QEMU_DISABLE_SNAPSHOTS'));
 }
 
 


### PR DESCRIPTION
https://progress.opensuse.org/issues/201633

Remove most of the conditions in the scheduling and only run the module if snapshots are supported
See more at https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25644#issuecomment-4552390767

- Verification run: https://openqa.suse.de/tests/22526208