### PR TITLE
data/journal_check: Ignore expected combustion script output on Leap

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -1525,7 +1525,9 @@
                 "6.0"
             ],
             "opensuse": [
-                "Tumbleweed"
+                "Tumbleweed",
+                "16.0",
+                "16.1"
             ],
             "microos": [
                 "Tumbleweed"


### PR DESCRIPTION
Not just SLE and Tumbleweed.

- Failure: https://openqa.opensuse.org/tests/6006561#step/journal_check/9
- Verification run: https://openqa.opensuse.org/tests/6008186