### PR TITLE
SDAF Unify deployment tagging

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/configure_sap_systems_tfvars.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/configure_sap_systems_tfvars.pm
@@ -14,10 +14,9 @@ use Carp qw(croak);
 use utils qw(write_sut_file);
 use sles4sap::sap_deployment_automation_framework::deployment
   qw(get_os_variable validate_components get_fencing_mechanism);
-use sles4sap::sap_deployment_automation_framework::configure_workload_tfvars qw(write_tfvars_file);
+use sles4sap::sap_deployment_automation_framework::configure_workload_tfvars qw(write_tfvars_file get_tags_entry);
 use sles4sap::sap_deployment_automation_framework::naming_conventions
   qw(generate_resource_group_name get_sizing_filename convert_region_to_short);
-use sles4sap::sap_deployment_automation_framework::deployment_connector qw(no_cleanup_tag);
 
 =head1 SYNOPSIS
 
@@ -130,14 +129,10 @@ sub define_sap_systems_environment {
         bom_name => qq|"$args{bom_name}"|,
         enable_purge_control_for_keyvaults => 'false',
         use_spn => q|true|,
-        tags => q|{"DeployedBy" = "OpenQA-SDAF-automation"}|,
+        tags => get_tags_entry(),
         subscription_id => qq|"$args{subscription_id}"|,
         control_plane_name => qq|"$args{control_plane_name}"|
     );
-
-    # Add no cleanup tag if the deployment should be kept after test finished
-    $result{tags} = q|{"DeployedBy" = "OpenQA-SDAF-automation", "| . no_cleanup_tag() . q|" = "1"}|
-      if get_var('SDAF_RETAIN_DEPLOYMENT');
 
     return (\%result);
 }

--- a/lib/sles4sap/sap_deployment_automation_framework/configure_workload_tfvars.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/configure_workload_tfvars.pm
@@ -15,7 +15,7 @@ use utils qw(write_sut_file);
 use sles4sap::sap_deployment_automation_framework::deployment qw(get_os_variable get_fencing_mechanism);
 use sles4sap::sap_deployment_automation_framework::naming_conventions
   qw(convert_region_to_short generate_resource_group_name);
-use sles4sap::sap_deployment_automation_framework::deployment_connector qw(find_deployment_id no_cleanup_tag);
+use sles4sap::sap_deployment_automation_framework::deployment_connector qw(find_deployment_id get_deployment_tags);
 
 =head1 SYNOPSIS
 
@@ -29,6 +29,7 @@ https://github.com/Azure/SAP-automation-samples/blob/main/Terraform/WORKSPACES/S
 our @EXPORT = qw(
   create_workload_tfvars
   write_tfvars_file
+  get_tags_entry
 );
 
 =head2 write_tfvars_file
@@ -181,6 +182,19 @@ sub create_workload_tfvars {
     upload_logs($tfvars_file, log_name => 'workload_zone.tfvars.txt');
 }
 
+=head2 get_tags_entry
+
+    get_tags_entry();
+
+Returns string with tag list
+
+=cut
+
+sub get_tags_entry {
+    my $tags = get_deployment_tags();
+    return '{' . join(', ', map { qq|"$_" = "$tags->{$_}"| } keys %$tags) . '}';
+}
+
 =head2 define_workload_environment
 
     define_workload_environment(environment=>'LAB', location=>'swedencentral', resource_group=>'OpenQA');
@@ -225,17 +239,12 @@ sub define_workload_environment {
         # Defines the number of workload _vms to create
         utility_vm_count => q|0|,
         # These tags will be applied to all resources
-        tags => q|{"DeployedBy" = "OpenQA-SDAF-automation"}|,
+        tags => get_tags_entry(),
         deployer_tfstate_key => qq|"$args{environment}-${sdaf_region}-${vnet_code}-INFRASTRUCTURE.terraform.tfstate"|,
         public_network_access_enabled => q|true|,
         subscription_id => '"' . get_os_variable('ARM_SUBSCRIPTION_ID') . '"',
         control_plane_name => '"' . "$args{environment}-" . $sdaf_region . '-' . $vnet_code . '"'
     );
-
-    # Add no cleanup tag if the deployment should be kept after test finished
-    $result{tags} = q|{"DeployedBy" = "OpenQA-SDAF-automation", "| . no_cleanup_tag() . q|" = "1"}|
-      if get_var('SDAF_RETAIN_DEPLOYMENT');
-
     return (\%result);
 }
 

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
@@ -48,6 +48,7 @@ our @EXPORT = qw(
   destroy_orphaned_resources
   destroy_orphaned_peerings
   no_cleanup_tag
+  get_deployment_tags
 );
 
 our $DEPLOYMENT_ID;
@@ -474,6 +475,26 @@ This function ensures default value naming consistency across all modules, inste
 
 sub no_cleanup_tag {
     return get_var('SDAF_NO_CLEANUP_TAG', 'sdaf_cleanup_ignore');
+}
+
+
+=head2 get_deployment_tags
+
+    get_deployment_tags();
+
+Returns Hash of tag name and values to be applied on deployment resources.
+
+=cut
+
+sub get_deployment_tags {
+    my %tags = (
+        deployed_by => get_var('SDAF_DEPLOYMENT_OWNER', 'OpenQA-SDAF-automation'),
+        openqa_instance => get_required_var('WORKER_HOSTNAME'),
+        deployment_id => get_current_job_id()
+    );
+
+    $tags{no_cleanup_tag()} = '1' if get_var('SDAF_RETAIN_DEPLOYMENT');
+    return \%tags;
 }
 
 1;

--- a/t/26_deployment_connector.t
+++ b/t/26_deployment_connector.t
@@ -15,6 +15,9 @@ sub undef_variables {
     my @openqa_variables = qw(
       SDAF_DEPLOYER_RESOURCE_GROUP
       SDAF_DEPLOYER_VNET_CODE
+      WORKER_HOSTNAME
+      SDAF_RETAIN_DEPLOYMENT
+      SDAF_DEPLOYMENT_OWNER
     );
     set_var($_, '') foreach @openqa_variables;
 }
@@ -304,6 +307,20 @@ subtest '[destroy_orphaned_peerings]' => sub {
     });
     ok(!destroy_orphaned_peerings(), 'Delete orphaned peering');
 
+    undef_variables;
+};
+
+subtest '[get_deployment_tags] Check returned value' => sub {
+    my $mock_function = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment_connector', no_auto => 1);
+    $mock_function->redefine(get_current_job_id => sub { '42' });
+    set_var('SDAF_RETAIN_DEPLOYMENT', 'yes');
+    set_var('WORKER_HOSTNAME', 'OSD');
+    set_var('SDAF_DEPLOYMENT_OWNER', 'Unit test');
+
+    my %result = %{get_deployment_tags()};
+    is $result{deployed_by}, 'Unit test', 'Apply "deployed_by" tag';
+    is $result{openqa_instance}, 'OSD', 'Apply "openqa_instance" tag.';
+    is $result{deployment_id}, '42', 'Apply "deployment_id" tag.';
     undef_variables;
 };
 

--- a/t/34_sdaf_configure_sap_systems_tfvars.t
+++ b/t/34_sdaf_configure_sap_systems_tfvars.t
@@ -46,7 +46,7 @@ subtest '[create_sap_systems_tfvars] ENSA2 cluster settings' => sub {
     $ms_sdaf->redefine(get_os_variable => sub { return 'espresso'; });
     $ms_sdaf->redefine(generate_resource_group_name => sub { return 'NoSleepSquad'; });
     $ms_sdaf->redefine(write_tfvars_file => sub { $tfvars_data = $_[1]; return 'lungo'; });
-    $ms_sdaf->redefine(upload_logs => sub { return; });
+    $ms_sdaf->noop(qw(get_tags_entry upload_logs));
 
     set_openqa_settings;
     set_var('SDAF_DEPLOYER_VNET_CODE', 'DEP00');
@@ -68,7 +68,7 @@ subtest '[create_sap_systems_tfvars] Simple HanaSR cluster settings' => sub {
     $ms_sdaf->redefine(get_os_variable => sub { return 'espresso'; });
     $ms_sdaf->redefine(generate_resource_group_name => sub { return 'NoSleepSquad'; });
     $ms_sdaf->redefine(write_tfvars_file => sub { $tfvars_data = $_[1]; return 'lungo'; });
-    $ms_sdaf->redefine(upload_logs => sub { return; });
+    $ms_sdaf->noop(qw(get_tags_entry upload_logs));
 
     set_openqa_settings;
     set_var('SDAF_DEPLOYMENT_SCENARIO', 'db_install,db_ha');

--- a/tests/sles4sap/sap_deployment_automation_framework/create_deployer_vm.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/create_deployer_vm.pm
@@ -14,11 +14,12 @@
 # Optional:
 # 'SDAF_DEPLOYER_SNAPSHOT' define existing snapshot name to be used as a source
 # 'SDAF_DEPLOYER_MACHINE' override default value for VM size
+# 'SDAF_DEPLOYMENT_OWNER' Set deployed_by tag on all resources. Helps identifying deployment origin.
 
 use Mojo::Base 'sles4sap::sap_deployment_automation_framework::basetest';
 use sles4sap::sap_deployment_automation_framework::deployment
   qw(serial_console_diag_banner az_login sdaf_deployment_reused check_credentials);
-use sles4sap::sap_deployment_automation_framework::deployment_connector qw(get_deployer_ip no_cleanup_tag);
+use sles4sap::sap_deployment_automation_framework::deployment_connector;
 use sles4sap::sap_deployment_automation_framework::naming_conventions qw(generate_deployer_name);
 use sles4sap::azure_cli qw(az_disk_create);
 use serial_terminal qw(select_serial_terminal);
@@ -40,16 +41,14 @@ sub run {
     my $deployer_vm_size = get_var('SDAF_DEPLOYER_MACHINE', 'Standard_D4ds_v5');    # Small VM to control costs
     my $new_deployer_vm_name = generate_deployer_name();
     my $deployer_disk_name = "$new_deployer_vm_name\_OS";
+    az_login();
 
     # VM resource tags are used for sharing information between test modules and test jobs
     # 'deployment_id' (equals test ID) tag identifies which test used the VM for deployment.
     # Check SYNOPSIS section of: sles4sap::sap_deployment_automation_framework::deployment_connector
     # for more details
-    my @deployment_tags = ('deployment_id=' . get_current_job_id());
-
-    # Add no cleanup tag if the deployment should be kept after test finished
-    push @deployment_tags, no_cleanup_tag() . "=1" if get_var('SDAF_RETAIN_DEPLOYMENT');
-    az_login();
+    my $tagsref = get_deployment_tags();
+    my $deployment_tags = join ' ', map { "$_=$tagsref->{$_}" } keys %$tagsref;
 
     # Fetch keyvault secrets and compare them with openQA settings
     check_credentials();
@@ -65,7 +64,7 @@ sub run {
         resource_group => $deployer_resource_group,
         name => $deployer_disk_name,
         source => $snapshot_source_disk,
-        tags => join(' ', @deployment_tags)
+        tags => $deployment_tags
     );
 
     # Create new VM clone
@@ -74,8 +73,8 @@ sub run {
         "--name $new_deployer_vm_name",
         "--attach-os-disk $deployer_disk_name",
         "--size $deployer_vm_size",
-        "--os-type Linux",
-        "--tags " . join(' ', @deployment_tags)    # This tag is used to find correct deployer VM by other modules
+        '--os-type Linux',
+        qq|--tags $deployment_tags|
     );
     assert_script_run($vm_create_cmd, timeout => 600);
 


### PR DESCRIPTION
SDAF test code tagging is currently located on multiple places and tags 
applied are not consistent. This PR is first step in improving and 
unifying tags applied to all resources. It adds central function for 
creating tag list and a new OpenQA setting `SDAF_DEPLOYMENT_OWNER` which
 helps with identifying origin of deployed resources. Tag 
 'openqa_instance' is added as well.

**Ticket**: https://jira.suse.com/browse/TEAM-11314
**Verification run:** 
_Deployer VM tags:_ https://openqaworker15.qe.prg2.suse.org/tests/373430#step/create_deployer_vm/123

_Workload zone tags:_
<img width="1909" height="391" alt="image" src="https://github.com/user-attachments/assets/7f65d6f4-bf1c-4af7-b15e-a5a7d2f378c2" />

_SAP systems tags:_
<img width="1932" height="351" alt="image" src="https://github.com/user-attachments/assets/cfc7236d-9687-471b-ac81-ea8f5b7c12f4" />

