### PR TITLE
Re-schedule year_2038_detection tests on MU

### DIFF
--- a/schedule/qam/common/mau-year_2038_detection.yaml
+++ b/schedule/qam/common/mau-year_2038_detection.yaml
@@ -1,0 +1,8 @@
+---
+name: mau-year_2038_detection
+description: run year_2038_detection
+schedule:
+- boot/boot_to_desktop
+- console/year_2038_detection
+- console/coredump_collect
+...

--- a/tests/console/year_2038_detection.pm
+++ b/tests/console/year_2038_detection.pm
@@ -100,8 +100,4 @@ sub run {
     }
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;


### PR DESCRIPTION
https://progress.opensuse.org/issues/201981

As the test changes the system time, so it has
impact for other test modules on setups which
snapper rollback are not supported.

So re-schedule it in a new test suite.

- Verification run: https://openqa.suse.de/tests/overview?build=rfan0615&distri=sle