### PR TITLE
Update kernel: Add zVM to LTP baremetal check

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -20,6 +20,7 @@ use kernel;
 use klp;
 use power_action_utils 'power_action';
 use repo_tools qw(add_qa_head_repo);
+use Utils::Architectures 'is_zvm';
 use Utils::Backends;
 use LTP::utils;
 use transactional;
@@ -510,7 +511,7 @@ sub run {
 
     $self->{repos} = {};
 
-    if (((is_ipmi || is_pvm) && get_var('LTP_BAREMETAL')) || (is_transactional && (get_var('FLAVOR', '') !~ /Immutable/))) {
+    if (((is_ipmi || is_pvm || is_zvm) && get_var('LTP_BAREMETAL')) || (is_transactional && (get_var('FLAVOR', '') !~ /Immutable/))) {
         # System is already booted after installation, just switch terminal
         select_serial_terminal;
     } else {


### PR DESCRIPTION
Fix poo#201744: Added `is_zvm` condition to `update_kernel` module to
properly handle installations on a zVM machine, which should be
treated as bare metal. The `update_kernel` module was never scheduled
on zVM and was failing (when was added to schedule). This change fixes
its behavior on zVM.



- Related ticket: https://progress.opensuse.org/issues/201744
- Needles: none
- Verification run: 
zVM TW: https://openqa.opensuse.org/tests/6004548
qemu SLE 16: https://openqa.suse.de/tests/22761989
