### PR TITLE
Fix ensa2 cluster failed moved to another node

### DIFF
--- a/tests/sles4sap/redirection_tests/ensa2_kill_sapinstance.pm
+++ b/tests/sles4sap/redirection_tests/ensa2_kill_sapinstance.pm
@@ -149,6 +149,8 @@ sub run {
     record_info("Fail count: $fail_count", "Fail count is $fail_count");
 
     wait_for_idle_cluster();
+    record_info('Remove constraints', 'Removed migration constraints for ASCS. See bsc#1266289');
+    assert_script_run('crm resource clear ' . 'g-' . get_required_var('SAP_SID') . '_ASCS');
     record_info('Refresh', 'Refreshing resources using "crm resource refresh"');
     assert_script_run('crm resource refresh');
     wait_until_resources_started();


### PR DESCRIPTION
Fix ensa2 cluster failed moved to another node: remove the constraints added by MS SDAF playbook

See [Bug 1266289](https://bugzilla.suse.com/show_bug.cgi?id=1266289) - [PC][15SP7] 'sudo crm resource refresh' makes ASCS failover recovered to original node
The constraints are added here:
```
>> TASK [roles-sap/5.6-scsers-pacemaker : 5.6.6 SCS/ERS Pacemaker - Validation - Move cluster group g-QES_ASCS to qesscs01l1f0] ***
>> task path: /tmp/Azure_SAP_Automated_Deployment_369730/sap->> automation/deploy/ansible/roles-sap/5.6-scsers-pacemaker/tasks/5.6.6-validate.yml:98
>> ok: [qesscs01l1f0] => {"changed": false, 
>> "cmd": "crm resource move g-QES_ASCS qesscs01l1f0", 
>> "delta": "0:00:00.270702", "end": "2026-05-26 10:06:21.277755", "failed_when_result": false, 
>> "msg": "", "rc": 0, 
>> "start": "2026-05-26 10:06:21.007053", "stderr": "", "stderr_lines": [], 
>> "stdout": "INFO: Move constraint created for g-QES_ASCS to qesscs01l1f0\n
>> INFO: Use `crm resource clear g-QES_ASCS` to remove this constraint",  
>> "stdout_lines": ["INFO: Move constraint created for g-QES_ASCS to qesscs01l1f0", 
>> "INFO: Use `crm resource clear g-QES_ASCS` to remove this constraint"]}
```

- Related ticket: 
[TEAM-11259](https://jira.suse.com/browse/TEAM-11259) - [SDAF][15SP7] test 'ensa2_scenarios_sbd' failed on 'Kill_sapinstance_ASCS-takeover': Cluser resource 'rsc_sap_QES_ASCS01' was not moved to another node

- Verification run:
15-SP4 ensa2_scenarios_sbd: http://openqaworker15.qe.prg2.suse.org/tests/369980#dependencies (passed)
15-SP5 ensa2_scenarios: http://openqaworker15.qe.prg2.suse.org/tests/369975#dependencies (passed)
15-SP6 ensa2_scenarios_sbd: http://openqaworker15.qe.prg2.suse.org/tests/369972#dependencies (passed)
15-SP7 ensa2_scenarios_sbd: https://openqaworker15.qe.prg2.suse.org/tests/370149 (passed)
