### PR TITLE
Quit test on demand if coredump files are seen

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -250,7 +250,7 @@ sub upload_coredumps {
             upload_logs("backtrace$pid.txt", log_name => basename($core) . "_backtrace.txt", failok => 1);
         }
     }
-    die("COREDUMPS found");
+    die("COREDUMPS found") unless get_var('COREDUMP_IGNORE_ERRORS');
 }
 
 =head2 export_logs

--- a/variables.md
+++ b/variables.md
@@ -58,6 +58,7 @@ HELM_CHART | string | | Helm chart under test. See `main_containers.pm` for supp
 HELM_CONFIG | string | | Additional configuration file for helm |
 HELM_LOGIN | string | Comma-separated list of login information if required for a registry, e.g. `registry.suse.de:username:password,registry.suse.de:geekotest:notsecret`
 HELM_FULL_REGISTRY_PATH | string | Full path to the registry images used by the helm chart. e.g. `my.registry.com/myteam/secret_project`. Only necessary when using non-publicly available container images. | 
+COREDUMP_IGNORE_ERRORS | boolean | | Don't quit test if coredump files are seen
 COREDUMP_WITH_BACKTRACE | boolean | | Get a backtrace when analyzing coredumps
 CPU_BUGS | boolean | | Into Mitigations testing
 DESKTOP | string | | Indicates expected DM, e.g. `gnome`, `kde`, `textmode`, `xfce`, `lxde`. Does NOT prescribe installation mode. Installation is controlled by `VIDEOMODE` setting


### PR DESCRIPTION
With new logic, we can quit the test on demand via variable in case coredump files are seen

- Verification run: https://openqa.suse.de/tests/22729706