### PR TITLE
Don't break smbd AppArmor profile

### DIFF
--- a/tests/security/apparmor/aa_logprof.pm
+++ b/tests/security/apparmor/aa_logprof.pm
@@ -47,7 +47,7 @@ sub run {
 
     $self->aa_tmp_prof_prepare("$aa_tmp_prof", 1);
 
-    my @aa_logprof_items = is_sle('<=15-sp4') ? ('\/usr.*\/nscd mrix', 'nscd\.conf r') : ('\s+\/var\/spool\/samba\/.*rw', '\/usr.*\/smbd flags', '\s+\/usr\/lib\*\/samba\/auth\/\*\.so mr');
+    my @aa_logprof_items = is_sle('<=15-sp4') ? ('\/usr.*\/nscd mrix', 'nscd\.conf r') : ('\s+\/var\/spool\/samba\/.*rw', '\s+\/usr\/lib\*\/samba\/auth\/\*\.so mr');
 
     # Remove some rules from profile
     foreach my $item (@aa_logprof_items) {


### PR DESCRIPTION
Lines in @aa_logprof_items get removed from the profile (so that they can be re-added later via aa-logprof).

However, removing '\/usr.*\/smbd flags' (which is the "start of the profile" line) will make the profile invalid, and therefore break the tests. You can see this for example in

https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=opensuse&flavor=JeOS-for-kvm-and-xen&machine=64bit_virtio-2G&test=jeos-apparmor&version=Tumbleweed#step/aa_logprof/26

which says `ERROR: /tmp/apparmor.d/usr.sbin.smbd doesn't contain a valid profile (syntax error?)`

This patch changes the test to no longer remove the "start of the profile" line, so that the profile stays valid.

Fixes: 65cd9e8dfe7931c538abad07e87620f5fcc7e62b

- Related ticket: none
- Needles: none
- Verification run: https://openqa.opensuse.org/tests/6164470