### PR TITLE
virt_autotest: Use GUEST_FLAVOR to dynamically select guest installation media

### DIFF
--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -95,9 +95,13 @@ sub run {
     $self->run_test(7600, "", "yes", "yes", "/var/log/qa/", "guest-installation-logs", $upload_guest_assets_flag);
     #upload testing logs for s390x guest installation test
     if (is_s390x) {
-        #upload s390x_guest_install_test.log
-        upload_asset("/tmp/s390x_guest_install_test.log", 1, 1);
-        lpar_cmd("rm -r /tmp/s390x_guest_install_test.*");
+        # Find and upload the extracted virt-install log
+        my ($ret, $target_log) = lpar_cmd("ls /tmp/*_virt_install.log 2>/dev/null", {ignore_return_code => 1});
+        $target_log =~ s/^\s+|\s+$//g if defined $target_log;
+        lpar_upload_logs($target_log) if ($ret == 0 && $target_log);
+        # Upload s390x_guest_install_test.log
+        lpar_upload_logs("/tmp/s390x_guest_install_test.log");
+        lpar_cmd("rm -f /tmp/s390x_guest_install_test.* /tmp/*_virt_install.log");
     }
 }
 

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -31,7 +31,7 @@ sub update_package {
     $update_pkg_cmd = $update_pkg_cmd . " 2>&1 | tee /tmp/update_virt_rpms.log ";
     if (is_s390x) {
         lpar_cmd("$update_pkg_cmd");
-        upload_asset("/tmp/update_virt_rpms.log", 1, 1);
+        lpar_upload_logs("/tmp/update_virt_rpms.log");
         lpar_cmd("rm -f /tmp/update_virt_rpms.log");
     }
     else {

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -270,8 +270,8 @@ sub post_fail_hook {
     if (is_s390x) {
         #collect and upload required logs from S390X LPAR
         virt_utils::lpar_cmd("supportconfig -B supportconfig", {timeout => 600});
-        upload_asset("/var/log/scc_supportconfig.txz", 1, 1);
-        upload_asset("/tmp/s390x_guest_install_test.tar.bz2", 1, 1);
+        virt_utils::lpar_upload_logs("/var/log/scc_supportconfig.txz");
+        virt_utils::lpar_upload_logs("/tmp/s390x_guest_install_test.tar.bz2");
         virt_utils::lpar_cmd("rm -f /var/log/scc_supportconfig.*;rm -rf /tmp/s390x_guest_install_test.*");
         return;
     }

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -37,6 +37,7 @@ our @EXPORT = qw(
   handle_sp_in_settings_with_sp0
   clean_up_red_disks
   lpar_cmd
+  lpar_upload_logs
   generate_guest_asset_name
   get_guest_disk_name_from_guest_xml
   compress_single_qcow2_disk
@@ -133,7 +134,7 @@ sub repl_repo_in_sourcefile {
         my $soucefile = "/usr/share/qa/virtautolib/data/" . "sources." . locate_sourcefile;
         my $newrepo = get_repo_0_prefix . get_var("REPO_0");
         # for sles15sp2+, install host with Online installer, while install guest with Full installer
-        $newrepo =~ s/-Online-/-Full-/ if ($verorig =~ /15-sp[2-9]/i);
+        $newrepo =~ s/-Online-/-Full-/ if ($verorig =~ /15-sp[2-9]/i || get_var('GUEST_FLAVOR', '') =~ /full/i);
         my $shell_cmd
           = "if grep $veritem $soucefile >> /dev/null;then sed -i \"s#^$veritem=.*#$veritem=$newrepo#\" $soucefile;else echo \"$veritem=$newrepo\" >> $soucefile;fi";
         if (is_s390x) {
@@ -178,7 +179,7 @@ sub repl_module_in_sourcefile {
     if (is_s390x) {
         lpar_cmd("$command");
         lpar_cmd("grep Module $source_file -r");
-        upload_asset "/usr/share/qa/virtautolib/data/sources.de", 1, 1;
+        lpar_upload_logs("/usr/share/qa/virtautolib/data/sources.de");
     }
     else {
         assert_script_run($command, timeout => 120);
@@ -355,6 +356,33 @@ sub lpar_cmd {
 
     # Return context-aware results: list of (RC, output) or just RC
     return wantarray ? ($ret, $output) : $ret;
+}
+
+=head2 lpar_upload_logs
+
+  lpar_upload_logs($file_path, [$custom_upname])
+
+Upload a log file directly from the s390x LPAR host to the openQA web UI.
+This helper subroutine executes a native C<curl> command via C<lpar_cmd()>,
+bypassing the standard C<upload_logs()> to avoid fragile C<wait_serial> timeouts
+caused by console context mismatches. It takes the absolute C<$file_path> on the host,
+and an optional C<$custom_upname> for the openQA Assets tab (defaults to the file's base name).
+
+=cut
+
+sub lpar_upload_logs {
+    my ($file_path, $custom_upname) = @_;
+
+    my ($filename) = $file_path =~ m|([^/]+)$|;
+    my $upname = $custom_upname || $filename;
+    my $upload_url = autoinst_url("/uploadlog/$filename");
+
+    my $curl_cmd = "curl -s --form upload=\@$file_path " .
+      "--form upname=$upname " .
+      "--max-time 90 $upload_url";
+
+    record_info('Upload Log', "Uploading $file_path directly from LPAR");
+    lpar_cmd($curl_cmd);
 }
 
 # Guest xml will be uploaded with name format [generated_name_by_this_func].xml


### PR DESCRIPTION
### Summary
This PR refactors how the virtualization test module determines whether to use the "Full" installation media for the guest.
                                                                                                                                                                             
With this change, we decouple the guest media type from the job name by introducing a check for the           `GUEST_FLAVOR` variable. Setting `GUEST_FLAVOR=full`in our OSD job settings will now reliably instruct the framework to use the Full installer for the guest, while falling back to the online installer otherwise. 
                                                                                                                    
### Key Changes
- Added `get_var('GUEST_FLAVOR', '') =~ /full/i` to explicitly dictate the usage of `-Full-` media, ensuring  seamless forward compatibility for future SLES releases (e.g., SLES 16.2, 16.3).

- Related ticket: https://progress.opensuse.org/issues/189186
- Relevant job group yaml change: https://gitlab.suse.de/qa-testsuites/openqa-job-group-yaml/-/merge_requests/413/diffs
- Related PR:
https://github.com/SUSE/qa-automation/pull/866
https://github.com/SUSE/qa-testsuites/pull/1157
- Verification run: 
[gi-full-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/22987957#step/guest_installation_run/3) PASS
[gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/22827002#) PASS
[gi-online-guest_developing-on-host_sles15sp7-kvm](https://openqa.suse.de/tests/22853467#) PASS
[gi-online-guest_developing-on-host_sles16.0-kvm](https://openqa.suse.de/tests/22853468#) PASS
[gi-online-guest_sles16.0-on-host_developing-kvm](https://openqa.suse.de/tests/22864757#) PASS
[gi-guest_sles15sp7-on-host_developing-kvm](https://openqa.suse.de/tests/22886310#) PASS

