### PR TITLE
Feat: Add switch to allow cloud-init to fail

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -715,8 +715,8 @@ sub check_cloudinit() {
 
     # cloud-init status
     my $rc = $self->ssh_script_run(cmd => "sudo cloud-init status --wait", timeout => 300);
-    record_info("cloud-init", $self->ssh_script_output("sudo cloud-init status --long", proceed_on_failure => 1, timeout => 300));
-    die "cloud-init failed with return code $rc" if ($rc != 0);
+    record_info("cloud-init", $self->ssh_script_output("sudo cloud-init status --long", proceed_on_failure => 1, timeout => 300), result => $rc == 0 ? 'ok' : 'fail');
+    die "cloud-init failed with return code $rc" if ($rc != 0 && get_var('PUBLIC_CLOUD_IGNORE_CLOUDINIT_ERRORS') != 1);
 
     # cloud-id
     my $cloud_id = (is_azure) ? 'azure' : 'aws';

--- a/variables.md
+++ b/variables.md
@@ -354,6 +354,7 @@ PUBLIC_CLOUD_HDD2_TYPE | string | "" | If PUBLIC_CLOUD_ADDITIONAL_DISK_SIZE is s
 PUBLIC_CLOUD_IGNORE_EMPTY_REPO | boolean | false | Ignore empty maintenance update repos
 PUBLIC_CLOUD_IGNORE_UNREGISTERED | boolean | false | Ignore any failure related to the fact that system is unregistered.
 PUBLIC_CLOUD_IGNORE_EMPTY_UPDATES | boolean | false | Ignore no rpm list changes in patch_and_reboot
+PUBLIC_CLOUD_IGNORE_CLOUDINIT_ERRORS | boolean | false | Do not fail on cloud-init errors
 PUBLIC_CLOUD_IMAGE_ID | string | "" | The image ID we start the instance from
 PUBLIC_CLOUD_IMAGE_LOCATION | string | "" | The URL where the image gets downloaded from. The name of the image gets extracted from this URL.
 PUBLIC_CLOUD_IMAGE_PROJECT | string | "" | Google Compute Engine image project


### PR DESCRIPTION
Adds an optional switch to make tests ignore `cloud-init` failures. This is needed e.g. for [bsc#1268067](https://bugzilla.suse.com/show_bug.cgi?id=1268067) otherwise we cannot test Azure-Hardened images until the issue is resolved.

- Related failure: https://openqa.suse.de/tests/22703869
- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1268067
- Verification run: [Switch off](https://openqa.suse.de/tests/22781786#step/prepare_instance/210) [Switch on](https://openqa.suse.de/tests/22783584#step/prepare_instance/208)
