### PR TITLE
Tolerate instance-flavor-check FileNotFoundError

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -577,10 +577,10 @@ sub ipaddr2_internal_key_accept(%args) {
 
             # this score mechanism penalize more those systems
             # that are not ready when reaching this code.
-            $score += (defined($exit_code) && $exit_code eq 0) ? +1 : -1;
+            $score += (defined($exit_code) && $exit_code == 0) ? +1 : -1;
             last if $score > 1;
         }
-        die "ssh port 22 not available on VM $vm_name" if (!(defined($exit_code) && $exit_code eq 0));
+        die "ssh port 22 not available on VM $vm_name" if (!(defined($exit_code) && $exit_code == 0));
 
         # Try two different variants of the same command.
         $ret = script_run(join(' ',
@@ -832,12 +832,12 @@ sub ipaddr2_deployment_sanity {
     my $rg = ipaddr2_azure_resource_group();
     my $res = az_group_name_get();
     my $count = grep(/$rg/, @$res);
-    die "There are not exactly one but $count resource groups with name $rg" unless $count eq 1;
+    die "There are not exactly one but $count resource groups with name $rg" unless $count == 1;
 
     $res = az_vm_list(resource_group => $rg, query => '[].name');
     $count = grep(/$bastion_vm_name/, @$res);
-    die "There are not exactly 3 VMs but " . ($#{$res} + 1) unless ($#{$res} + 1) eq 3;
-    die "There are not exactly 1 but $count VMs with name $bastion_vm_name" unless $count eq 1;
+    die "There are not exactly 3 VMs but " . ($#{$res} + 1) unless ($#{$res} + 1) == 3;
+    die "There are not exactly 1 but $count VMs with name $bastion_vm_name" unless $count == 1;
 
     foreach (@$res) {
         az_vm_wait_running(
@@ -921,7 +921,7 @@ sub ipaddr2_cluster_sanity(%args) {
         bastion_ip => $args{bastion_ip});
 
     my @resources = $crm_configure =~ /primitive/g;
-    die "Cluster on VM $args{id} has " . scalar @resources . " primitives instead of expected 3" unless (scalar @resources) eq 3;
+    die "Cluster on VM $args{id} has " . scalar @resources . " primitives instead of expected 3" unless (scalar @resources) == 3;
 
     ipaddr2_ssh_internal(id => $args{id},
         cmd => '[ -f /usr/lib/ocf/resource.d/heartbeat/nginx ]',
@@ -1294,7 +1294,9 @@ sub ipaddr2_ssh_internal_cmd(%args) {
         retry => 2);
 
 Run a command on one of the two internal VM through the bastion
-using the assert_script_run API
+using the script_run testapi. It returns the exit code of the
+application.
+It dies for timeout and if exit code is not zero and no_assert is not defined.
 
 =over
 
@@ -1534,15 +1536,19 @@ sub ipaddr2_scc_check(%args) {
 
 =head2 ipaddr2_scc_registration_workaround_PAYG
 
-    my ipaddr2_scc_registration_workaround_PAYG(id => 1);
+    ipaddr2_scc_registration_workaround_PAYG(id => 1);
 
-Workaround for PAYG image scc registration.
-Do cleanup, reboot and re-register.
-Do debug.
+Wait for guestregister.service to complete on a PAYG image.
+If the service fails, collect diagnostics and attempt recovery
+by restarting it (matching the approach in
+ansible/playbooks/tasks/check-guestregister-service.yaml).
+
+Dies if registration cannot be recovered after restart.
+Records a soft failure (bsc#1254984) if restart was needed.
 
 =over
 
-=item B<id> - VM id where to install and configure the web server
+=item B<id> - VM id to check
 
 =item B<bastion_ip> - Public IP address of the bastion. Calculated if not provided.
                       Providing it as an argument is recommended
@@ -1555,75 +1561,96 @@ sub ipaddr2_scc_registration_workaround_PAYG(%args) {
     croak("Argument < id > missing") unless $args{id};
     $args{bastion_ip} //= ipaddr2_bastion_pubip();
 
-    # Debug purpose
-    record_info('Debug: check guestregister.service before reboot');
-    ipaddr2_ssh_internal(
-        id => $args{id},
-        cmd => 'sudo systemctl is-enabled guestregister.service',
-        bastion_ip => $args{bastion_ip},
-        no_assert => 1);
-
-    # Enable and start guestregister.service as it is 'disabled' sometime
-    ipaddr2_ssh_internal(
-        id => $args{id},
-        cmd => 'sudo systemctl enable --now guestregister.service',
-        bastion_ip => $args{bastion_ip});
-
-    # Clean registration before reboot
-    # NOTE: without cleanup the re-register will be failed when hit 'Credentials are invalid' error
-    ipaddr2_ssh_internal(
-        id => $args{id},
-        cmd => 'sudo registercloudguest --clean',
-        bastion_ip => $args{bastion_ip});
-
-    # Reboot: during 'reboot' it will do registration automatically if not
-    ipaddr2_ssh_internal(id => $args{id},
-        cmd => 'sudo reboot',
-        timeout => 60,
-        no_assert => 1,
-        bastion_ip => $args{bastion_ip});
-
-    # Check if reboot was done successfully
+    # Step 1: Wait for guestregister.service to reach terminal state (inactive or failed).
+    # Poll for up to 10 minutes (60 retries x 10s), matching Ansible retries/delay.
+    my $service_ok = 0;
     my $timeout = 600;
-    my $ip = ipaddr2_get_internal_vm_private_ip(id => $_);
+    my $interval = 10;
     while ($timeout > 0) {
-        if (script_run("ssh $args{bastion_ip} 'nc -vz -w 1 $ip 22'") != 0) {
-            record_info("waiting $ip boot");
-            sleep 60;
-            $timeout = $timeout - 60;
-        }
-        else {
-            record_info("$ip reboot successfully");
+        my $state = ipaddr2_ssh_internal_output(id => $args{id},
+            cmd => 'sudo systemctl show guestregister.service --property=ActiveState --property=Result',
+            bastion_ip => $args{bastion_ip});
+
+        if ($state =~ /ActiveState=inactive/) {
+            $service_ok = ($state =~ /Result=success/) ? 1 : 0;
             last;
         }
+        if ($state =~ /ActiveState=failed/) {
+            $service_ok = 0;
+            last;
+        }
+        # Still activating - wait
+        sleep $interval;
+        $timeout -= $interval;
     }
 
-    # Debug purpose
-    record_info('Debug: check guestregister.service after reboot');
-    ipaddr2_ssh_internal(
-        id => $args{id},
-        cmd => 'sudo systemctl is-enabled guestregister.service',
+    # If guestregister.service succeeded, nothing more to do
+    return if $service_ok;
+
+    # Step 2: Service failed or timed out. Collect diagnostics.
+    record_info('PAYG svc failed', 'guestregister.service did not complete successfully');
+    foreach my $cmd (
+        'sudo systemctl status guestregister.service',
+        'sudo journalctl -u guestregister.service --no-pager',
+        'sudo grep -E "ERROR:|WARNING:|401|422|failed" /var/log/cloudregister || true',
+        'sudo zypper lr -u || true'
+    ) {
+        ipaddr2_ssh_internal(id => $args{id},
+            cmd => $cmd,
+            bastion_ip => $args{bastion_ip},
+            no_assert => 1);
+    }
+
+    # Step 3: Recovery - restart guestregister.service
+    record_info('PAYG recovery', 'Attempting guestregister.service restart');
+    ipaddr2_ssh_internal(id => $args{id},
+        cmd => 'sudo systemctl restart guestregister.service',
         bastion_ip => $args{bastion_ip},
         no_assert => 1);
-    record_info('Debug: check SUSEConnect -s after reboot');
-    ipaddr2_ssh_internal(
-        id => $args{id},
-        cmd => 'sudo SUSEConnect -s',
-        bastion_ip => $args{bastion_ip},
-        no_assert => 0);
 
-    # Try registration cleaup and registercloudguest again manually
-    # NOTE: reboot automatic registration can not fully register all modules sometime
-    # Clean registration
-    ipaddr2_ssh_internal(
-        id => $args{id},
-        cmd => 'sudo registercloudguest --clean',
+    # Step 4: Wait again for restart to reach terminal state (30 retries x 5s = 150s)
+    my $retry_ok = 0;
+    $timeout = 150;
+    $interval = 5;
+    while ($timeout > 0) {
+        my $state = ipaddr2_ssh_internal_output(id => $args{id},
+            cmd => 'sudo systemctl show guestregister.service --property=ActiveState --property=Result',
+            bastion_ip => $args{bastion_ip});
+
+        if ($state =~ /ActiveState=inactive/) {
+            $retry_ok = ($state =~ /Result=success/) ? 1 : 0;
+            last;
+        }
+        if ($state =~ /ActiveState=failed/) {
+            $retry_ok = 0;
+            last;
+        }
+        sleep $interval;
+        $timeout -= $interval;
+    }
+
+    # Step 5: Verify with SUSEConnect -s (5 retries x 120s delay, matching Ansible)
+    my $sc_ret;
+    for my $attempt (1 .. 5) {
+        $sc_ret = ipaddr2_ssh_internal(id => $args{id},
+            cmd => 'sudo SUSEConnect -s',
+            bastion_ip => $args{bastion_ip},
+            no_assert => 1);
+        last if (defined $sc_ret && $sc_ret == 0);
+        sleep 120 if $attempt < 5;
+    }
+
+    die "FATAL: SUSEConnect -s failed after guestregister.service restart (rc=$sc_ret)" if $sc_ret;
+
+    my $sc_out = ipaddr2_ssh_internal_output(id => $args{id},
+        cmd => 'sudo SUSEConnect -s',
         bastion_ip => $args{bastion_ip});
-    # Re-register
-    ipaddr2_ssh_internal(
-        id => $args{id},
-        cmd => 'sudo registercloudguest --force-new',
-        bastion_ip => $args{bastion_ip});
+
+    if ($sc_out =~ /Not Registered/) {
+        die "FATAL: System still 'Not Registered' after guestregister.service restart";
+    }
+
+    record_soft_failure('bsc#1254984 - guestregister.service required restart for successful registration');
 }
 
 =head2 ipaddr2_scc_register
@@ -1660,7 +1687,8 @@ sub ipaddr2_scc_register(%args) {
     $args{scc_endpoint} //= 'registercloudguest';
     $args{timeout} //= 360;
     $args{retry} //= 3;
-    croak("SCC endpoint $args{scc_endpoint} is not supported.") unless ($args{scc_endpoint} eq 'SUSEConnect' || $args{scc_endpoint} eq 'registercloudguest');
+    croak("SCC endpoint $args{scc_endpoint} is not supported.")
+      unless ($args{scc_endpoint} eq 'SUSEConnect' || $args{scc_endpoint} eq 'registercloudguest');
 
     ipaddr2_ssh_internal(id => $args{id},
         cmd => "sudo $args{scc_endpoint} --clean",
@@ -1676,14 +1704,29 @@ sub ipaddr2_scc_register(%args) {
 
 =head2 ipaddr2_billing_model_get
 
-    my $is_byos_or_payg = ipaddr2_billing_model_get(id => 1);
+    my $billing = ipaddr2_billing_model_get(id => 1);
 
-Return the billing model of the running image, between BYOS and PAYG,
-internally calling instance-flavor-check
+Return the billing model of the running image by calling instance-flavor-check.
+Possible return values:
 
 =over
 
-=item B<id> - VM id where to install and configure the web server
+=item C<PAYG> - instance-flavor-check exit code 10 (valid PAYG metadata)
+
+=item C<BYOS> - instance-flavor-check exit code 11 or 12
+
+=item C<UNKNOWN> - instance-flavor-check crashed with bsc#1267739
+(FileNotFoundError on fresh BYOS images where /var/cache/cloudregister/
+does not exist). A record_soft_failure is emitted.
+
+=back
+
+The function dies on unexpected exit codes or when rc=1 without the
+known FileNotFoundError signature.
+
+=over
+
+=item B<id> - VM id where to run instance-flavor-check
 
 =item B<bastion_ip> - Public IP address of the bastion. Calculated if not provided.
                       Providing it as an argument is recommended
@@ -1696,19 +1739,35 @@ sub ipaddr2_billing_model_get(%args) {
     croak("Argument < id > missing") unless $args{id};
     $args{bastion_ip} //= ipaddr2_bastion_pubip();
 
-    # Check for image type with instance-flavor-check
+    # Run instance-flavor-check (never fatal for exit code)
     my $ret = ipaddr2_ssh_internal(id => $args{id},
         cmd => 'sudo instance-flavor-check',
         bastion_ip => $args{bastion_ip},
         no_assert => 1);
 
-    # Valid instance metadata verified successfully
-    return 'PAYG' if ($ret eq 10);
-    # 11: not valid instance metadata verified successfully
-    # 12: we could not reliably determine the flavor of the instance. The instance is labeled as BYOS
-    return 'BYOS' if (($ret eq 11) || ($ret eq 12));
+    # rc 10: Valid instance metadata verified successfully
+    return 'PAYG' if ($ret == 10);
+    # rc 11: not valid instance metadata verified successfully
+    # rc 12: we could not reliably determine the flavor of the instance
+    return 'BYOS' if (($ret == 11) || ($ret == 12));
 
-    die "Invalid instance-flavor-check ret:$ret";
+    # bsc#1267739: instance-flavor-check crashes with FileNotFoundError
+    # on fresh BYOS images where /var/cache/cloudregister/ does not exist.
+    # Detect the known bug signature and return UNKNOWN so the caller can
+    # fall back to SUSEConnect -s.
+    if ($ret == 1) {
+        my $out = ipaddr2_ssh_internal_output(id => $args{id},
+            cmd => 'sudo instance-flavor-check 2>&1 || true',
+            bastion_ip => $args{bastion_ip});
+
+        if ($out =~ /FileNotFoundError/) {
+            record_soft_failure('bsc#1267739 - instance-flavor-check crashed with FileNotFoundError');
+            return 'UNKNOWN';
+        }
+    }
+
+    # Any other unexpected exit code or rc=1 without known signature
+    die "instance-flavor-check unexpected result ret:$ret";
 }
 
 =head2 ipaddr2_configure_web_server

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -890,17 +890,17 @@ subtest '[ipaddr2_scc_check] SUSEConnect execution failed' => sub {
     ok(($ret eq 0), "Is not registered ret:$ret");
 };
 
-subtest '[ipaddr2_scc_registration_workaround_PAYG] apply registration workaround' => sub {
+subtest '[ipaddr2_scc_registration_workaround_PAYG] service succeeds immediately' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
     $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
-    $ipaddr2->redefine(ipaddr2_ssh_internal => sub { return 0; });
     $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
-    $ipaddr2->redefine(ipaddr2_get_internal_vm_private_ip => sub { '192.168.1.1'; });
-    $ipaddr2->redefine(script_run => sub { return 0; });
+    $ipaddr2->redefine(ipaddr2_ssh_internal_output => sub {
+            return "ActiveState=inactive\nResult=success";
+    });
 
     ipaddr2_scc_registration_workaround_PAYG(id => 42);
 
-    ok('Workaround applying passed');
+    ok(1, 'Workaround returns immediately when service succeeds');
 };
 
 subtest '[ipaddr2_scc_register]' => sub {
@@ -1503,7 +1503,7 @@ subtest '[ipaddr2_ssh_intrusion_detection] no lines in the journal' => sub {
     ok(($ret == 0), "Ret:$ret expected to be 0");
 };
 
-subtest '[ipaddr2_billing_model_get]' => sub {
+subtest '[ipaddr2_billing_model_get] PAYG' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2');
 
     my @calls;
@@ -1515,6 +1515,137 @@ subtest '[ipaddr2_billing_model_get]' => sub {
     my $ret = ipaddr2_billing_model_get(id => 1, bastion_ip => '2.3.4.5');
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok(($ret eq 'PAYG'), "Ret:'$ret' expected to be 'PAYG'");
+};
+
+subtest '[ipaddr2_billing_model_get] BYOS rc11' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2');
+
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub { return 11; });
+
+    my $ret = ipaddr2_billing_model_get(id => 1, bastion_ip => '2.3.4.5');
+    ok(($ret eq 'BYOS'), "Ret:'$ret' expected to be 'BYOS' for rc=11");
+};
+
+subtest '[ipaddr2_billing_model_get] BYOS rc12' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2');
+
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub { return 12; });
+
+    my $ret = ipaddr2_billing_model_get(id => 1, bastion_ip => '2.3.4.5');
+    ok(($ret eq 'BYOS'), "Ret:'$ret' expected to be 'BYOS' for rc=12");
+};
+
+subtest '[ipaddr2_billing_model_get] UNKNOWN bsc#1267739' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2');
+
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub { return 1; });
+    $ipaddr2->redefine(ipaddr2_ssh_internal_output => sub {
+            return "FileNotFoundError: [Errno 2] No such file or directory: '/var/cache/cloudregister/availableSMTInfo_1.obj'";
+    });
+    $ipaddr2->redefine(record_soft_failure => sub { note("SOFT_FAILURE --> $_[0]"); });
+
+    my $ret = ipaddr2_billing_model_get(id => 1, bastion_ip => '2.3.4.5');
+    ok(($ret eq 'UNKNOWN'), "Ret:'$ret' expected to be 'UNKNOWN' for bsc#1267739");
+};
+
+subtest '[ipaddr2_billing_model_get] die on rc=1 without FileNotFoundError' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2');
+
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub { return 1; });
+    $ipaddr2->redefine(ipaddr2_ssh_internal_output => sub {
+            return "Some other traceback error without known signature";
+    });
+
+    dies_ok { ipaddr2_billing_model_get(id => 1, bastion_ip => '2.3.4.5') }
+    "Die on rc=1 without FileNotFoundError signature";
+};
+
+subtest '[ipaddr2_billing_model_get] die on unexpected rc' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2');
+
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub { return 99; });
+
+    dies_ok { ipaddr2_billing_model_get(id => 1, bastion_ip => '2.3.4.5') }
+    "Die on unexpected exit code 99";
+};
+
+subtest '[ipaddr2_scc_registration_workaround_PAYG] service succeeds' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    my @calls;
+    $ipaddr2->redefine(ipaddr2_ssh_internal_output => sub {
+            my (%args) = @_;
+            push @calls, $args{cmd};
+            # Simulate service completed successfully
+            return "ActiveState=inactive\nResult=success";
+    });
+
+    ipaddr2_scc_registration_workaround_PAYG(id => 1, bastion_ip => '1.2.3.4');
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /systemctl show guestregister/ } @calls), 'Polls guestregister.service state');
+    ok((none { /systemctl restart/ } @calls), 'No restart needed when service succeeds');
+};
+
+subtest '[ipaddr2_scc_registration_workaround_PAYG] service fails then recovers' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $ipaddr2->redefine(record_soft_failure => sub { note("SOFT_FAILURE --> $_[0]"); });
+
+    my $poll_count = 0;
+    my @calls;
+    $ipaddr2->redefine(ipaddr2_ssh_internal_output => sub {
+            my (%args) = @_;
+            push @calls, $args{cmd};
+            if ($args{cmd} =~ /systemctl show guestregister/) {
+                $poll_count++;
+                # First poll: service failed
+                return "ActiveState=failed\nResult=exit-code" if $poll_count == 1;
+                # After restart: service succeeded
+                return "ActiveState=inactive\nResult=success";
+            }
+            if ($args{cmd} =~ /SUSEConnect -s/) {
+                return '[{"status":"Registered"}]';
+            }
+            return '';
+    });
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub {
+            my (%args) = @_;
+            push @calls, $args{cmd};
+            return 0;
+    });
+
+    ipaddr2_scc_registration_workaround_PAYG(id => 1, bastion_ip => '1.2.3.4');
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /systemctl restart guestregister/ } @calls), 'Service restarted after failure');
+    ok((any { /SUSEConnect -s/ } @calls), 'SUSEConnect verification after restart');
+};
+
+subtest '[ipaddr2_scc_registration_workaround_PAYG] recovery fails' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    my $poll_count = 0;
+    $ipaddr2->redefine(ipaddr2_ssh_internal_output => sub {
+            my (%args) = @_;
+            if ($args{cmd} =~ /systemctl show guestregister/) {
+                $poll_count++;
+                # Always report failure
+                return "ActiveState=failed\nResult=exit-code";
+            }
+            if ($args{cmd} =~ /SUSEConnect -s/) {
+                return '[{"status":"Not Registered"}]';
+            }
+            return '';
+    });
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub { return 0; });
+
+    dies_ok { ipaddr2_scc_registration_workaround_PAYG(id => 1, bastion_ip => '1.2.3.4') }
+    "Die when system remains Not Registered after restart";
 };
 
 done_testing;

--- a/tests/sles4sap/ipaddr2/registration.pm
+++ b/tests/sles4sap/ipaddr2/registration.pm
@@ -15,9 +15,11 @@ for the ipaddr2 test.
 Its behavior depends on whether cloud-init was used for the initial setup.
 
 If cloud-init is disabled (B<IPADDR2_CLOUDINIT> is 0), this module will:
-- Check the registration status
-- If the image is Not Registered: register the two SUT VMs
-  with the SUSE Customer Center (SCC) using the provided registration code.
+- Determine the billing model (PAYG, BYOS, or UNKNOWN) via instance-flavor-check
+- For PAYG images: wait for guestregister.service to complete (restart if needed)
+- For BYOS images: register with SCC using the provided registration code
+- For UNKNOWN (bsc#1267739): fall back to SUSEConnect -s to detect status,
+  then register if needed
 - Register any specified add-on products.
 
 After registration (or if cloud-init was enabled), it refreshes the software repositories
@@ -86,36 +88,37 @@ sub run {
     if (check_var('IPADDR2_CLOUDINIT', 0)) {
         foreach (1 .. 2) {
             my $type = ipaddr2_billing_model_get(id => $_, bastion_ip => $bastion_ip);
+            record_info('BILLING', "VM$_ type:$type");
 
-            # Check if somehow the image is already registered or not
-            my $is_registered = ipaddr2_scc_check(
-                bastion_ip => $bastion_ip,
-                id => $_);
-            record_info('REG INITIAL', "type:$type is_registered:$is_registered");
-
-            # Apply registration clean and reboot to redo registercloudguest if failed on PAYG image
-            if (($is_registered ne 1) && ($type eq 'PAYG')) {
+            if ($type eq 'PAYG') {
+                # PAYG images are auto-registered by guestregister.service.
+                # Wait for it to complete; restart if it failed.
                 ipaddr2_scc_registration_workaround_PAYG(
                     bastion_ip => $bastion_ip,
                     id => $_);
+                next;
+            }
 
-                # Record softfail and check again if image is fully registered
-                record_soft_failure('bsc#1254984 - Occasional registration issues on Azure and GCE OnDemand issues');
+            if ($type eq 'UNKNOWN') {
+                # bsc#1267739: instance-flavor-check failed.
+                # Fall back to SUSEConnect -s to determine registration status.
                 my $is_registered = ipaddr2_scc_check(
                     bastion_ip => $bastion_ip,
                     id => $_);
-                record_info('REG WORKAROUND', "type:$type is_registered:$is_registered");
+                record_info('REG FALLBACK', "is_registered:$is_registered");
+                # If already registered, nothing more to do
+                next if $is_registered;
+                # Otherwise, needs registration like BYOS
+                $type = 'BYOS';
             }
 
-            if (($is_registered ne 1) && ($type eq 'BYOS')) {
-                # Conditionally register the SLES for SAP instance.
-                # Registration is attempted only if the instance is not currently registered and a
-                # registration code ('SCC_REGCODE_SLES4SAP') is available.
+            if ($type eq 'BYOS') {
                 my %reg_args = (
                     bastion_ip => $bastion_ip,
                     id => $_,
                     scc_code => get_required_var('SCC_REGCODE_SLES4SAP'));
-                $reg_args{scc_endpoint} = get_var('PUBLIC_CLOUD_SCC_ENDPOINT') if (get_var('PUBLIC_CLOUD_SCC_ENDPOINT'));
+                $reg_args{scc_endpoint} = get_var('PUBLIC_CLOUD_SCC_ENDPOINT')
+                  if (get_var('PUBLIC_CLOUD_SCC_ENDPOINT'));
                 ipaddr2_scc_register(%reg_args);
             }
         }


### PR DESCRIPTION
Tollerate known problem (bsc#1267739): On fresh SLES 16.0 BYOS images, instance-flavor-check crashes.
The previous code treated any non-standard exit code as fatal, blocking registration before the SUSEConnect fallback could run. The PAYG workaround relied on a full VM reboot which was slow. Align with the approach implemented in SUSE/qe-sap-deployment#474: detect bsc#1267739 and fall back to SUSEConnect -s for billing model detection, recover PAYG registration failures by restarting guestregister.service instead of rebooting (bsc#1254984).

- Related ticket: https://jira.suse.com/browse/TEAM-11310

#  Verification run:

## 16.0
sle-16.0-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE16.0-ipaddr2_azure_test az_Standard_B1s
- http://openqaworker15.qe.prg2.suse.org/tests/372637 :green_circle:  here the fallback in all its glory https://openqaworker15.qe.prg2.suse.org/tests/372637#step/registration/53


## 15sp7
sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-ipaddr2_azure_test az_Standard_B1s
- http://openqaworker15.qe.prg2.suse.org/tests/372638 :green_circle: 

## 12sp5
sle-12-SP5-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE12_5-ipaddr2_azure_ltss_es_test az_Standard_B1s
- http://openqaworker15.qe.prg2.suse.org/tests/372639 :green_circle: 
