### PR TITLE
zypper_call: Use /var/tmp for log with tmpfs arg

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -635,9 +635,10 @@ sub zypper_call {
     my $allow_exit_codes = $args{exitcode} || [0];
     my $timeout = $args{timeout} || 700;
     my $log = $args{log};
+    my $var = $args{tmpfs} ? '/var' : '';
     my $dumb_term = $args{dumb_term} // is_serial_terminal;
 
-    my $printer = $log ? "| tee /tmp/$log" : $dumb_term ? '| cat' : '';
+    my $printer = $log ? "| tee $var/tmp/$log" : $dumb_term ? '| cat' : '';
     die 'Exit code is from PIPESTATUS[0], not grep' if $command =~ /^((?!`).)*\| ?grep/;
 
     $IN_ZYPPER_CALL = 1;
@@ -723,7 +724,7 @@ sub zypper_call {
         });
     }
 
-    upload_logs("/tmp/$log") if $log;
+    upload_logs("$var/tmp/$log") if $log;
 
     unless (grep { $_ == $ret } @$allow_exit_codes) {
         upload_logs('/var/log/zypper.log');

--- a/tests/qam-updinstall/SLFO_update_install.pm
+++ b/tests/qam-updinstall/SLFO_update_install.pm
@@ -153,13 +153,13 @@ sub run {
             record_info 'Conflicts', "@single_conflicts";
             for my $single_package (@single_conflicts) {
                 record_info 'Conflict preinstall', "Install conflicting package $single_package before update repo is enabled";
-                zypper_call("-v in -l --force-resolution --solver-focus Update $single_package", exitcode => [0, 102, 103], log => "prepare_${patch}_${single_package}.log", timeout => 1500);
+                zypper_call("-v in -l --force-resolution --solver-focus Update $single_package", exitcode => [0, 102, 103], log => "prepare_${patch}_${single_package}.log", timeout => 1500, tmpfs => 1);
 
                 enable_test_repositories($repos_count);
 
                 # Patch binaries already installed.
                 record_info 'Conflict install', "Install patch $patch with conflicting $single_package";
-                zypper_call("in -l -t patch $patch", exitcode => [0, 102, 103], log => "zypper_$patch.log", timeout => 1500);
+                zypper_call("in -l -t patch $patch", exitcode => [0, 102, 103], log => "zypper_$patch.log", timeout => 1500, tmpfs => 1);
 
                 record_info 'Conflict rollback', "Rollback patch $patch with conflicting $single_package";
                 assert_script_run("snapper rollback $rollback_number");
@@ -171,20 +171,20 @@ sub run {
         # Install released binaries present in patch
         record_info 'Preinstall', 'Install affected packages before update repo is enabled';
         if (grep { /\S/ } @patch_conflicts) {
-            zypper_call("--ignore-unknown in -l --force-resolution --solver-focus Update @patch_conflicts", exitcode => [0, 102, 103, 104], log => "prepare_$patch.log", timeout => 1500);
-            record_soft_failure "poo#1234 Preinstalled package is missing, check log prepare_${patch}." if (script_run("grep 'not found in package names' /tmp/prepare_${patch}.log") == 0);
+            zypper_call("--ignore-unknown in -l --force-resolution --solver-focus Update @patch_conflicts", exitcode => [0, 102, 103, 104], log => "prepare_$patch.log", timeout => 1500, tmpfs => 1);
+            record_soft_failure "poo#1234 Preinstalled package is missing, check log prepare_${patch}." if (script_run("grep 'not found in package names' /var/tmp/prepare_${patch}.log") == 0);
         }
         enable_test_repositories($repos_count);
 
         # Patch binaries installed in preinstall
         record_info 'Patch', "Install patch $patch";
-        zypper_call("in -l -t patch $patch", exitcode => [0, 102, 103], log => "zypper_$patch.log", timeout => 1500);
+        zypper_call("in -l -t patch $patch", exitcode => [0, 102, 103], log => "zypper_$patch.log", timeout => 1500, tmpfs => 1);
 
         # Install binaries newly added by the incident
         my @new_binaries;
         if (scalar @new_binaries) {
             record_info 'New packages', "New packages: @new_binaries";
-            zypper_call("in -l @new_binaries", exitcode => [0, 102, 103], log => "new_$patch.log", timeout => 1500);
+            zypper_call("in -l @new_binaries", exitcode => [0, 102, 103], log => "new_$patch.log", timeout => 1500, tmpfs => 1);
         }
 
         if (is_s390x) {
@@ -204,11 +204,13 @@ sub run {
         }
     }
 
+    assert_script_run("mount");
+    assert_script_run("ls -l /var/tmp");
     # merge logs from all patches into one which is testreport template expecting
     foreach (qw(prepare zypper new)) {
-        next if script_run("timeout 20 ls /tmp|grep ${_}_");
-        assert_script_run("cat /tmp/$_* > /tmp/$_.log");
-        upload_logs("/tmp/$_.log");
+        next if script_run("timeout 20 ls /var/tmp|grep ${_}_");
+        assert_script_run("cat /var/tmp/$_* > /var/tmp/$_.log");
+        upload_logs("/var/tmp/$_.log");
     }
 }
 


### PR DESCRIPTION
On SLE16 is /tmp Non-Persistent tmpfs
In some cases we need zypper logs after reboot

- Related ticket: https://progress.opensuse.org/issues/200832
- Verification run: https://openqa.suse.de/tests/22797848#downloads
