### PR TITLE
Remove duplicate test modules in extra_tests_textmode_immutable

### DIFF
--- a/schedule/functional/sle16/extra_tests_textmode_immutable.yaml
+++ b/schedule/functional/sle16/extra_tests_textmode_immutable.yaml
@@ -25,14 +25,6 @@ conditional_schedule:
         ARCH:
             x86_64:
                 - console/wpa_supplicant
-    libjpeg_turbo:
-        ARCH:
-            x86_64:
-                - console/libjpeg_turbo
-            ppc64le:
-                - console/libjpeg_turbo
-            s390x:
-                - console/libjpeg_turbo
 schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop
@@ -97,9 +89,6 @@ schedule:
     - console/firewalld
     - console/nftables
     - console/aaa_base
-    - console/vmstat
-    - '{{libjpeg_turbo}}'
-    - console/libgit2
     - '{{wpa_supplicant}}'
     - console/osinfo_db
     - console/journalctl


### PR DESCRIPTION
Remove duplicate test modules in extra_tests_textmode_immutable

- Related ticket: https://progress.opensuse.org/issues/201567
- Verification run: https://openqa.suse.de/tests/22663173#       
    - vmstat
    - libjpeg_turbo
    - libgit2
    Those three test modules has been tested in extra_tests_textmode_phub, removed them from extra_tests_textmode_immutable

