### PR TITLE
containers/container_diff: Add Virtualization:containes on Leap 16.0+

### DIFF
--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -14,11 +14,16 @@ use utils;
 use containers::common;
 use containers::container_images;
 use containers::urls 'get_image_uri';
+use version_utils 'is_leap';
 
 sub run {
     my ($self) = @_;
     select_serial_terminal;
     my $docker = $self->containers_factory('docker');
+
+    # Not in the main repo, use it from the devel one for this test.
+    # Prio 150 to only use this repo for packages not available elsewhere.
+    zypper_call('addrepo -fG -p 150 obs://Virtualization:containers/' . get_required_var('VERSION') . ' containers') if is_leap("16.0+");
 
     zypper_call("install container-diff") if (script_run("which container-diff") != 0);
 


### PR DESCRIPTION
Not available elsewhere ATM.

- Failure: https://openqa.opensuse.org/tests/6006407#step/container_diff/98
- Verification run: https://openqa.opensuse.org/tests/6006533
