### PR TITLE
feat(CI): Add conventional commits to .gitlint

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,6 +1,7 @@
 [general]
 ignore=body-min-length,body-is-missing
 regex-style-search=True
+contrib = contrib-title-conventional-commits
 
 [title-max-length]
 line-length=72
@@ -21,3 +22,4 @@ regex=^([A-Z]|\S+:|git subrepo (clone|pull)).*(?<!\.)$
 [ignore-body-lines]
 # Accept lines stating only a long unwrappable URL
 regex=^https?:\/\/\S+$
+


### PR DESCRIPTION
There was an idea to use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) specification.

This is fine by me, but broader poll or at least heads-up will be needed.

- Related ticket: [poo#200492](https://progress.opensuse.org/issues/200492)
- Feature docummentation: [jorisroovers.com/gitlint/latest/rules/contrib_rules](https://jorisroovers.com/gitlint/latest/rules/contrib_rules/#ct1-contrib-title-conventional-commits)
