### PR TITLE
cleanup_known_coredumps: Remove entry for resolved bsc#1261625

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -181,10 +181,6 @@ sub cleanup_known_coredumps {
             cmdline => q(unzip-mem "" v files.zip),
             signals => [qw(FPE)],
         },
-        'bsc#1261625' => {
-            cmdline => q(gvfs-udisks2-volume-monitor),
-            signals => [qw(SEGV)],
-        },
         'bsc#1261358' => {
             cmdline => q(ovs-vswitchd unix:),
             signals => [qw(ABRT)],


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1261625 is fixed by  S:M:44524:412508 & S:M:44523:412506

Clean osd runs with no [known coredump notification](https://openqa.suse.de/tests/22537242#step/coredump_collect/20):
- 15-SP4: https://openqa.suse.de/tests/22594128
- 15-SP5: https://openqa.suse.de/tests/22593703
- 15-SP6: https://openqa.suse.de/tests/22593511
- 15-SP7: https://openqa.suse.de/tests/22593926

Latest:
- https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&groupid=421&test=mau-extratests-yast2ui
- https://openqa.suse.de/tests/overview?distri=sle&version=15-SP5&groupid=421&test=mau-extratests-yast2ui
- https://openqa.suse.de/tests/overview?distri=sle&version=15-SP6&groupid=421&test=mau-extratests-yast2ui
- https://openqa.suse.de/tests/overview?distri=sle&version=15-SP7&groupid=421&test=mau-extratests-yast2ui