### PR TITLE
Enlarge Arm64 guest cpu/memory to ensure performance

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_aarch64_agama_full_repo.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_aarch64_agama_full_repo.xml
@@ -13,8 +13,8 @@
     <guest_arch>aarch64</guest_arch>
     <guest_name/>
     <guest_domain_name/>
-    <guest_memory>16384</guest_memory>
-    <guest_vcpus>2,maxvcpus=4</guest_vcpus>
+    <guest_memory>4096,maxmemory=8192</guest_memory>
+    <guest_vcpus>4,maxvcpus=8</guest_vcpus>
     <guest_cpumodel>host-passthrough</guest_cpumodel>
     <guest_metadata/>
     <guest_boot_settings>loader=/usr/share/qemu/aavmf-aarch64-code.bin,loader.readonly=yes,loader.type=pflash,loader.secure=no,nvram.template=/usr/share/qemu/aavmf-aarch64-vars.bin,hd,bootmenu.enable=yes,menu=on</guest_boot_settings>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_aarch64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_aarch64_agama_online_iso.xml
@@ -13,8 +13,8 @@
     <guest_arch>aarch64</guest_arch>
     <guest_name/>
     <guest_domain_name/>
-    <guest_memory>2048,maxmemory=4096</guest_memory>
-    <guest_vcpus>2,maxvcpus=4</guest_vcpus>
+    <guest_memory>4096,maxmemory=8192</guest_memory>
+    <guest_vcpus>4,maxvcpus=8</guest_vcpus>
     <guest_cpumodel>host-passthrough</guest_cpumodel>
     <guest_metadata/>
     <guest_boot_settings>loader=/usr/share/qemu/aavmf-aarch64-code.bin,loader.readonly=yes,loader.type=pflash,loader.secure=no,nvram.template=/usr/share/qemu/aavmf-aarch64-vars.bin,hd,bootmenu.enable=yes,menu=on</guest_boot_settings>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_kvm_hvm_aarch64_agama_full_repo.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_kvm_hvm_aarch64_agama_full_repo.xml
@@ -13,8 +13,8 @@
     <guest_arch>aarch64</guest_arch>
     <guest_name/>
     <guest_domain_name/>
-    <guest_memory>16384</guest_memory>
-    <guest_vcpus>2,maxvcpus=4</guest_vcpus>
+    <guest_memory>4096,maxmemory=8192</guest_memory>
+    <guest_vcpus>4,maxvcpus=8</guest_vcpus>
     <guest_cpumodel>host-passthrough</guest_cpumodel>
     <guest_metadata/>
     <guest_boot_settings>loader=/usr/share/qemu/aavmf-aarch64-code.bin,loader.readonly=yes,loader.type=pflash,loader.secure=no,nvram.template=/usr/share/qemu/aavmf-aarch64-vars.bin,hd,bootmenu.enable=yes,menu=on</guest_boot_settings>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_kvm_hvm_aarch64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_kvm_hvm_aarch64_agama_online_iso.xml
@@ -13,8 +13,8 @@
     <guest_arch>aarch64</guest_arch>
     <guest_name/>
     <guest_domain_name/>
-    <guest_memory>2048,maxmemory=4096</guest_memory>
-    <guest_vcpus>2,maxvcpus=4</guest_vcpus>
+    <guest_memory>4096,maxmemory=8192</guest_memory>
+    <guest_vcpus>4,maxvcpus=8</guest_vcpus>
     <guest_cpumodel>host-passthrough</guest_cpumodel>
     <guest_metadata/>
     <guest_boot_settings>loader=/usr/share/qemu/aavmf-aarch64-code.bin,loader.readonly=yes,loader.type=pflash,loader.secure=no,nvram.template=/usr/share/qemu/aavmf-aarch64-vars.bin,hd,bootmenu.enable=yes,menu=on</guest_boot_settings>


### PR DESCRIPTION
* **Enlarge** Arm64 cpu/memory in profiles:
  * ```sles_16_1_traditional_64_kvm_hvm_aarch64_agama_online_iso.xml```
  * ```sles_16_1_traditional_64_kvm_hvm_aarch64_agama_full_iso.xml```
  * ```sles_16_kvm_hvm_aarch64_agama_online_iso.xml```
  * ```sles_16_kvm_hvm_aarch64_agama_full_iso.xml```

* **This** pull request can solve/mitigate issues:
  * Arm64 guest reboot hang after successful installation
  * Fails to establish ssh connection to Arm64 guest
  * Very slow ssh connection to Arm64 guest

* **Verification Runs:**
  * [sle-16.1-Online-aarch64-Build44.4-uefi-gi-guest_postsles16-on-host_developing-kvm](https://openqa.suse.de/tests/22604228)
  * [sle-16.1-Online-aarch64-Build44.4-uefi-gi-guest_presles16-on-host_developing-kvm](https://openqa.suse.de/tests/22583711)