### PR TITLE
Skip samba_adcli test as qamaster is down

### DIFF
--- a/schedule/functional/sle16/extra_tests_textmode2.yaml
+++ b/schedule/functional/sle16/extra_tests_textmode2.yaml
@@ -34,5 +34,5 @@ schedule:
     - console/zypper_log_packages
     - console/rabbitmq
     - console/libxslt
-    - network/samba/samba_adcli
+    # - network/samba/samba_adcli
     - shutdown/shutdown

--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -27,7 +27,7 @@ schedule:
   - console/aaa_base
   - console/gd
   - console/vsftpd
-  - network/samba/samba_adcli
+  # - network/samba/samba_adcli
   - console/pciutils
   - '{{version_specific}}'
   - console/coredump_collect


### PR DESCRIPTION
Will add the test back once sever is back

- Verification run: n/a