### PR TITLE
Remove CD-ROM repo after installation

### DIFF
--- a/tests/console/validate_repos.pm
+++ b/tests/console/validate_repos.pm
@@ -21,12 +21,8 @@ sub run {
     my @actual_aliases = split(/\n/, script_output("zypper -n lr --uri | awk \'NR>4 && \$1 ~ /[0-9]/ {print \$3}\'"));
     my $unexpected_aliases = '';
     my @skip_aliases = (
-        qr/home_images/,
-        qr/home_sles16/,
         qr/Increment_repo/,
         qr/^SLES$/,    # This is on SLE 16 Full install of QE Security
-        qr/SLES15-SP7-15\.7-0/,
-        qr/SLE-15-SP7-SAP-15\.7-0/,
     );
 
     script_output 'zypper -n lr --uri';

--- a/tests/yam/migration/migration_unattended.pm
+++ b/tests/yam/migration/migration_unattended.pm
@@ -38,16 +38,21 @@ sub run {
         }
     }
 
-    # clean migration repo
+    # clean repos before migration
     if ((get_var('SCC_URL', "") =~ /proxy/)) {
         zypper_call("rr Migration");
     }
+    my $repo_num = script_output(q(zypper lr -u | awk -F '|' '/(cd|ftp):/ {printf $1}'));
+    zypper_call("rr $repo_num") if $repo_num;
 
     # Add product increment repo
     if (my $repo_increment = get_var('INCREMENT_REPO')) {
         $repo_increment .= '/repo/' . (get_var('PRODUCT')) . '-' . (get_var('VERSION')) . '-' . (get_var('ARCH'));
         zypper_call("ar --refresh $repo_increment Increment_repo");
     }
+
+    # list repos before migration
+    record_info('list repos', script_output('zypper lr -u'));
 
     # upload logs to know system state before migration
     upload_logs("/boot/grub2/grub.cfg", failok => 1);


### PR DESCRIPTION
##
### Remove CD-ROM repo after installation and remove some useless repos after migration.

- Related ticket: 
  - Quick PR
- Needles: 
  - N/A
- Verification run: 
  - [__validate_repos__](https://openqa.suse.de/tests/overview?build=hjluo%2Fos-autoinst-distri-opensuse%23remove_pre_mig_repos&version=16.1&distri=sle)

##
