### PR TITLE
Skip note 1680803 on Azure

### DIFF
--- a/tests/sles4sap/saptune/mr_test_run.pm
+++ b/tests/sles4sap/saptune/mr_test_run.pm
@@ -525,6 +525,8 @@ sub test_notes {
         # The ASE docs don't recommend any specific value or formula, so it must
         # be tested with an override file in test_overrides()
         next if ($note eq "1805750");
+        # Skip 1680803 on Azure, note 1680803 does nothing on Azure
+        next if ($note eq "1680803" and is_azure());
         $self->test_note($note);
     }
 }


### PR DESCRIPTION
the note 1680803 in saptune 3.2.3 updated, it does noting on Azure, so I create this PR to skip note 1680803 test.

- Related ticket: https://jira.suse.com/browse/TEAM-11257
- Needles: None
- Verification run:
    https://openqa.suse.de/tests/22795451 (QR 15-SP7 ppc64le)
    https://openqa.suse.de/tests/22796355 (15-SP7 GCE)
    https://openqa.suse.de/tests/22796342 (15-SP7 Azure,  skipped note 1680803)
    https://openqa.suse.de/tests/22796370 (15-SP4 Azure)
