### PR TITLE
Prevent supportconfig from hanging indefinitely over SSH

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -25,6 +25,7 @@ use hacluster qw($crm_mon_cmd cluster_status_matches_regex);
 use publiccloud::utils qw( get_ssh_private_key_path register_addon);
 use sles4sap::ibsm;
 use sles4sap::azure_cli;
+use version_utils qw(package_version_cmp);
 
 
 =head1 SYNOPSIS
@@ -1561,7 +1562,7 @@ sub ipaddr2_scc_registration_workaround_PAYG(%args) {
     croak("Argument < id > missing") unless $args{id};
     $args{bastion_ip} //= ipaddr2_bastion_pubip();
 
-    # Step 1: Wait for guestregister.service to reach terminal state (inactive or failed).
+    # Wait for guestregister.service to reach terminal state (inactive or failed).
     # Poll for up to 10 minutes (60 retries x 10s), matching Ansible retries/delay.
     my $service_ok = 0;
     my $timeout = 600;
@@ -1587,7 +1588,7 @@ sub ipaddr2_scc_registration_workaround_PAYG(%args) {
     # If guestregister.service succeeded, nothing more to do
     return if $service_ok;
 
-    # Step 2: Service failed or timed out. Collect diagnostics.
+    # Service failed or timed out. Collect diagnostics.
     record_info('PAYG svc failed', 'guestregister.service did not complete successfully');
     foreach my $cmd (
         'sudo systemctl status guestregister.service',
@@ -1601,14 +1602,14 @@ sub ipaddr2_scc_registration_workaround_PAYG(%args) {
             no_assert => 1);
     }
 
-    # Step 3: Recovery - restart guestregister.service
+    # Recovery - restart guestregister.service
     record_info('PAYG recovery', 'Attempting guestregister.service restart');
     ipaddr2_ssh_internal(id => $args{id},
         cmd => 'sudo systemctl restart guestregister.service',
         bastion_ip => $args{bastion_ip},
         no_assert => 1);
 
-    # Step 4: Wait again for restart to reach terminal state (30 retries x 5s = 150s)
+    # Wait again for restart to reach terminal state (30 retries x 5s = 150s)
     my $retry_ok = 0;
     $timeout = 150;
     $interval = 5;
@@ -1629,7 +1630,7 @@ sub ipaddr2_scc_registration_workaround_PAYG(%args) {
         $timeout -= $interval;
     }
 
-    # Step 5: Verify with SUSEConnect -s (5 retries x 120s delay, matching Ansible)
+    # Verify with SUSEConnect -s (5 retries x 120s delay, matching Ansible)
     my $sc_ret;
     for my $attempt (1 .. 5) {
         $sc_ret = ipaddr2_ssh_internal(id => $args{id},
@@ -2627,7 +2628,23 @@ sub ipaddr2_logs_collect(%args) {
                 $worker_tmp_dir = ipaddr2_get_worker_tmp_for_internal_vm(id => $id);
                 assert_script_run("mkdir -p $worker_tmp_dir || echo 'Folder $worker_tmp_dir already exist'");
                 %log_data = %{$log->{f_log}->($id)};
+                $log_data{name} = $log->{name} if defined $log->{name};
                 $remote_file = $log_data{file};
+
+                # bsc#1268173: ausearch (called by supportconfig for the SELinux section) reads from
+                # stdin when stdin is not a terminal, blocking indefinitely over SSH. Redirect stdin
+                # from /dev/null so ausearch falls back to reading /var/log/audit/audit.log directly.
+                if (defined $log_data{name} && $log_data{name} eq 'supportconfig') {
+                    my $supportutils_ver = ipaddr2_ssh_internal_output(
+                        id => $id,
+                        bastion_ip => $args{bastion_ip},
+                        cmd => "rpm -q --queryformat '%{VERSION}' supportutils");
+                    # The ausearch call was introduced in supportutils 3.1.25 (bsc#1209979, Jun 2023).
+                    if (package_version_cmp($supportutils_ver, '3.1.25') >= 0) {
+                        $log_data{cmd} =~ s/(sudo supportconfig .+?)\s*&&/$1 < \/dev\/null &&/;
+                        record_soft_failure('bsc#1268173 - supportconfig hangs when run non-interactively.');
+                    }
+                }
 
                 # Execute command on the remote VM to generate the log file, if there is a command to run.
                 my $cmd_ret = 0;

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -50,7 +50,6 @@ subtest '[ipaddr2_infra_deploy] cloudinit_profile' => sub {
     $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
     my @calls;
     $ipaddr2->redefine(assert_script_run => sub { push @calls, ['ipaddr2', $_[0]]; return; });
-    $ipaddr2->redefine(upload_logs => sub { return '/Faggin'; });
     $ipaddr2->redefine(az_vm_wait_running => sub { return 300; });
     $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
@@ -112,7 +111,6 @@ subtest '[ipaddr2_infra_deploy] diagnostic' => sub {
     my @calls;
     $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
     $ipaddr2->redefine(write_sut_file => sub { return; });
-    $ipaddr2->redefine(upload_logs => sub { return '/Faggin'; });
     $ipaddr2->redefine(az_vm_wait_running => sub { return 300; });
     $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
@@ -488,7 +486,6 @@ subtest '[ipaddr2_internal_key_gen]' => sub {
     ipaddr2_internal_key_gen();
 
     note("\n  -->  " . join("\n  -->  ", @calls));
-
     ok((any { /ssh-keygen/ } @calls), 'Generate the keys if they does not exist');
     # search through all the ssh-keygen and extract the ssh key file path after -f
     # then check if there's a scp uploading it
@@ -1004,8 +1001,7 @@ subtest '[ipaddr2_cloudinit_create]' => sub {
     $ipaddr2->redefine(write_sut_file => sub {
             $cloud_init_content = $_[1];
             return; });
-    $ipaddr2->redefine(upload_logs => sub { return '/Faggin'; });
-
+    $ipaddr2->noop('upload_logs');
     ipaddr2_cloudinit_create();
 
     note("cloud_init_content:\n" .
@@ -1023,7 +1019,7 @@ subtest '[ipaddr2_cloudinit_create] with scc_code' => sub {
     $ipaddr2->redefine(write_sut_file => sub {
             $cloud_init_content = $_[1];
             return; });
-    $ipaddr2->redefine(upload_logs => sub { return '/Faggin'; });
+    $ipaddr2->noop('upload_logs');
 
     ipaddr2_cloudinit_create(scc_code => 'ABCD');
 
@@ -1041,7 +1037,7 @@ subtest '[ipaddr2_cloudinit_create] nginx_root' => sub {
     $ipaddr2->redefine(write_sut_file => sub {
             $cloud_init_content = $_[1];
             return; });
-    $ipaddr2->redefine(upload_logs => sub { return '/Faggin'; });
+    $ipaddr2->noop('upload_logs');
 
     ipaddr2_cloudinit_create(nginx_root => 'ABCD');
 
@@ -1323,7 +1319,7 @@ subtest '[ipaddr2_cleanup] ipaddr2_deployment_logs' => sub {
     my $called = 0;
     $ipaddr2->redefine(ipaddr2_azure_resource_group => sub { return 'Volta'; });
     $ipaddr2->redefine(az_vm_diagnostic_log_get => sub { $called = 1; return ('aaaaa.log', 'bbbbbb.log'); });
-    $ipaddr2->redefine(upload_logs => sub { return; });
+    $ipaddr2->noop('upload_logs');
     $ipaddr2->redefine(ipaddr2_infra_destroy => sub { return; });
 
     ipaddr2_cleanup(diagnostic => 1, cloudinit => 0);
@@ -1348,6 +1344,7 @@ subtest '[ipaddr2_logs_collect]' => sub {
     });
     $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
     $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    $ipaddr2->redefine(ipaddr2_ssh_internal_output => sub { return '3.0.0'; });
 
     note("Testing log collection with successful SSH commands...");
     ipaddr2_logs_collect();
@@ -1390,12 +1387,15 @@ subtest '[ipaddr2_logs_collect] skip scp on failure' => sub {
             push @scp_calls, $_[0] if $_[0] =~ /^scp /;
             return 0;
     });
-    $ipaddr2->redefine(assert_script_run => sub { return; });
+    my @calls;
+    $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
     $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    $ipaddr2->redefine(ipaddr2_ssh_internal_output => sub { return '3.0.0'; });
 
     note("Testing log collection with failing SSH commands (skip scp)...");
     ipaddr2_logs_collect();
 
+    note("\n  -->  " . join("\n  -->  ", @calls));
     is(scalar @ssh_calls, 8, "ipaddr2_ssh_internal still called 8 times for log generation");
     is(scalar @scp_calls, 0, "scp is NOT called because all log generation failed");
     is(scalar @upload_calls, 2, "upload_logs called only 2 times for local logs");
@@ -1646,6 +1646,73 @@ subtest '[ipaddr2_scc_registration_workaround_PAYG] recovery fails' => sub {
 
     dies_ok { ipaddr2_scc_registration_workaround_PAYG(id => 1, bastion_ip => '1.2.3.4') }
     "Die when system remains Not Registered after restart";
+};
+
+subtest '[ipaddr2_logs_collect] supportconfig workaround applied when supportutils >= 3.1.25' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $ipaddr2->noop('upload_logs');
+    my @calls;
+    $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+    $ipaddr2->redefine(script_run => sub { return 0; });
+
+    my @version_cmds;
+    $ipaddr2->redefine(ipaddr2_ssh_internal_output => sub {
+            my (%args) = @_;
+            push @version_cmds, $args{cmd};
+            return '3.2.12.2';
+    });
+
+    my @ssh_cmds;
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub {
+            my (%args) = @_;
+            push @ssh_cmds, $args{cmd};
+            return 0;
+    });
+
+    my @soft_failures;
+    $ipaddr2->redefine(record_soft_failure => sub { push @soft_failures, $_[0]; });
+
+    ipaddr2_logs_collect();
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    note("\n  VERSION CMDS -->  " . join("\n  VERSION CMDS -->  ", @version_cmds));
+    note("\n  SSH CMDS -->  " . join("\n  SSH CMDS -->  ", @ssh_cmds));
+    note("\n  SOFT FAILURES -->  " . join("\n  SOFT FAILURES -->  ", @soft_failures));
+
+    ok((any { /rpm.*queryformat.*supportutils/ } @version_cmds), 'Version check queries supportutils package');
+    ok((any { /sudo supportconfig.*< \/dev\/null/ } @ssh_cmds), 'supportconfig cmd has /dev/null stdin redirect (bsc#1268173 workaround)');
+    ok((any { /bsc#1268173/ } @soft_failures), 'record_soft_failure called with bsc#1268173');
+};
+
+subtest '[ipaddr2_logs_collect] supportconfig workaround not applied when supportutils < 3.1.25' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return '1.2.3.4'; });
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $ipaddr2->noop('upload_logs');
+    my @calls;
+    $ipaddr2->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+    $ipaddr2->redefine(script_run => sub { return 0; });
+    $ipaddr2->redefine(ipaddr2_ssh_internal_output => sub { return '3.1.24'; });
+
+    my @ssh_cmds;
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub {
+            my (%args) = @_;
+            push @ssh_cmds, $args{cmd};
+            return 0;
+    });
+
+    my @soft_failures;
+    $ipaddr2->redefine(record_soft_failure => sub { push @soft_failures, $_[0]; });
+
+    ipaddr2_logs_collect();
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    note("\n  SSH CMDS -->  " . join("\n  SSH CMDS -->  ", @ssh_cmds));
+
+    ok((none { /sudo supportconfig.*< \/dev\/null/ } @ssh_cmds), 'supportconfig cmd has no /dev/null redirect when supportutils < 3.1.25');
+    ok((none { /bsc#1268173/ } @soft_failures), 'record_soft_failure not called when supportutils < 3.1.25');
 };
 
 done_testing;


### PR DESCRIPTION
The ausearch utility, called by supportconfig as part of its SELinux plugin, reads from stdin if stdin is not a terminal. When supportconfig is run non-interactively over an SSH connection during ipaddr2 log collection, this causes the command to hang indefinitely. Solve by redirect supportconfig's stdin from /dev/null causing ausearch to bypass stdin and read the audit log directly, preventing the hang. Only do it for supportutils package version >= 3.1.25 (where ausearch integration was added for bsc#1209979).

- Related ticket: https://jira.suse.com/browse/TEAM-11263

# Verification run

 - sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-ipaddr2_azure_test@az_Standard_B1s -> http://openqaworker15.qe.prg2.suse.org/tests/372862
 - sle-16.0-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE16.0-ipaddr2_azure_test@az_Standard_B1s -> http://openqaworker15.qe.prg2.suse.org/tests/372863