### PR TITLE
feat(PC): Add developer access and instance preservation

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -643,8 +643,12 @@ Destroys the current terraform deployment
 sub terraform_destroy {
     my ($self) = @_;
     record_info('TFM DESTROY', 'Running terraform_destroy() now');
+
     # Do not destroy if terraform has not been applied or the environment doesn't exist
     return unless ($self->terraform_applied);
+
+    # Do not destroy if PUBLIC_CLOUD_NO_TEARDOWN=1
+    return if check_var('PUBLIC_CLOUD_NO_TEARDOWN', '1');
 
     select_host_console(force => 1);
 
@@ -715,6 +719,9 @@ sub terraform_param_tags
         openqa_var_server => $openqa_var_server,
         custodian_ttl => calculate_custodian_ttl($openqa_ttl)
     };
+
+    # Add pcw_ignore tag if requested
+    $tags->{pcw_ignore} = '1' if (check_var('PUBLIC_CLOUD_PCW_IGNORE', '1'));
 
     return encode_json($tags);
 }

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -642,13 +642,20 @@ Destroys the current terraform deployment
 
 sub terraform_destroy {
     my ($self) = @_;
-    record_info('TFM DESTROY', 'Running terraform_destroy() now');
 
     # Do not destroy if terraform has not been applied or the environment doesn't exist
-    return unless ($self->terraform_applied);
+    unless ($self->terraform_applied) {
+        record_info('NO TFM DESTROY', 'Skipping terraform_destroy() due to missing $self->terraform_applied');
+        return;
+    }
 
     # Do not destroy if PUBLIC_CLOUD_NO_TEARDOWN=1
-    return if check_var('PUBLIC_CLOUD_NO_TEARDOWN', '1');
+    if (check_var('PUBLIC_CLOUD_NO_TEARDOWN', '1')) {
+        record_info('NO TFM DESTROY', 'Skipping terraform_destroy() due to PUBLIC_CLOUD_NO_TEARDOWN=1');
+        return;
+    }
+
+    record_info('TFM DESTROY', 'Running terraform_destroy() now');
 
     select_host_console(force => 1);
 

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -433,7 +433,7 @@ sub add_additional_authorized_keys {
     # Accept either a URL (fetched with curl on the remote) or a base64-encoded string.
     # Encode a key with: PUBLIC_CLOUD_AUTHORIZED_KEYS=$(base64 -w0 ~/.ssh/id_ed25519.pub)
     if ($keys_source =~ m{^https?://}) {
-        $instance->ssh_script_run(cmd => qq(curl -sSf '$keys_source' | tee -a ~/.ssh/authorized_keys));
+        $instance->ssh_script_run(cmd => qq(curl -sLSf '$keys_source' | tee -a ~/.ssh/authorized_keys));
     } else {
         $instance->ssh_script_run(cmd => qq(echo "$keys_source" | base64 -d | tee -a ~/.ssh/authorized_keys));
     }

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -427,11 +427,16 @@ sub prepare_ssh_tunnel {
 
 sub add_additional_authorized_keys {
     my ($instance) = @_;
-    # Encode your public key with: PUBLIC_CLOUD_AUTHORIZED_KEYS=$(cat ~/.ssh/id_ed25519.pub | base64)
-    my $encoded_keys = get_var('PUBLIC_CLOUD_AUTHORIZED_KEYS');
-    return unless $encoded_keys;
+    my $keys_source = get_var('PUBLIC_CLOUD_AUTHORIZED_KEYS');
+    return unless $keys_source;
 
-    $instance->ssh_script_run(cmd => qq(echo "$encoded_keys" | base64 -d | tee -a ~/.ssh/authorized_keys));
+    # Accept either a URL (fetched with curl on the remote) or a base64-encoded string.
+    # Encode a key with: PUBLIC_CLOUD_AUTHORIZED_KEYS=$(base64 -w0 ~/.ssh/id_ed25519.pub)
+    if ($keys_source =~ m{^https?://}) {
+        $instance->ssh_script_run(cmd => qq(curl -sSf '$keys_source' | tee -a ~/.ssh/authorized_keys));
+    } else {
+        $instance->ssh_script_run(cmd => qq(echo "$keys_source" | base64 -d | tee -a ~/.ssh/authorized_keys));
+    }
 }
 
 

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -54,6 +54,7 @@ our @EXPORT = qw(
   get_ssh_private_key_path
   permit_root_login
   prepare_ssh_tunnel
+  add_additional_authorized_keys
   allow_openqa_port_selinux
   ssh_update_transactional_system
   create_script_file
@@ -421,6 +422,16 @@ sub prepare_ssh_tunnel {
     # Create log file for ssh tunnel
     my $ssh_sut = '/var/tmp/ssh_sut.log';
     assert_script_run "touch $ssh_sut; chmod 777 $ssh_sut";
+}
+
+
+sub add_additional_authorized_keys {
+    my ($instance) = @_;
+    # Encode your public key with: PUBLIC_CLOUD_AUTHORIZED_KEYS=$(cat ~/.ssh/id_ed25519.pub | base64)
+    my $encoded_keys = get_var('PUBLIC_CLOUD_AUTHORIZED_KEYS');
+    return unless $encoded_keys;
+
+    $instance->ssh_script_run(cmd => qq(echo "$encoded_keys" | base64 -d | tee -a ~/.ssh/authorized_keys));
 }
 
 

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -52,6 +52,9 @@ sub run {
     $instance->enable_kdump() if (get_var('PUBLIC_CLOUD_ENABLE_KDUMP'));
 
     $provider->initialize_logging($instance);
+    # Add additional authorized_keys for human users
+    # It's probably wise to add PUBLIC_CLOUD_NO_TEARDOWN=1 and PUBLIC_CLOUD_PCW_IGNORE=1
+    add_additional_authorized_keys($instance);
 
     # ssh-tunnel settings
     prepare_ssh_tunnel($instance) if (is_tunneled());

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -53,7 +53,6 @@ sub run {
 
     $provider->initialize_logging($instance);
     # Add additional authorized_keys for human users
-    # It's probably wise to add PUBLIC_CLOUD_NO_TEARDOWN=1 and PUBLIC_CLOUD_PCW_IGNORE=1
     add_additional_authorized_keys($instance);
 
     # ssh-tunnel settings

--- a/variables.md
+++ b/variables.md
@@ -421,7 +421,7 @@ TERRAFORM_VERSION | string | "1.5.7" | Version of terraform to include into PC T
 TERRAFORM_TIMEOUT | integer | 1800 | Set timeout for terraform actions
 _SECRET_PUBLIC_CLOUD_INSTANCE_SSH_KEY | string | "" | The `~/.ssh/id_rsa` existing key allowed by `PUBLIC_CLOUD_INSTANCE_IP` instance
 _SECRET_PUBLIC_CLOUD_PERF_DB_TOKEN | string | "" | this required variable is the token to access PUBLIC_CLOUD_PERF_DB_URI (defined in `salt workerconf`)
-PUBLIC_CLOUD_AUTHORIZED_KEYS | string | "" | Base64-encoded SSH public keys to append to authorized_keys file for human users. Encode using: `base64 -w0 ~/.ssh/id_rsa.pub` or `base64 < ~/.ssh/id_rsa.pub | tr -d '\n'`. Multiple keys can be concatenated with newlines before encoding. Recommended to use with PUBLIC_CLOUD_NO_TEARDOWN=1.
+PUBLIC_CLOUD_AUTHORIZED_KEYS | string | "" | SSH public keys to append to the authorized_keys file for human users. Accepts either a URL (e.g. `https://github.com/user.keys`) which is fetched with curl on the remote instance, or a base64-encoded key string (encode with `base64 -w0 ~/.ssh/id_ed25519.pub`). Multiple keys can be concatenated with newlines before encoding. Recommended to use with PUBLIC_CLOUD_NO_TEARDOWN=1.
 PUBLIC_CLOUD_PCW_IGNORE | boolean | false | If set to 1, adds `pcw_ignore=1` tag to cloud resources to prevent Public Cloud Watchdog from cleaning them up automatically based on TTL.
 
 

--- a/variables.md
+++ b/variables.md
@@ -421,6 +421,8 @@ TERRAFORM_VERSION | string | "1.5.7" | Version of terraform to include into PC T
 TERRAFORM_TIMEOUT | integer | 1800 | Set timeout for terraform actions
 _SECRET_PUBLIC_CLOUD_INSTANCE_SSH_KEY | string | "" | The `~/.ssh/id_rsa` existing key allowed by `PUBLIC_CLOUD_INSTANCE_IP` instance
 _SECRET_PUBLIC_CLOUD_PERF_DB_TOKEN | string | "" | this required variable is the token to access PUBLIC_CLOUD_PERF_DB_URI (defined in `salt workerconf`)
+PUBLIC_CLOUD_AUTHORIZED_KEYS | string | "" | Base64-encoded SSH public keys to append to authorized_keys file for human users. Encode using: `base64 -w0 ~/.ssh/id_rsa.pub` or `base64 < ~/.ssh/id_rsa.pub | tr -d '\n'`. Multiple keys can be concatenated with newlines before encoding. Recommended to use with PUBLIC_CLOUD_NO_TEARDOWN=1.
+PUBLIC_CLOUD_PCW_IGNORE | boolean | false | If set to 1, adds `pcw_ignore=1` tag to cloud resources to prevent Public Cloud Watchdog from cleaning them up automatically based on TTL.
 
 
 ### Wicked testsuite specific variables


### PR DESCRIPTION
Add support for injecting SSH authorized_keys and preventing teardown. `terraform_destroy()` now emits a descriptive `record_info` message on all exit paths: skipped when `terraform_applied` is unset, skipped when `PUBLIC_CLOUD_NO_TEARDOWN=1`, or proceeding normally.

`PUBLIC_CLOUD_AUTHORIZED_KEYS` now accepts either a URL (e.g. `https://github.com/user.keys`) or a base64-encoded key string, making it easier to inject keys for human access.

## Commits

- `1c6541e6b8` feat(PC): Add developer access and instance preservation
- `a0a3c3e846` feat(PC): Add record_info messages to all terraform_destroy() exit paths
- `4295250` fix(prepare_instance): remove operational hint from test code
- `1fc4c40a79` feat(utils): accept URLs for PUBLIC_CLOUD_AUTHORIZED_KEYS

* Verification run:
[Build20260622-1](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=20260622-1&distri=sle&version=15-SP7) of sle-15-SP7-Azure-BYOS-Updates.aarch64	[pcw_ignore_dev_noTearDown@64bit](https://pdostal-workbench.qe.prg2.suse.org/tests/781)
[Build20260622-1](https://pdostal-workbench.qe.prg2.suse.org/tests/overview?build=20260622-1&distri=sle&version=15-SP7) of sle-15-SP7-Azure-BYOS-Updates.aarch64	[pcw_ignore_dev_noTearDown@64bit](https://pdostal-workbench.qe.prg2.suse.org/tests/782)