### PR TITLE
Elemental3: fix code to use default GH branch

### DIFF
--- a/tests/elemental3/test_framework.pm
+++ b/tests/elemental3/test_framework.pm
@@ -14,8 +14,12 @@ use transactional qw(trup_call);
 use Utils::Git;
 
 sub run {
-    my ($repo, $branch) = get_required_var('TEST_FRAMEWORK_REPO') =~ /(\S*)@(\S*)/;
     my $timeout = 1200;
+
+    # Extract test framework to use and set default branch if none is provided
+    my ($repo, $branch) = get_required_var('TEST_FRAMEWORK_REPO') =~ /(\S*)@(\S*)/;
+    $repo //= get_required_var('TEST_FRAMEWORK_REPO');
+    $branch //= 'main';
 
     # Add git/go package(s)
     trup_call('pkg install git go kubernetes-client-provider', timeout => $timeout);


### PR DESCRIPTION
If no branch is defined use the default one (`main`).

- Related ticket: N/A
- Needles: N/A
- Verification run: [singlenode](http://10.116.2.38/tests/overview?distri=sle&distri=sle-micro&version=16.0&build=23.1_rke2-manifest-image&groupid=5), [master_singlenode](http://10.116.2.38/tests/2336#step/test_framework/39)