### PR TITLE
Make validation for migration test continue for next even failed

### DIFF
--- a/tests/yam/validate/validate_connectivity.pm
+++ b/tests/yam/validate/validate_connectivity.pm
@@ -19,4 +19,8 @@ sub run {
     validate_script_output("nmcli networking connectivity check", sub { m/\b$connectivity\b/ });
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;

--- a/tests/yam/validate/validate_product.pm
+++ b/tests/yam/validate/validate_product.pm
@@ -26,4 +26,8 @@ sub run {
     }
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;


### PR DESCRIPTION
We need set fatal=0 to make these validation test can continue for next module.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/22729539#details
