### PR TITLE
Fix `az_storage_blob_lease_acquire` in `azure_cli.pm`

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -1972,9 +1972,11 @@ sub az_storage_blob_lease_acquire(%args) {
         "--account-name $args{storage_account_name}",
         "--blob-name $args{blob_name}",
         "--lease-duration $args{lease_duration}",
-        '--output tsv'    # Json output won't work here.
-                          # If it is not possible to acquire lease command will return a message which is not in json format.
-                          # decode_json() would cause function to fail instead of just returning
+        '--output tsv',
+        # Json output won't work here.
+        # If it is not possible to acquire lease command will return a message which is not in json format.
+        # decode_json() would cause function to fail instead of just returning
+        $SDAF_Azure_podman_flake_filter
     );
 
     my $lease_id = script_output($az_cmd, $args{timeout}, proceed_on_failure => 1);


### PR DESCRIPTION
With SLE16 container based `az cli`, command pollutes outputs with unnecessary messages. 
This PR applies filter to a failing `az_storage_blob_lease_acquire` function.

Ticket: https://bugzilla.suse.com/show_bug.cgi?id=1261229
VR:
https://openqaworker15.qe.prg2.suse.org/tests/370164#step/deploy_workload_zone/75
https://openqaworker15.qe.prg2.suse.org/tests/370161#step/deploy_workload_zone/75
https://openqaworker15.qe.prg2.suse.org/tests/370158#step/deploy_workload_zone/75
https://openqaworker15.qe.prg2.suse.org/tests/370155#step/deploy_workload_zone/75