### PR TITLE
Update migration test for change of proxy SCC

### DIFF
--- a/data/yam/autoyast/ha.xml.ep
+++ b/data/yam/autoyast/ha.xml.ep
@@ -5,6 +5,7 @@
     <do_registration config:type="boolean">true</do_registration>
     <email/>
     <reg_code>{{SCC_REGCODE}}</reg_code>
+    <reg_server>{{SCC_URL}}</reg_server>
     <install_updates config:type="boolean">true</install_updates>
     <addons config:type="list">
       <addon>

--- a/data/yam/autoyast/ha_s390x.xml.ep
+++ b/data/yam/autoyast/ha_s390x.xml.ep
@@ -5,6 +5,7 @@
     <do_registration config:type="boolean">true</do_registration>
     <email/>
     <reg_code>{{SCC_REGCODE}}</reg_code>
+    <reg_server>{{SCC_URL}}</reg_server>
     <install_updates config:type="boolean">true</install_updates>
     <addons config:type="list">
       <addon>

--- a/data/yam/autoyast/sles_sap_migration.xml.ep
+++ b/data/yam/autoyast/sles_sap_migration.xml.ep
@@ -118,6 +118,7 @@
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>
     <reg_code>{{SCC_REGCODE_SLES4SAP}}</reg_code>
+    <reg_server>{{SCC_URL}}</reg_server>
   </suse_register>
   <users t="list">
     <user t="map">

--- a/data/yam/autoyast/sles_sap_migration_bug1235701.xml.ep
+++ b/data/yam/autoyast/sles_sap_migration_bug1235701.xml.ep
@@ -118,6 +118,7 @@
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>
     <reg_code>{{SCC_REGCODE_SLES4SAP}}</reg_code>
+    <reg_server>{{SCC_URL}}</reg_server>
   </suse_register>
   <users t="list">
     <user t="map">

--- a/data/yam/autoyast/textmode.xml.ep
+++ b/data/yam/autoyast/textmode.xml.ep
@@ -5,6 +5,7 @@
       <do_registration config:type="boolean">true</do_registration>
       <email/>
       <reg_code>{{SCC_REGCODE}}</reg_code>
+      <reg_server>{{SCC_URL}}</reg_server>
       <install_updates config:type="boolean">true</install_updates>
       <addons config:type="list">
         <addon>

--- a/data/yam/autoyast/textmode_all_modules_and_extensions_aarch64.xml.ep
+++ b/data/yam/autoyast/textmode_all_modules_and_extensions_aarch64.xml.ep
@@ -5,6 +5,7 @@
     <do_registration config:type="boolean">true</do_registration>
     <email/>
     <reg_code>{{SCC_REGCODE}}</reg_code>
+    <reg_server>{{SCC_URL}}</reg_server>
     <install_updates config:type="boolean">true</install_updates>
     <addons config:type="list">
       <addon>

--- a/data/yam/autoyast/textmode_all_modules_and_extensions_ppc64le.xml.ep
+++ b/data/yam/autoyast/textmode_all_modules_and_extensions_ppc64le.xml.ep
@@ -5,6 +5,7 @@
     <do_registration config:type="boolean">true</do_registration>
     <email/>
     <reg_code>{{SCC_REGCODE}}</reg_code>
+    <reg_server>{{SCC_URL}}</reg_server>
     <install_updates config:type="boolean">true</install_updates>
     <addons config:type="list">
       <addon>

--- a/data/yam/autoyast/textmode_all_modules_and_extensions_s390x.xml.ep
+++ b/data/yam/autoyast/textmode_all_modules_and_extensions_s390x.xml.ep
@@ -5,6 +5,7 @@
     <do_registration config:type="boolean">true</do_registration>
     <email/>
     <reg_code>{{SCC_REGCODE}}</reg_code>
+    <reg_server>{{SCC_URL}}</reg_server>
     <install_updates config:type="boolean">true</install_updates>
     <addons config:type="list">
       <addon>

--- a/data/yam/autoyast/textmode_all_modules_and_extensions_x86_64.xml.ep
+++ b/data/yam/autoyast/textmode_all_modules_and_extensions_x86_64.xml.ep
@@ -5,6 +5,7 @@
     <do_registration config:type="boolean">true</do_registration>
     <email/>
     <reg_code>{{SCC_REGCODE}}</reg_code>
+    <reg_server>{{SCC_URL}}</reg_server>
     <install_updates config:type="boolean">true</install_updates>
     <addons config:type="list">
       <addon>

--- a/data/yam/autoyast/textmode_s390x.xml.ep
+++ b/data/yam/autoyast/textmode_s390x.xml.ep
@@ -5,6 +5,7 @@
       <do_registration config:type="boolean">true</do_registration>
       <email/>
       <reg_code>{{SCC_REGCODE}}</reg_code>
+      <reg_server>{{SCC_URL}}</reg_server>
       <install_updates config:type="boolean">true</install_updates>
       <addons config:type="list">
         <addon>

--- a/data/yam/autoyast/textmode_zvm.xml.ep
+++ b/data/yam/autoyast/textmode_zvm.xml.ep
@@ -101,6 +101,7 @@
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>
     <reg_code>{{SCC_REGCODE}}</reg_code>
+    <reg_server>{{SCC_URL}}</reg_server>
   </suse_register>
   <users t="list">
     <user t="map">

--- a/tests/yam/migration/migration_unattended.pm
+++ b/tests/yam/migration/migration_unattended.pm
@@ -38,10 +38,9 @@ sub run {
         }
     }
 
-    # clean migration repo and configure SUSEConnect when using proxy
+    # clean migration repo
     if ((get_var('SCC_URL', "") =~ /proxy/)) {
         zypper_call("rr Migration");
-        assert_script_run("echo 'url: " . get_var('SCC_URL') . "' > /etc/SUSEConnect");
     }
 
     # Add product increment repo

--- a/tests/yam/migration/restore_upgrade_env.pm
+++ b/tests/yam/migration/restore_upgrade_env.pm
@@ -13,7 +13,7 @@ use migration 'reset_consoles_tty';
 sub run {
     # Restore the original value of the variables
     my $env_content = '';
-    foreach my $var (qw(AGAMA BETA SCC_ADDONS SCC_URL VERSION)) {
+    foreach my $var (qw(AGAMA BETA SCC_ADDONS VERSION)) {
         if (get_var($var . "_ENV")) {
             set_var($var, get_var($var . "_ENV"));
             $env_content .= "$var=" . get_var($var) . "\n";

--- a/tests/yam/migration/setup_upgrade_env.pm
+++ b/tests/yam/migration/setup_upgrade_env.pm
@@ -21,7 +21,7 @@ sub run {
             get_var('SCC_ADDONS')));
 
     # Save the original value of the variables in order to restore it later if needed
-    foreach my $var (qw(AGAMA BETA SCC_ADDONS SCC_URL VERSION)) {
+    foreach my $var (qw(AGAMA BETA SCC_ADDONS VERSION)) {
         set_var($var . "_ENV", get_var($var)) if (get_var($var));
     }
 
@@ -30,7 +30,6 @@ sub run {
         AGAMA => $agama,
         BETA => '0',
         SCC_ADDONS => $scc_addons,
-        SCC_URL => 'https://scc.suse.com',
         VERSION => $version,
     );
     my $env_content = '';


### PR DESCRIPTION
Following the [MR](https://gitlab.suse.de/scc/qa-proxy/-/merge_requests/9) merged for https://bugzilla.suse.com/show_bug.cgi?id=1265196, we need update migration test. The idea is to ensure register new proxy SCC url SCC_URL=http://version-15-sp7.product-all.build-44.4.proxy.scc.suse.de/ and don't need to set /etc/SUSEConnect parameter any more.

- Related ticket: N/A
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/809
- Needles:  N/A
- Verification run: 
 https://openqa.suse.de/tests/22540684#  15SP7 -> 16.1
 https://openqa.suse.de/tests/22540713#live  15SP5 -> 16.1
  https://openqa.suse.de/tests/22540708#details    15SP7 ->16.0
  
