### PR TITLE
saltbase: Ignore bsc#1262135

### DIFF
--- a/lib/saltbase.pm
+++ b/lib/saltbase.pm
@@ -125,6 +125,11 @@ sub logs_from_salt {
             record_soft_failure('bsc#1213635');
             $softfail_flag = 1;
         }
+        if (script_run('grep -Pzo \'(?s)Failed to import module pip(?:(?!\n.DEBUG).)*?ModuleNotFoundError: No module named .pkg_resources.\' /var/log/salt/minion') == 0) {
+            record_soft_failure('bsc#1262135');
+            $softfail_flag = 1;
+        }
+
         return if $softfail_flag;
         die "Salt logs are containing errors!";
     }


### PR DESCRIPTION
According to package mantainer messages in debug mode with
"ModuleNotFoundError: No module named 'pkg_resources'" aren't
harmful in any way [1].

[1]: https://bugzilla.opensuse.org/show_bug.cgi?id=1262135#c1

openqa: clone https://openqa.opensuse.org/tests/6007476

Note: failure in parallel job is the same as this PR is trying to fix.


#### Results from cloned jobs:
- [![https://openqa.opensuse.org/tests/6012757](https://openqa.opensuse.org/tests/6012757/badge)](https://openqa.opensuse.org/tests/6012757)
- [![https://openqa.opensuse.org/tests/6012758](https://openqa.opensuse.org/tests/6012758/badge)](https://openqa.opensuse.org/tests/6012758)

<sub>The above list is generated with a script with information from the "clone_mentioned_job" workflow.</sub>
