### PR TITLE
Unify registercloudguest workflow

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -131,14 +131,14 @@ sub load_latest_publiccloud_tests {
     elsif (get_var('PUBLIC_CLOUD_ACCNET')) {
         loadtest 'publiccloud/az_accelerated_net', run_args => $args;
     }
-    elsif (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
-        loadtest "publiccloud/registercloudguest", run_args => $args;
-    }
     elsif (get_var('PUBLIC_CLOUD_AZURE_AITL')) {
         loadtest "publiccloud/azure_aitl", run_args => $args;
     } else {    # All test cases below require prepare_instance
         loadtest "publiccloud/prepare_instance", run_args => $args;
-        if (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
+        if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
+            loadtest "publiccloud/registercloudguest", run_args => $args;
+        }
+        elsif (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
             loadtest "publiccloud/img_proof", run_args => $args;
         } else {    # All test cases below require registration
             loadtest("publiccloud/registration", run_args => $args);

--- a/tests/publiccloud/registercloudguest.pm
+++ b/tests/publiccloud/registercloudguest.pm
@@ -48,14 +48,8 @@ sub run {
     # $self->{my_instance} is used in this test module
     # $args->{my_instance} is used in base module
     # $args->{my_provider} is used in base module
-    if (get_var('PUBLIC_CLOUD_QAM', 0)) {
-        $provider = $args->{my_provider};
-        $instance = $self->{my_instance} = $args->{my_instance};
-    } else {
-        $provider = $args->{my_provider} = $self->provider_factory();
-        $instance = $self->{my_instance} = $args->{my_instance} = $provider->create_instance();
-        $instance->wait_for_guestregister() if (is_ondemand());
-    }
+    $provider = $args->{my_provider};
+    $instance = $self->{my_instance} = $args->{my_instance};
 
     if (check_var('PUBLIC_CLOUD_SCC_ENDPOINT', 'SUSEConnect')) {
         record_info('SKIP', 'PUBLIC_CLOUD_SCC_ENDPOINT is hardcoded to SUSEConnect - skipping registration testing. Falling back to registration module behavior');


### PR DESCRIPTION
In some cases publiccloud/registercloudguest
expects ready instance (from prepare_instance), in others it does it.
This PR is intended to unify the workflow.

- Related ticket: https://progress.opensuse.org/issues/202482
- Verification run:
- https://openqa.suse.de/tests/22823053