### PR TITLE
xfstests: umount after get fsxops

### DIFF
--- a/lib/xfstests_utils.pm
+++ b/lib/xfstests_utils.pm
@@ -455,6 +455,7 @@ sub copy_fsxops {
         my $fsxops = script_output("cat $TEST_FOLDER/junk.fsxops 2>/dev/null", 30, proceed_on_failure => 1);
         record_info('fsxops', $fsxops) if $fsxops;
     }
+    script_run("umount $TEST_FOLDER 2>/dev/null");
 }
 
 =head2 raw_dump


### PR DESCRIPTION
The copy_fsxops mount TEST_DEV but forgot to umount TEST_DEV, which will cause some unexpected error after a test fails in BTRFS

- Related ticket: https://progress.opensuse.org/issues/202317
- Verification run: https://openqa.opensuse.org/tests/6004177