### PR TITLE
Add workaround for bsc#1265431 on production

### DIFF
--- a/tests/yam/agama/agama_cli.pm
+++ b/tests/yam/agama/agama_cli.pm
@@ -29,12 +29,15 @@ sub run {
 
     assert_script_run('agama config show | jq -C');
 
-    assert_script_run("jq -n '.root.password = \"$testapi::password\"' | agama config load");
+    my $enable_workaround = !(is_sle('16.1+') && get_var('FLAVOR', '') =~ /agama-installer/);
+    my $workaround = $enable_workaround ? " > /dev/null" : "";
+    record_soft_failure("bsc#1265431 - Agama config load blocks in BUSY state") if $enable_workaround;
+    assert_script_run("jq -n '.root.password = \"$testapi::password\"' | agama config load $workaround");
 
     assert_script_run("agama config show | grep -C 4 $testapi::password");
 
     my $product_id = get_var('AGAMA_PRODUCT_ID');
-    assert_script_run("jq -n '.product.id = \"$product_id\"' | agama config load");
+    assert_script_run("jq -n '.product.id = \"$product_id\"' | agama config load $workaround");
     assert_script_run("agama config show | grep -C 4 $product_id");
 
     my $rpm_url = data_url('yam/agama/hello-world-0.1-1.1.noarch.rpm');

--- a/tests/yam/agama/import_agama_profile.pm
+++ b/tests/yam/agama/import_agama_profile.pm
@@ -5,7 +5,7 @@
 # Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
 
 use Mojo::Base 'Yam::Agama::patch_agama_base';
-use testapi qw(assert_script_run data_url get_required_var set_var get_var check_var select_console script_run);
+use testapi qw(assert_script_run data_url get_required_var set_var get_var check_var select_console script_run record_soft_failure);
 use autoyast qw(expand_agama_profile generate_json_profile);
 use version_utils qw(is_sle);
 
@@ -17,7 +17,10 @@ sub run {
     set_var('AGAMA_PROFILE', $profile_url);
 
     select_console 'install-shell';
-    assert_script_run("agama config load $profile_url", timeout => 300) if (!check_var('AGAMA_PROFILE_LOAD', '0'));
+    my $enable_workaround = !(is_sle('16.1+') && get_var('FLAVOR', '') =~ /agama-installer/);
+    my $workaround = $enable_workaround ? " > /dev/null" : "";
+    record_soft_failure("bsc#1265431 - Agama config load blocks in BUSY state") if $enable_workaround;
+    assert_script_run("agama config load $profile_url" . $workaround, timeout => 300) if (!check_var('AGAMA_PROFILE_LOAD', '0'));
 }
 
 1;


### PR DESCRIPTION
Due to the fix for bsc#1265431 not patched on build 46.1, we need add back workaround for  bsc#1265431 to production group.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?build=lemon-suse%2Fos-autoinst-distri-opensuse%23add-workaround-bsc%231265431-for-production&distri=sle&version=16.1
