### PR TITLE
wsl/distro_install.pm: Wait for the WSL welcome window before Alt-F4

### DIFF
--- a/tests/wsl/distro_install.pm
+++ b/tests/wsl/distro_install.pm
@@ -94,6 +94,7 @@ sub run {
         assert_and_click 'wsl-suse-startup-search';
         if (check_var('DISTRI', 'sle') || is_aarch64) {
             assert_and_click("welcome_to_wsl", timeout => 120);
+            assert_screen("welcome_to_wsl-window");
             send_key "alt-f4";
         }
     } elsif ($install_from eq 'msstore') {
@@ -120,6 +121,7 @@ sub run {
         }
         if (check_var('DISTRI', 'sle')) {
             assert_and_click("welcome_to_wsl", timeout => 120);
+            assert_screen("welcome_to_wsl-window");
             send_key "alt-f4";
         }
 


### PR DESCRIPTION
Otherwise it may be missed and the window stays open.

- Failure: https://openqa.opensuse.org/tests/6008064#step/firstrun/1
- Needles: Created on o3
- Verification runs:
  * https://openqa.opensuse.org/tests/6009458
  * https://openqa.opensuse.org/tests/6009459
  * https://openqa.opensuse.org/tests/6009460
  Reruns of the above:
  * https://openqa.opensuse.org/tests/6011015
  * https://openqa.opensuse.org/tests/6011016
  * https://openqa.opensuse.org/tests/6011017

5/6 got past distro_install
