### PR TITLE
Restore to setup environment of scc_url for sle160 migration testing

### DIFF
--- a/tests/yam/migration/restore_upgrade_env.pm
+++ b/tests/yam/migration/restore_upgrade_env.pm
@@ -13,7 +13,7 @@ use migration 'reset_consoles_tty';
 sub run {
     # Restore the original value of the variables
     my $env_content = '';
-    foreach my $var (qw(AGAMA BETA SCC_ADDONS VERSION)) {
+    foreach my $var (qw(AGAMA BETA SCC_ADDONS SCC_URL VERSION)) {
         if (get_var($var . "_ENV")) {
             set_var($var, get_var($var . "_ENV"));
             $env_content .= "$var=" . get_var($var) . "\n";

--- a/tests/yam/migration/setup_upgrade_env.pm
+++ b/tests/yam/migration/setup_upgrade_env.pm
@@ -19,9 +19,10 @@ sub run {
       get_var('SCC_ADDONS_UPGRADE_FROM',
         get_var('SCC_ADDONS_UPGRADE_TO',
             get_var('SCC_ADDONS')));
+    my $scc_url = get_var('SCC_URL');
 
     # Save the original value of the variables in order to restore it later if needed
-    foreach my $var (qw(AGAMA BETA SCC_ADDONS VERSION)) {
+    foreach my $var (qw(AGAMA BETA SCC_ADDONS SCC_URL VERSION)) {
         set_var($var . "_ENV", get_var($var)) if (get_var($var));
     }
 
@@ -30,6 +31,7 @@ sub run {
         AGAMA => $agama,
         BETA => '0',
         SCC_ADDONS => $scc_addons,
+        SCC_URL => (($version =~ /^(\d+)/ && $1 < 16) ? $scc_url : 'https://scc.suse.com'),
         VERSION => $version,
     );
     my $env_content = '';


### PR DESCRIPTION
The SLES15SPx migration testings are using a different proxySCC url compareing with SLE16.0 migration testings. For SLES15SPx, the new url could register both 15SPx and target product, so they don't need to resetup SCC_URL before or after migration; while the SLE16.0 cases are using the old proxySCC url, they still need to set the SCC_URL to https://scc.suse.com before migration.

- To fix failure: https://openqa.suse.de/tests/22647152#step/agama_auto/1
- Verification run: [SLES16.1_Production](https://openqa.suse.de/tests/overview?version=16.1&distri=sle&build=chcao_45.1) || [SLES16.0_Increments](https://openqa.suse.de/tests/overview?build=chcao_45.1&distri=sle&version=16.0)
