### PR TITLE
Skip checking SIGQUIT coredump for wicked tests

### DIFF
--- a/lib/wicked/wlan.pm
+++ b/lib/wicked/wlan.pm
@@ -369,6 +369,7 @@ sub hostapd_kill {
     my ($self, %args) = @_;
     $args{name} //= 'hostapd';
     assert_script_run("kill \$(cat /tmp/$args{name}.pid)");
+    sleep 3;    # slow down hostapd_kill cycle a bit
 }
 
 sub assert_connection {

--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -1177,10 +1177,11 @@ sub check_coredump {
     my $self = shift;
 
     install_coredump;
-    return if (script_run('[ -z "$(coredumpctl -1 --no-pager --no-legend)" ]') == 0);
+    # Skip checking SIGQUIT coredump files
+    record_info('List all coredump files', script_output('coredumpctl list --no-pager', proceed_on_failure => 1));
+    return if (script_run('[ -z "$(coredumpctl -1 --no-pager --no-legend | grep -v SIGQUIT)" ]') == 0);
 
-    record_info('List all coredump files', script_output('coredumpctl list --no-pager'));
-    my @core_pids = split(/\s+/, script_output(q(coredumpctl list --no-pager --no-legend | perl -ne '$_ =~ m/ ([0-9]+) / && print $1 .$/')));
+    my @core_pids = split(/\s+/, script_output(q(coredumpctl list --no-pager --no-legend | grep -v SIGQUIT | perl -ne '$_ =~ m/ ([0-9]+) / && print $1 .$/')));
     for my $pid (@core_pids) {
         my $core;
         my $is_wicked = script_run('coredumpctl info ' . $pid . ' | grep -E "Executable:.*wicked"') == 0;


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1268083

Skip checking coredump files which caused by SIGQUIT from test script

- Verification run: 
https://openqa.suse.de/tests/22823478

In case SIGQUIT coredumps, https://openqa.suse.de/tests/22823478#step/t10_multi_networks_priority/567