### PR TITLE
Fix vmware guest first boot stall issue

### DIFF
--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -51,8 +51,8 @@ sub grub_test {
         # avoid timeout for booting to HDD
         send_key 'ret';
     }
-    # Avoid return key not received occasionally for hyperv-uefi guest at first boot
-    send_key 'ret' if (check_var('VIRSH_VMM_FAMILY', 'hyperv') && get_var('UEFI'));
+    # Avoid return key not received occasionally for hyperv-uefi and vmware-uefi guests at first boot
+    send_key 'ret' if ((check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('VIRSH_VMM_FAMILY', 'vmware')) && get_var('UEFI'));
 }
 
 =head2 handle_installer_medium_bootup

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -18,6 +18,12 @@ use testapi;
 use x11utils 'turn_off_plasma_tooltips';
 
 sub run {
+    # Workaround: on vmware or hyperv the 'ret' from grub_test is occasionally
+    # lost across a VNC reconnect, leaving the SUT at the GRUB menu.
+    if (check_screen('grub2', 5)) {
+        record_info('bootloader still visible, resending ret');
+        send_key 'ret';
+    }
     shift->wait_boot_past_bootloader;
     # This only works with generic-desktop. In the opensuse-welcome case,
     # the opensuse-welcome module will handle it instead.


### PR DESCRIPTION
To resolve the stall failure in grub2, add 'ret' key to send in first_boot.pm & grub_utils.pm.
Failure runs:
https://openqa.suse.de/tests/22774005
https://openqa.suse.de/tests/22774805

- Related ticket: https://progress.opensuse.org/issues/200967
- Verification run: https://openqa.suse.de/tests/22798869
