### PR TITLE
Check for repeated nodes in sbd list and soft fail

### DIFF
--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -131,7 +131,13 @@ sub run {
                 last;
             }
             elsif (!$count) {
-                die "Unexpected node count in sdb list command output";
+                # Fail only if after removing repeated nodes, the number still does not match
+                my %aux = map { (split(/\s/, $_))[1] => 1 } (grep { /clear/ } split(/\n/, $sbd_output));
+                my $actual_node_count = keys %aux;
+                die 'Unexpected node count in sbd list command output' if (get_node_number != $actual_node_count);
+                # If actual number of nodes match, then we're here because some of the nodes are listed
+                # more than once
+                record_soft_failure 'bsc#1249216 - Cluster node listed more than one time in sbd device';
             }
             sleep 2;
             record_info('Retry');


### PR DESCRIPTION
The module `ha/ha_cluster_init` has a check where it verifies the number of nodes listed in the output of `sdb -d $device list` against the number of nodes configured in the cluster (as reported by `hacluster::get_node_number()` which runs `crm_mon -1` internally); when the number does not match, the module fails. For this issue, the bug bsc#1249216 has been filed, but it only occurs when performance on the cluster nodes and the iSCSI server is not optimal.

As the issue is known, and a fix is not expected soon, this commit changes the failure to a soft failure with a bugref.

To avoid potential issues unrelated to bsc#1249216, code has also been updated to remove repeated nodes on the output of `sbd -d $device list` and compare again: if the number does not match, module will fail, while if the number matches but there are nodes listed more than one time, then it will only soft fail.

- Related Ticket: https://jira.suse.com/browse/TEAM-11313
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/22778977 :green_circle: , [nodes listed more than once](https://openqa.suse.de/tests/22778977#step/ha_cluster_init/110), [soft failure](https://openqa.suse.de/tests/22778977#step/ha_cluster_init/127)
- Other Verification runs: [16.0](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR25778&distri=sle&version=16.0) :green_circle: , [15-SP7](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR25778&distri=sle&version=15-SP7) :green_circle: , [15-SP6](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR25778&distri=sle&version=15-SP6) :green_circle: , [15-SP5](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR25778&distri=sle&version=15-SP5) :green_circle: , [15-SP4](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR25778&distri=sle&version=15-SP4) :green_circle: , [12-SP5](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=VR4PR25778&distri=sle&version=12-SP5) :green_circle: 
