### PR TITLE
Test vmware mouse and keyboard during agama installation

### DIFF
--- a/schedule/virt_autotest/sle16_install_vmware_keyboard_mouse.yaml
+++ b/schedule/virt_autotest/sle16_install_vmware_keyboard_mouse.yaml
@@ -1,0 +1,11 @@
+name:         sle16_install_vmware_keyboard_mouse
+description:  >
+    Maintainer: nan.zhang@suse.com, qe-virt@suse.de
+    Vmware guest installation with keyboard and mouse tests
+schedule:
+    - installation/bootloader_svirt
+    - yam/agama/boot_agama
+    - virt_autotest/check_keyboard_mouse
+    - yam/agama/patch_agama_tests
+    - yam/agama/agama
+    - installation/first_boot

--- a/tests/virt_autotest/check_keyboard_mouse.pm
+++ b/tests/virt_autotest/check_keyboard_mouse.pm
@@ -1,0 +1,94 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Check if mouse and keyboard work properly after boot
+# This test verifies basic mouse and keyboard functionality in the VM during installation
+# with agama by testing mouse movement, clicking, and keyboard input
+# Maintainer: Nan Zhang <nan.zhang@suse.com>, qa-virt@suse.de
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use version_utils qw(is_vmware);
+
+sub run {
+    my $self = shift;
+
+    record_info('Mouse & Keyboard Check', 'Starting mouse and keyboard functionality tests');
+
+    my @agama_screens = qw(agama-product-selection agama-configuring-the-product agama-installing agama-sle-overview);
+    assert_screen(\@agama_screens, 30);
+    test_keyboard_input(\@agama_screens);
+
+    my $on_product_selection = match_has_tag('agama-product-selection');
+    if ($on_product_selection) {
+        test_mouse_movement();
+    } else {
+        record_info('Mouse Test Failed', 'Not on agama-product-selection screen — no safe click target on current screen');
+        die "Mouse test failed: not on expected screen for mouse interaction";
+    }
+
+    record_info('Test Complete', 'Mouse and keyboard tests passed successfully');
+}
+
+sub test_keyboard_input {
+    my ($agama_screens) = @_;
+    record_info('Keyboard Test', 'Testing keyboard input via focus movement');
+
+    # Each tab must move focus highlight; assert_screen_change dies if it doesn't.
+    for (1 .. 3) {
+        assert_screen_change { send_key 'tab' };
+        wait_still_screen(2);
+        save_screenshot;
+    }
+    for (1 .. 3) {
+        assert_screen_change { send_key 'shift-tab' };
+        wait_still_screen(2);
+        save_screenshot;
+    }
+
+    assert_screen($agama_screens, 10);
+    record_info('Keyboard OK', 'Keyboard input verified via screen change');
+}
+
+sub test_mouse_movement {
+    record_info('Mouse Test', 'Testing mouse via click on a known UI element');
+
+    # Click a product radio button; verify its selected-state needle appears.
+    # If the click never reaches the guest, assert_and_click or the post-click
+    # assert_screen will fail loudly.
+    assert_and_click('agama-product-selection-sle16', timeout => 10);
+    assert_screen('agama-product-selection-sle16-selected', 10);
+
+    record_info('Mouse OK', 'Mouse click verified via UI state change');
+}
+
+sub test_flags {
+    return {fatal => 0};
+}
+
+sub post_fail_hook {
+    my $self = shift;
+
+    save_screenshot;
+
+    # Upload system logs for debugging if test fails
+    select_console 'install-shell';
+
+    # Collect relevant logs
+    script_run('dmesg > /tmp/dmesg.log');
+    upload_logs('/tmp/dmesg.log', failok => 1);
+
+    # Check for input device issues
+    script_run('cat /proc/bus/input/devices > /tmp/input_devices.log');
+    upload_logs('/tmp/input_devices.log', failok => 1);
+
+    # VMware tools logs if applicable
+    if (is_vmware) {
+        upload_logs('/var/log/vmware-vmsvc.log', failok => 1);
+        upload_logs('/var/log/vmware-vmtoolsd-root.log', failok => 1);
+    }
+}
+
+1;

--- a/tests/yam/agama/agama.pm
+++ b/tests/yam/agama/agama.pm
@@ -23,6 +23,7 @@ use testapi qw(
 );
 use Utils::Architectures qw(is_s390x is_ppc64le);
 use Utils::Backends qw(is_pvm is_svirt);
+use version_utils qw(is_vmware);
 use power_action_utils 'power_action';
 
 sub is_headless_installation {
@@ -68,7 +69,7 @@ sub run {
         my $svirt = console('svirt')->change_domain_element(os => boot => {dev => 'hd'});
     }
 
-    (is_s390x() || is_pvm() || is_headless_installation()) ?
+    (is_s390x() || is_pvm() || is_headless_installation()) || is_vmware() ?
       # reboot via console
       power_action('reboot', keepconsole => 1, first_reboot => 1) :
       # graphical reboot


### PR DESCRIPTION
1. Test mouse and keyboard functionality during agama installation
2. Add test scheduler `schedule/virt_autotest/sle16_default_vmware.yaml`
3. Support vmware reboot during installation

- Related ticket: https://progress.opensuse.org/issues/200051
- Verification run: https://openqa.suse.de/tests/22773914
