### PR TITLE
Remove duplicate test modules in extra_tests_textmode job

### DIFF
--- a/schedule/functional/sle16/extra_tests_textmode.yaml
+++ b/schedule/functional/sle16/extra_tests_textmode.yaml
@@ -96,9 +96,6 @@ schedule:
     - console/firewalld
     - console/nftables
     - console/aaa_base
-    - console/vmstat
-    - console/libjpeg_turbo
-    - console/libgit2
     - network/cifs
     - '{{wpa_supplicant}}'
     - console/osinfo_db


### PR DESCRIPTION
Remove duplicate test modules in extra_tests_textmode job

- Related ticket: https://progress.opensuse.org/issues/201567
- Verification run: https://openqa.suse.de/tests/22663356
  - vmstat
  - libjpeg_turbo
  - libgit2
  Those three test modules has been tested in extra_tests_textmode_phub, removed them from extra_tests_textmode