### PR TITLE
bats/runc: Apply PR#4842 on runc v1.3.4+ to fix ppc64le test on SLES

### DIFF
--- a/data/containers/patches.yaml
+++ b/data/containers/patches.yaml
@@ -217,7 +217,7 @@ runc:
   # https://github.com/opencontainers/runc/pull/5295 - Update busybox:glibc in integration tests to latest (1.38.0) builds
   4842:
     merged: "1.5.0"
-    min: "1.4.0"
+    min: "1.3.4"
   5079:
     merged: "1.5.0"
   5124:


### PR DESCRIPTION
This patch is needed to apply the recently added PR#5295 that fixed the tests on Tumbleweed.

Failed job: https://openqa.suse.de/tests/22534902#step/coredump_collect/49
Verification run: https://openqa.suse.de/tests/22535186