### PR TITLE
Wrong encoding in MLS solved in bsc#1259131

### DIFF
--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -13,14 +13,7 @@ use serial_terminal qw(select_serial_terminal);
 
 sub run {
     my $self = shift;
-    # There's a kernel bug in MLS8. bsc#1259131
-    # Wrong encoding when shutting down after kernel update
-    if (check_var("VERSION", "mls8")) {
-        select_serial_terminal;
-        record_soft_failure("bsc#1259131 - Wrong encoding in MLS8 when shutting down after kernel update");
-    } else {
-        select_console("root-console");
-    }
+    select_console("root-console");
     systemctl 'list-timers --all';
     power_action('poweroff');
 }


### PR DESCRIPTION
The bug has already been solved and the proper behaviour verified in a local VM.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1259131
- Verification run: https://openqa.suse.de/tests/22796603
