### PR TITLE
Extend wait after soft reboot and console reset after reboot

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -147,6 +147,11 @@ sub process_reboot {
             assert_screen 'grub2', 300;
             wait_screen_change { send_key 'ret' };
         }
+        else {
+            #Need to wait 3s to start tty6 service refer bsc#1269251
+            assert_screen 'linux-login', 200;
+            wait_still_screen(3);
+        }
         assert_screen 'linux-login', 200;
 
         # Login & clear login needle


### PR DESCRIPTION
If prev console is root console, should not change again

- Related ticket: https://progress.opensuse.org/issues/201939
- Verification run: https://openqa.suse.de/tests/22772005#details
                                https://openqa.suse.de/tests/22772044
                        https://openqa.suse.de/tests/overview?build=tinawang123%2Fos-autoinst-distri-opensuse%23console
  Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25768
                       https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25747

