### PR TITLE
Kselftests: install_from_git: Refactor and tidy up test variables

### DIFF
--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -82,18 +82,16 @@ sub install_from_git
 {
     my ($collection) = @_;
 
-    my $git_tree = get_var('KERNEL_GIT_TREE', 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git');
-    my $git_tag = get_var('KERNEL_GIT_TAG', '');
+    my $git_tree = get_var('KSELFTEST_GIT_TREE', 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git');
+    my $git_ref = get_var('KSELFTEST_GIT_REF', '');
 
     install_package('git', trup_apply => 1);
-    assert_script_run("git clone --depth 1 --single-branch --branch master $git_tree linux", 240);
+    my $clone_cmd = "git clone --depth 1 --single-branch";
+    $clone_cmd .= " --branch $git_ref" if $git_ref ne '';
+    $clone_cmd .= " $git_tree linux";
+    assert_script_run($clone_cmd, 240);
 
     assert_script_run("cd ./linux");
-
-    if ($git_tag ne '') {
-        assert_script_run("git fetch --unshallow --tags", 7200);
-        assert_script_run("git checkout $git_tag");
-    }
 
     record_info("GIT Commit", script_output("git --no-pager log -1 --oneline"));
 
@@ -113,7 +111,7 @@ sub install_upstream_harness
     my $version = script_output('uname -r');
     $install_dir //= "/lib/modules/$version/build/kselftest/kselftest_install";
 
-    my $git_tree = get_var('KERNEL_GIT_TREE', 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git');
+    my $git_tree = get_var('KSELFTEST_GIT_TREE', 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git');
     my $tmpdir = '/var/tmp/linux-harness';
 
     install_package('git', trup_apply => 1);

--- a/tests/kernel/kselftests_prepare.pm
+++ b/tests/kernel/kselftests_prepare.pm
@@ -48,19 +48,44 @@ Specifies the name of the kselftest collection to install, as reported by:
 
 =head2 KSELFTEST_FROM_GIT
 
-If set, kselftests are installed from a kernel git tree instead of using
-packaged RPMs. Allows to point to C<KERNEL_GIT_TREE>. Defaults to the
-upstream tree: C<torvalds/linux.git>.
+If set, kselftests are cloned and built directly from a kernel git tree
+instead of using packaged RPMs. The repository and ref are controlled by
+C<KSELFTEST_GIT_TREE> and C<KSELFTEST_GIT_REF>.
+
+=head2 KSELFTEST_GIT_TREE
+
+URL of the kernel git repository to clone when C<KSELFTEST_FROM_GIT> is set.
+Defaults to the upstream Linus tree:
+
+  https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+
+=head2 KSELFTEST_GIT_REF
+
+Git ref (branch, tag, or commit SHA) to check out from C<KSELFTEST_GIT_TREE>
+when C<KSELFTEST_FROM_GIT> is set. When unset the repository's default branch
+is used.
+
+Examples:
+
+  KSELFTEST_GIT_REF=stable
+  KSELFTEST_GIT_REF=v6.10
+  KSELFTEST_GIT_REF=a3b1c2d
 
 =head2 KSELFTEST_FROM_SRC
 
 If set, kselftests are built from the kernel source tree provided by the
 C<kernel-source> package instead of using packaged RPMs. The test harness
 (C<run_kselftest.sh> and the C<kselftest/> support directory) is then
-replaced with the version from the upstream linux tree (C<KERNEL_GIT_TREE>,
+replaced with the version from the upstream linux tree (C<KSELFTEST_GIT_TREE>,
 default: C<torvalds/linux.git> master branch), so that the SUSE-patched test
 binaries run under the upstream harness. This step requires network access
 and C<git>.
+
+=head2 KSELFTEST_REPO
+
+URL of a zypper repository providing the C<kselftests> RPM package. Required
+when neither C<KSELFTEST_FROM_GIT> nor C<KSELFTEST_FROM_SRC> is set (the
+default install path).
 
 =head2 KSELFTEST_BUILD_ENV
 


### PR DESCRIPTION
Let's keep using the KSELFTEST_ namespace, so rename the test variables. For KERNEL_GIT_BRANCH, use _REF instead so that branches, tags and commits can be used.

- Verification run: https://openqa.opensuse.org/tests/5993755
