### PR TITLE
Revert "clamav_upgrade: Update all clamav packages"

### DIFF
--- a/tests/console/clamav_upgrade.pm
+++ b/tests/console/clamav_upgrade.pm
@@ -36,7 +36,7 @@ sub run {
     validate_script_output("clamscan --version", qr/ClamAV $ver/);
 
     # Upgrade to the latest version available in the repo
-    zypper_call("up @pkgs", timeout => 300);
+    zypper_call("up clamav", timeout => 300);
 
     # Verify the upgrade was successful
     my $new_version = script_output("clamscan --version | awk '{print \$2}' | cut -d/ -f1");


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#25607
* Related ticket: https://progress.opensuse.org/issues/196760
* Verified : https://openqa.suse.de/tests/22604407#step/clamav_upgrade/18 (12-sp3)
                    https://openqa.suse.de/tests/22604399#step/clamav_upgrade/18 (12-sp5)