### PR TITLE
Ensure disk boot after Agama installation

### DIFF
--- a/tests/installation/agama_reboot.pm
+++ b/tests/installation/agama_reboot.pm
@@ -27,6 +27,7 @@ use x11utils 'ensure_unlocked_desktop';
 use Utils::Backends qw(is_ipmi is_pvm is_svirt);
 use Utils::Architectures qw(is_aarch64 is_s390x);
 use power_action_utils 'assert_shutdown_and_restore_system';
+use ipmi_backend_utils 'set_disk_boot';
 
 sub upload_agama_logs {
     return if (get_var('NOLOGS'));
@@ -64,6 +65,7 @@ sub run {
         verify_agama_auto_install_done_cmdline();
         upload_agama_logs();
         record_info 'Reboot system to disk boot';
+        set_disk_boot() if (is_ipmi and get_var('IPMI_BACKEND_BOOTDEV_DISK'));
         enter_cmd 'reboot';
         # Swith back to sol console, then user can monitor the boot log
         select_console 'sol', await_console => 0 if is_ipmi;


### PR DESCRIPTION
* **Call** ```set_disk_boot``` for ipmi backend after Agama installation to ensure installed system boots from disk if ipmi backend worker has ```IPMI_BACKEND_BOOTDEV_DISK``` set.

* **New** setting ```IPMI_BACKEND_BOOTDEV_DISK``` should be treated as machine or worker settings instead of test suite level setting because it is more about backend and controls backend. Repository [salt-pillars-openqa/openqa/workerconf.sls](https://gitlab.suse.de/openqa/salt-pillars-openqa/-/blob/master/openqa/workerconf.sls?ref_type=heads) is the most proper place to use this setting.

* **Existing** setting ```IPXE_SET_HDD_BOOTSCRIPT``` and suroutine ```set_bootscript_hdd``` can not guarantee hard disk boot and just quits network actually. The most reliable way to set disk boot is to use ```ipmitool``` in ```set_disk_boot```.

* **Without** setting disk boot, system (like pegasus) may boot into, for example, uefi shell like [this one](https://openqa.suse.de/tests/22682045#step/login_console/76). Although ```IPXE_SET_HDD_BOOTSCRIPT``` and ```set_bootscript_hdd``` can work from time to time, but there is no guarantee, for example, [three failed test runs 1](https://openqa.suse.de/tests/22749068#step/login_console/75), [2](https://openqa.suse.de/tests/22749069#step/login_console/75) and [3](https://openqa.suse.de/tests/22749070#step/login_console/75) follows [one successful run](https://openqa.suse.de/tests/22729721).

* **With** setting disk boot, system (like pegasus) boots from disk successfully, for example, [this one](https://openqa.suse.de/tests/22703772). And verification runs confirmed that [consecutive five runs 1](https://openqa.suse.de/tests/22750266), [2](https://openqa.suse.de/tests/22750267), [3](https://openqa.suse.de/tests/22750268), [4](https://openqa.suse.de/tests/22752928), [5](https://openqa.suse.de/tests/22752929) all passed.

* **First** application of ```IPMI_BACKEND_BOOTDEV_DISK``` is applied in [this merge request](https://gitlab.suse.de/openqa/salt-pillars-openqa/-/merge_requests/1286).

* **Verification Runs:**
  * [sle-16.1-Online-x86_64-Build45.1-gi-guest_oraclelinux-on-host_developing-kvm with IPMI_BACKEND_BOOTDEV_DISK=1](https://openqa.suse.de/tests/22761876)
  * [sle-16.1-Full-ppc64le-Build45.1-non-uefi-gi-full-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/22771893)
  * [sle-16.1-Full-x86_64-Build45.1-tdx-gi-full-developing-guest_on-host_sle16-full-kvm](https://openqa.suse.de/tests/22761878)
  * [sle-16.1-Base-SelfInstall-pxe-x86_64-Build10.31-gi-guest_slem6dot2-on-host_developing-kvm](https://openqa.suse.de/tests/22771891)
  * [sle-16.1-Online-aarch64-Build45.1-uefi-gi-guest_developing-on-host_sles16dot0-kvm](https://openqa.suse.de/tests/22703783)
  * [sle-16.1-Online-x86_64-Build45.1-immutable-gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/22771900)