### PR TITLE
publiccloud: replace pc_data_url() with testapi::data_url() + scp

### DIFF
--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -13,7 +13,7 @@ use Mojo::JSON 'decode_json';
 use testapi;
 use version_utils qw(is_transactional is_sle);
 use Utils::Architectures qw(is_aarch64);
-use publiccloud::utils qw(is_byos pc_data_url);
+use publiccloud::utils qw(is_byos);
 use publiccloud::zypper qw(pc_zypper_call);
 use publiccloud::aws_client;
 use publiccloud::ssh_interactive 'select_host_console';
@@ -415,16 +415,20 @@ sub _install_dmesg_capture_to_log
 
     my $svc_file = 'dmesg-capture.service';
     my $svc_target = '/etc/systemd/system/' . $svc_file;
+    assert_script_run("curl -sLo /var/tmp/$svc_file " . data_url("publiccloud/$svc_file"));
+    $instance->scp("/var/tmp/$svc_file", "remote:/var/tmp/$svc_file");
     $instance->ssh_assert_script_run(
-        "sudo curl -sLo $svc_target " . pc_data_url("publiccloud/$svc_file") . " && " .
+        "sudo mv /var/tmp/$svc_file $svc_target && " .
           "sudo systemctl daemon-reload && " .
           "sudo systemctl enable --now $svc_file"
     );
 
     my $logrotate_file = 'dmesg-capture-logrotate.conf';
     my $logrotate_target = '/etc/logrotate.d/dmesg';
+    assert_script_run("curl -sLo /var/tmp/$logrotate_file " . data_url("publiccloud/$logrotate_file"));
+    $instance->scp("/var/tmp/$logrotate_file", "remote:/var/tmp/$logrotate_file");
     $instance->ssh_assert_script_run(
-        "sudo curl -sLo $logrotate_target " . pc_data_url("publiccloud/$logrotate_file") . " && " .
+        "sudo mv /var/tmp/$logrotate_file $logrotate_target && " .
           "sudo logrotate -d $logrotate_target"
     );
 }
@@ -476,7 +480,9 @@ sub _install_ec2_cloudwatch_agent
     my $cfg_file = 'cloudwatch_config.json';
     my $cfg_target = '/opt/aws/amazon-cloudwatch-agent/etc/' . $cfg_file;
     $instance->ssh_assert_script_run("sudo mkdir -p /opt/aws/amazon-cloudwatch-agent/etc");
-    $instance->ssh_assert_script_run("sudo curl -sLo $cfg_target " . pc_data_url("publiccloud/$cfg_file"));
+    assert_script_run("curl -sLo /var/tmp/$cfg_file " . data_url("publiccloud/$cfg_file"));
+    $instance->scp("/var/tmp/$cfg_file", "remote:/var/tmp/$cfg_file");
+    $instance->ssh_assert_script_run("sudo mv /var/tmp/$cfg_file $cfg_target");
     $instance->ssh_assert_script_run(
         "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl " .
           "-a fetch-config " .

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -62,7 +62,6 @@ our @EXPORT = qw(
   get_python_exec
   detect_worker_ip
   calculate_custodian_ttl
-  pc_data_url
 );
 
 # Check if we are a BYOS test run
@@ -705,30 +704,6 @@ sub calculate_custodian_ttl {
     return $custodian_expiration_date;
 }
 
-=head2 pc_data_url
-
-  pc_data_url($path);
-
-returns the URL to download osado artifact much like testapi::data_url
-
-Note: Use with curl -L to follow redirects.
-
-=cut
-
-sub pc_data_url {
-    my $path = shift;
-    # Note: We can't use CASEDIR because internally is a local path in vars.json
-    my $git_url = get_required_var("TEST_GIT_URL");
-    my $commit = get_required_var("TEST_GIT_HASH");
-
-    # Strip .git suffix
-    $git_url =~ s{\.git$}{};
-
-    return "$git_url/raw/$commit/data/$path" if ($git_url =~ m{^https?://(?:www\.)?github\.com});
-    return "$git_url/-/raw/$commit/$path" if ($git_url =~ m{^https?://(?:www\.)?gitlab\.});
-    # Assume Gitea (used by src.suse.de & src.opensuse.org)
-    return "$git_url/src/commit/$commit/$path";
-}
 
 =head2 additional_repos
 

--- a/tests/publiccloud/app-images/php.pm
+++ b/tests/publiccloud/app-images/php.pm
@@ -10,7 +10,6 @@
 use Mojo::Base 'consoletest';
 use testapi;
 use utils;
-use publiccloud::utils;
 use publiccloud::ssh_interactive 'select_host_console';
 
 
@@ -42,9 +41,14 @@ sub prepare_assets {
     my $instance = $self->{run_args}->{my_instance};
     my $htdocs_path = "/srv/www/htdocs/hello-suse";
     $instance->ssh_assert_script_run("sudo mkdir -p $htdocs_path");
-    $instance->ssh_assert_script_run("sudo curl -sLo $htdocs_path/index.php " . pc_data_url("publiccloud/app_images/php/index.php"));
-    $instance->ssh_assert_script_run("sudo curl -sLo $start_dev_server_script_path " . pc_data_url("publiccloud/app_images/php/start-dev-server.sh"));
-    $instance->ssh_assert_script_run("sudo chmod +x $start_dev_server_script_path");
+
+    assert_script_run("curl -sLo /var/tmp/index.php " . data_url("publiccloud/app_images/php/index.php"));
+    $instance->scp("/var/tmp/index.php", "remote:/var/tmp/index.php");
+    $instance->ssh_assert_script_run("sudo mv /var/tmp/index.php $htdocs_path/index.php");
+
+    assert_script_run("curl -sLo /var/tmp/start-dev-server.sh " . data_url("publiccloud/app_images/php/start-dev-server.sh"));
+    $instance->scp("/var/tmp/start-dev-server.sh", "remote:/var/tmp/start-dev-server.sh");
+    $instance->ssh_assert_script_run("sudo mv /var/tmp/start-dev-server.sh $start_dev_server_script_path && sudo chmod +x $start_dev_server_script_path");
 }
 
 1;

--- a/tests/publiccloud/app-images/tomcat.pm
+++ b/tests/publiccloud/app-images/tomcat.pm
@@ -11,8 +11,6 @@ use Mojo::Base 'consoletest';
 use testapi;
 use utils;
 use publiccloud::ssh_interactive 'select_host_console';
-use publiccloud::utils 'pc_data_url';
-
 
 sub run {
     my ($self, $args) = @_;
@@ -37,11 +35,10 @@ sub run {
     );
 
     # 3. Try a different example .war page.
-    $instance->ssh_assert_script_run(
-        'sudo curl -sL '
-          . pc_data_url('publiccloud/hello-suse.war')
-          . ' -o /usr/share/tomcat/webapps/hello-suse.war'
-    );
+    my $war_file = 'hello-suse.war';
+    assert_script_run("curl -sLo /var/tmp/$war_file " . data_url("publiccloud/$war_file"));
+    $instance->scp("/var/tmp/$war_file", "remote:/var/tmp/$war_file");
+    $instance->ssh_assert_script_run("sudo mv /var/tmp/$war_file /usr/share/tomcat/webapps/$war_file");
     $instance->ssh_script_retry(
         "curl -f -s http://localhost:8080/hello-suse/ | grep \"Hello\ SUSE\"",
         retry => 10,


### PR DESCRIPTION
## Summary

Removes the `pc_data_url()` helper from `publiccloud::utils` and replaces all
its call sites with the standard `testapi::data_url()` function. This eliminates the need to download from external source. We have the data locally so we should use them directly.

## Approach

Files are now transferred in two steps:

1. Helper VM downloads the file from the openQA asset server:
   `assert_script_run("curl -sLo /var/tmp/$file " . data_url("publiccloud/$file"))`
2. Helper VM scps it to the SUT:
   `$instance->scp("/var/tmp/$file", "remote:/var/tmp/$file")`
3. SUT moves it into the final (potentially root-owned) destination:
   `$instance->ssh_assert_script_run("sudo mv /var/tmp/$file $target")`

`/var/tmp` is used on the SUT side rather than `/tmp` to avoid issues on
immutable systems such as SLE Micro where `/tmp` may be read-only.

## Files changed

- `lib/publiccloud/utils.pm` — deleted `pc_data_url()` sub, pod and export
- `lib/publiccloud/ec2.pm` — converted 3 call sites (dmesg-capture.service, dmesg-capture-logrotate.conf, cloudwatch_config.json)
- `tests/publiccloud/app-images/tomcat.pm` — converted, removed `use publiccloud::utils` import
- `tests/publiccloud/app-images/php.pm` — converted, removed `use publiccloud::utils` import