### PR TITLE
CI: Pass CI env vars to isotovideo container

### DIFF
--- a/tools/test_isotovideo
+++ b/tools/test_isotovideo
@@ -3,6 +3,6 @@ cre="${cre:-"$(command -v podman || command -v docker ||:)"}"
 cre="${cre:?"Need either 'podman' or 'docker'"}"
 out="${out:-$(mktemp)}"
 
-$cre run --pull=always --rm -it -v .:/opt/tests registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86-os-autoinst-distri-opensuse -d casedir=/opt/tests productdir=products/opensuse/ _exit_after_schedule=1  |& tee $out
+$cre run --pull=always --rm -it -e CI -e GITHUB_ACTIONS -v .:/opt/tests registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86-os-autoinst-distri-opensuse -d casedir=/opt/tests productdir=products/opensuse/ _exit_after_schedule=1  |& tee $out
 # Color sequences have to be removed now
 diff -u <(sed -n 's/\r//;s/^.*scheduling \w* //p' $out | sed -r "s/\x1b\[([0-9]{1,2}(;[0-9]{1,2})*)?m//" ) t/data/test_schedule.out


### PR DESCRIPTION
The isotovideo HDDSIZEGB free-space check is skipped when CI or GITHUB_ACTIONS environment variables are set. However, these variables were not forwarded to the container started by tools/test_isotovideo, causing intermittent failures on GitHub runners with limited available disk space:

```
  Not enough storage for requested HDDSIZEGB (requested 10 GiB,
  available keeping 20% free: 0 GiB, generally available 15 GiB)
```

https://progress.opensuse.org/issues/200769
