### PR TITLE
Adapt coredump collection logic

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -1177,18 +1177,21 @@ sub check_coredump {
     my $self = shift;
 
     install_coredump;
-    return if (script_run('[ -z "$(coredumpctl -1 --no-pager --no-legend | grep wicked )" ]') == 0);
+    return if (script_run('[ -z "$(coredumpctl -1 --no-pager --no-legend)" ]') == 0);
 
-    my @core_pids = split(/\s+/, script_output(q(coredumpctl list --no-pager --no-legend | grep wicked | perl -ne '$_ =~ m/ ([0-9]+) / && print $1 .$/')));
+    record_info('List all coredump files', script_output('coredumpctl list --no-pager'));
+    my @core_pids = split(/\s+/, script_output(q(coredumpctl list --no-pager --no-legend | perl -ne '$_ =~ m/ ([0-9]+) / && print $1 .$/')));
     for my $pid (@core_pids) {
         my $core;
-        if ($self->coredumpctl_has_debug() && script_run('command -v gdb') == 0 && script_run('rpm -q --qf "" wicked-debuginfo') == 0) {
+        my $is_wicked = script_run('coredumpctl info ' . $pid . ' | grep -E "Executable:.*wicked"') == 0;
+        if ($is_wicked && $self->coredumpctl_has_debug() && script_run('command -v gdb') == 0 && script_run('rpm -q --qf "" wicked-debuginfo') == 0) {
             $core = script_output(qq(coredumpctl debug $pid --debugger-arguments='-quiet -ex "set pagination off" -ex "set debuginfod off" -ex bt -ex quit'));
         } else {
             $core = script_output(qq(coredumpctl info $pid));
         }
-        record_info('CORE DUMP', $core, result => 'fail');
-        $self->result('fail');
+        my $result = $is_wicked ? 'fail' : 'softfail';
+        record_info('CORE DUMP', $core, result => $result);
+        $self->result($result);
     }
 }
 


### PR DESCRIPTION
1. Before we only list core dump files related to wicked, now all files are shown up
2.  It can help us to investigate test failures with new logic

- Verification run:
[15SP7](http://openqa.suse.de/tests/22795674#dependencies)
[15SP6](http://openqa.suse.de/tests/22795482#dependencies)
