### PR TITLE
Remove registration server in autoyast profile

### DIFF
--- a/data/yam/autoyast/ha.xml.ep
+++ b/data/yam/autoyast/ha.xml.ep
@@ -5,7 +5,6 @@
     <do_registration config:type="boolean">true</do_registration>
     <email/>
     <reg_code>{{SCC_REGCODE}}</reg_code>
-    <reg_server>{{SCC_URL}}</reg_server>
     <install_updates config:type="boolean">true</install_updates>
     <addons config:type="list">
       <addon>

--- a/data/yam/autoyast/ha_s390x.xml.ep
+++ b/data/yam/autoyast/ha_s390x.xml.ep
@@ -5,7 +5,6 @@
     <do_registration config:type="boolean">true</do_registration>
     <email/>
     <reg_code>{{SCC_REGCODE}}</reg_code>
-    <reg_server>{{SCC_URL}}</reg_server>
     <install_updates config:type="boolean">true</install_updates>
     <addons config:type="list">
       <addon>

--- a/data/yam/autoyast/sles_sap_migration.xml.ep
+++ b/data/yam/autoyast/sles_sap_migration.xml.ep
@@ -118,7 +118,6 @@
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>
     <reg_code>{{SCC_REGCODE_SLES4SAP}}</reg_code>
-    <reg_server>{{SCC_URL}}</reg_server>
   </suse_register>
   <users t="list">
     <user t="map">

--- a/data/yam/autoyast/sles_sap_migration_bug1235701.xml.ep
+++ b/data/yam/autoyast/sles_sap_migration_bug1235701.xml.ep
@@ -118,7 +118,6 @@
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>
     <reg_code>{{SCC_REGCODE_SLES4SAP}}</reg_code>
-    <reg_server>{{SCC_URL}}</reg_server>
   </suse_register>
   <users t="list">
     <user t="map">

--- a/data/yam/autoyast/textmode.xml.ep
+++ b/data/yam/autoyast/textmode.xml.ep
@@ -5,7 +5,6 @@
       <do_registration config:type="boolean">true</do_registration>
       <email/>
       <reg_code>{{SCC_REGCODE}}</reg_code>
-      <reg_server>{{SCC_URL}}</reg_server>
       <install_updates config:type="boolean">true</install_updates>
       <addons config:type="list">
         <addon>

--- a/data/yam/autoyast/textmode_all_modules_and_extensions_aarch64.xml.ep
+++ b/data/yam/autoyast/textmode_all_modules_and_extensions_aarch64.xml.ep
@@ -5,7 +5,6 @@
     <do_registration config:type="boolean">true</do_registration>
     <email/>
     <reg_code>{{SCC_REGCODE}}</reg_code>
-    <reg_server>{{SCC_URL}}</reg_server>
     <install_updates config:type="boolean">true</install_updates>
     <addons config:type="list">
       <addon>

--- a/data/yam/autoyast/textmode_all_modules_and_extensions_ppc64le.xml.ep
+++ b/data/yam/autoyast/textmode_all_modules_and_extensions_ppc64le.xml.ep
@@ -5,7 +5,6 @@
     <do_registration config:type="boolean">true</do_registration>
     <email/>
     <reg_code>{{SCC_REGCODE}}</reg_code>
-    <reg_server>{{SCC_URL}}</reg_server>
     <install_updates config:type="boolean">true</install_updates>
     <addons config:type="list">
       <addon>

--- a/data/yam/autoyast/textmode_all_modules_and_extensions_s390x.xml.ep
+++ b/data/yam/autoyast/textmode_all_modules_and_extensions_s390x.xml.ep
@@ -5,7 +5,6 @@
     <do_registration config:type="boolean">true</do_registration>
     <email/>
     <reg_code>{{SCC_REGCODE}}</reg_code>
-    <reg_server>{{SCC_URL}}</reg_server>
     <install_updates config:type="boolean">true</install_updates>
     <addons config:type="list">
       <addon>

--- a/data/yam/autoyast/textmode_all_modules_and_extensions_x86_64.xml.ep
+++ b/data/yam/autoyast/textmode_all_modules_and_extensions_x86_64.xml.ep
@@ -5,7 +5,6 @@
     <do_registration config:type="boolean">true</do_registration>
     <email/>
     <reg_code>{{SCC_REGCODE}}</reg_code>
-    <reg_server>{{SCC_URL}}</reg_server>
     <install_updates config:type="boolean">true</install_updates>
     <addons config:type="list">
       <addon>

--- a/data/yam/autoyast/textmode_s390x.xml.ep
+++ b/data/yam/autoyast/textmode_s390x.xml.ep
@@ -5,7 +5,6 @@
       <do_registration config:type="boolean">true</do_registration>
       <email/>
       <reg_code>{{SCC_REGCODE}}</reg_code>
-      <reg_server>{{SCC_URL}}</reg_server>
       <install_updates config:type="boolean">true</install_updates>
       <addons config:type="list">
         <addon>

--- a/data/yam/autoyast/textmode_zvm.xml.ep
+++ b/data/yam/autoyast/textmode_zvm.xml.ep
@@ -101,7 +101,6 @@
     <do_registration t="boolean">true</do_registration>
     <install_updates t="boolean">true</install_updates>
     <reg_code>{{SCC_REGCODE}}</reg_code>
-    <reg_server>{{SCC_URL}}</reg_server>
   </suse_register>
   <users t="list">
     <user t="map">

--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -547,6 +547,7 @@ sub validate_repo_properties {
     }
 
     if ($args->{URI}) {
+	diag("actual=$actual_repo_data->{URI} data=$args->{URI}");
         assert_true($actual_repo_data->{URI} =~ /$args->{URI}/,
             "Repository $args->{Name} has wrong URI, expected: '$args->{URI}', got: '$actual_repo_data->{URI}'");
     }

--- a/schedule/yam/agama_migration_15spx.yaml
+++ b/schedule/yam/agama_migration_15spx.yaml
@@ -7,10 +7,13 @@ schedule:
   - autoyast/prepare_profile
   - installation/bootloader_start
   - autoyast/installation
+  - autoyast/console
   - installation/first_boot
   - yam/migration/restore_upgrade_env
   - console/system_prepare
   - console/hostname
+  - autoyast/clone
+  - autoyast/logs
   - yam/migration/migration_unattended
   - installation/grub_test
   - installation/first_boot

--- a/tests/autoyast/clone.pm
+++ b/tests/autoyast/clone.pm
@@ -16,6 +16,10 @@ use utils qw(zypper_call);
 sub run {
     my $self = shift;
     assert_script_run 'rm -f /root/autoinst.xml';
+
+    assert_script_run 'SUSEConnect -s > /tmp/suseconnect.txt';
+    upload_logs '/tmp/suseconnect.txt';
+
     zypper_call('in autoyast2', 300);
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'clone_system', yast2_opts => '--ncurses');
     if (check_screen 'autoyast2-install-accept', 10) {


### PR DESCRIPTION


- Related ticket: N/A
- Needles: N/A
- Verification run:  https://openqa.suse.de/tests/overview?build=lemon-suse%2Fos-autoinst-distri-opensuse%23remove-registration-server-in-autoyast-profile&version=16.1&distri=sle
