### PR TITLE
fix(rebootmgr) Immutable images support soft-reboot

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -86,14 +86,14 @@ sub check_reboot_strategy_and_reboot {
     # as this will likely grow, it is better to have single line checks to give room to more
     # complex expressions
     my $has_soft_reboot = 1;
-    $has_soft_reboot = 0 if (is_sle_micro || is_sle);
+    $has_soft_reboot = 0 if (is_sle_micro || is_sle('<16.1'));
 
     if ($has_soft_reboot) {
-        my $regex = qr/Minimally required reboot level:\s(.*)[\r\n]/;
+        my $regex = qr/Minimally required reboot level:\s([a-zA-Z-]+)/;
         my $output = wait_serial($regex, timeout => 300) or die "Could not capture reboot type";
         if ($output =~ $regex) {
             @reboot_args = (expected_grub => 0) if $1 eq 'soft-reboot';
-            record_info("Reboot strategy: $1");
+            record_info("Reboot strategy", "$1");
         }
     }
     process_reboot(@reboot_args);


### PR DESCRIPTION
trup calls can trigger soft reboot of the SUT.

```
transactional-update[2355]: Options: --log=console reboot auto
transactional-update[2355]: Minimally required reboot level: soft-reboot
transactional-update[2355]: Triggering reboot using rebootmgrctl soft-reboot.
transactional-update[2355]: Transaction completed.
```

- Verification run: https://openqa.suse.de/tests/22685861#step/rebootmgr/21


Disclaimer: The regex was fine, I was mislead by the empty custom field of the `record_info`. Although, since I have made it less greedy, maybe we can keep it. No objections if I should revert it back 
