### PR TITLE
Fix check_hana_database error: No instances found

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -1979,7 +1979,7 @@ sub az_storage_blob_lease_acquire(%args) {
         $SDAF_Azure_podman_flake_filter
     );
 
-    my $lease_id = script_output($az_cmd, $args{timeout}, proceed_on_failure => 1);
+    my $lease_id = script_output($az_cmd, $args{timeout}, proceed_on_failure => 1, timeout => 180);
     record_info('AZ CLI out', "AZ CLI returned output:\n $lease_id");
     # Return a string if az_validate_uuid_pattern return "true"
     # otherwise return undef, thanks to Perl's implicit return that get value from the if statement.

--- a/lib/sles4sap/sap_host_agent.pm
+++ b/lib/sles4sap/sap_host_agent.pm
@@ -75,6 +75,16 @@ sub saphostctrl_list_instances {
     my $sudo = $args{as_root} ? 'sudo' : '';
     my $running = $args{running} ? '-running' : '';
     my $cmd = join(' ', $sudo, $saphostctrl, '-function', 'ListInstances', $running, "| grep 'Inst Info'");
+
+    # Add retry mechanism
+    my $retry = 0;
+    while (++$retry) {
+        last if (!script_run($cmd));
+        record_info("Retry $retry", 'sleep 10 and retry');
+        sleep 10;
+        die "No instances found after retry $retry" if ($retry >= 6);
+    }
+
     for my $instance (split("\n", script_output($cmd))) {
         my @instance_data = split(/\s:\s|\s-\s/, $instance);
         push(@instances, {

--- a/t/31_sap_host_agent.t
+++ b/t/31_sap_host_agent.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use Test::Mock::Time;
 use Test::More;
 use Test::Exception;
 use Test::Warnings;
@@ -25,6 +26,8 @@ subtest '[saphostctrl_list_instances] Command composition' => sub {
     my $saphostagent = Test::MockModule->new('sles4sap::sap_host_agent', no_auto => 1);
     my $mock_data = ' Inst Info : HDB - 00 - qesdhdb01l000 - 753, patch 1236, changelist 2222163';
     my @cmd_args;
+    $saphostagent->redefine(script_run => sub { return 0; });
+    $saphostagent->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $saphostagent->redefine(script_output => sub { @cmd_args = @_; return $mock_data; });
     $saphostagent->redefine(get_instance_type => sub { return 'ERS'; });
 
@@ -34,12 +37,17 @@ subtest '[saphostctrl_list_instances] Command composition' => sub {
     ok((grep /-function/, @cmd_args), 'Add "-function" argument');
     ok((grep /ListInstances/, @cmd_args), 'Execute "ListInstances" function');
     ok((grep /| grep 'Inst Info'/, @cmd_args), 'Filter out instance info');
+
+    $saphostagent->redefine(script_run => sub { return 1; });
+    dies_ok { saphostctrl_list_instances() } 'Die if no instances found after retry';
 };
 
 subtest '[saphostctrl_list_instances] Command composition - switch user' => sub {
     my $saphostagent = Test::MockModule->new('sles4sap::sap_host_agent', no_auto => 1);
     my $mock_data = ' Inst Info : HDB - 00 - qesdhdb01l000 - 753, patch 1236, changelist 2222163';
     my @cmd_args;
+    $saphostagent->redefine(script_run => sub { return 0; });
+    $saphostagent->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $saphostagent->redefine(script_output => sub { @cmd_args = @_; return $mock_data; });
     $saphostagent->redefine(get_instance_type => sub { return 'ERS'; });
 


### PR DESCRIPTION
Fix sporadic "check_hana_database": "saphostctrl -function ListInstances -running" reports "No instances found"
1. Add retry for debugging as it is hard to reproduce and doing VRs are time consuming
2. Fix sporadic timeout issue, for example: https://openqaworker15.qe.prg2.suse.org/tests/373179#step/deploy_workload_zone/73
https://openqaworker15.qe.prg2.suse.org/tests/373151#step/deploy_workload_zone/100
https://openqaworker15.qe.prg2.suse.org/tests/373150#step/deploy_workload_zone/73
`Test died: script timeout: az storage blob lease acquire --only-show-errors --container-name network-spaces --account-name labsecetfstate23d --blob-name 192.168.8.64 --lease-duration 60 --output tsv 2> >(grep -Ev 'FutureWarning|Launching flake|self.' >&2) at /usr/lib/os-autoinst/distribution.pm line 300.`

Related ticket:  
[TEAM-11298](https://jira.suse.com/browse/TEAM-11298) - [SDAF][sporadic] HanaSR deployment failed on  "check_hana_database": "saphostctrl -function ListInstances -running" reports "No instances found"

Verification run (no regression introduced):
https://openqaworker15.qe.prg2.suse.org/tests/372846#step/check_hana_database/43 (passed)
https://openqaworker15.qe.prg2.suse.org/tests/372861#step/check_hana_database/43 (passed)

Retry works: 
http://openqaworker15.qe.prg2.suse.org/tests/373423#step/check_hana_database/39
`sleep 10 and retry`
