### PR TITLE
docker_engine: Update xfail list

### DIFF
--- a/tests/containers/docker_engine.pm
+++ b/tests/containers/docker_engine.pm
@@ -116,8 +116,10 @@ sub run {
         push @xfails, (
             # We don't yet support CDI
             "github.com/moby/moby/v2/integration/container::TestEtcCDI",
+            # Flaky tests:
             "github.com/moby/moby/v2/integration/container::TestContainerRestartWithCancelledRequest",
             "github.com/moby/moby/v2/integration/container::TestHealthKillContainer",
+            "github.com/moby/moby/v2/integration/container::TestStopContainerWithTimeoutCancel",
             "github.com/moby/moby/v2/integration/service::TestRestoreIngressRulesOnFirewalldReload",
         );
         # This may fail on SLES 15 due to older version of rootlesskit (1.1.1)


### PR DESCRIPTION
We ignore TestStopContainerWithTimeoutCancel also on Docker v28 with a different path:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/containers/docker_engine.pm#L133

Failed job: https://openqa.suse.de/tests/22700078 (tagged as passed)