### PR TITLE
If clamav version is 1.4.3, update all needed packages

### DIFF
--- a/tests/console/clamav_upgrade.pm
+++ b/tests/console/clamav_upgrade.pm
@@ -36,7 +36,12 @@ sub run {
     validate_script_output("clamscan --version", qr/ClamAV $ver/);
 
     # Upgrade to the latest version available in the repo
-    zypper_call("up @pkgs", timeout => 300);
+    if ($ver =~ /1.4.3/) {
+        # Failed with version 1.4.3 is expected, bsc#1267420
+        zypper_call("up @pkgs", timeout => 300);
+    } else {
+        zypper_call("up clamav", timeout => 300);
+    }
 
     # Verify the upgrade was successful
     my $new_version = script_output("clamscan --version | awk '{print \$2}' | cut -d/ -f1");


### PR DESCRIPTION
If clamav version is 1.4.3, update all needed packages

- Related ticket: https://progress.opensuse.org/issues/201927
- Verification run: https://openqa.suse.de/tests/22702233
                                https://openqa.suse.de/tests/22702305

