### PR TITLE
pc: Import subroutines from publiccloud::utils

### DIFF
--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -12,9 +12,9 @@ use Mojo::Base 'publiccloud::basetest';
 use registration;
 use testapi;
 use utils qw(ssh_fully_patch_system);
-use publiccloud::utils qw(ssh_update_transactional_system is_cloudinit_supported permit_root_login);
+use publiccloud::utils;
 use publiccloud::ssh_interactive qw(select_host_console);
-use version_utils qw(is_sle_micro is_sle is_azure is_ondemand);
+use version_utils qw(is_sle_micro is_sle);
 
 sub run {
     my ($self, $args) = @_;


### PR DESCRIPTION
Fix CI in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25721

```
# ########### ERROR: "is_azure" is not exported by the version_utils module
# "is_ondemand" is not exported by the version_utils module
# Can't continue after import errors at ./tests/publiccloud/patch_and_reboot.pm line 17.
```