### PR TITLE
Collect SDAF registercloudguest log

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
@@ -307,7 +307,7 @@ sub post_fail_hook {
 
         # Upload SUTs logs
         for my $instance_type (keys(%redirection_data)) {
-            next() unless grep /$instance_type/, qw(db_hana nw_ers nw_ascs);
+            next() unless grep /$instance_type/, qw(db_hana nw_ers nw_ascs nw_iscsi nw_pas nw_aas);
             for my $hostname (keys(%{$redirection_data{$instance_type}})) {
                 my %host_data = %{$redirection_data{$instance_type}{$hostname}};
                 connect_target_to_serial(

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -1133,6 +1133,10 @@ sub sdaf_upload_logs {
     record_info('crm configure show', 'Failed to run "crm configure show"', result => 'fail') if (script_run("sudo crm configure show > $crm_cfg_log", timeout => 120));
     upload_logs("$crm_cfg_log", failok => 1);
 
+    # Upload registercloudguest log
+    collect_guestregister_logs();
+    upload_logs('/var/log/cloudregister', log_name => "$autotest::current_test->{name}-${hostname}_cloudregister.log", failok => 1);
+
     # Upload zypper log
     upload_logs('/var/log/zypper.log', log_name => "$autotest::current_test->{name}-${hostname}_zypper.log", failok => 1);
 

--- a/tests/sles4sap/sap_deployment_automation_framework/upload_logs.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/upload_logs.pm
@@ -50,7 +50,7 @@ sub run {
 
     # Upload logs appearing in SUT
     for my $instance_type (keys(%redirection_data)) {
-        next() unless grep /$instance_type/, qw(db_hana nw_ers nw_ascs);
+        next() unless grep /$instance_type/, qw(db_hana nw_ers nw_ascs nw_iscsi nw_pas nw_aas);
         for my $hostname (keys(%{$redirection_data{$instance_type}})) {
             my %host_data = %{$redirection_data{$instance_type}{$hostname}};
             connect_target_to_serial(


### PR DESCRIPTION
Collect registercloudguest log

- Related ticket: [TEAM-11282](https://jira.suse.com/browse/TEAM-11282) - [SDAF] Collect registercloudguest log
- Verification run:

16.0 deploy_HanaSR_sbd (`post_fail_hook()` upload logs):
http://openqaworker15.qe.prg2.suse.org/tests/373638#downloads (5 `cloudregister.log` files are uploaded)
http://openqaworker15.qe.prg2.suse.org/tests/373638#step/os_preparation/274 (`record_info()` logs)

 sle-15-SP5- cleanup_ENSA2_sbd (`cleanup` upload logs, no iscsi/pas/aas logs yet as I added the support just now but did not rerun the jobs)
http://openqaworker15.qe.prg2.suse.org/tests/373641#downloads (`record_info()` logs)
http://openqaworker15.qe.prg2.suse.org/tests/373641#step/upload_logs/135  (4 `cloudregister.log` files are uploaded)


 sle-15-SP7 cleanup_HanaSR (`cleanup` upload logs, no iscsi/pas/aas logs yet as I added the support just now but did not rerun the jobs)
http://openqaworker15.qe.prg2.suse.org/tests/373645#downloads (2 `cloudregister.log` files are uploaded)
http://openqaworker15.qe.prg2.suse.org/tests/373645#step/upload_logs/123 (`record_info()` logs)

sle-15-SP5 cleanup_ENSA2_sbd (`cleanup` upload logs)
https://openqaworker15.qe.prg2.suse.org/tests/373841#downloads (9 `cloudregister.log` files are uploaded)

