### PR TITLE
Create NTP-Configuration in Agama for interactive installation

### DIFF
--- a/schedule/yam/agama_extended.yaml
+++ b/schedule/yam/agama_extended.yaml
@@ -14,3 +14,4 @@ schedule:
   - yam/validate/validate_hostname
   - yam/validate/validate_connectivity
   - yam/validate/validate_bootloader_timeout
+  - yam/validate/validate_ntp

--- a/test_data/yam/agama_sle_extended.yaml
+++ b/test_data/yam/agama_sle_extended.yaml
@@ -13,3 +13,5 @@ repos:
     filter: name
 bootloader_timeout: '8'
 self_update_enabled: 1
+ntp_servers:
+  - 3.suse.pool.ntp.org

--- a/tests/yam/validate/validate_ntp.pm
+++ b/tests/yam/validate/validate_ntp.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Validate the ntp servers and chronyc tracking by checking
+# - NTP servers are present in /etc/chrony.d/99-installer.conf
+# - No Pending Leap Seconds are detected via chronyc tracking.
+
+# Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
+
+use Mojo::Base 'consoletest';
+use testapi;
+use scheduler qw(get_test_suite_data);
+
+sub run {
+    my $test_data = get_test_suite_data();
+    select_console 'root-console';
+
+    my $chrony_config = '/etc/chrony.d/99-installer.conf';
+    assert_script_run("cat $chrony_config");
+    assert_script_run("grep '$_' $chrony_config") foreach @{$test_data->{ntp_servers}};
+
+    my $tracking_output = script_output('chronyc tracking');
+
+    if ($tracking_output =~ /Leap\s+status\s*:\s*(?<status>.+?)\s*$/m) {
+        my $status = $+{status};
+        $status =~ s/\s+$//;
+        die "Chrony tracking failed. Expected Leap status 'Normal', but got '$status'." if $status ne 'Normal';
+    } else {
+        die "Could not parse Leap status from chronyc tracking output.";
+    }
+}
+
+1;


### PR DESCRIPTION
##
 ### Create NTP-Configuration in Agama for interactive installation
 
- Related ticket: 
  - https://progress.opensuse.org/issues/201399
- Needles: N/A
- Related MR:
  - https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/839
- Related PR: 
  - https://github.com/qe-installation-and-migration/agama-integration-test-webpack/pull/261
- Verification run: 
  - [__sles_extended_dev__](https://openqa.suse.de/tests/overview?version=16.1&build=hjluo_ntp_configure_888&distri=sle)
##