### PR TITLE
Update self-update validation to use systemctl instead of result file

### DIFF
--- a/tests/yam/validate/validate_self_update.pm
+++ b/tests/yam/validate/validate_self_update.pm
@@ -14,12 +14,16 @@ use scheduler qw(get_test_suite_data);
 sub run {
     my $self_update_enabled = get_test_suite_data()->{self_update_enabled};
     if ($self_update_enabled) {
-        my $retcode = script_output('cat /run/live-self-update/result');
-
-        # Pass validation if retcode is 0 (All OK) or 4 - ZYPPER_EXIT_ERR_ZYPP A problem is reported by ZYPP library
-        if ($retcode != 0 && $retcode != 4) {
-            die "Self update did not ended successfully";
+        my $systemctl_output = script_output('systemctl status live-self-update.service', proceed_on_failure => 1);
+        unless ($systemctl_output =~ /status=0\/SUCCESS/) {
+            die "Self update did not end successfully";
         }
+
+        my $self_update_url = get_var('SCC_URL') =~ /proxy/
+          ? get_var('SCC_URL')
+          : get_var('INST_SELF_UPDATE', 'https://scc.suse.com');
+        assert_script_run("journalctl -t live-self-update --no-pager | grep 'Will use a custom registration server " .
+              "$self_update_url for obtaining the self-update repository'");
     } else {
         systemctl('is-active live-self-update', expect_false => 1);
         assert_script_run("journalctl -t live-self-update | grep \"Self update not configured\"");


### PR DESCRIPTION
  ## Summary

  This PR improves the self-update validation by checking the `live-self-update.service`
  status via systemctl instead of reading a result file. The new approach directly queries
  the service exit status, simplifying the validation logic and removing the need for special
  handling of zypper exit code 4.

  ## Changes

  - Replaced file-based validation (`/run/live-self-update/result`) with `systemctl status`
  command
  - Validation now fails if the service didn't exit with code 0
  - Removed special case for ZYPPER_EXIT_ERR_ZYPP (exit code 4)
  
---

- Related ticket: https://progress.opensuse.org/issues/201720
- Needles: N/A
- Verification run: 
  - devel (good repo): https://openqa.suse.de/tests/22923804
  - devel (bad repo): https://openqa.suse.de/tests/22923800
  - prod: https://openqa.suse.de/tests/22923801
  - QR: https://openqa.suse.de/tests/22923802
