### PR TITLE
podman: Backport patches to fix test issues

### DIFF
--- a/data/containers/patches.yaml
+++ b/data/containers/patches.yaml
@@ -146,6 +146,7 @@ podman:
   # https://github.com/containers/podman/pull/28338 - test: relax rootless runc pid namespace assertion
   # https://github.com/containers/podman/pull/28448 - test/system: Fix 260-sdnotify being silently skipped
   # https://github.com/containers/podman/pull/28603 - test/system: quadlet - rootfs failure on kernel 7.1
+  # https://github.com/containers/podman/pull/28794 - Test fixes/skips for new CI system
   21875:
     merged: "5.0.0"
   24068:
@@ -195,6 +196,8 @@ podman:
   28448:
     min: "5.7.1"
   28603:
+    min: "5.4.2"
+  28794:
     min: "5.4.2"
 
 podman-py:

--- a/data/containers/patches.yaml
+++ b/data/containers/patches.yaml
@@ -147,6 +147,7 @@ podman:
   # https://github.com/containers/podman/pull/28448 - test/system: Fix 260-sdnotify being silently skipped
   # https://github.com/containers/podman/pull/28603 - test/system: quadlet - rootfs failure on kernel 7.1
   # https://github.com/containers/podman/pull/28794 - Test fixes/skips for new CI system
+  # https://github.com/containers/podman/pull/28804 - More test fixes for new CI
   21875:
     merged: "5.0.0"
   24068:
@@ -198,6 +199,8 @@ podman:
   28603:
     min: "5.4.2"
   28794:
+    min: "5.4.2"
+  28804:
     min: "5.4.2"
 
 podman-py:

--- a/data/containers/patches/podman/28794.patch
+++ b/data/containers/patches/podman/28794.patch
@@ -1,0 +1,381 @@
+From 9aca6010eeab1f2a53029633c17754d6f8076399 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Thu, 21 May 2026 11:11:03 +0200
+Subject: [PATCH 01/10] test/system: skip "IPv6 default address assignment"
+
+It is not working in all ipv6 setups. In the new lima testing env
+default_addr is just null causing the test to fail because the container
+address was "fec0::5055:55ff:fe2b:6cc9".
+
+For now skip this until we can figure something better out.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/system/505-networking-pasta.bats | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/test/system/505-networking-pasta.bats b/test/system/505-networking-pasta.bats
+index 4da8fc83f72..b3166df7c14 100644
+--- a/test/system/505-networking-pasta.bats
++++ b/test/system/505-networking-pasta.bats
+@@ -302,6 +302,7 @@ function pasta_test_do() {
+ }
+ 
+ @test "IPv6 default address assignment" {
++    skip "Host ipv6 set can vary vastly and may not have one true default address"
+     skip_if_no_ipv6 "IPv6 not routable on the host"
+ 
+     run_podman run --rm --net=pasta $IMAGE ip -j -6 address show
+
+From 39ee9baf6633485d06238120bd3d82ea0ae8aa2c Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Thu, 21 May 2026 11:35:00 +0200
+Subject: [PATCH 02/10] test/system: fix "add username to /etc/passwd if
+ --userns=keep-id"
+
+The test assumed /home/$USER == $HOME which may not be the case. In fact
+it is not the case in the new lima VM runners.
+
+Fix the test to actually use the path we want to test for, $HOME.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/system/030-run.bats | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/system/030-run.bats b/test/system/030-run.bats
+index 158b8658639..a3bc64fa872 100644
+--- a/test/system/030-run.bats
++++ b/test/system/030-run.bats
+@@ -393,7 +393,7 @@ EOF
+         tests="
+                 |  /home/podman /home/podman /home/podman    | no vol mount
+ /home/x$whoami  |  /home/podman /home/podman /home/podman    | bad vol mount
+-/home/$whoami   |  /home/podman /home/$whoami /home/$whoami  | vol mount
++$HOME           |  /home/podman $HOME $HOME                  | vol mount
+ "
+         while read vol expect name; do
+             opts=
+
+From 1de60ebf7bbfca4a893f2862adefae09f381e67f Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Thu, 21 May 2026 11:39:51 +0200
+Subject: [PATCH 03/10] test/e2e: skip "sshd and API services required"
+
+The test assumes a local id_ed25519 ssh key exists and is setup to
+connect to its own user. That is basically never the case locally so the
+test is broken by design.
+
+If the test should run in some special CI setup where that is the case
+we need to enable it and guard based on that later.
+
+For now I just like to get the lima VM tests passing.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/e2e/system_connection_test.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/test/e2e/system_connection_test.go b/test/e2e/system_connection_test.go
+index 1526cdca8d1..d4241a047d0 100644
+--- a/test/e2e/system_connection_test.go
++++ b/test/e2e/system_connection_test.go
+@@ -510,6 +510,7 @@ qe ssh://root@podman.test:2222/run/podman/podman.sock ~/.ssh/id_rsa false true
+ 		var u *user.User
+ 
+ 		BeforeAll(func() {
++			Skip("FIXME: test assumes local ssh key is setup for the own user")
+ 			// These tests are unique in as much as they require podman, podman-remote, systemd and sshd.
+ 			// podman-remote commands will be executed by ginkgo directly.
+ 			SkipIfContainerized("sshd is not available when running in a container")
+
+From 07e257e7f666b3fe8ae920db859b7a409bb3330c Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Thu, 21 May 2026 13:49:24 +0200
+Subject: [PATCH 04/10] test/e2e: skip "podman run --shm-size-systemd" as root
+
+The container prints "Failed to set RLIMIT_CORE: Operation not permitted"
+I do not know why this fails when run with sudo but lets just skip it it
+for now.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/e2e/run_test.go | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/test/e2e/run_test.go b/test/e2e/run_test.go
+index ab85888d66c..879b1b9fa5f 100644
+--- a/test/e2e/run_test.go
++++ b/test/e2e/run_test.go
+@@ -2331,6 +2331,8 @@ WORKDIR /madethis`, BB)
+ 	})
+ 
+ 	It("podman run --shm-size-systemd", func() {
++		// I can reproduce this locally with sudo make localintegration FOCUS="podman run --shm-size-systemd"
++		SkipIfNotRootless("FIXME: This fails with 'Failed to set RLIMIT_CORE: Operation not permitted' printed in the container logs")
+ 		ctrName := "testShmSizeSystemd"
+ 		run := podmanTest.Podman([]string{"run", "--name", ctrName, "--shm-size-systemd", "10mb", "-d", SYSTEMD_IMAGE, "/sbin/init"})
+ 		run.WaitWithDefaultTimeout()
+
+From 97d0279e94e71ba0f2949ce1941ba999a994c891 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Thu, 21 May 2026 14:47:51 +0200
+Subject: [PATCH 05/10] test/e2e: fix some duplciated network subnets
+
+This is really not nice but it is a quick fix to avoid more flakes.
+
+The 10.11.12.0/24 was used by several tests and podman will only allow
+the network to be created once with a given subnet so we need to ensure
+they are conflict free, otherwise in parallel runs they will fail
+randomly.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/e2e/network_create_test.go | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/test/e2e/network_create_test.go b/test/e2e/network_create_test.go
+index 08722448368..ea20cf45279 100644
+--- a/test/e2e/network_create_test.go
++++ b/test/e2e/network_create_test.go
+@@ -22,7 +22,7 @@ func removeNetworkDevice(name string) {
+ var _ = Describe("Podman network create", func() {
+ 	It("podman network create with name and subnet", func() {
+ 		netName := "subnet-" + stringid.GenerateRandomID()
+-		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--ip-range", "10.11.12.0/26", netName})
++		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.17.0/24", "--ip-range", "10.11.17.0/26", netName})
+ 		nc.WaitWithDefaultTimeout()
+ 		defer podmanTest.removeNetwork(netName)
+ 		Expect(nc).Should(ExitCleanly())
+@@ -33,11 +33,11 @@ var _ = Describe("Podman network create", func() {
+ 		result := results[0]
+ 		Expect(result).To(HaveField("Name", netName))
+ 		Expect(result.Subnets).To(HaveLen(1))
+-		Expect(result.Subnets[0].Subnet.String()).To(Equal("10.11.12.0/24"))
+-		Expect(result.Subnets[0].Gateway.String()).To(Equal("10.11.12.1"))
++		Expect(result.Subnets[0].Subnet.String()).To(Equal("10.11.17.0/24"))
++		Expect(result.Subnets[0].Gateway.String()).To(Equal("10.11.17.1"))
+ 		Expect(result.Subnets[0].LeaseRange).ToNot(BeNil())
+-		Expect(result.Subnets[0].LeaseRange.StartIP.String()).To(Equal("10.11.12.1"))
+-		Expect(result.Subnets[0].LeaseRange.EndIP.String()).To(Equal("10.11.12.63"))
++		Expect(result.Subnets[0].LeaseRange.StartIP.String()).To(Equal("10.11.17.1"))
++		Expect(result.Subnets[0].LeaseRange.EndIP.String()).To(Equal("10.11.17.63"))
+ 
+ 		// Once a container executes a new network, the nic will be created. We should clean those up
+ 		// best we can
+@@ -47,7 +47,7 @@ var _ = Describe("Podman network create", func() {
+ 		try.WaitWithDefaultTimeout()
+ 		Expect(try).To(ExitCleanly())
+ 
+-		_, subnet, err := net.ParseCIDR("10.11.12.0/24")
++		_, subnet, err := net.ParseCIDR("10.11.17.0/24")
+ 		Expect(err).ToNot(HaveOccurred())
+ 		// Note this is an IPv4 test only!
+ 		containerIP, _, err := net.ParseCIDR(try.OutputToString())
+@@ -391,9 +391,9 @@ var _ = Describe("Podman network create", func() {
+ 	})
+ 
+ 	It("podman network create with invalid gateway for subnet", func() {
+-		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--gateway", "192.168.1.1", stringid.GenerateRandomID()})
++		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.15.0/24", "--gateway", "192.168.1.1", stringid.GenerateRandomID()})
+ 		nc.WaitWithDefaultTimeout()
+-		Expect(nc).To(ExitWithError(125, "gateway 192.168.1.1 not in subnet 10.11.12.0/24"))
++		Expect(nc).To(ExitWithError(125, "gateway 192.168.1.1 not in subnet 10.11.15.0/24"))
+ 	})
+ 
+ 	It("podman network create two networks with same name should fail", func() {
+
+From 0dbe00d2724620fc202233a90c239b97a78c5f75 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Thu, 21 May 2026 14:55:44 +0200
+Subject: [PATCH 06/10] test/system: skip one new pasta flake
+
+I saw this already in openQA and now with the new rawhide images we hit
+it in upstream as well. Skip this for now to not cause so many flakes.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/system/500-networking.bats | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/test/system/500-networking.bats b/test/system/500-networking.bats
+index 12256db9177..71d66c005fe 100644
+--- a/test/system/500-networking.bats
++++ b/test/system/500-networking.bats
+@@ -856,9 +856,10 @@ nameserver 8.8.8.8" "nameserver order is correct"
+ 
+     local -a netmodes=("bridge")
+     # pasta only works rootless
+-    if is_rootless; then
+-        netmodes+=("pasta")
+-    fi
++    # FIXME: skip pasta because this is super flaky, https://bugs.passt.top/show_bug.cgi?id=202
++    #if is_rootless; then
++    #    netmodes+=("pasta")
++    #fi
+ 
+     for netmode in "${netmodes[@]}"; do
+         local range=$(random_free_port_range 3)
+
+From 472c53b1224a8d2bef08bf7d2ca7668ee628c193 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Tue, 26 May 2026 18:22:09 +0200
+Subject: [PATCH 07/10] test/e2e: fix static port assignment
+
+This seems to flake in the parallel CI runs as another process might
+also use 8080 already.
+
+We can use any port here so use GetPort() which should give us a
+conflict free one.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/e2e/container_inspect_test.go | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/test/e2e/container_inspect_test.go b/test/e2e/container_inspect_test.go
+index f0d2af040f5..0abca8e442b 100644
+--- a/test/e2e/container_inspect_test.go
++++ b/test/e2e/container_inspect_test.go
+@@ -63,8 +63,9 @@ var _ = Describe("Podman container inspect", func() {
+ 	})
+ 
+ 	It("podman inspect exposed ports includes published ports", func() {
++		hostPort := GetPort()
+ 		c1 := "ctr1"
+-		c1s := podmanTest.Podman([]string{"run", "-d", "--expose", "22/tcp", "-p", "8080:80/tcp", "--name", c1, ALPINE, "top"})
++		c1s := podmanTest.Podman([]string{"run", "-d", "--expose", "22/tcp", "-p", fmt.Sprintf("%d:80/tcp", hostPort), "--name", c1, ALPINE, "top"})
+ 		c1s.WaitWithDefaultTimeout()
+ 		Expect(c1s).Should(ExitCleanly())
+ 
+
+From 34137c40f65489727fc330e9fc378f13e1baae0a Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Wed, 27 May 2026 12:03:02 +0200
+Subject: [PATCH 08/10] test/system: fix "podman stop - unlock while waiting
+ for timeout"
+
+In highly parallel runs this can fail its timeout due the fact that we
+run podman ps -a which takes all contianer locks, even the ones from
+unrelated tests. thus this command can take a long time, from a CI log I
+see:
+[18:22:30.932958589] # /var/tmp/podman/bin/podman  ps -a
+[18:22:34.338904713] CONTAINER ID  IMAGE
+
+So like a 4s delay just on that and hence the test later failed with
+"Operations took too long" as it took 7 seconds overall.
+
+So since we know podman inspect takes the lock just keep that and not
+try to get all containers for no reason.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/system/050-stop.bats | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/test/system/050-stop.bats b/test/system/050-stop.bats
+index 59c4576e1fb..032c6b293d2 100644
+--- a/test/system/050-stop.bats
++++ b/test/system/050-stop.bats
+@@ -198,9 +198,7 @@ load helpers
+         sleep 0.5
+     done
+ 
+-    # Other commands can acquire the lock
+-    run_podman ps -a
+-
++    # This command must be able to take the container lock.
+     # The container state transitioned to "stopping"
+     run_podman inspect --format '{{.State.Status}}' $ctrname
+     is "$output" "stopping" "Status of container should be 'stopping'"
+
+From 90ba6562d5d82f1dc649dd3f779d2a0f25362383 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Wed, 27 May 2026 12:14:45 +0200
+Subject: [PATCH 09/10] test/system: fix "stop container when healthcheck runs"
+ flake
+
+This is a long standing flake but I see it again in the lima CI, the
+problem seems to happen when we stop the container before the background
+healthcheck fires.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/system/220-healthcheck.bats | 20 +++++++++++++++++++-
+ 1 file changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/test/system/220-healthcheck.bats b/test/system/220-healthcheck.bats
+index 6d1bb121b16..d5a3d23e5e9 100644
+--- a/test/system/220-healthcheck.bats
++++ b/test/system/220-healthcheck.bats
+@@ -430,7 +430,7 @@ function _check_health_log {
+     hcStatus=$PODMAN_TMPDIR/hcStatus
+ 
+     run_podman run -d --name $ctr             \
+-           --health-cmd "sleep 20; echo $msg" \
++           --health-cmd "touch /tmp/abc; sleep 20; echo $msg" \
+            $IMAGE /home/podman/pause
+ 
+     timeout --foreground -v --kill=10 60 \
+@@ -440,6 +440,24 @@ function _check_health_log {
+     run_podman inspect $ctr --format "{{.State.Status}}"
+     assert "$output" == "running" "Container is running"
+ 
++    ### Flake, sometimes it is possible that the background healthcheck runs so slow that
++    # it starts after the podman stop below and then fails with
++    # "can only create exec sessions on running containers: container state improper".
++    # To fix this we wait for a file th healthcheck creates right away to know it is running.
++    timeout=5
++    while :; do
++        run_podman '?' exec $ctr cat /tmp/abc
++        if [[ "$status" -eq 0 ]]; then
++                break
++        fi
++
++        timeout=$((timeout - 1))
++        if [[ $timeout -eq 0 ]]; then
++            die "timed out waiting for healthcheck to run and create test file"
++        fi
++        sleep 1
++    done
++
+     run_podman stop $ctr
+ 
+     # Wait for background healthcheck to finish and make sure the exit status is 1
+
+From b498cefd5cd8ec174a809959f1ee9afc406ca751 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Wed, 27 May 2026 12:20:40 +0200
+Subject: [PATCH 10/10] test/system: do not run "podman pause/unpause" in
+ parallel
+
+podman ps -a causes unexpected timing delays as it tries to take locks for
+all containers and parallel tests may cause it to block for a while.
+
+In CI logs I see ps -a take over 3 seconds which is enough to mess with
+the expect time and make the test fail. Since testing the ps -a output
+as part of the test just switch the test to not run in parallel.
+
+This failed with "delta t between paused and restarted" where it took 10
+seconds instead of the max expected 6 seconds.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/system/080-pause.bats | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/test/system/080-pause.bats b/test/system/080-pause.bats
+index 7ce8e9b5cef..8dc18648c12 100644
+--- a/test/system/080-pause.bats
++++ b/test/system/080-pause.bats
+@@ -6,7 +6,9 @@
+ load helpers
+ load helpers.systemd
+ 
+-# bats test_tags=ci:parallel
++# SHOULD NOT BE PARALLELIZED! The use of podman ps -a makes it timing sensitive
++# as this command takes locks of all containers and parallel containers may
++# block for a while.
+ @test "podman pause/unpause" {
+     if is_rootless && ! is_cgroupsv2; then
+         skip "'podman pause' (rootless) only works with cgroups v2"

--- a/data/containers/patches/podman/28804.patch
+++ b/data/containers/patches/podman/28804.patch
@@ -1,0 +1,225 @@
+From d1d0c84a56bf43f600ef6aae09619d7e2454a00e Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Wed, 27 May 2026 19:27:32 +0200
+Subject: [PATCH 1/4] test/system: bump "unlock while waiting for timeout"
+ timeout
+
+In parallel runs the timings might be a bit slower than normal. Increase
+the timeout here, it should not affect the test as we use a 20s stop
+timeout which is more than the ready loop which uses 5s now.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/system/050-stop.bats | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/test/system/050-stop.bats b/test/system/050-stop.bats
+index 032c6b293d2..bdf0b2703f4 100644
+--- a/test/system/050-stop.bats
++++ b/test/system/050-stop.bats
+@@ -187,7 +187,7 @@ load helpers
+ 
+     # Wait for container to acknowledge the signal. We can't use wait_for_output
+     # because that aborts if .State.Running != true
+-    local timeout=5
++    local timeout=10
+     while [[ $timeout -gt 0 ]]; do
+         run_podman logs $ctrname
+         if [[ "$output" =~ "Received SIGTERM, ignoring" ]]; then
+@@ -206,7 +206,7 @@ load helpers
+     # Time check: make sure we were able to run 'ps' before the container
+     # exited. If this takes too long, it means ps had to wait for lock.
+     local delta_t=$(( $SECONDS - t0 ))
+-    assert $delta_t -le 5 "Operations took too long"
++    assert $delta_t -le 7 "Operations took too long"
+ 
+     run_podman kill $ctrname
+     run_podman wait $ctrname
+
+From a2581cc82f57f31e884c47d73565aca7338c3335 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Wed, 27 May 2026 19:33:37 +0200
+Subject: [PATCH 2/4] test/e2e: deduplicate some network subnets
+
+With a high parallel node run we have much more test cases run in
+parallel, as such I am seeing a lot of network subnet flakes as they
+were using the same one and thus failed since there can only be one
+config using it at a time.
+
+Now hard coding this here is ugly, yes. But for now I just need to get
+the flakes down in the new CI. Long term we should likely have a helper
+that hands out known unused subnets for the tests.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/e2e/container_iface_name_test.go | 12 ++++++------
+ test/e2e/run_networking_test.go       |  4 ++--
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/test/e2e/container_iface_name_test.go b/test/e2e/container_iface_name_test.go
+index b49f9866232..86fa1f89bf6 100644
+--- a/test/e2e/container_iface_name_test.go
++++ b/test/e2e/container_iface_name_test.go
+@@ -101,7 +101,7 @@ var _ = Describe("Podman container interface name", func() {
+ 
+ 				// There is no nic created by the macvlan/ipvlan driver.
+ 				defer podmanTest.removeNetwork(netName1)
+-				nc1 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "--subnet", "10.10.0.0/24", netName1})
++				nc1 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "--subnet", "10.9.0.0/24", netName1})
+ 				nc1.WaitWithDefaultTimeout()
+ 				Expect(nc1).Should(ExitCleanly())
+ 
+@@ -115,7 +115,7 @@ var _ = Describe("Podman container interface name", func() {
+ 				Expect(exec1.OutputToString()).Should(ContainSubstring("eth0"))
+ 
+ 				defer podmanTest.removeNetwork(netName2)
+-				nc2 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "--subnet", "10.25.40.0/24", netName2})
++				nc2 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "--subnet", "10.25.41.0/24", netName2})
+ 				nc2.WaitWithDefaultTimeout()
+ 				Expect(nc2).Should(ExitCleanly())
+ 
+@@ -158,7 +158,7 @@ var _ = Describe("Podman container interface name", func() {
+ 			createNetworkDevice(nicName1)
+ 
+ 			defer podmanTest.removeNetwork(netName1)
+-			nc1 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "-o", parent1, "--subnet", "10.10.0.0/24", netName1})
++			nc1 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "-o", parent1, "--subnet", "10.9.1.0/24", netName1})
+ 			nc1.WaitWithDefaultTimeout()
+ 			Expect(nc1).Should(ExitCleanly())
+ 
+@@ -175,7 +175,7 @@ var _ = Describe("Podman container interface name", func() {
+ 			createNetworkDevice(nicName2)
+ 
+ 			defer podmanTest.removeNetwork(netName2)
+-			nc2 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "-o", parent2, "--subnet", "10.25.40.0/24", netName2})
++			nc2 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "-o", parent2, "--subnet", "10.25.42.0/24", netName2})
+ 			nc2.WaitWithDefaultTimeout()
+ 			Expect(nc2).Should(ExitCleanly())
+ 
+@@ -219,7 +219,7 @@ var _ = Describe("Podman container interface name", func() {
+ 			createNetworkDevice(nicName1)
+ 
+ 			defer podmanTest.removeNetwork(netName1)
+-			nc1 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "-o", parent1, "--subnet", "10.10.0.0/24", netName1})
++			nc1 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "-o", parent1, "--subnet", "10.9.2.0/24", netName1})
+ 			nc1.WaitWithDefaultTimeout()
+ 			Expect(nc1).Should(ExitCleanly())
+ 
+@@ -236,7 +236,7 @@ var _ = Describe("Podman container interface name", func() {
+ 			createNetworkDevice(nicName2)
+ 
+ 			defer podmanTest.removeNetwork(netName2)
+-			nc2 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "-o", parent2, "--subnet", "10.25.40.0/24", netName2})
++			nc2 := podmanTest.Podman([]string{"network", "create", "-d", driverType, "-o", parent2, "--subnet", "10.25.43.0/24", netName2})
+ 			nc2.WaitWithDefaultTimeout()
+ 			Expect(nc2).Should(ExitCleanly())
+ 
+diff --git a/test/e2e/run_networking_test.go b/test/e2e/run_networking_test.go
+index 60ed1c95f31..48bcd84ae04 100644
+--- a/test/e2e/run_networking_test.go
++++ b/test/e2e/run_networking_test.go
+@@ -935,9 +935,9 @@ EXPOSE 2004-2005/tcp`, ALPINE)
+ 
+ 	It("podman run with new:pod and static-ip", func() {
+ 		netName := stringid.GenerateRandomID()
+-		ipAddr := "10.25.40.128"
++		ipAddr := "10.25.44.128"
+ 		podname := "testpod"
+-		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.40.0/24", netName})
++		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.25.44.0/24", netName})
+ 		create.WaitWithDefaultTimeout()
+ 		Expect(create).Should(ExitCleanly())
+ 		defer podmanTest.removeNetwork(netName)
+
+From ea51ae73053436a858a2e894149f0db63c92b2a4 Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Thu, 28 May 2026 12:56:40 +0200
+Subject: [PATCH 3/4] test/system: use DISABLE_HC_SYSTEMD for 2 tests
+
+The problem is by default we create the systemd timers and run hc in the
+background. This means any tests who depend on exact hc timing can get
+broken by this so use the DISABLE_HC_SYSTEMD=true env which makes podman
+skip creating the systemd timers but still allows you to manually run
+the commands.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/system/220-healthcheck.bats | 2 ++
+ test/system/250-systemd.bats     | 4 +++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/test/system/220-healthcheck.bats b/test/system/220-healthcheck.bats
+index d5a3d23e5e9..200bad33bf4 100644
+--- a/test/system/220-healthcheck.bats
++++ b/test/system/220-healthcheck.bats
+@@ -429,6 +429,8 @@ function _check_health_log {
+     msg="hc-msg-$(random_string)"
+     hcStatus=$PODMAN_TMPDIR/hcStatus
+ 
++    # Disable systemd healthcheck in the background as they mess up the timings of the manual commands.
++    export DISABLE_HC_SYSTEMD="true"
+     run_podman run -d --name $ctr             \
+            --health-cmd "touch /tmp/abc; sleep 20; echo $msg" \
+            $IMAGE /home/podman/pause
+diff --git a/test/system/250-systemd.bats b/test/system/250-systemd.bats
+index 614185dbab7..23e3abc1fad 100644
+--- a/test/system/250-systemd.bats
++++ b/test/system/250-systemd.bats
+@@ -55,6 +55,7 @@ function mv-safely() {
+ 
+ # Helper to start a systemd service running a container
+ function service_setup() {
++    local extra_args="$1"
+     # January 2024: we can no longer do "run_podman generate systemd" followed
+     # by "echo $output >file", because generate-systemd is deprecated and now
+     # says so loudly, to stderr, with no way to silence it. Since BATS gloms
+@@ -65,6 +66,7 @@ function service_setup() {
+         run_podman generate systemd --files --name \
+                -e http_proxy -e https_proxy -e no_proxy \
+                -e HTTP_PROXY -e HTTPS_PROXY -e NO_PROXY \
++               $extra_args \
+                --new $cname
+         mv-safely "container-$cname.service" $UNIT_FILE
+     )
+@@ -359,7 +361,7 @@ LISTEN_FDNAMES=listen_fdnames" | sort)
+                $IMAGE /home/podman/pause
+ 
+     # run container in systemd unit
+-    service_setup
++    service_setup "-e DISABLE_HC_SYSTEMD=true"
+ 
+     run_podman container inspect $cname --format "{{.ID}}"
+     oldID="$output"
+
+From c4c27787764a3ba2115a4d50dd84a4ac9ab96bca Mon Sep 17 00:00:00 2001
+From: Paul Holzinger <pholzing@redhat.com>
+Date: Thu, 28 May 2026 13:01:58 +0200
+Subject: [PATCH 4/4] test/system: fix "podman kill - concurrent stop"
+
+It is possible that the background podman stop -t 1 completes before we
+get to podman kill making the kill fail as the container is not running.
+
+The result is this error in the test:
+"Error: can only kill running containers. xxx is in state exited: container state improper"
+
+We can just bump the stop timeout to have a larger time where we can
+trigger kill on a stopping container.
+
+Signed-off-by: Paul Holzinger <pholzing@redhat.com>
+---
+ test/system/130-kill.bats | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/system/130-kill.bats b/test/system/130-kill.bats
+index 5ce67abb57d..b3470bcf69b 100644
+--- a/test/system/130-kill.bats
++++ b/test/system/130-kill.bats
+@@ -124,7 +124,7 @@ load helpers
+     # 14761 - concurrent kill/stop must record the exit code
+     cname=c-$(safename)
+     run_podman run -d --replace --name=$cname $IMAGE sh -c "trap 'echo Received SIGTERM, ignoring' SIGTERM; echo READY; while :; do sleep 0.2; done"
+-    "${PODMAN_CMD[@]}" stop -t 1 $cname &
++    "${PODMAN_CMD[@]}" stop -t 5 $cname &
+     run_podman kill $cname
+     run_podman wait $cname
+     run_podman rm -f $cname

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -50,11 +50,6 @@ sub run_tests {
                 "252-quadlet.bats::quadlet kube - start error",
             ) if (version->parse(numeric_version($version)) >= version->parse("5.4.0"));
         }
-        push @xfails, (
-            # These sometimes fail for user on SLES 16.0 & Tumbleweed
-            "505-networking-pasta.bats::TCP/IPv4 large transfer, tap",
-            "505-networking-pasta.bats::IPv6 default address assignment",
-        ) if (version->parse(numeric_version($version)) >= version->parse("5.4.0"));
     } else {
         if (!$remote) {
             push @xfails, (

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -60,10 +60,6 @@ sub run_tests {
         }
     }
     push @xfails, (
-        # https://bugzilla.suse.com/show_bug.cgi?id=1246607
-        "125-import.bats::podman export, alter tarball, re-import",
-    ) if (!is_x86_64 && version->parse(numeric_version($version)) >= version->parse("5.4.0"));
-    push @xfails, (
         # Sporadic issue fixed in
         # https://github.com/containers/podman/commit/f172ff789b14226b51cea39f9373e7de2a35905a
         "550-pause-process.bats::podman system migrate works with conmon being killed",


### PR DESCRIPTION
- Backport https://github.com/containers/podman/pull/28794
- Backport https://github.com/containers/podman/pull/28804
- Remove xfail for resolved https://bugzilla.suse.com/show_bug.cgi?id=1246607

Failed job: https://openqa.opensuse.org/tests/6001484

Verification runs:
 - Tumbleweed podman_e2e -> https://openqa.opensuse.org/tests/6001976
 - Tumbleweed podman -> https://openqa.opensuse.org/tests/6002027
 - sle-16.1 podman_e2e -> https://openqa.suse.de/tests/22724687
 - sle-16.1 podman -> https://openqa.suse.de/tests/22727950
 - sle-16.0 podman -> https://openqa.suse.de/tests/22727951
