### PR TITLE
Revert "Revert "clamav_upgrade: Update all clamav packages""

### DIFF
--- a/tests/console/clamav_upgrade.pm
+++ b/tests/console/clamav_upgrade.pm
@@ -36,7 +36,7 @@ sub run {
     validate_script_output("clamscan --version", qr/ClamAV $ver/);
 
     # Upgrade to the latest version available in the repo
-    zypper_call("up clamav", timeout => 300);
+    zypper_call("up @pkgs", timeout => 300);
 
     # Verify the upgrade was successful
     my $new_version = script_output("clamscan --version | awk '{print \$2}' | cut -d/ -f1");


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#25679

Workaround for https://bugzilla.suse.com/show_bug.cgi?id=1267420

VR: https://openqa.suse.de/tests/22640547