### PR TITLE
Add 16.0 to ha/check_iscsi_initiator workaround on ppc64le

### DIFF
--- a/tests/ha/check_iscsi_initiator.py
+++ b/tests/ha/check_iscsi_initiator.py
@@ -93,7 +93,7 @@ def run(self):
             # issued to make the SUT boot from the ISO again.
             # WARNING: if using this module right before a module that expects an installed
             # SUT, then it will be destroyed and test will fail.
-            need_workaround = (check_var("ARCH", "ppc64le") and perl.version_utils.is_sle(">=16.1"))
+            need_workaround = (check_var("ARCH", "ppc64le") and perl.version_utils.is_sle(">=16"))
             if (need_workaround):
                 # Assume HDDMODEL is virtio-blk by default
                 lsblk_opt = "v"


### PR DESCRIPTION
Apply workaround from 6de3c8e6fd02629953b29d7b18739f46de80c0cc also on 16.0.

- Related Ticket: https://jira.suse.com/browse/TEAM-11309
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/22777872 :green_circle: 
