### PR TITLE
sles4sap: Use "ignore_timeout_failure" in "run_cmd_retry"

### DIFF
--- a/lib/sles4sap/publiccloud.pm
+++ b/lib/sles4sap/publiccloud.pm
@@ -172,7 +172,7 @@ sub run_cmd_retry {
     delete($args{proceed_on_failure});
 
     for (1 .. $retry) {
-        my $ret = eval { $self->run_cmd(timeout => $timeout, proceed_on_failure => 0, %args); };
+        my $ret = eval { $self->run_cmd(timeout => $timeout, ignore_timeout_failure => 1, proceed_on_failure => 0, %args); };
         return $ret if (defined $ret);
 
         # Unblock console in case the previous command hung and timed out


### PR DESCRIPTION
After the function `run_cmd_retry` is introduced, a new parameter `ignore_timeout_failure` is introduced for `ssh_script_run`, we need to use this parameter, otherwise the ssh command is not wrapped in timeout and the retry mechanism will fail.

- Related ticket: https://jira.suse.com/browse/TEAM-11280
- Needles: none
- Verification run:
https://openqa.suse.de/tests/22605156
Now you can see from serial console log:
`# timeout --foreground -k 10s 180 ssh  -E /var/tmp/ssh_sut.log "cloudadmin@xxx`