### PR TITLE
docker_engine: Add xfail for Docker v29.4 on SLES 15

### DIFF
--- a/tests/containers/docker_engine.pm
+++ b/tests/containers/docker_engine.pm
@@ -120,6 +120,10 @@ sub run {
             "github.com/moby/moby/v2/integration/container::TestHealthKillContainer",
             "github.com/moby/moby/v2/integration/service::TestRestoreIngressRulesOnFirewalldReload",
         );
+        # This may fail on SLES 15 due to older version of rootlesskit (1.1.1)
+        push @xfails, (
+            "github.com/moby/moby/v2/integration/container::TestNetworkLoopbackNat",
+        ) if (is_sle("<16") && get_var("ROOTLESS"));
     } else {
         # These fail on Docker v28:
         push @xfails, (


### PR DESCRIPTION
Docker v29.4 is landing on SLES 15 and we already have this xfailure for Docker v28 [here](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/containers/docker_engine.pm#L128). 

Failed jobs:
- 15-SP6: https://openqa.suse.de/tests/22639034
- 15-SP7: https://openqa.suse.de/tests/22639064 