### PR TITLE
Upload coredump files for wicked tests

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -26,6 +26,7 @@ use File::Basename;
 use version_utils 'check_version';
 use List::MoreUtils qw(uniq);
 use containers::common qw(install_podman_when_needed install_docker_when_needed);
+use Utils::Logging qw(upload_coredumps);
 
 
 use strict;
@@ -1177,6 +1178,8 @@ sub check_coredump {
     my $self = shift;
 
     install_coredump;
+    record_info('Upload coredump files if any');
+    upload_coredumps;
     return if (script_run('[ -z "$(coredumpctl -1 --no-pager --no-legend | grep wicked )" ]') == 0);
 
     my @core_pids = split(/\s+/, script_output(q(coredumpctl list --no-pager --no-legend | grep wicked | perl -ne '$_ =~ m/ ([0-9]+) / && print $1 .$/')));


### PR DESCRIPTION
Based on https://bugzilla.suse.com/show_bug.cgi?id=1267732,  sometimes job is failed but not caused by wicked itself, so adapt the logic a bit to collect core dump files which can help us to debug job failures.

- Verification run: https://openqa.suse.de/tests/overview?build=rfan06081&distri=sle

It can work as expected at https://openqa.suse.de/tests/22729356#step/t20_teaming_ab_all_link/15, coredump files is uploaded as well `core.teamd.472.36d82831f8d3446bb5b86e52fc81edbf.7044.1780901768000000.zst.txt `