### PR TITLE
Soft-fail audit-remote tests 4 and 5 and clean up test server

### DIFF
--- a/lib/audit_test.pm
+++ b/lib/audit_test.pm
@@ -117,8 +117,14 @@ sub parse_lines {
 # Compare baseline testing result and current testing result
 # input: $testcase - test case name (the test module name in openQA code,
 # if test module is 'audit_tools.pm' then $testcase = audit_tools, etc)
+#
+# optional arguments:
+#   softfail_ids => { $id => 1, ... }   Test # that should be reported as
+#                                       softfail (instead of fail) when their
+#                                       result differs from the baseline.
 sub compare_run_log {
-    my ($testcase) = @_;
+    my ($testcase, %args) = @_;
+    my $softfail_ids = $args{softfail_ids} // {};
 
     # Read the current test result from rollup.log
     my $output = script_output('cat ./rollup.log');
@@ -140,16 +146,17 @@ sub compare_run_log {
         my $c_id = $current_result->{id};
         my $c_result = $current_result->{result};
         my $name = $current_result->{name};
+        my $is_expected_softfail = exists $softfail_ids->{$c_id};
         unless ($baseline_results{$c_id}) {
             my $msg = "poo#93441\nNo baseline found(defined).\n[$c_id] $name $c_result";
-            $flag = _parse_results_with_diff_baseline($name, $c_result, $msg, $flag);
+            $flag = _parse_results_with_diff_baseline($name, $c_result, $msg, $flag, $is_expected_softfail);
             next;
         }
         my $b_name = $baseline_results{$c_id}->{name};
         my $b_result = $baseline_results{$c_id}->{result};
         if ($c_result ne $b_result) {
             my $info = "Test result is NOT same as baseline \nCurrent:  [$c_id] $name $c_result\nBaseline: [$c_id] $b_name $b_result";
-            $flag = _parse_results_with_diff_baseline($name, $c_result, $info, $flag);
+            $flag = _parse_results_with_diff_baseline($name, $c_result, $info, $flag, $is_expected_softfail);
             next;
         }
         record_info($name, "Test result is the same as baseline\n[$c_id] $name $c_result", result => 'ok');
@@ -173,9 +180,14 @@ sub compare_run_log {
 # ERROR            PASS/FAIL    fail
 #
 sub _parse_results_with_diff_baseline {
-    my ($name, $result, $msg, $flag) = @_;
+    my ($name, $result, $msg, $flag, $is_expected_softfail) = @_;
     my $softfail_tests = {};
     if ($result eq 'PASS') {
+        record_info('Softfail', $msg, result => 'softfail');
+        $flag = 'softfail' if ($flag ne 'fail');
+    }
+    elsif ($is_expected_softfail) {
+        # If expected, record as softfail
         record_info('Softfail', $msg, result => 'softfail');
         $flag = 'softfail' if ($flag ne 'fail');
     }

--- a/schedule/security/cc_audit_remote.yaml
+++ b/schedule/security/cc_audit_remote.yaml
@@ -5,7 +5,7 @@ schedule:
     - installation/bootloader_start
     - security/boot_disk
     - '{{setup_multimachine}}'
-    - '{{cc_audit_test_setup}}'
+    - security/cc/cc_audit_test_setup
     - security/selinux/selinux_setup
     - security/cc/cc_selinux_setup
     - '{{disable_root_ssh}}'
@@ -17,10 +17,6 @@ conditional_schedule:
                 - network/setup_multimachine
             x86_64:
                 - network/setup_multimachine
-    cc_audit_test_setup:
-        ARCH:
-            s390x:
-                - security/cc/cc_audit_test_setup
     disable_root_ssh:
         ARCH:
             s390x:

--- a/tests/security/cc/audit_remote.pm
+++ b/tests/security/cc/audit_remote.pm
@@ -32,7 +32,7 @@ sub run {
     assert_script_run("ip addr add $server_ip/24 dev $netdev") if (is_s390x && $test_node eq 'server');
     assert_script_run("ip addr add $client_ip/24 dev $netdev") if (is_s390x && $test_node eq 'client');
 
-    prepare_for_test(make => 1, timeout => 900, make_netconfig => 1);
+    prepare_for_test(make => 1, timeout => 1200, make_netconfig => 1);
 
     # Export password of root
     assert_script_run("export PASSWD=$testapi::password");
@@ -41,10 +41,17 @@ sub run {
     assert_script_run('export SYSTEMD_PAGER=""');
 
     if ($test_node eq 'server') {
-        my $pid = background_script_run("$audit_test::test_dir/audit-test/utils/network-server/lblnet_tst_server");
+        # Redirect the test server's output to a log file.
+        my $server_log = '/tmp/tst_server.log';
+        my $pid = background_script_run(
+            "$audit_test::test_dir/audit-test/utils/network-server/lblnet_tst_server > $server_log 2>&1");
 
         mutex_create('AUDIT_REMOTE_SERVER_READY');
         wait_for_children;
+
+        # Shut the test server down so the serial console is responsive again
+        script_run("kill $pid; sleep 1; kill -9 $pid 2>/dev/null", timeout => 30);
+        upload_logs($server_log) if (script_run("test -s $server_log") == 0);
 
         # Delete the ip that we added if arch is s390x
         assert_script_run("ip addr del $server_ip/24 dev $netdev") if (is_s390x);
@@ -65,15 +72,30 @@ sub run {
         # result comparison will be done against the baseline when all the tests have run
         for (my $case = 0; $case < $ncases; $case++) {
             record_info "Running $test_name #$case ...";
-            script_run("./run.bash $case", timeout => 600);
+            script_run("./run.bash $case", timeout => 1200);
         }
         upload_audit_test_logs($test_name);
-        # The 4th and 5th may fail because the audit log is generated slowly in server, we need to rerun it again
-        assert_script_run('./run.bash 0', timeout => 600) if (script_run('grep -E "[0].*FAIL" rollup.log') == 0);
-        assert_script_run('./run.bash 4', timeout => 600) if (script_run('grep -E "[4].*FAIL" rollup.log') == 0);
-        assert_script_run('./run.bash 5', timeout => 600) if (script_run('grep -E "[5].*FAIL" rollup.log') == 0);
 
-        my $result = compare_run_log($test_name);
+        # Tests 4 and 5 may fail when run after test 3 because the audit log
+        # is generated slowly in server. Accept failures as softfail poo#197378
+        my %expected_softfail_ids = (4 => 1, 5 => 1);
+
+        # Collect which of the expected softfails actually failed,
+        # so we can attach a single softfail.
+        my $fail_output = script_output('grep -E "FAIL|ERROR" rollup.log', proceed_on_failure => 1);
+        my @soft_failed;
+        foreach my $line (split(/\n/, $fail_output)) {
+            # Test names can contain spaces, so match greedily up to the trailing result word.
+            if ($line =~ /\[(\d+)\]\s+(.*)\s+(FAIL|ERROR)\s*$/) {
+                my ($id, $name, $res) = ($1, $2, $3);
+                push @soft_failed, "[$id] $name $res" if $expected_softfail_ids{$id};
+            }
+        }
+        record_soft_failure("poo#197378 - expected failure(s): "
+              . join(', ', @soft_failed)
+              . " (server side error)") if @soft_failed;
+
+        my $result = compare_run_log($test_name, softfail_ids => \%expected_softfail_ids);
         $self->result($result);
 
         # Delete the ip that we added if arch is s390x


### PR DESCRIPTION
Tests 4 and 5 fail intermittently after test 3; downgrade to softfail. Also stop lblnet_tst_server to keep the serial console responsive.

- Related ticket: https://progress.opensuse.org/issues/197378
- Verification run: https://openqa.suse.de/group_overview/468 (runs with 20260528-1, the job group does not work correctly autonomously)