### PR TITLE
Schedule: drop yast2-rmt from openSUSE schedules

### DIFF
--- a/schedule/yast/opensuse/yast2_ncurses/yast2_ncurses.yaml
+++ b/schedule/yast/opensuse/yast2_ncurses/yast2_ncurses.yaml
@@ -12,7 +12,6 @@ schedule:
   - console/prepare_test_data
   - console/consoletest_setup
   - console/setup_libyui_running_system
-  - console/yast2_rmt
   - console/yast2_ntpclient
   - console/yast2_tftp
   - console/yast2_proxy


### PR DESCRIPTION
yast2-rmt has been removed from openSUSE:Factory for good after it has
not been building for a long time already
The test was mostly there for reference for future SLE products, where
yast is no longer a topic.

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1235404
- Needles: N/A
- Verification run: N/A (test no longer scheduled)
