### PR TITLE
ci: Work around pedantic cc errors for Module::Build as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ prepare:
 	./tools/wheel --fetch
 	$(MAKE) check-links
 	# https://rt.cpan.org/Ticket/Display.html?id=133363
-	cd os-autoinst && PERL_MM_OPT="OPTIMIZE=-Wno-error=implicit-function-declaration" cpanm -v -nq --installdeps .
-	PERL_MM_OPT="OPTIMIZE=-Wno-error=implicit-function-declaration" cpanm -v -nq --installdeps .
+	cd os-autoinst && PERL_MB_OPT="--config optimize=-Wno-error=implicit-function-declaration" PERL_MM_OPT="OPTIMIZE=-Wno-error=implicit-function-declaration" cpanm -v -nq --installdeps .
+	PERL_MB_OPT="--config optimize=-Wno-error=implicit-function-declaration" PERL_MM_OPT="OPTIMIZE=-Wno-error=implicit-function-declaration" cpanm -v -nq --installdeps .
 
 os-autoinst/:
 	@test -d os-autoinst || (echo "Missing test requirements, \


### PR DESCRIPTION
    lib/Net/IDN/Punycode.xs:256:19: error: implicit declaration of function 'uvuni_to_utf8_flags'; did you mean 'uvchr_to_utf8_flags'? [-Wimplicit-function-declaration]

The problem is that there are basically two build modules in perl, and PERL_MM_OPT is for ExtUtils::MakeMaker, PERL_MB_OPT for Module::Build.

