### PR TITLE
Remove always_rollback flag for libssh test

### DIFF
--- a/tests/console/libssh.pm
+++ b/tests/console/libssh.pm
@@ -152,9 +152,4 @@ EOF
     assert_script_run("docker stop libssh_container");
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;
-


### PR DESCRIPTION
https://progress.opensuse.org/issues/201984

Based on https://github.com/os-autoinst/os-autoinst/pull/2948,
test will fail with flag 'always_rollback' + job setting
'QEMU_DISABLE_SNAPSHOT=1'.
Remove the flag to make sure it can work on all backends

- Verification run: n/a