### PR TITLE
SLFO_update_install: Add rmt-server-(config|pubcloud) conflict

### DIFF
--- a/tests/qam-updinstall/SLFO_update_install.pm
+++ b/tests/qam-updinstall/SLFO_update_install.pm
@@ -43,6 +43,7 @@ my @conflicting_packages = (
     'ImageMagick-config-7-upstream-open',
     'ImageMagick-config-7-upstream-secure',
     'ImageMagick-config-7-upstream-websafe',
+    'rmt-server-pubcloud', 'rmt-server-config',
     'cloud-netconfig-ec2', 'cloud-netconfig-gce', 'cloud-netconfig-azure',
     'apache2-mod_php8'
 );


### PR DESCRIPTION
```
%package config
Summary:        RMT default configuration
Group:          Productivity/Networking/Web/Proxy
Requires:       rmt-server = %version
Provides:       rmt-server-configuration
Conflicts:      rmt-server-configuration

%description config
Default nginx configuration for RMT.

%package pubcloud
Summary:        RMT pubcloud extensions
Group:          Productivity/Networking/Web/Proxy
Requires:       rmt-server = %version
Recommends:     valkey
Provides:       rmt-server-configuration
Conflicts:      rmt-server-configuration
```

- Related ticket: https://openqa.suse.de/tests/22800918#step/SLFO_update_install/76
- Verification run: https://openqa.suse.de/tests/overview?build=%3Agit%3A5295%3Armt-server&groupid=656&not_group_glob=*Devel*%2C*Test*&flavor=Online-Updates-Staging-Install
