### PR TITLE
feat(publiccloud): add flexible license switch test for GCE

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -45,6 +45,8 @@ sub load_maintenance_publiccloud_tests {
         } else {
             die('Currently supported versions to migrate from are SLE12 SP5 and SLE15 SP7.');
         }
+    } elsif (get_var('PUBLIC_CLOUD_FLEXIBLE_LICENSE') && is_sle('=15-SP7') && is_gce()) {
+        loadtest 'publiccloud/flexible_license', run_args => $args;
     } elsif (get_var('PUBLIC_CLOUD_LTP')) {
         loadtest 'publiccloud/run_ltp', run_args => $args;
     } elsif (get_var('PUBLIC_CLOUD_FUNCTIONAL')) {

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -45,7 +45,7 @@ sub load_maintenance_publiccloud_tests {
         } else {
             die('Currently supported versions to migrate from are SLE12 SP5 and SLE15 SP7.');
         }
-    } elsif (get_var('PUBLIC_CLOUD_FLEXIBLE_LICENSE') && is_sle('=15-SP7') && is_gce()) {
+    } elsif (get_var('PUBLIC_CLOUD_FLEXIBLE_LICENSE') && is_gce()) {
         loadtest 'publiccloud/flexible_license', run_args => $args;
     } elsif (get_var('PUBLIC_CLOUD_LTP')) {
         loadtest 'publiccloud/run_ltp', run_args => $args;

--- a/tests/publiccloud/flexible_license.pm
+++ b/tests/publiccloud/flexible_license.pm
@@ -1,0 +1,60 @@
+# SUSE's openQA tests
+#
+# Copyright 2022 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Flexible License BYOS->PAYG and PAYG->BYOS
+# Source: https://www.suse.com/c/switching-licensing-models-on-google-cloud-for-sles-and-sles-for-sap-instances-flexible-licenses/
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use publiccloud::ssh_interactive "select_host_console";
+use publiccloud::utils qw(registercloudguest is_byos);
+
+sub run {
+    my ($self, $args) = @_;
+
+    select_host_console();
+    my $instance = $args->{my_instance};
+    my $provider = $args->{my_provider};
+    my $instance_id = $instance->instance_id();
+    my $zone = $provider->{provider_client}->region . "-" . $provider->{provider_client}->availability_zone;
+
+    record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
+    record_info('Repos', $instance->ssh_script_output("sudo zypper lr", timeout => 300));
+
+    my ($old_license, $new_license);
+    if (is_byos()) {
+        record_info('BYOS->PAYG', "Switching from BYOS to on-demand");
+        $old_license = 'projects/suse-byos-cloud/global/licenses/sles-15-byos';
+        $new_license = 'projects/suse-cloud/global/licenses/sles-15';
+    } else {
+        record_info('PAYG->BYOS', "Switching from on-demand to BYOS");
+        $old_license = 'projects/suse-cloud/global/licenses/sles-15';
+        $new_license = 'projects/suse-byos-cloud/global/licenses/sles-15-byos';
+    }
+
+    $instance->ssh_assert_script_run("sudo systemctl stop guestregister-lic-watcher.timer");
+    $instance->ssh_assert_script_run("sudo registercloudguest --clean", timeout => 180);
+
+    record_info('Repos cleared', $instance->ssh_script_output("sudo zypper lr ||:", timeout => 300));
+
+    $provider->stop_instance($instance);
+    assert_script_run("gcloud compute disks update $instance_id --zone $zone --replace-license=$old_license,$new_license", timeout => 120);
+    $provider->start_instance($instance);
+    $instance->wait_for_ssh(scan_ssh_host_key => 1);
+
+    if (is_byos()) {
+        set_var('FLAVOR', 'GCE-Updates');
+    } else {
+        set_var('FLAVOR', 'GCE-BYOS-Updates');
+    }
+
+    registercloudguest($instance);
+    record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
+    record_info('Repos', $instance->ssh_script_output("sudo zypper lr", timeout => 300));
+}
+
+1;
+

--- a/tests/publiccloud/flexible_license.pm
+++ b/tests/publiccloud/flexible_license.pm
@@ -11,6 +11,7 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use publiccloud::ssh_interactive "select_host_console";
 use publiccloud::utils qw(registercloudguest is_byos);
+use version_utils 'is_sle';
 
 sub run {
     my ($self, $args) = @_;
@@ -35,7 +36,7 @@ sub run {
         $new_license = 'projects/suse-byos-cloud/global/licenses/sles-15-byos';
     }
 
-    $instance->ssh_assert_script_run("sudo systemctl stop guestregister-lic-watcher.timer");
+    $instance->ssh_assert_script_run("sudo systemctl stop guestregister-lic-watcher.timer") unless (is_sle('=12-SP5'));
     $instance->ssh_assert_script_run("sudo registercloudguest --clean", timeout => 180);
 
     record_info('Repos cleared', $instance->ssh_script_output("sudo zypper lr ||:", timeout => 300));

--- a/tests/publiccloud/flexible_license.pm
+++ b/tests/publiccloud/flexible_license.pm
@@ -46,6 +46,11 @@ sub run {
     $provider->start_instance($instance);
     $instance->wait_for_ssh(scan_ssh_host_key => 1);
 
+    my $disk_licenses = script_output("gcloud compute disks describe $instance_id --zone $zone --format='get(licenses)'", timeout => 120);
+    die("Expected new license '$new_license' not found on disk after switch") unless ($disk_licenses =~ /\Q$new_license\E/);
+    die("Old license '$old_license' still present on disk after switch") if ($disk_licenses =~ /\Q$old_license\E/);
+    record_info('License OK', "Disk license verified: $disk_licenses");
+
     if (is_byos()) {
         set_var('FLAVOR', 'GCE-Updates');
     } else {
@@ -55,6 +60,13 @@ sub run {
     registercloudguest($instance);
     record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
     record_info('Repos', $instance->ssh_script_output("sudo zypper lr", timeout => 300));
+
+    if ($instance->ssh_script_run("sudo which instance-flavor-check") == 0) {
+        my $expected_flavor = is_byos() ? 'BYOS' : 'PAYG';
+        my $flavor = $instance->ssh_script_output("sudo instance-flavor-check || true", timeout => 120);
+        die("instance-flavor-check returned '$flavor', expected '$expected_flavor'") unless ($flavor =~ /^$expected_flavor$/m);
+        record_info('Flavor OK', "instance-flavor-check confirmed: $expected_flavor");
+    }
 }
 
 1;

--- a/variables.md
+++ b/variables.md
@@ -335,6 +335,7 @@ PUBLIC_CLOUD_HIMMELBLAU | boolean | false | Scheduling variable for running the 
 PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY | string | "" | Name for public cloud registry for the container images used on kubernetes tests.
 PUBLIC_CLOUD_CREDENTIALS_URL | string | "" | Base URL where to get the credentials from. This will be used to compose the full URL together with `PUBLIC_CLOUD_NAMESPACE`.
 PUBLIC_CLOUD_DMS_REPO | string | "" | The Repo URL for migration test.
+PUBLIC_CLOUD_FLEXIBLE_LICENSE | boolean | false | If set, load the flexible license test module.
 PUBLIC_CLOUD_DOWNLOAD_TESTREPO | boolean | false | If set, it schedules `publiccloud/download_repos` job.
 PUBLIC_CLOUD_EC2_BOOT_MODE | string | "uefi-preferred" | The `--boot-mode` parameter for `ec2uploadimg` script. Available values: `legacy-bios`, `uefi`, `uefi-preferred` Currently unused variable. Use `git blame` to get context.
 PUBLIC_CLOUD_EC2_IPV6_ADDRESS_COUNT | string | 0 | How many IPv6 addresses should the instance have


### PR DESCRIPTION
## Summary
- Add `tests/publiccloud/flexible_license.pm` to test BYOS↔PAYG license switching on GCE for SLE 15-SP7
- Schedule via `PUBLIC_CLOUD_FLEXIBLE_LICENSE` variable

* Related ticket: [poo#181589](https://progress.opensuse.org/issues/181589)
* Verification runs: https://pdostal-workbench.qe.prg2.suse.org/tests/569