### PR TITLE
Remove year_2038_detection from immutable job group and s390x

### DIFF
--- a/schedule/functional/sle16/extra_tests_textmode.yaml
+++ b/schedule/functional/sle16/extra_tests_textmode.yaml
@@ -22,6 +22,14 @@ conditional_schedule:
         ARCH:
             x86_64:
                 - console/wpa_supplicant
+    year_2038_detection:
+        ARCH:
+            aarch64:
+                - console/year_2038_detection
+            x86_64:
+                - console/year_2038_detection
+            ppc64le:
+                - console/year_2038_detection
 schedule:
     - installation/bootloader_start
     - boot/boot_to_desktop
@@ -83,7 +91,7 @@ schedule:
     - console/pciutils
     - console/supportutils
     - console/vsftpd
-    - console/year_2038_detection
+    - '{{year_2038_detection}}'
     - console/redis
     - console/mdadm
     - console/quota

--- a/schedule/functional/sle16/extra_tests_textmode_immutable.yaml
+++ b/schedule/functional/sle16/extra_tests_textmode_immutable.yaml
@@ -78,7 +78,6 @@ schedule:
     - console/pciutils
     - console/supportutils
     - console/vsftpd
-    - console/year_2038_detection
     - console/redis
     - console/mdadm
     - console/quota


### PR DESCRIPTION
Remove year_2038_detection from immutable job group and s390x

- Related ticket: year_2038_detection is a destructive test remove from  immutable job group and s390x

