### PR TITLE
Fix the permission issue in sssd_389ds_functional on TW

### DIFF
--- a/schedule/opensuse/textmode_extra_tests_networking.yaml
+++ b/schedule/opensuse/textmode_extra_tests_networking.yaml
@@ -37,6 +37,7 @@ schedule:
     - boot/boot_to_desktop
     - console/prepare_test_data
     - '{{consoletest_setup}}'
+    - console/sssd_389ds_functional
     - console/chrony
     - console/dnsmasq
     - console/ping

--- a/schedule/opensuse/textmode_extra_tests_networking.yaml
+++ b/schedule/opensuse/textmode_extra_tests_networking.yaml
@@ -37,7 +37,6 @@ schedule:
     - boot/boot_to_desktop
     - console/prepare_test_data
     - '{{consoletest_setup}}'
-    - console/sssd_389ds_functional
     - console/chrony
     - console/dnsmasq
     - console/ping

--- a/tests/console/sssd_389ds_functional.pm
+++ b/tests/console/sssd_389ds_functional.pm
@@ -104,7 +104,10 @@ sub configure_sssd_client ($container_engine, $run_as_user = 'root') {
         record_info('Config', 'Configuring SSSD to run as root');
         # Ensure root ownership (or default)
         assert_script_run("rm -f /etc/systemd/system/sssd.service.d/override.conf");
-        assert_script_run("chown -R root:root /etc/sssd /var/lib/sss /var/log/sssd");
+        assert_script_run("chown -R root:root /etc/sssd /var/lib/sss /var/log/sssd /etc/sssd/sssd.conf");
+	assert_script_run("chown -R sssd:sssd /var/lib/sss /var/log/sssd");
+        assert_script_run("chmod 0600 /etc/sssd/sssd.conf");
+        assert_script_run("chmod 0750 /var/lib/sss/db /var/log/sssd");
         # Clear cache for clean state
         assert_script_run("rm -rf /var/lib/sss/db/* /var/lib/sss/mc/*");
     }
@@ -121,6 +124,7 @@ sub configure_sssd_client ($container_engine, $run_as_user = 'root') {
         script_retry("ping -c 1 ldapserver", retry => 5, delay => 2);
     }
     script_run("systemctl enable --now sssd.service");
+    script_run("journalctl -xeu sssd.service");
 }
 
 sub change_and_verify_password ($user, $old_pass, $new_pass) {

--- a/tests/console/sssd_389ds_functional.pm
+++ b/tests/console/sssd_389ds_functional.pm
@@ -105,7 +105,7 @@ sub configure_sssd_client ($container_engine, $run_as_user = 'root') {
         # Ensure root ownership (or default)
         assert_script_run("rm -f /etc/systemd/system/sssd.service.d/override.conf");
         assert_script_run("chown -R root:root /etc/sssd /var/lib/sss /var/log/sssd /etc/sssd/sssd.conf");
-	assert_script_run("chown -R sssd:sssd /var/lib/sss /var/log/sssd");
+        assert_script_run("chown -R sssd:sssd /var/lib/sss /var/log/sssd") if is_tumbleweed;
         assert_script_run("chmod 0600 /etc/sssd/sssd.conf");
         assert_script_run("chmod 0750 /var/lib/sss/db /var/log/sssd");
         # Clear cache for clean state
@@ -124,7 +124,6 @@ sub configure_sssd_client ($container_engine, $run_as_user = 'root') {
         script_retry("ping -c 1 ldapserver", retry => 5, delay => 2);
     }
     script_run("systemctl enable --now sssd.service");
-    script_run("journalctl -xeu sssd.service");
 }
 
 sub change_and_verify_password ($user, $old_pass, $new_pass) {


### PR DESCRIPTION
Fix the permission issue in sssd_389ds_functional on TW

- Related ticket: https://progress.opensuse.org/issues/200000
- Verification run: https://openqa.suse.de/tests/overview?build=tinawang123%2Fos-autoinst-distri-opensuse%23389dssssd
                                https://openqa.opensuse.org/tests/6006798