### PR TITLE
Fix lack os logging in registercloudguest PC test

### DIFF
--- a/tests/publiccloud/registercloudguest.pm
+++ b/tests/publiccloud/registercloudguest.pm
@@ -55,6 +55,7 @@ sub run {
         $provider = $args->{my_provider} = $self->provider_factory();
         $instance = $self->{my_instance} = $args->{my_instance} = $provider->create_instance();
         $instance->wait_for_guestregister() if (is_ondemand());
+        $provider->initialize_logging($instance);
     }
 
     if (check_var('PUBLIC_CLOUD_SCC_ENDPOINT', 'SUSEConnect')) {


### PR DESCRIPTION
This is a hotfix for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25535. PC destroy method calls `finalize_logging` even though in case of this test, instance was created inside the test module directly (not `prepare_instance`, thus not calling `initialize_logging`. While it's not clear why `prepare_instance` workflow is not utilized in this test scenario, adding a hotfix to call `initialize_logging` inside `tests/publiccloud/registercloudguest.pm` right after instance creation.
- Related ticket: https://progress.opensuse.org/issues/202482
- Verification run:
  - sle-16.1-EC2-x86_64-Build0888-publiccloud_registrationtests@ec2_t3a.large -> https://openqa.suse.de/tests/22804760