### PR TITLE
blktests: make BLKTESTS_QUICK optional

### DIFF
--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -35,7 +35,7 @@ sub run {
     #definition, so that it allows flexible ways of re-runing the tests
     my $tests = get_required_var('BLKTESTS');
     my $devices = get_required_var('BLKTESTS_TEST_DEVS');
-    my $quick = get_var('BLKTESTS_QUICK', 60);
+    my $quick = get_var('BLKTESTS_QUICK');
     my $exclude = get_var('BLKTESTS_EXCLUDE');
     my $trtypes = get_var('BLKTESTS_TRTYPES');
     my $issues = get_var('BLKTESTS_KNOWN_ISSUES');
@@ -80,7 +80,8 @@ sub run {
 
     foreach my $i (@tests) {
         my $config = $devices eq 'none' ? '' : '-c /etc/blktests/config';
-        script_run("${trtypes} ./check $config -o ${log_dir}/results --quick=$quick $exclude $i", 1200);
+        my $quick_arg = $quick ? "--quick=$quick" : '';
+        script_run("${trtypes} ./check $config -o ${log_dir}/results $quick_arg $exclude $i", 1200);
     }
 
     script_run("cd ${log_dir}");
@@ -176,7 +177,8 @@ For blktests, C<test_variant> matches C<BLKTESTS_TRTYPES>.
 
 =head2 BLKTESTS_QUICK
 
-Optional. Value passed to C<./check --quick>. Defaults to C<60>.
+Optional. Value passed to C<./check --quick>. If unset, C<--quick> is not
+passed and all tests run regardless of their C<QUICK> flag.
 
 =head2 BLKTESTS_TRTYPES
 


### PR DESCRIPTION
Not all upstream tests are marked with QUICK=1, so hardcoding --quick=60 as default silently skips entire test groups, including all ublk tests. Remove the default so all tests run unless BLKTESTS_QUICK is explicitly set.

This PR means more blktests will be running in OSD... so I'm doing extensive test runs to avoid silly regressions later on.

- Related ticket: https://progress.opensuse.org/issues/202122
- Verification run:
  - sle16.1: https://openqa.suse.de/tests/22849069
  - sle16.1: https://openqa.suse.de/tests/22849087
  - sle16.1: https://openqa.suse.de/tests/22849089
  - sle16.1: https://openqa.suse.de/tests/22849775
  - sle16.1: https://openqa.suse.de/tests/22849162
  - sle16.1: https://openqa.suse.de/tests/22849164
  - sle16.0: https://openqa.suse.de/tests/22849780
  - sle16.0: https://openqa.suse.de/tests/22849790
  - sle16.0: https://openqa.suse.de/tests/22849798
  - sle16.0: https://openqa.suse.de/tests/22849800
  - sle16.0: https://openqa.suse.de/tests/22849802
