### PR TITLE
Update self-update validation to use systemctl instead of result file

### DIFF
--- a/lib/main_containers.pm
+++ b/lib/main_containers.pm
@@ -408,6 +408,7 @@ sub load_container_tests {
         if (is_container_image_test()) {
             if (get_var('BCI_TESTS')) {
                 loadtest('containers/bci_prepare');
+                loadtest('containers/bci_signature_check') if (get_var("CONTAINERS_CHECK_SIGNATURE"));
                 loadtest('containers/bci_test', run_args => $run_args, name => 'bci_test_' . $run_args->{runtime});
                 # For Base image we also run traditional image.pm test
                 load_image_test($run_args) if (is_sle(">=15-SP3") && check_var('BCI_TEST_ENVS', 'base'));

--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -1,12 +1,7 @@
 # SUSE's openQA tests
 #
-# Copyright 2022-2023 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
-#
-# Copying and distribution of this file, with or without modification,
-# are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
 
 # Summary: bci-tests runner
 #   SUSE Linux Enterprise Base Container Images (SLE BCI)
@@ -135,37 +130,6 @@ sub update_test_repos {
     assert_script_run("git clone $branch -q --depth 1 $bci_tests_repo /root/BCI-tests");
 }
 
-sub check_container_signature {
-    my $engines = get_required_var('CONTAINER_RUNTIMES');
-    my $engine;
-    if ($engines =~ /podman|k3s/) {
-        $engine = 'podman';
-    } elsif ($engines =~ /docker/) {
-        $engine = 'docker';
-    } else {
-        die('No valid container engines defined in CONTAINER_RUNTIMES variable!');
-    }
-
-    my $image = get_required_var('CONTAINER_IMAGE_TO_TEST');
-    record_info('Image signature', "Checking signature of $image");
-
-    # cosign 2.5 is build upon registry.suse.com/bci/bci-micro:15.7
-    # works with power8 and power10
-    # cosign 3 requires only power9+
-    my $tag = check_var('MACHINE', 'ppc64le-p8-virtio') ? '2.5' : 'latest';
-    my $cosign_image = "registry.suse.com/suse/cosign:$tag";
-
-    my $engine_options = "-v /usr/share/pki/trust/anchors/SUSE_Trust_Root.crt.pem:/SUSE_Trust_Root.crt.pem:ro";
-    my $options = "--key /usr/share/pki/containers/suse-container-key.pem";
-    if ($image =~ "registry.suse.de") {
-        $options .= " --registry-cacert=/SUSE_Trust_Root.crt.pem";    # include SUSE CA for registry.suse.de
-        $options .= " --insecure-ignore-tlog=true";    # ignore missing transparency log entries for registry.suse.de
-    }
-
-    script_retry("$engine pull -q $image", timeout => 300, delay => 60, retry => 2);
-    assert_script_run("$engine run --rm -q $engine_options $cosign_image verify $options $image", timeout => 300);
-}
-
 sub run {
     select_serial_terminal;
     my ($version, $sp, $host_distri) = get_os_release;
@@ -185,11 +149,6 @@ sub run {
     install_buildah_when_needed($host_distri) if ($engines =~ /podman/ && $host_distri !~ /micro/i);
 
     my $host_version = get_var("HOST_VERSION", get_required_var("VERSION"));    # VERSION is the version of the container, not the host.
-    check_container_signature()
-      if (get_var('CONTAINER_IMAGE_TO_TEST')
-        && get_var("CONTAINERS_SKIP_SIGNATURE", "0") != 1
-        && $host_version =~ "15-SP7|16\..*|slem-6\.1"
-      );
 }
 
 sub test_flags {

--- a/tests/containers/bci_signature_check.pm
+++ b/tests/containers/bci_signature_check.pm
@@ -1,0 +1,56 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Checks the container signature
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'consoletest';
+use XML::LibXML;
+use utils qw(zypper_call script_retry systemctl);
+use version_utils qw(get_os_release is_sle);
+use db_utils qw(push_image_data_to_db);
+use containers::common;
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use containers::helm;
+use containers::k8s qw(install_k3s install_helm);
+use transactional qw(trup_call reboot_on_changes);
+
+sub run {
+    select_serial_terminal;
+    my $engines = get_required_var('CONTAINER_RUNTIMES');
+    my $engine;
+    if ($engines =~ /podman|k3s/) {
+        $engine = 'podman';
+    } elsif ($engines =~ /docker/) {
+        $engine = 'docker';
+    } else {
+        die('No valid container engines defined in CONTAINER_RUNTIMES variable!');
+    }
+
+    my $image = get_required_var('CONTAINER_IMAGE_TO_TEST');
+
+    # cosign 2.5 is build upon registry.suse.com/bci/bci-micro:15.7
+    # works with power8 and power10
+    # cosign 3 requires only power9+
+    my $tag = check_var('MACHINE', 'ppc64le-p8-virtio') ? '2.5' : 'latest';
+    my $cosign_image = "registry.suse.com/suse/cosign:$tag";
+
+    my $engine_options = "-v /usr/share/pki/trust/anchors/SUSE_Trust_Root.crt.pem:/SUSE_Trust_Root.crt.pem:ro";
+    my $options = "--key /usr/share/pki/containers/suse-container-key.pem";
+    if ($image =~ "registry.suse.de") {
+        $options .= " --registry-cacert=/SUSE_Trust_Root.crt.pem";    # include SUSE CA for registry.suse.de
+        $options .= " --insecure-ignore-tlog=true";    # ignore missing transparency log entries for registry.suse.de
+    }
+
+    script_retry("$engine pull -q $image", timeout => 300, delay => 60, retry => 2);
+    assert_script_run("$engine run --rm -q $engine_options $cosign_image verify $options $image", timeout => 300);
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;

--- a/tests/security/eal4/chrony_pid_file.pm
+++ b/tests/security/eal4/chrony_pid_file.pm
@@ -45,8 +45,4 @@ sub run {
     validate_script_output('touch /run/test 2>&1', sub { m/Permission denied/ }, proceed_on_failure => 1);
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/eal4/dbus_fuzzer.pm
+++ b/tests/security/eal4/dbus_fuzzer.pm
@@ -100,7 +100,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1, fatal => 0};
+    return {fatal => 0};
 }
 
 1;

--- a/tests/security/eal4/dbus_services_exposure.pm
+++ b/tests/security/eal4/dbus_services_exposure.pm
@@ -141,8 +141,4 @@ sub run {
     }
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/eal4/drng_test_preparation.pm
+++ b/tests/security/eal4/drng_test_preparation.pm
@@ -60,8 +60,4 @@ sub run {
     }
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/eal4/kvm_check.pm
+++ b/tests/security/eal4/kvm_check.pm
@@ -41,8 +41,4 @@ sub run {
     validate_script_output 'virsh net-list --all | grep default', qr/default\s+active\s+no\s+yes/;
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/eal4/netlink_message.pm
+++ b/tests/security/eal4/netlink_message.pm
@@ -62,8 +62,4 @@ sub run {
     $self->result($test_module_result);
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/eal4/syscall_thrasher.pm
+++ b/tests/security/eal4/syscall_thrasher.pm
@@ -51,10 +51,6 @@ sub run {
     upload_logs("$log_file");
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 sub post_fail_hook {
     my ($self) = @_;
     upload_logs("$log_file");

--- a/tests/security/ebpf/disable_unprivileged_ebpf.pm
+++ b/tests/security/ebpf/disable_unprivileged_ebpf.pm
@@ -93,8 +93,4 @@ sub run {
     $self->reboot_and_check('0');
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/pam/pam_config.pm
+++ b/tests/security/pam/pam_config.pm
@@ -63,10 +63,6 @@ sub run {
     }
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 sub post_fail_hook {
     assert_script_run 'cp -pr /mnt/pam.d /etc';
 }

--- a/tests/security/pam/pam_faillock.pm
+++ b/tests/security/pam/pam_faillock.pm
@@ -97,8 +97,4 @@ EOF
     assert_script_run("userdel -r -f $user_name");
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/security/pam/pam_login.pm
+++ b/tests/security/pam/pam_login.pm
@@ -128,10 +128,6 @@ END
     assert_script_run "mv $pam_login_bak $pam_login";
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 sub post_fail_hook {
     assert_script_run 'cp -pr /mnt/pam.d /etc';
 }

--- a/tests/security/pam/pam_mount.pm
+++ b/tests/security/pam/pam_mount.pm
@@ -120,10 +120,6 @@ END
     assert_script_run "mv $pam_mount_cfg_bak $pam_mount_cfg";
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 sub post_fail_hook {
     select_console 'root-console';
     assert_script_run 'cp -pr /mnt/pam.d /etc';

--- a/tests/security/pam/pam_su.pm
+++ b/tests/security/pam/pam_su.pm
@@ -90,10 +90,6 @@ expect {
     assert_script_run "mv $sul_file_bak $sul_file";
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 sub post_fail_hook {
     select_console 'root-console';
     assert_script_run 'cp -pr /mnt/pam.d /etc';

--- a/tests/security/pam/pam_u2f.pm
+++ b/tests/security/pam/pam_u2f.pm
@@ -40,8 +40,4 @@ sub run {
     validate_script_output('pamu2fcfg 2>&1 || true', sub { m/No .* found. Aborting/ });
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;

--- a/tests/yam/validate/validate_self_update.pm
+++ b/tests/yam/validate/validate_self_update.pm
@@ -14,11 +14,16 @@ use scheduler qw(get_test_suite_data);
 sub run {
     my $self_update_enabled = get_test_suite_data()->{self_update_enabled};
     if ($self_update_enabled) {
-        my $retcode = script_output('cat /run/live-self-update/result');
-
-        # Pass validation if retcode is 0 (All OK) or 4 - ZYPPER_EXIT_ERR_ZYPP A problem is reported by ZYPP library
-        if ($retcode != 0 && $retcode != 4) {
+        my $systemctl_trace = script_output('systemctl status live-self-update.service', proceed_on_failure => 1);
+        record_info($systemctl_trace);
+        unless ($systemctl_trace =~ /status=0\/SUCCESS/) {
             die "Self update did not ended successfully";
+        }
+
+        my $self_update_trace = script_output('journalctl -t live-self-update --no-pager');
+        record_info($self_update_trace);
+        unless ($self_update_trace =~ get_var('INST_SELF_UPDATE', 'https://scc.suse.com')) {
+            die "Self update did not use specified URL";
         }
     } else {
         systemctl('is-active live-self-update', expect_false => 1);

--- a/tools/test_isotovideo
+++ b/tools/test_isotovideo
@@ -3,6 +3,6 @@ cre="${cre:-"$(command -v podman || command -v docker ||:)"}"
 cre="${cre:?"Need either 'podman' or 'docker'"}"
 out="${out:-$(mktemp)}"
 
-$cre run --pull=always --rm -it -v .:/opt/tests registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86-os-autoinst-distri-opensuse -d casedir=/opt/tests productdir=products/opensuse/ _exit_after_schedule=1  |& tee $out
+$cre run --pull=always --rm -it -e CI -e GITHUB_ACTIONS -v .:/opt/tests registry.opensuse.org/devel/openqa/containers/isotovideo:qemu-x86-os-autoinst-distri-opensuse -d casedir=/opt/tests productdir=products/opensuse/ _exit_after_schedule=1  |& tee $out
 # Color sequences have to be removed now
 diff -u <(sed -n 's/\r//;s/^.*scheduling \w* //p' $out | sed -r "s/\x1b\[([0-9]{1,2}(;[0-9]{1,2})*)?m//" ) t/data/test_schedule.out

--- a/variables.md
+++ b/variables.md
@@ -53,7 +53,7 @@ CONTAINERS_UNTESTED_IMAGES | boolean | false | Whether to use `untested_images` 
 CONTAINERS_CRICTL_VERSION | string | v1.23.0 | The version of CriCtl tool.
 CONTAINERS_NERDCTL_VERSION | string | 0.16.1 | The version of NerdCTL tool.
 CONTAINERS_DOCKER_FLAVOUR | string | | Flavour of docker to install. Valid options are `stable` or undefined (for standard docker package)
-CONTAINERS_SKIP_SIGNATURE | string | | Skip image signature checks in BCI tests
+CONTAINERS_CHECK_SIGNATURE | boolean | false | Perform image signature check in BCI tests
 HELM_CHART | string | | Helm chart under test. See `main_containers.pm` for supported chart types |
 HELM_CONFIG | string | | Additional configuration file for helm |
 HELM_LOGIN | string | Comma-separated list of login information if required for a registry, e.g. `registry.suse.de:username:password,registry.suse.de:geekotest:notsecret`


### PR DESCRIPTION
  ## Summary

  This PR improves the self-update validation by checking the `live-self-update.service`
  status via systemctl instead of reading a result file. The new approach directly queries
  the service exit status, simplifying the validation logic and removing the need for special
  handling of zypper exit code 4.

  ## Changes

  - Replaced file-based validation (`/run/live-self-update/result`) with `systemctl status`
  command
  - Validation now fails if the service didn't exit with code 0
  - Removed special case for ZYPPER_EXIT_ERR_ZYPP (exit code 4)
  
---

- Related ticket: https://progress.opensuse.org/issues/201720
- Needles: N/A
- Verification run: 
  - devel (good repo): https://openqa.suse.de/tests/22820455
  - devel (bad repo): https://openqa.suse.de/tests/22820454
  - prod: https://openqa.suse.de/tests/22820483 (Pending to discuss)
  - QR: https://openqa.suse.de/tests/22820990
