### PR TITLE
kdump_utils: apply KDUMP_SAVEDIR on transactional systems

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -327,6 +327,7 @@ sub activate_kdump_without_yast {
 }
 
 sub activate_kdump_transactional {
+    set_kdump_config('KDUMP_SAVEDIR', get_var('KDUMP_SAVEDIR')) if get_var('KDUMP_SAVEDIR');
     if (get_var('CRASH_MEMORY')) {
         # show and get crashkernel memory
         my $crash_memory = determine_crash_memory;


### PR DESCRIPTION
activate_kdump_transactional was not calling set_kdump_config for KDUMP_SAVEDIR, causing kdump_over_nfs to fail on immutable systemsl the crash kernel had no NFS target configured and the vmcore was never written to the NFS share.

- Related ticket: https://progress.opensuse.org/issues/202137
- Verification run: 
https://openqa.suse.de/tests/22696273
https://openqa.suse.de/tests/22696271
https://openqa.suse.de/tests/22696272

non-immutable system: VR to make sure there is no regression if `KDUMP_SAVEDIR` is correctly set:
https://openqa.suse.de/tests/22702916
https://openqa.suse.de/tests/22702915
https://openqa.suse.de/tests/22702917
