### PR TITLE
feat(Git): Introduce local git hooks config

### DIFF
--- a/.githooks.config
+++ b/.githooks.config
@@ -1,0 +1,3 @@
+[hook "commit-message-linter"]
+    event = commit-msg
+    command = gitlint --msg-filename "$1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,20 @@ local::lib, or others), from within the working copy: call
 
 * For linting YAML, you need the openSUSE package `python3-yamllint` or install `yamllint` via pip
 
+#### Optional: Enable local git hooks
+
+Starting with git 2.54.0, you can enable local git hooks that automatically validate your commits before they are created. This provides immediate feedback and helps avoid CI failures later.
+
+To enable the optional commit message linter hook:
+
+```
+git config --local include.path ../.githooks.config
+```
+
+```
+git config --local --unset include.path
+```
+
 #### Relevant documentation
 
 * All openQA documentation in a single [html page](https://open.qa/docs/)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ In case of adding new test for Installation, please use approach described in th
 ## How to contribute
 Please, refer to [Contributing Guide](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/CONTRIBUTING.md)
 
+**Tip:** You can enable optional local git hooks for automatic commit message validation (requires git 2.54.0+). See the Contributing Guide for setup instructions.
+
 ## How to get in touch
 Reach us via https://open.qa/contact, we are also on twitter as https://twitter.com/openQAhq
 


### PR DESCRIPTION
This feature is available only from `git-2.54.0` and is **opt-in**.

For now, it runs just `gitlint --msg-filename "$1"` which we already do in GitHub Actions.
The benefit of this is that user gets feedback earlier instead of waiting several minutes for GitHub.