### PR TITLE
fix(gitlint): Fix git hook syntax

### DIFF
--- a/.githooks.config
+++ b/.githooks.config
@@ -1,3 +1,3 @@
 [hook "commit-message-linter"]
     event = commit-msg
-    command = gitlint --msg-filename "$1"
+    command = gitlint --verbose --msg-filename 


### PR DESCRIPTION
After rebase I found error with #25698

The output now looks like this:
```bash
$ g commit -am "fix(gitlint): Fix git hook syntax"
[gitlint ac5b84a57e] fix(gitlint): Fix git hook syntax
 1 file changed, 1 insertion(+), 1 deletion(-)
```