### PR TITLE
Extract BCI signature check to test module

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -408,6 +408,7 @@ sub load_container_tests {
         if (is_container_image_test()) {
             if (get_var('BCI_TESTS')) {
                 loadtest('containers/bci_prepare');
+                loadtest('containers/bci_signature_check') if (get_var("CONTAINERS_CHECK_SIGNATURE"));
                 loadtest('containers/bci_test', run_args => $run_args, name => 'bci_test_' . $run_args->{runtime});
                 # For Base image we also run traditional image.pm test
                 load_image_test($run_args) if (is_sle(">=15-SP3") && check_var('BCI_TEST_ENVS', 'base'));

--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -1,12 +1,7 @@
 # SUSE's openQA tests
 #
-# Copyright 2022-2023 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
 
 # Summary: bci-tests runner
 #   SUSE Linux Enterprise Base Container Images (SLE BCI)
@@ -135,37 +130,6 @@ sub update_test_repos {
     assert_script_run("git clone $branch -q --depth 1 $bci_tests_repo /root/BCI-tests");
 }
 
-sub check_container_signature {
-    my $engines = get_required_var('CONTAINER_RUNTIMES');
-    my $engine;
-    if ($engines =~ /podman|k3s/) {
-        $engine = 'podman';
-    } elsif ($engines =~ /docker/) {
-        $engine = 'docker';
-    } else {
-        die('No valid container engines defined in CONTAINER_RUNTIMES variable!');
-    }
-
-    my $image = get_required_var('CONTAINER_IMAGE_TO_TEST');
-    record_info('Image signature', "Checking signature of $image");
-
-    # cosign 2.5 is build upon registry.suse.com/bci/bci-micro:15.7
-    # works with power8 and power10
-    # cosign 3 requires only power9+
-    my $tag = check_var('MACHINE', 'ppc64le-p8-virtio') ? '2.5' : 'latest';
-    my $cosign_image = "registry.suse.com/suse/cosign:$tag";
-
-    my $engine_options = "-v /usr/share/pki/trust/anchors/SUSE_Trust_Root.crt.pem:/SUSE_Trust_Root.crt.pem:ro";
-    my $options = "--key /usr/share/pki/containers/suse-container-key.pem";
-    if ($image =~ "registry.suse.de") {
-        $options .= " --registry-cacert=/SUSE_Trust_Root.crt.pem";    # include SUSE CA for registry.suse.de
-        $options .= " --insecure-ignore-tlog=true";    # ignore missing transparency log entries for registry.suse.de
-    }
-
-    script_retry("$engine pull -q $image", timeout => 300, delay => 60, retry => 2);
-    assert_script_run("$engine run --rm -q $engine_options $cosign_image verify $options $image", timeout => 300);
-}
-
 sub run {
     select_serial_terminal;
     my ($version, $sp, $host_distri) = get_os_release;
@@ -185,11 +149,6 @@ sub run {
     install_buildah_when_needed($host_distri) if ($engines =~ /podman/ && $host_distri !~ /micro/i);
 
     my $host_version = get_var("HOST_VERSION", get_required_var("VERSION"));    # VERSION is the version of the container, not the host.
-    check_container_signature()
-      if (get_var('CONTAINER_IMAGE_TO_TEST')
-        && get_var("CONTAINERS_SKIP_SIGNATURE", "0") != 1
-        && $host_version =~ "15-SP7|16\..*|slem-6\.1"
-      );
 }
 
 sub test_flags {

--- a/tests/containers/bci_signature_check.pm
+++ b/tests/containers/bci_signature_check.pm
@@ -1,0 +1,56 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Checks the container signature
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'consoletest';
+use XML::LibXML;
+use utils qw(zypper_call script_retry systemctl);
+use version_utils qw(get_os_release is_sle);
+use db_utils qw(push_image_data_to_db);
+use containers::common;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use containers::helm;
+use containers::k8s qw(install_k3s install_helm);
+use transactional qw(trup_call reboot_on_changes);
+
+sub run {
+    select_serial_terminal;
+    my $engines = get_required_var('CONTAINER_RUNTIMES');
+    my $engine;
+    if ($engines =~ /podman|k3s/) {
+        $engine = 'podman';
+    } elsif ($engines =~ /docker/) {
+        $engine = 'docker';
+    } else {
+        die('No valid container engines defined in CONTAINER_RUNTIMES variable!');
+    }
+
+    my $image = get_required_var('CONTAINER_IMAGE_TO_TEST');
+
+    # cosign 2.5 is build upon registry.suse.com/bci/bci-micro:15.7
+    # works with power8 and power10
+    # cosign 3 requires only power9+
+    my $tag = check_var('MACHINE', 'ppc64le-p8-virtio') ? '2.5' : 'latest';
+    my $cosign_image = "registry.suse.com/suse/cosign:$tag";
+
+    my $engine_options = "-v /usr/share/pki/trust/anchors/SUSE_Trust_Root.crt.pem:/SUSE_Trust_Root.crt.pem:ro";
+    my $options = "--key /usr/share/pki/containers/suse-container-key.pem";
+    if ($image =~ "registry.suse.de") {
+        $options .= " --registry-cacert=/SUSE_Trust_Root.crt.pem";    # include SUSE CA for registry.suse.de
+        $options .= " --insecure-ignore-tlog=true";    # ignore missing transparency log entries for registry.suse.de
+    }
+
+    script_retry("$engine pull -q $image", timeout => 300, delay => 60, retry => 2);
+    assert_script_run("$engine run --rm -q $engine_options $cosign_image verify $options $image", timeout => 300);
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;

--- a/variables.md
+++ b/variables.md
@@ -53,7 +53,7 @@ CONTAINERS_UNTESTED_IMAGES | boolean | false | Whether to use `untested_images` 
 CONTAINERS_CRICTL_VERSION | string | v1.23.0 | The version of CriCtl tool.
 CONTAINERS_NERDCTL_VERSION | string | 0.16.1 | The version of NerdCTL tool.
 CONTAINERS_DOCKER_FLAVOUR | string | | Flavour of docker to install. Valid options are `stable` or undefined (for standard docker package)
-CONTAINERS_SKIP_SIGNATURE | string | | Skip image signature checks in BCI tests
+CONTAINERS_CHECK_SIGNATURE | boolean | false | Perform image signature check in BCI tests
 HELM_CHART | string | | Helm chart under test. See `main_containers.pm` for supported chart types |
 HELM_CONFIG | string | | Additional configuration file for helm |
 HELM_LOGIN | string | Comma-separated list of login information if required for a registry, e.g. `registry.suse.de:username:password,registry.suse.de:geekotest:notsecret`


### PR DESCRIPTION
Extract the BCI signature check into a separate test module and enable it only if set to.

The signature check only needs to be run once per architecture. With this setting we can only run it on one job instead of running this check on all jobs.

- Related failure: https://openqa.suse.de/tests/22796671#step/bci_prepare/47
- Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2867
- Verification runs: [Disabled](https://openqa.suse.de/tests/22798825#details) [Enabled](https://openqa.suse.de/tests/22798826#details)