### PR TITLE
Fix test module name in schedule yaml file

### DIFF
--- a/schedule/virt_autotest/sle16_default_svirt.yaml
+++ b/schedule/virt_autotest/sle16_default_svirt.yaml
@@ -4,7 +4,7 @@ name: 'svirt hyperv and vmware'
 schedule:
     - '{{bootloader}}'
     - yam/agama/boot_agama
-    - yam/agama/agama_auto.pm
+    - yam/agama/agama_auto
     - installation/grub_test
     - installation/first_boot
     - console/system_prepare


### PR DESCRIPTION
Updated the name for vmware&hyperv tests in sle16 schedule yaml

- Related ticket: https://progress.opensuse.org/issues/202362
- Verification run: https://openqa.suse.de/tests/22805590
