### PR TITLE
feat(PC_DMS): Make DMS repository optional

### DIFF
--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -35,10 +35,10 @@ sub run {
         # LTSS should be disabled before the migration
         $instance->ssh_assert_script_run("sudo SUSEConnect -d -p SLES-LTSS/12.5/x86_64", timeout => 180);
 
-        $instance->ssh_assert_script_run("sudo zypper -n -p 110 ar -Gef " . get_required_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_12_SP5 Migration");
+        $instance->ssh_assert_script_run("sudo zypper -n -p 110 ar -Gef " . get_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_12_SP5 Migration") if (get_var("PUBLIC_CLOUD_DMS_REPO"));
         $instance->ssh_script_run("sudo zypper -n ref", timeout => 1800) if (is_ec2());
         $instance->ssh_assert_script_run("sudo timeout -k 15 $migration_timeout zypper -n in SLES15-Migration suse-migration-sle15-activation", timeout => $migration_timeout + 30);
-        $instance->ssh_assert_script_run("sudo zypper -n rr Migration", timeout => 900);
+        $instance->ssh_assert_script_run("sudo zypper -n rr Migration", timeout => 900) if (get_var("PUBLIC_CLOUD_DMS_REPO"));
         $instance->ssh_assert_script_run("sudo zypper refresh-services --force", timeout => 180);
 
         # Disable maintenance updates for the migration as directory is not available during it
@@ -65,10 +65,10 @@ sub run {
             $instance->ssh_assert_script_run(qq(echo -e "network:\\n    wicked2nm-continue-migration: true\\n" | sudo tee -a /etc/sle-migration-service.yml));
         }
 
-        $instance->ssh_assert_script_run("sudo zypper -n -p 110 ar -Gef " . get_required_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_15_SP7 Migration");
+        $instance->ssh_assert_script_run("sudo zypper -n -p 110 ar -Gef " . get_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_15_SP7 Migration") if (get_var("PUBLIC_CLOUD_DMS_REPO"));
         $instance->ssh_script_run("sudo zypper -n ref", timeout => 1800) if (is_ec2());
         $instance->ssh_assert_script_run("sudo timeout -k 15 $migration_timeout zypper -n in SLES16-Migration suse-migration-sle16-activation", timeout => $migration_timeout + 30);
-        $instance->ssh_assert_script_run("sudo zypper -n rr Migration", timeout => 900);
+        $instance->ssh_assert_script_run("sudo zypper -n rr Migration", timeout => 900) if (get_var("PUBLIC_CLOUD_DMS_REPO"));
         $instance->ssh_assert_script_run("sudo zypper refresh-services --force", timeout => 180);
 
         # Disable maintenance updates for the migration as directory is not available during it

--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -15,7 +15,6 @@ use version_utils 'is_sle';
 use publiccloud::ssh_interactive "select_host_console";
 use publiccloud::utils qw(is_ec2 is_gce is_azure registercloudguest);
 
-
 sub run {
     my ($self, $args) = @_;
     my $migration_timeout = 2401;
@@ -32,8 +31,8 @@ sub run {
         $instance->ssh_script_run("sudo zypper -n rm aws-cli", timeout => 900) if (is_ec2());
         $instance->ssh_script_run("sudo zypper -n rm azure-cli python3-azure-devops python3-azure-nspkg", timeout => 900) if (is_azure());
 
-        # LTSS should be disabled before the migration
-        $instance->ssh_assert_script_run("sudo SUSEConnect -d -p SLES-LTSS/12.5/x86_64", timeout => 180);
+        # LTSS should be disabled before the migration if registered
+        $instance->ssh_script_run("sudo SUSEConnect -d -p SLES-LTSS/12.5/x86_64", timeout => 180);
 
         $instance->ssh_assert_script_run("sudo zypper -n -p 110 ar -Gef " . get_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_12_SP5 Migration") if (get_var("PUBLIC_CLOUD_DMS_REPO"));
         $instance->ssh_script_run("sudo zypper -n ref", timeout => 1800) if (is_ec2());
@@ -42,7 +41,7 @@ sub run {
         $instance->ssh_assert_script_run("sudo zypper refresh-services --force", timeout => 180);
 
         # Disable maintenance updates for the migration as directory is not available during it
-        $instance->ssh_script_run("sudo sudo sed -i 's/^enabled=1/enabled=0/' /etc/zypp/repos.d/SUSE_Maintenance_*");
+        $instance->ssh_script_run("sudo sed -i 's/^enabled=1/enabled=0/' /etc/zypp/repos.d/SUSE_Maintenance_*");
 
         # Reboot to run the migration
         $instance->softreboot(check_connectivity => 0, timeout => 3600);
@@ -53,7 +52,7 @@ sub run {
         record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
 
         # Re-enable maintenance updates for the migration
-        $instance->ssh_script_run("sudo sudo sed -i 's/^enabled=0/enabled=1/' /etc/zypp/repos.d/SUSE_Maintenance_*");
+        $instance->ssh_script_run("sudo sed -i 's/^enabled=0/enabled=1/' /etc/zypp/repos.d/SUSE_Maintenance_*");
 
         # Try to install aws-cli and azure-cli as they were removed for the migration
         $instance->ssh_script_run("sudo zypper -n ref", timeout => 1800) if (is_ec2());
@@ -76,11 +75,38 @@ sub run {
         $instance->ssh_assert_script_run("sudo zypper refresh-services --force", timeout => 180);
 
         # Disable maintenance updates for the migration as directory is not available during it
-        $instance->ssh_script_run("sudo sudo sed -i 's/^enabled=1/enabled=0/' /etc/zypp/repos.d/SUSE_Maintenance_*");
+        $instance->ssh_script_run("sudo sed -i 's/^enabled=1/enabled=0/' /etc/zypp/repos.d/SUSE_Maintenance_*");
 
         my $arch = get_required_var('ARCH');
-        $instance->ssh_script_run("echo 'migration_product: SLES/16.0/$arch\\n' | sudo tee -a /etc/sle-migration-service.yml");
+        $instance->ssh_assert_script_run("echo 'migration_product: SLES/16.0/$arch' | sudo tee -a /etc/sle-migration-service.yml");
         $instance->ssh_script_run("cat /etc/sle-migration-service.yml");
+
+        # Deregister modules with no SLE 16.0 equivalents on the cloud SMT.
+        # Each module needs two steps:
+        #   1. SUSEConnect -d  — server-side; prevents HTTP 422 from zypper migration.
+        #   2. zypper removeservice — local; prevents exit 104 (no provider found).
+        # Order matters: dependents before dependencies, as SUSEConnect -d rejects
+        # removal while dependent modules are still registered.
+        # sle-module-basesystem and sle-module-server-applications exist in 16.0 and are kept.
+        my @modules_to_remove = (
+            # Dependents first
+            ['sle-module-development-tools', 'Development_Tools_Module_x86_64'],
+            ['sle-module-legacy', 'Legacy_Module_x86_64'],
+            ['sle-module-systems-management', 'Systems_Management_Module_x86_64'],
+            ['sle-module-web-scripting', 'Web_and_Scripting_Module_x86_64'],
+            # Dependencies last
+            ['sle-module-desktop-applications', 'Desktop_Applications_Module_x86_64'],
+            ['sle-module-python3', 'Python_3_Module_x86_64'],
+        );
+        my @removed;
+        for my $entry (@modules_to_remove) {
+            my ($module, $svc) = @{$entry};
+            $instance->ssh_script_run("sudo SUSEConnect -d -p $module/15.7/$arch", timeout => 120);
+            my $ret = $instance->ssh_script_run("sudo zypper -n removeservice $svc", timeout => 120);
+            push @removed, $svc if $ret == 0;
+        }
+        record_info('Removed services', join("\n", @removed) || 'none');
+        record_info('SUSEConnect post-removal', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 120));
 
         # Reboot to run the migration
         $instance->softreboot(check_connectivity => 0, timeout => 3600);

--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -48,6 +48,8 @@ sub run {
         $instance->softreboot(check_connectivity => 0, timeout => 3600);
         $instance->wait_for_ssh();
         validate_version($instance);
+
+        # Reboot again so the system will freshly boot into the new system
         $instance->softreboot(check_connectivity => 0, timeout => 3600);
         $instance->wait_for_ssh();
         record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
@@ -113,6 +115,8 @@ sub run {
         $instance->softreboot(check_connectivity => 0, timeout => 3600);
         $instance->wait_for_ssh();
         validate_version($instance);
+
+        # Reboot again so the system will freshly boot into the new system
         $instance->softreboot(check_connectivity => 0, timeout => 3600);
         $instance->wait_for_ssh();
         record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));

--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -46,11 +46,11 @@ sub run {
 
         # Reboot to run the migration
         $instance->softreboot(check_connectivity => 0, timeout => 3600);
-	$instance->wait_for_ssh();
+        $instance->wait_for_ssh();
         validate_version($instance);
         $instance->softreboot(check_connectivity => 0, timeout => 3600);
-	$instance->wait_for_ssh();
-	record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
+        $instance->wait_for_ssh();
+        record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
 
         # Re-enable maintenance updates for the migration
         $instance->ssh_script_run("sudo sudo sed -i 's/^enabled=0/enabled=1/' /etc/zypp/repos.d/SUSE_Maintenance_*");
@@ -84,11 +84,11 @@ sub run {
 
         # Reboot to run the migration
         $instance->softreboot(check_connectivity => 0, timeout => 3600);
-	$instance->wait_for_ssh();
+        $instance->wait_for_ssh();
         validate_version($instance);
         $instance->softreboot(check_connectivity => 0, timeout => 3600);
-	$instance->wait_for_ssh();
-	record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
+        $instance->wait_for_ssh();
+        record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
     }
 }
 

--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -14,6 +14,7 @@ use Time::Piece;
 use version_utils 'is_sle';
 use publiccloud::ssh_interactive "select_host_console";
 use publiccloud::utils qw(is_ec2 is_gce is_azure registercloudguest);
+use publiccloud::zypper qw(pc_zypper_call pc_refresh);
 
 sub run {
     my ($self, $args) = @_;
@@ -28,17 +29,17 @@ sub run {
     if (is_sle('=12-SP5')) {
         # https://bugzilla.suse.com/show_bug.cgi?id=1230009
         # aws-cli and azure-cli break the migration. This is known issue.
-        $instance->ssh_script_run("sudo zypper -n rm aws-cli", timeout => 900) if (is_ec2());
-        $instance->ssh_script_run("sudo zypper -n rm azure-cli python3-azure-devops python3-azure-nspkg", timeout => 900) if (is_azure());
+        pc_zypper_call($instance, "rm aws-cli", timeout => 900, proceed_on_failure => 1) if (is_ec2());
+        pc_zypper_call($instance, "rm azure-cli python3-azure-devops python3-azure-nspkg", timeout => 900, proceed_on_failure => 1) if (is_azure());
 
         # LTSS should be disabled before the migration if registered
         $instance->ssh_script_run("sudo SUSEConnect -d -p SLES-LTSS/12.5/x86_64", timeout => 180);
 
-        $instance->ssh_assert_script_run("sudo zypper -n -p 110 ar -Gef " . get_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_12_SP5 Migration") if (get_var("PUBLIC_CLOUD_DMS_REPO"));
-        $instance->ssh_script_run("sudo zypper -n ref", timeout => 1800) if (is_ec2());
-        $instance->ssh_assert_script_run("sudo timeout -k 15 $migration_timeout zypper -n in SLES15-Migration suse-migration-sle15-activation", timeout => $migration_timeout + 30);
-        $instance->ssh_assert_script_run("sudo zypper -n rr Migration", timeout => 900) if (get_var("PUBLIC_CLOUD_DMS_REPO"));
-        $instance->ssh_assert_script_run("sudo zypper refresh-services --force", timeout => 180);
+        pc_zypper_call($instance, "-p 110 ar -fG " . get_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_12_SP5 Migration") if (get_var("PUBLIC_CLOUD_DMS_REPO"));
+        pc_refresh($instance, timeout => 1800) if (is_ec2());
+        pc_zypper_call($instance, "in SLES15-Migration suse-migration-sle15-activation", timeout => $migration_timeout + 30);
+        pc_zypper_call($instance, "rr Migration", timeout => 900) if (get_var("PUBLIC_CLOUD_DMS_REPO"));
+        pc_zypper_call($instance, "refresh-services --force", timeout => 180);
 
         # Disable maintenance updates for the migration as directory is not available during it
         $instance->ssh_script_run("sudo sed -i 's/^enabled=1/enabled=0/' /etc/zypp/repos.d/SUSE_Maintenance_*");
@@ -55,9 +56,9 @@ sub run {
         $instance->ssh_script_run("sudo sed -i 's/^enabled=0/enabled=1/' /etc/zypp/repos.d/SUSE_Maintenance_*");
 
         # Try to install aws-cli and azure-cli as they were removed for the migration
-        $instance->ssh_script_run("sudo zypper -n ref", timeout => 1800) if (is_ec2());
-        $instance->ssh_assert_script_run("sudo zypper -n in aws-cli", timeout => 1800) if (is_ec2());
-        $instance->ssh_assert_script_run("sudo zypper -n in azure-cli", timeout => 1800) if (is_azure());
+        pc_refresh($instance, timeout => 1800) if (is_ec2());
+        pc_zypper_call($instance, "in aws-cli", timeout => 1800) if (is_ec2());
+        pc_zypper_call($instance, "in azure-cli", timeout => 1800) if (is_azure());
     }
 
     if (is_sle('=15-SP7')) {
@@ -68,11 +69,11 @@ sub run {
             $instance->ssh_assert_script_run(qq(echo -e "network:\\n    wicked2nm-continue-migration: true\\n" | sudo tee -a /etc/sle-migration-service.yml));
         }
 
-        $instance->ssh_assert_script_run("sudo zypper -n -p 110 ar -Gef " . get_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_15_SP7 Migration") if (get_var("PUBLIC_CLOUD_DMS_REPO"));
-        $instance->ssh_script_run("sudo zypper -n ref", timeout => 1800) if (is_ec2());
-        $instance->ssh_assert_script_run("sudo timeout -k 15 $migration_timeout zypper -n in SLES16-Migration suse-migration-sle16-activation", timeout => $migration_timeout + 30);
-        $instance->ssh_assert_script_run("sudo zypper -n rr Migration", timeout => 900) if (get_var("PUBLIC_CLOUD_DMS_REPO"));
-        $instance->ssh_assert_script_run("sudo zypper refresh-services --force", timeout => 180);
+        pc_zypper_call($instance, "-p 110 ar -fG " . get_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_15_SP7 Migration") if (get_var("PUBLIC_CLOUD_DMS_REPO"));
+        pc_refresh($instance, timeout => 1800) if (is_ec2());
+        pc_zypper_call($instance, "in SLES16-Migration suse-migration-sle16-activation", timeout => $migration_timeout + 30);
+        pc_zypper_call($instance, "rr Migration", timeout => 900) if (get_var("PUBLIC_CLOUD_DMS_REPO"));
+        pc_zypper_call($instance, "refresh-services --force", timeout => 180);
 
         # Disable maintenance updates for the migration as directory is not available during it
         $instance->ssh_script_run("sudo sed -i 's/^enabled=1/enabled=0/' /etc/zypp/repos.d/SUSE_Maintenance_*");
@@ -102,7 +103,7 @@ sub run {
         for my $entry (@modules_to_remove) {
             my ($module, $svc) = @{$entry};
             $instance->ssh_script_run("sudo SUSEConnect -d -p $module/15.7/$arch", timeout => 120);
-            my $ret = $instance->ssh_script_run("sudo zypper -n removeservice $svc", timeout => 120);
+            my $ret = pc_zypper_call($instance, "removeservice $svc", timeout => 120, proceed_on_failure => 1);
             push @removed, $svc if $ret == 0;
         }
         record_info('Removed services', join("\n", @removed) || 'none');

--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -45,8 +45,12 @@ sub run {
         $instance->ssh_script_run("sudo sudo sed -i 's/^enabled=1/enabled=0/' /etc/zypp/repos.d/SUSE_Maintenance_*");
 
         # Reboot to run the migration
-        $instance->softreboot(timeout => 3600);
+        $instance->softreboot(check_connectivity => 0, timeout => 3600);
+	$instance->wait_for_ssh();
         validate_version($instance);
+        $instance->softreboot(check_connectivity => 0, timeout => 3600);
+	$instance->wait_for_ssh();
+	record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
 
         # Re-enable maintenance updates for the migration
         $instance->ssh_script_run("sudo sudo sed -i 's/^enabled=0/enabled=1/' /etc/zypp/repos.d/SUSE_Maintenance_*");
@@ -79,8 +83,12 @@ sub run {
         $instance->ssh_script_run("cat /etc/sle-migration-service.yml");
 
         # Reboot to run the migration
-        $instance->softreboot(timeout => 3600);
+        $instance->softreboot(check_connectivity => 0, timeout => 3600);
+	$instance->wait_for_ssh();
         validate_version($instance);
+        $instance->softreboot(check_connectivity => 0, timeout => 3600);
+	$instance->wait_for_ssh();
+	record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
     }
 }
 

--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -49,7 +49,7 @@ sub run {
         $instance->wait_for_ssh();
         validate_version($instance);
 
-        # Reboot again so the system will freshly boot into the new system
+        # Second reboot as it has been recommended by the DMS package maintainer
         $instance->softreboot(check_connectivity => 0, timeout => 3600);
         $instance->wait_for_ssh();
         record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));

--- a/variables.md
+++ b/variables.md
@@ -335,7 +335,7 @@ PUBLIC_CLOUD_CONTAINERS | boolean | false | If set, containers tests are added t
 PUBLIC_CLOUD_HIMMELBLAU | boolean | false | Scheduling variable for running the himmelblau tests.
 PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY | string | "" | Name for public cloud registry for the container images used on kubernetes tests.
 PUBLIC_CLOUD_CREDENTIALS_URL | string | "" | Base URL where to get the credentials from. This will be used to compose the full URL together with `PUBLIC_CLOUD_NAMESPACE`.
-PUBLIC_CLOUD_DMS_REPO | string | "" | The Repo URL for migration test.
+PUBLIC_CLOUD_DMS_REPO | string | "" | Optional. The Repo URL for migration test. If not set, migration packages will be installed from default repositories without adding a custom migration repository.
 PUBLIC_CLOUD_DOWNLOAD_TESTREPO | boolean | false | If set, it schedules `publiccloud/download_repos` job.
 PUBLIC_CLOUD_EC2_BOOT_MODE | string | "uefi-preferred" | The `--boot-mode` parameter for `ec2uploadimg` script. Available values: `legacy-bios`, `uefi`, `uefi-preferred` Currently unused variable. Use `git blame` to get context.
 PUBLIC_CLOUD_EC2_IPV6_ADDRESS_COUNT | string | 0 | How many IPv6 addresses should the instance have


### PR DESCRIPTION
This PR includes two improvements to public cloud migration testing:

## 1. Make DMS repository optional
Now the `PUBLIC_CLOUD_DMS_REPO` variable is optional. In that case, no repo will be added nor removed.

## 2. Improve migration verification and reboot handling
- Explicitly wait for SSH availability after each reboot
- Add additional reboot after the system is successfully migrated
- Record SUSEConnect status to aid in debugging migration issues

## 3. Deregister modules with no SLE 16.0 equivalents on the cloud SMT
Each module needs two steps:
1. SUSEConnect -d  — server-side; prevents HTTP 422 from zypper migration.
2. zypper removeservice — local; prevents exit 104 (no provider found).

---

- Related ticket: [poo#201819](https://progress.opensuse.org/issues/201819)
- Verification rus:
[Build20260616-1](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=20260616-1&distri=sle&version=12-SP5) of sle-12-SP5-Azure-BYOS-Updates.x86_64	[publiccloud_migration_skipMU_@64bit](https://pdostal-workbench.qe.prg2.suse.org/tests/727)
[Build20260616-1](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=20260616-1&distri=sle&version=15-SP7) of sle-15-SP7-Azure-BYOS-Updates.aarch64	[publiccloud_migration@64bit](https://pdostal-workbench.qe.prg2.suse.org/tests/731)
[Build20260616-1](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=20260616-1&distri=sle&version=12-SP5) of sle-12-SP5-GCE-BYOS-Updates.x86_64	[publiccloud_migration_skipMU_@64bit](https://pdostal-workbench.qe.prg2.suse.org/tests/725)
[Build20260616-1](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=20260616-1&distri=sle&version=12-SP5) of sle-12-SP5-GCE-BYOS-Updates.x86_64	[publiccloud_migration@64bit](https://pdostal-workbench.qe.prg2.suse.org/tests/718)
[Build20260616-1](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=20260616-1&distri=sle&version=12-SP5) of sle-12-SP5-Azure-BYOS-Updates.x86_64	[publiccloud_migration@64bit](https://pdostal-workbench.qe.prg2.suse.org/tests/717)