### PR TITLE
feat: ensure serial marker hook is persistent across become_root

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -409,7 +409,7 @@ Log in as root in the current console
 sub become_root {
     my ($self) = @_;
 
-    $self->_detect_serial_marker_capability() if get_var('PRETTY_SERIAL_MARKER');
+    $self->detect_serial_marker_capability() if $self->get_pretty_serial_marker();
     $self->script_sudo('bash', 1);
     $self->invalidate_serial_marker_hook();
     # No need to apply on more recent kernels

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -409,7 +409,9 @@ Log in as root in the current console
 sub become_root {
     my ($self) = @_;
 
+    $self->_detect_serial_marker_capability() if get_var('PRETTY_SERIAL_MARKER');
     $self->script_sudo('bash', 1);
+    $self->invalidate_serial_marker_hook();
     # No need to apply on more recent kernels
     if (is_sle('<=15-SP2') || is_leap('<=15.2')) {
         disable_serial_getty() unless $self->script_run("systemctl is-enabled serial-getty\@$testapi::serialdev");


### PR DESCRIPTION
Motivation:
When switching from an unprivileged user to root via become_root, the
PRETTY_SERIAL_MARKER hook might not have been installed for the original
user if no script_run calls occurred yet. This leads to timeouts if the
root shell is closed and a new unprivileged shell is opened.

Design Choices:
Updated the openSUSE-specific become_root implementation to proactively
trigger capability detection before the sudo switch. Invalidate the hook
status immediately after the switch to ensure re-installation for root.

Benefits:
Consistent serial marker synchronization across multiple terminal windows
and user privilege transitions.

Verification run:
```
openqa-clone-custom-git-refspec --clone-job-args='--badge' https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25817 https://openqa.opensuse.org/tests/6033118
openqa-clone-custom-git-refspec --clone-job-args='--badge' https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25817 https://openqa.opensuse.org/tests/6033118 PRETTY_SERIAL_MARKER=1
```

* [![opensuse-Tumbleweed-agama-installer-x86_64-Build20260618-desktop_amusement_kde@uefi-3G](https://openqa.opensuse.org/tests/6033532/badge?label=opensuse-Tumbleweed-agama-installer-x86_64-Build20260618-desktop_amusement_kde@uefi-3G)](https://openqa.opensuse.org/tests/6033532) (no pretty serial marker, passed)
* [![opensuse-Tumbleweed-agama-installer-x86_64-Build20260618-desktop_amusement_kde@uefi-3G](https://openqa.opensuse.org/tests/6034184/badge?label=opensuse-Tumbleweed-agama-installer-x86_64-Build20260618-desktop_amusement_kde@uefi-3G)](https://openqa.opensuse.org/tests/6034184) (pretty serial marker, passed)

Related issue: https://progress.opensuse.org/issues/199934

Needs:
* https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25817