### PR TITLE
Remove always_rollback for libssh

### DIFF
--- a/tests/console/libssh.pm
+++ b/tests/console/libssh.pm
@@ -26,7 +26,7 @@
 
 package libssh;
 use Mojo::Base 'consoletest';
-use testapi qw(is_serial_terminal :DEFAULT);
+use testapi;
 use utils;
 use Utils::Systemd 'disable_and_stop_service';
 use version_utils;
@@ -152,9 +152,4 @@ EOF
     assert_script_run("docker stop libssh_container");
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;
-


### PR DESCRIPTION
Remove always_rollback for libssh

- Related ticket: https://progress.opensuse.org/issues/201984
- Verification run: https://openqa.suse.de/tests/22682055