### PR TITLE
CI: Add missing libxml2-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get -y update
-        apt-get -y install libdbus-1-dev libssh2-1-dev parallel python3-dev python3-yaml python3-jsonschema python3-pip liblua5.3-dev
+        apt-get -y install libdbus-1-dev libssh2-1-dev libxml2-dev parallel python3-dev python3-yaml python3-jsonschema python3-pip liblua5.3-dev
         PIP_BREAK_SYSTEM_PACKAGES=1 CFLAGS="-Wno-implicit-function-declaration -Wno-int-conversion" pip3 install yamllint jsonnet==0.22.0
         # FFI needs cargo (newer than the packaged version)
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
Otherwise CI may fail with:
`fatal error: libxml/xmlversion.h: No such file or directory`

https://github.com/os-autoinst/os-autoinst-distri-opensuse/actions/runs/26777996414/job/78934625667?pr=25688