### PR TITLE
Remove test_flags for post_registration

### DIFF
--- a/tests/yam/validate/post_registration.pm
+++ b/tests/yam/validate/post_registration.pm
@@ -20,8 +20,4 @@ sub run {
     assert_script_run "SUSEConnect -s | grep 'Not Registered'";
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;


### PR DESCRIPTION
##
### Remove test_flags for post_registration

- Related ticket: 
   - Quick PR to fix
- Related job: 
  - https://openqa.suse.de/tests/22755107/
- Needles: N/A
- Verification run: 
  - [**sles_post_registration_unattended**](https://openqa.suse.de/tests/overview?version=16.0&build=hjluo%2Fos-autoinst-distri-opensuse%23fix_always_snapshot&distri=sle)

##
