### PR TITLE
Fix CI by using the more stable perl:$version-trixie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get -y update
-        apt-get -y install libdbus-1-dev libssh2-1-dev libxml2-dev parallel python3-dev python3-yaml python3-jsonnet python3-jsonschema python3-pip liblua5.3-dev
-        PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install yamllint
+        apt-get -y install libdbus-1-dev libssh2-1-dev libxml2-dev parallel python3-dev python3-yaml python3-jsonnet python3-jsonschema liblua5.3-dev yamllint
         # FFI needs cargo (newer than the packaged version)
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     - name: Setup perl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           - test: check-strict
             perl-version: '5.42'
     container:
-      image: perldocker/perl-tester:${{ matrix.perl-version }}
+      image: perl:${{ matrix.perl-version }}-trixie
     steps:
     - uses: actions/checkout@v6
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
       run: |
         # Prefix with space to bypass ./tools/update_spec
         echo " requires 'Code::DRY';" >> cpanfile
+        echo " requires 'Code::TidyAll';" >> cpanfile
         echo " requires 'Date::Parse';" >> cpanfile
+        echo " requires 'List::Compare';" >> cpanfile
         echo " requires 'Regexp::Common';" >> cpanfile
         echo " requires 'Syntax::Keyword::Try';" >> cpanfile
         echo " requires 'Perl::Tidy', '== 20250616.0.0';" >> cpanfile


### PR DESCRIPTION
perldocker/perl-tester is behaving erratically by changing the Debian image base.  Use perl:$version-trixie that is fixed to Debian trixie.

Follow suggestion in https://suse.slack.com/archives/C02CANHLANP/p1780909131859409?thread_ts=1780908625.357989&cid=C02CANHLANP

Fixes https://github.com/os-autoinst/os-autoinst-distri-opensuse/actions/runs/27126271115/job/80055561454?pr=25752