### PR TITLE
CI: Use python3-jsonnet instead of pulling it from PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get -y update
-        apt-get -y install libdbus-1-dev libssh2-1-dev libxml2-dev parallel python3-dev python3-yaml python3-jsonschema python3-pip liblua5.3-dev
-        PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install yamllint jsonnet-binary
+        apt-get -y install libdbus-1-dev libssh2-1-dev libxml2-dev parallel python3-dev python3-yaml python3-jsonnet python3-jsonschema python3-pip liblua5.3-dev
+        PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install yamllint
         # FFI needs cargo (newer than the packaged version)
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     - name: Setup perl


### PR DESCRIPTION
CI: Use python3-jsonnet instead of pulling it from PyPI
    
The base image for perldocker/perl-tester has been oscillating between Debian 10 (Buster) & 13 (Trixie).  For now it seems to have been settled on the latter.
    
On Debian 13 the compilation fails due to gcc pedantic warnings but trying to use the package from PyPI results in ["ImportError: ...  undefined symbol: PyEval_CallObject"](https://github.com/os-autoinst/os-autoinst-distri-opensuse/actions/runs/27095755297/job/79967508351).
    
Use the Debian packaged jsonnet (v0.20.0) to avoid any compilation.

Fixes: https://github.com/os-autoinst/os-autoinst-distri-opensuse/actions/runs/27095217240/job/79966007992?pr=25745