### PR TITLE
If prev console is root console, should not change again

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -156,6 +156,7 @@ sub process_reboot {
     }
 
     # Switch to the previous console
+    reset_consoles;
     select_console $prev_console;
 }
 

--- a/tests/transactional/rebootmgr.pm
+++ b/tests/transactional/rebootmgr.pm
@@ -56,6 +56,7 @@ sub check_strategy_instantly {
 
 #2 Test maint-window strategy
 sub check_strategy_maint_window {
+    reset_consoles;
     select_console('root-console');
     rbm_call "set-strategy maint-window";
     # Trigger reboot during maint-window


### PR DESCRIPTION
If prev console is root console, should not change again

- Related ticket: https://progress.opensuse.org/issues/201939
- Verification run: https://openqa.suse.de/tests/overview?version=16.1&distri=sle&build=tinawang123%2Fos-autoinst-distri-opensuse%23rebootmgr
