### PR TITLE
journalctl: Accept both error message variants for missing boot entries

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -183,7 +183,8 @@ sub run {
             assert_script_run "rpm -q --conflicts systemd-logger | tee -a /dev/$serialdev | grep syslog";
         }
     } else {
-        validate_script_output('journalctl --no-pager --boot=-1 2>&1', qr/no persistent journal was found/i, fail_message => "Persistent journal present where it shouldn't be") unless is_sle('<15');
+        my $expected_msg = is_public_cloud() ? qr/(no persistent journal was found|no journal boot entry found)/i : qr/no persistent journal was found/i;
+        validate_script_output('journalctl --no-pager --boot=-1 2>&1', $expected_msg, fail_message => "Persistent journal present where it shouldn't be") unless is_sle('<15');
         assert_script_run "mkdir -p ${\ PERSISTENT_LOG_DIR }";
         assert_script_run "systemd-tmpfiles --create --prefix ${\ PERSISTENT_LOG_DIR }";
         # https://bugzilla.suse.com/show_bug.cgi?id=1196637


### PR DESCRIPTION
Accept both "no persistent journal was found" (info message when no persistent files exist) and "no journal boot entry found" (error message when persistent journal exists but boot entry missing, introduced in systemd v254).

Fixes test failures in public cloud where persistent journal directory is created but boot entries aren't available yet.

Related ticket: https://progress.opensuse.org/issues/202524

Failed job: https://openqa.suse.de/tests/22840012#step/journalctl/22