### PR TITLE
wsl/distro_install: Increase WSL 2 timeouts if QEMU_NO_KVM == 1

### DIFF
--- a/tests/wsl/distro_install.pm
+++ b/tests/wsl/distro_install.pm
@@ -41,6 +41,11 @@ sub run {
         timeout => 30
     ) unless (get_var('WSL2'));
 
+    # Raise timeouts on sloooow software emulation
+    $self->run_in_powershell(
+        cmd => 'echo "[wsl2]`nvmIdleTimeout=-1`ninstanceIdleTimeout=-1`ndistributionStartTimeout=600000`nkernelBootTimeout=300000" | Out-File -Append -FilePath ~/.wslconfig -Encoding utf8'
+    ) if check_var('QEMU_NO_KVM', '1');
+
     my $WSL_version = '';
     if (is_sle('<=15-sp4')) {
         $WSL_version = "SUSE-Linux-Enterprise-Server-" . get_required_var("VERSION");


### PR DESCRIPTION
Without this, most of the test runs fail due to WSL-internal timeouts.

- Related ticket: https://progress.opensuse.org/issues/197642
- Verification runs:
  * https://openqa.opensuse.org/tests/6006473
  * https://openqa.opensuse.org/tests/6006474
  * https://openqa.opensuse.org/tests/6006475
