### PR TITLE
Revert always_rollback flag from publiccloud CLI tests

### DIFF
--- a/tests/publiccloud/aws_cli.pm
+++ b/tests/publiccloud/aws_cli.pm
@@ -109,7 +109,7 @@ sub post_fail_hook {
 }
 
 sub test_flags {
-    return {fatal => 0, milestone => 0, always_rollback => 1};
+    return {fatal => 0, milestone => 0};
 }
 
 1;

--- a/tests/publiccloud/azure_cli.pm
+++ b/tests/publiccloud/azure_cli.pm
@@ -97,7 +97,7 @@ sub post_fail_hook {
 }
 
 sub test_flags {
-    return {fatal => 0, milestone => 0, always_rollback => 1};
+    return {fatal => 0, milestone => 0};
 }
 
 1;


### PR DESCRIPTION
## Summary
- Remove `always_rollback => 1` from `aws_cli.pm` and `azure_cli.pm` `test_flags`, partially reverting #13680
- This flag is incompatible with os-autoinst/os-autoinst#2948
