### PR TITLE
Fix CI with new Debian 13 (Trixie) image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         apt-get -y update
         apt-get -y install libdbus-1-dev libssh2-1-dev parallel python3-dev python3-yaml python3-jsonschema python3-pip liblua5.3-dev
-        pip3 install yamllint jsonnet==0.20.0
+        PIP_BREAK_SYSTEM_PACKAGES=1 CFLAGS="-Wno-implicit-function-declaration -Wno-int-conversion" pip3 install yamllint jsonnet==0.22.0
         # FFI needs cargo (newer than the packaged version)
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     - name: Setup perl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,24 +9,23 @@ jobs:
       matrix:
         include:
           - test: static
-            perl-version: 5.32
+            perl-version: '5.40'
           - test: unit
-            perl-version: 5.32
+            perl-version: '5.40'
           - test: compile-changed
-            perl-version: 5.26
+            perl-version: '5.40'
           - test: compile
-            perl-version: 5.26
+            perl-version: '5.40'
           - test: compile-os-autoinst
             perl-version: '5.40'
           - test: check-strict
-            perl-version: '5.40'
+            perl-version: '5.42'
     container:
       image: perldocker/perl-tester:${{ matrix.perl-version }}
     steps:
     - uses: actions/checkout@v6
     - name: Install dependencies
       run: |
-        sed -ri '/buster/s/(deb|security)\.debian\.org/archive.debian.org/' /etc/apt/sources.list
         apt-get -y update
         apt-get -y install libdbus-1-dev libssh2-1-dev parallel python3-dev python3-yaml python3-jsonschema python3-pip liblua5.3-dev
         pip3 install yamllint jsonnet==0.20.0

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ prepare:
 	git clone https://github.com/os-autoinst/os-autoinst.git
 	./tools/wheel --fetch
 	$(MAKE) check-links
-	cd os-autoinst && cpanm -nq --installdeps .
-	cpanm -nq --installdeps .
+	# https://rt.cpan.org/Ticket/Display.html?id=133363
+	cd os-autoinst && PERL_MM_OPT="OPTIMIZE=-Wno-error=implicit-function-declaration" cpanm -v -nq --installdeps .
+	PERL_MM_OPT="OPTIMIZE=-Wno-error=implicit-function-declaration" cpanm -v -nq --installdeps .
 
 os-autoinst/:
 	@test -d os-autoinst || (echo "Missing test requirements, \

--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -23,7 +23,7 @@ use testapi;
 use utils;
 use Utils::Backends 'is_remote_backend';
 use power_action_utils 'power_action';
-use y2snapper_common qw(y2snapper_close_snapper_module);
+use y2snapper_common;
 use x11utils 'default_gui_terminal';
 use version_utils;
 


### PR DESCRIPTION
- Use Perl 5.40.  See discussion in https://suse.slack.com/archives/C02CANHLANP/p1780309883139409
- Work around gcc pedantic warnings that prevent compilation.
- Pass PIP_BREAK_SYSTEM_PACKAGES=1 to pip to allow `pip install`

Failed CI: https://github.com/os-autoinst/os-autoinst-distri-opensuse/actions/runs/26749232203/job/78833339724