### PR TITLE
Setup customized id file for ssh connection

### DIFF
--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -290,6 +290,14 @@ sub prepare_ssh_key {
         assert_script_run("ssh-keygen -f $_host_params{ssh_key_file} -q -P \"\" <<<y");
     }
     assert_script_run("chmod 600 $_host_params{ssh_key_file} $_host_params{ssh_key_file}.pub");
+    if (get_var('GUEST_SSH_KEYFILE')) {
+        record_info("Customized ssh key file $_host_params{ssh_key_file} on host being used for guest installation",
+            "Update already imported key, specify identity_file on ssh or call setup_common_ssh_config to stay intact");
+        setup_common_ssh_config(ssh_id_file => $_host_params{ssh_key_file});
+    }
+    else {
+        record_info("The ssh key file on host being used for guest installation is $_host_params{ssh_key_file}");
+    }
     $_host_params{ssh_public_key} = script_output("cat $_host_params{ssh_key_file}.pub");
     $_host_params{ssh_private_key} = script_output("cat $_host_params{ssh_key_file}");
     if (is_sle('16+')) {

--- a/lib/guest_installation_and_configuration_metadata.pm
+++ b/lib/guest_installation_and_configuration_metadata.pm
@@ -270,7 +270,10 @@ our %_host_params = (
     'host_version_major' => '',    # Major version of host os release from /etc/os-release on host
     'host_version_minor' => '',    # Minor version of host os release from /etc/os-release on host
     'host_version_id' => '',    # Version ID of host os release from /etc/os-release on host
-    'ssh_key_file' => get_var('GUEST_SSH_KEYFILE', '/root/.ssh/id_ed25519'),    # SSH key file used for guest installation and login
+    'ssh_key_file' => get_var('GUEST_SSH_KEYFILE', '/root/.ssh/id_ed25519'),    # SSH key file resides on host used for guest installation and login.
+        # SSH Key file that is provided by GUEST_SSH_KEYFILE is a customized instead of the default one,
+        # so it is necessary to update previously already imported key, specify identity file to be used
+        # on ssh command or call setup_common_ssh_config to include identity file to be used for ssh.
     'ssh_public_key' => '',    # Public key used for ssh login to guest
     'ssh_private_key' => '',    # Private key used for ssh login to guest
     'ssh_command' => '',    # SSH command used for ssh login, for example, "ssh -vvv -i identity_file username"


### PR DESCRIPTION
* **Customized** ssh key file can be specified by passing in using test suite setting ```GUEST_SSH_KEYFILE``` if the default one is corrupt.

* **In** order to ensure the key can still be used in all subsequent modules, it needs to be added in as preferred key file to be chosen by ssh connection by calling subroutine ```setup_common_ssh_config```.

* **Without** ```setup_common_ssh_config``` if ```GUEST_SSH_KEYFILE``` is specified, test run fails [like this one](https://openqa.suse.de/tests/22506098#step/uefi_guest_verification/50).

* **Verification Runs:**
  * [sle-16.1-Online-aarch64-Build44.4-uefi-gi-guest_postsles16-on-host_developing-kvm](https://openqa.suse.de/tests/22618842)
  * [sle-16.1-Online-aarch64-Build44.4-uefi-gi-guest_presles16-on-host_developing-kvm](https://openqa.suse.de/tests/22618843)
  * [sle-16.1-Online-x86_64-Build44.4-uefi-gi-full-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/22639049)
  * [sle-16.1-Online-x86_64-Build44.4-uefi-gi-guest_sles15sp7-on-host_developing-kvm](https://openqa.suse.de/tests/22639051)
  * [Test run with GUEST_SSH_KEYFILE](https://openqa.suse.de/tests/22649375#step/unified_guest_installation/41)
  * [Test run without GUEST_SSH_KEYFILE](https://openqa.suse.de/tests/22650825)
