### PR TITLE
Do not use always_rollback flag in some modules

### DIFF
--- a/tests/security/eal4/chrony_pid_file.pm
+++ b/tests/security/eal4/chrony_pid_file.pm
@@ -45,8 +45,4 @@ sub run {
     validate_script_output('touch /run/test 2>&1', sub { m/Permission denied/ }, proceed_on_failure => 1);
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/eal4/dbus_fuzzer.pm
+++ b/tests/security/eal4/dbus_fuzzer.pm
@@ -100,7 +100,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1, fatal => 0};
+    return {fatal => 0};
 }
 
 1;

--- a/tests/security/eal4/dbus_services_exposure.pm
+++ b/tests/security/eal4/dbus_services_exposure.pm
@@ -141,8 +141,4 @@ sub run {
     }
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/eal4/drng_test_preparation.pm
+++ b/tests/security/eal4/drng_test_preparation.pm
@@ -60,8 +60,4 @@ sub run {
     }
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/eal4/kvm_check.pm
+++ b/tests/security/eal4/kvm_check.pm
@@ -41,8 +41,4 @@ sub run {
     validate_script_output 'virsh net-list --all | grep default', qr/default\s+active\s+no\s+yes/;
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/eal4/netlink_message.pm
+++ b/tests/security/eal4/netlink_message.pm
@@ -62,8 +62,4 @@ sub run {
     $self->result($test_module_result);
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/eal4/syscall_thrasher.pm
+++ b/tests/security/eal4/syscall_thrasher.pm
@@ -51,10 +51,6 @@ sub run {
     upload_logs("$log_file");
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 sub post_fail_hook {
     my ($self) = @_;
     upload_logs("$log_file");

--- a/tests/security/ebpf/disable_unprivileged_ebpf.pm
+++ b/tests/security/ebpf/disable_unprivileged_ebpf.pm
@@ -93,8 +93,4 @@ sub run {
     $self->reboot_and_check('0');
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/pam/pam_config.pm
+++ b/tests/security/pam/pam_config.pm
@@ -63,10 +63,6 @@ sub run {
     }
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 sub post_fail_hook {
     assert_script_run 'cp -pr /mnt/pam.d /etc';
 }

--- a/tests/security/pam/pam_faillock.pm
+++ b/tests/security/pam/pam_faillock.pm
@@ -97,8 +97,4 @@ EOF
     assert_script_run("userdel -r -f $user_name");
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/pam/pam_login.pm
+++ b/tests/security/pam/pam_login.pm
@@ -128,10 +128,6 @@ END
     assert_script_run "mv $pam_login_bak $pam_login";
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 sub post_fail_hook {
     assert_script_run 'cp -pr /mnt/pam.d /etc';
 }

--- a/tests/security/pam/pam_mount.pm
+++ b/tests/security/pam/pam_mount.pm
@@ -120,10 +120,6 @@ END
     assert_script_run "mv $pam_mount_cfg_bak $pam_mount_cfg";
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 sub post_fail_hook {
     select_console 'root-console';
     assert_script_run 'cp -pr /mnt/pam.d /etc';

--- a/tests/security/pam/pam_su.pm
+++ b/tests/security/pam/pam_su.pm
@@ -90,10 +90,6 @@ expect {
     assert_script_run "mv $sul_file_bak $sul_file";
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 sub post_fail_hook {
     select_console 'root-console';
     assert_script_run 'cp -pr /mnt/pam.d /etc';

--- a/tests/security/pam/pam_u2f.pm
+++ b/tests/security/pam/pam_u2f.pm
@@ -40,8 +40,4 @@ sub run {
     validate_script_output('pamu2fcfg 2>&1 || true', sub { m/No .* found. Aborting/ });
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;


### PR DESCRIPTION
 svirt backend on s390 does not support rollbacks
 always_rollback flag cannot be enabled on arch basis

- Related ticket: https://progress.opensuse.org/issues/202128
- Needles: n/a
- Verification run: 
  - 16.0:
    - https://openqa.suse.de/tests/22695767
    - https://openqa.suse.de/tests/22695768

  - 15SP7:
    - https://openqa.suse.de/tests/22693235
    - https://openqa.suse.de/tests/22704621
    - https://openqa.suse.de/tests/22704622
    - https://openqa.suse.de/tests/22704623
    - https://openqa.suse.de/tests/22704620

  - 15SP6:
    - https://openqa.suse.de/tests/22704628
    - https://openqa.suse.de/tests/22704625
    - https://openqa.suse.de/tests/22704626

  - 15SP5:
    - https://openqa.suse.de/tests/22705764
    - https://openqa.suse.de/tests/22705765
    - https://openqa.suse.de/tests/22705766
    - https://openqa.suse.de/tests/22705767
    - https://openqa.suse.de/tests/22705768
    - https://openqa.suse.de/tests/22705769

  - 15SP4:
    - https://openqa.suse.de/tests/22705770
    - https://openqa.suse.de/tests/22705771
    - https://openqa.suse.de/tests/22705772