### PR TITLE
SDAF retry registration playbook 

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/ansible.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/ansible.pm
@@ -229,6 +229,8 @@ If undefined, it will use standard output without adding any B<-v> flag. See fun
 
 =item * B<sut>: SAP SUT type. Default 'sid', ['sid' | 'iscsi']
 
+=item * B<retry>: Number of times to retry playbook execution. Default: 0
+
 =back
 =cut
 
@@ -240,6 +242,7 @@ sub sdaf_execute_playbook {
     $args{sap_sid} //= get_required_var('SAP_SID');
     $args{verbosity_level} //= get_var('SDAF_ANSIBLE_VERBOSITY_LEVEL');
     $args{sut} //= 'sid';
+    $args{retry} //= 0;
 
     croak 'Missing mandatory argument "playbook_filename".' unless defined($args{playbook_filename});
     croak 'Missing mandatory argument "sdaf_config_root_dir".' unless $args{sdaf_config_root_dir};
@@ -254,15 +257,28 @@ sub sdaf_execute_playbook {
         '--ssh-common-args="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=120"'
     );
 
-    $output_log_file = log_dir() . "/$args{playbook_filename}" =~ s/.yaml|.yml/.txt/r;
     my $playbook_file = join('/', deployment_dir(), 'sap-automation', 'deploy', 'ansible', $args{playbook_filename});
     my $playbook_cmd = join(' ', 'ansible-playbook', $playbook_options, $playbook_file);
 
     record_info('Playbook run', "Executing playbook: $playbook_file\nExecuted command:\n$playbook_cmd");
     assert_script_run("cd $args{sdaf_config_root_dir}");
-    my $rc = script_run(log_command_output(command => $playbook_cmd, log_file => $output_log_file),
-        timeout => $args{timeout}, output => "Executing playbook: $args{playbook_filename}");
-    upload_logs($output_log_file);
+    my $rc = 1;
+    my $run_no = 0;
+    my $max_runs = $args{retry} + 1;
+    until ($rc == 0 || ($run_no > $max_runs)) {
+        $run_no++;
+        diag("\nPlaybook '$args{playbook_filename}'. Attempt $run_no/$max_runs START\n");
+        # Changing log file extension to txt allows direct viewing in OpenQA WebUI
+        $output_log_file = (log_dir() . "/$args{playbook_filename}") =~ s/\.ya?ml$/_$run_no.txt/r;
+        $rc = script_run(log_command_output(command => $playbook_cmd, log_file => $output_log_file),
+            timeout => $args{timeout}, output => "Executing playbook: $args{playbook_filename}");
+
+        upload_logs($output_log_file);
+        record_soft_failure("Retry: Playbook '$args{playbook_filename}' failed with RC '$rc'. bsc#1253777")
+          if ($rc && $args{retry});
+        diag("\nPlaybook '$args{playbook_filename}'. Attempt no $run_no/$max_runs END\n");
+    }
+
     die "Execution of playbook failed with RC: $rc" if $rc;
     record_info('Playbook OK', "Playbook execution finished: $playbook_file");
     # Update the reference and mark playbook as PASSED

--- a/t/40_sdaf_ansible_library.t
+++ b/t/40_sdaf_ansible_library.t
@@ -18,6 +18,7 @@ sub undef_variables {
 
 subtest '[sdaf_execute_playbook] Fail with missing mandatory arguments' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::ansible', no_auto => 1);
+    $ms_sdaf->noop(qw(record_soft_failure diag));
     my $croak_message;
     $ms_sdaf->redefine(croak => sub { $croak_message = $_[0]; die(); });
 
@@ -37,7 +38,7 @@ subtest '[sdaf_execute_playbook] Command execution' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::ansible', no_auto => 1);
     my @calls;
     $ms_sdaf->redefine(script_run => sub { push(@calls, $_[0]); return 0; });
-    $ms_sdaf->noop(qw(assert_script_run record_info log_dir upload_logs deployment_dir));
+    $ms_sdaf->noop(qw(diag assert_script_run record_info log_dir upload_logs deployment_dir record_soft_failure));
     set_var('SAP_SID', 'QES');
     set_var('SDAF_ANSIBLE_VERBOSITY_LEVEL', undef);
 
@@ -57,10 +58,10 @@ subtest '[sdaf_execute_playbook] Command verbosity' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::ansible', no_auto => 1);
     my @calls;
 
-    $ms_sdaf->redefine(script_run => sub { return; });
+    $ms_sdaf->redefine(script_run => sub { return 0; });
     $ms_sdaf->redefine(deployment_dir => sub { return '/directory'; });
     $ms_sdaf->redefine(log_command_output => sub { push(@calls, $_[1]); return 0; });
-    $ms_sdaf->noop(qw(assert_script_run record_info log_dir upload_logs));
+    $ms_sdaf->noop(qw(diag assert_script_run record_info record_soft_failure log_dir upload_logs));
     set_var('SAP_SID', 'QES');
 
     my %verbosity_levels = (
@@ -76,6 +77,18 @@ subtest '[sdaf_execute_playbook] Command verbosity' => sub {
         ok(grep(/$verbosity_levels{$level}/, @calls), "Append '$verbosity_levels{$level}' with verbosity parameter: '$level'");
     }
 
+    undef_variables();
+};
+
+subtest '[sdaf_execute_playbook] Retry execution' => sub {
+    my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::ansible', no_auto => 1);
+    my $executions = 0;
+    my $retries = 5;
+    $ms_sdaf->redefine(script_run => sub { $executions++; $executions == 6 ? 0 : 1; });
+    $ms_sdaf->noop(qw(diag assert_script_run record_info log_dir upload_logs deployment_dir record_soft_failure));
+    set_var('SAP_SID', 'QES');
+    sdaf_execute_playbook(playbook_filename => 'playbook_01_os_base_config.yaml', sdaf_config_root_dir => '/tmp/', retry => $retries);
+    is $executions, $retries + 1, "Playbook is retried $retries times";
     undef_variables();
 };
 

--- a/tests/sles4sap/sap_deployment_automation_framework/os_preparation.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/os_preparation.pm
@@ -90,7 +90,8 @@ sub run {
     my $playbook_options = $playbook_setup->get();
     # Request next playbook in loop until all are executed
     while ($playbook_options->{playbook_filename}) {
-        sdaf_execute_playbook(%{$playbook_options}, sdaf_config_root_dir => $sdaf_config_root_dir);
+        my $retry = ($playbook_options->{playbook_filename} =~ 'playbook_01_os_base_config') ? 1 : 0;
+        sdaf_execute_playbook(%{$playbook_options}, sdaf_config_root_dir => $sdaf_config_root_dir, retry => $retry);
         # Tasks needed to be run after playbook 'pb_get-sshkey.yaml'
         if ($playbook_options->{playbook_filename} =~ /pb_get-sshkey/) {
             # Check if SSH key was created by playbook


### PR DESCRIPTION
There is an sporadic issue with registrations on Azure due to bsc#1253777. This PR adds `retry` option to repeat ansible playbook execution.

Ticket: https://jira.suse.com/browse/TEAM-11286

Verification run:
https://openqaworker15.qe.prg2.suse.org/tests/372218
https://openqaworker15.qe.prg2.suse.org/tests/372215
https://openqaworker15.qe.prg2.suse.org/tests/372212
https://openqaworker15.qe.prg2.suse.org/tests/372460


Mocked failure on first run : https://openqaworker15.qe.prg2.suse.org/tests/372457#step/os_preparation/74
