### PR TITLE
Fix az_storage_blob_update in azure_cli.pm

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -2057,11 +2057,12 @@ sub az_storage_blob_update(%args) {
         '--container-name', $args{container_name},
         '--account-name', $args{account_name},
         '--name', $args{name},
-        '--output json'
+        '--output json',
+        $SDAF_Azure_podman_flake_filter
     );
     push(@az_cmd, "--lease-id $args{lease_id}") if $args{lease_id};
 
-    return script_run(join(' ', @az_cmd));
+    return script_run(join(' ', @az_cmd), timeout => 180);
 }
 
 =head2 az_keyvault_list


### PR DESCRIPTION
Fix az_storage_blob_update failure in azure_cli.pm
With SLE16 container based az cli, command pollutes outputs with unnecessary messages.
This PR applies filter to a failing az_storage_blob_update function.

Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1261229

- Related ticket: NA
- Verification run:
https://openqaworker15.qe.prg2.suse.org/tests/370311#step/deploy_workload_zone/75 (according test step passed)
