### PR TITLE
Define 2G /home in installtest ay

### DIFF
--- a/data/autoyast_qam/15_installtest.xml.ep
+++ b/data/autoyast_qam/15_installtest.xml.ep
@@ -288,11 +288,51 @@
       </zone>
     </zones>
   </firewall>
-  <partitioning config:type="list">
+  <partitioning t="list">
     <drive>
       <disklabel>gpt</disklabel>
-      <enable_snapshots config:type="boolean">true</enable_snapshots>
-      <initialize config:type="boolean">true</initialize>
+      <enable_snapshots t="boolean">true</enable_snapshots>
+      <initialize t="boolean">true</initialize>
+      <partitions t="list">
+        <partition t="map">
+          <create t="boolean">true</create>
+          <filesystem t="symbol">btrfs</filesystem>
+          <format t="boolean">true</format>
+          <mount>/</mount>
+          <partition_id t="integer">131</partition_id>
+          <partition_nr t="integer">1</partition_nr>
+          <size>max</size>
+        </partition>
+        <partition t="map">
+          <create t="boolean">true</create>
+          <filesystem t="symbol">ext4</filesystem>
+          <format t="boolean">true</format>
+          <mount>/home</mount>
+          <partition_id t="integer">131</partition_id>
+          <partition_nr t="integer">2</partition_nr>
+          <size>2G</size>
+        </partition>
+        <partition t="map">
+          <create t="boolean">true</create>
+          <filesystem t="symbol">swap</filesystem>
+          <format t="boolean">true</format>
+          <mount>swap</mount>
+          <partition_id t="integer">130</partition_id>
+          <partition_nr t="integer">3</partition_nr>
+          <size>2G</size>
+        </partition>
+        % if ($check_var->('ARCH', 's390x')) {
+        <partition t="map">
+          <create t="boolean">true</create>
+          <filesystem t="symbol">ext2</filesystem>
+          <format t="boolean">true</format>
+          <mount>/boot/zipl</mount>
+          <partition_id t="integer">131</partition_id>
+          <partition_nr t="integer">4</partition_nr>
+          <size>300M</size>
+        </partition>
+        % }
+      </partitions>
       <use>all</use>
     </drive>
   </partitioning>


### PR DESCRIPTION
- Related ticket: https://openqa.suse.de/tests/22640224#step/update_install/849 https://jira.suse.com/browse/TEAM-11284
- Verification run:
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP7&build=%3Asmelt%3A44814%3AImageMagick&groupid=644&flavor=Server-DVD-Incidents-Install SLES
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP7&build=%3Asmelt%3A44821%3Aglib-networking&groupid=651&flavor=Server-DVD-HA-Incidents-Install HA
It's not really visible in test unless it will fail but I got `df -h` manually, or pause test and check :wink: 
s390x
<img width="815" height="637" alt="Screenshot_2026-06-11_19-47-31" src="https://github.com/user-attachments/assets/43384938-7ac9-41b2-bdad-71090eea172b" />
x86_64
<img width="765" height="508" alt="Screenshot_2026-06-11_19-37-06" src="https://github.com/user-attachments/assets/0ade8365-093e-49d4-b433-a5eab1860b15" />
