### PR TITLE
openqa/webui/login: No login needed anymore with None auth

### DIFF
--- a/tests/openqa/webui/login.pm
+++ b/tests/openqa/webui/login.pm
@@ -10,7 +10,6 @@ use Mojo::Base 'x11test';
 use testapi;
 
 sub run {
-    assert_and_click 'openqa-login';
     assert_screen 'openqa-logged-in';
 }
 


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/201729
VR: https://openqa.opensuse.org/tests/5970734