### PR TITLE
feat: Allow including PR number in `VERSION`

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -135,6 +135,13 @@ sub init_main {
         my $errors = verify_checksum();
         set_var('CHECKSUM_FAILED', $errors) if $errors;
     }
+    # allow scheduling jobs with e.g. `VERSION=16.0:gitea:pr:1234` instead of just `VERSION=16.0`
+    # note: This is useful because then jobs for individual submissions are not wrongly considered
+    #       to be for consecutive builds and e.g. wrong bugref carry over is avoided.
+    if (my $version = get_var('VERSION')) {
+        set_var('VERSION_ORIGINAL', $version);
+        set_var('VERSION', $version =~ s/:(?:(git|smelt)[-:])?(?:pr[-:])\d+$//rgi);
+    }
 }
 
 sub loadtest {


### PR DESCRIPTION
This will allow us to create jobs with e.g. `VERSION=15.7:PR-0815` or `VERSION=16.0:gitea:pr:1234` instead of just `VERSION=15.7` or `VERSION=16.0`. This is useful because then jobs for individual submissions are not wrongly considered to be for consecutive builds and e.g. wrong carry over is avoided.

To be able to schedule jobs with such a version via job templates the openQA change https://github.com/os-autoinst/openQA/pull/7489 is needed.

I tested this change by cloning a job from the "scenario" https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=opensuse&flavor=staged-Updates&machine=uefi-3G&test=gnome-agama&version=16.0 with `VERSION+=:gitea:pr:2069`. Without this change it failed in the Agama product selection, probably because checks like `is_leap('>16.0')` no longer worked. With this change the test no longer ran into those problems and `vars.json` contained just the main version `VERSION=16.0`.

Related ticket: https://progress.opensuse.org/issues/200991