### PR TITLE
rootless docker: Configure pull-through cache to avoid DockerHub rate-limits

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -203,6 +203,9 @@ sub configure_rootless_docker {
 
     run_command 'install -D -m 0600 <(echo {}) $HOME/.config/docker/daemon.json';
     if (script_output(q(docker --version | awk -F'[. ]' '{ print $3 }')) > 28) {
+        # Docker v29 increased minimum API version from 1.24 to 1.44 which broke some tests and stuff like
+        # docker-compose & container_diff and also some tests.  Docker v29.3 lowered it from 1.44 to 1.40.
+        # Remove this when we no longer have Docker v29.2 in SLES 16.1.
         my $docker_min_api_version = get_var("DOCKER_MIN_API_VERSION", "1.24");
         run_command qq(echo '{"min-api-version": "$docker_min_api_version"}' > \$HOME/.config/docker/daemon.json);
     }

--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -201,11 +201,13 @@ sub configure_rootless_docker {
 
     switch_to_user;
 
+    run_command 'install -D -m 0600 <(echo {}) $HOME/.config/docker/daemon.json';
     if (script_output(q(docker --version | awk -F'[. ]' '{ print $3 }')) > 28) {
-        run_command 'mkdir -p ${XDG_CONFIG_HOME:-$HOME/.config}/docker';
         my $docker_min_api_version = get_var("DOCKER_MIN_API_VERSION", "1.24");
-        run_command qq(echo '{"min-api-version": "$docker_min_api_version"}' > \${XDG_CONFIG_HOME:-\$HOME/.config}/docker/daemon.json);
+        run_command qq(echo '{"min-api-version": "$docker_min_api_version"}' > \$HOME/.config/docker/daemon.json);
     }
+    run_command qq(DAEMON_JSON=\$(jq '.+{"registry-mirrors": ["http://$registry"]}' \$HOME/.config/docker/daemon.json));
+    run_command q(tee $HOME/.config/docker/daemon.json <<< "$DAEMON_JSON");
 
     # https://docs.docker.com/engine/security/rootless/
     run_command "dockerd-rootless-setuptool.sh install";


### PR DESCRIPTION
Failed job: https://openqa.opensuse.org/tests/5972733
Verification run: https://openqa.opensuse.org/tests/5972907