### PR TITLE
Enhance s390x kvm installation a bit

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1318,7 +1318,7 @@ sub zkvm_add_disk {
                 $hdd_path or die "Unable to find image $basename in $hdd_dir";
                 diag("HDD path found: $hdd_path");
 
-                enter_cmd("# copying image ($basename)...");
+                record_info("copying image ($basename)...");
                 if (my $size = get_var("HDDSIZEGB_$di")) {
                     $size .= "G";
                     $svirt->add_disk({file => $hdd_path, backingfile => 1, dev_id => $dev_id, size => $size});

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -950,7 +950,6 @@ sub activate_console {
         handle_password_prompt($console);
         assert_screen('text-logged-in-root', 60) unless is_hyperv;
         $self->set_standard_prompt('root', os_type => $os_type, skip_set_standard_prompt => $args{skip_set_standard_prompt});
-        save_svirt_pty;
     }
     elsif (
         $console eq 'installation'

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -194,7 +194,8 @@ Does B<not> work on B<Hyper-V>.
 sub save_svirt_pty {
     return if check_var('VIRSH_VMM_FAMILY', 'hyperv');
     my $name = console('svirt')->name;
-    enter_cmd "pty=`virsh dumpxml $name 2>/dev/null | grep \"console type=\" | sed \"s/'/ /g\" | awk '{ print \$5 }'`";
+    enter_cmd "pty=`virsh ttyconsole $name`";
+    wait_still_screen 1;
     enter_cmd "echo \$pty";
 }
 
@@ -392,6 +393,7 @@ sub unlock_if_encrypted {
 
     if (get_var('S390_ZKVM')) {
         select_console('svirt');
+        save_svirt_pty;
 
         # enter passphrase twice (before grub and after grub) if full disk is encrypted
         if (get_var('FULL_LVM_ENCRYPT')) {


### PR DESCRIPTION
https://progress.opensuse.org/issues/202626

1. Fix Terminal Background Process / Echo Race Condition
2. Show 'copying image' info with 'record_info'
3. Use simple 'virsh ttyconsole' cmd to list $pty
4. Don't check $pty when `select_console('svirt')`


- Verification run:  
[install &boot](https://openqa.suse.de/tests/overview?arch=s390x&distri=sle&build=rfan0617)
[migration](https://openqa.suse.de/tests/overview?version=16.1&distri=sle&build=rfan0618) **please ignore the failed modules, they are known issues**
[qe-security](https://openqa.suse.de/tests/overview?distri=sle&version=15-SP7&build=rfan0623)

Old_installation:  https://openqa.suse.de/tests/22750846#step/bootloader_zkvm/13 [`save_svirt_pty` once]
New installation: https://openqa.suse.de/tests/22871712#step/bootloader_start/19  [no `save_svirt_pty`]

Old boot: https://openqa.suse.de/tests/22750849#step/boot_to_desktop/9 [`save_svirt_pty` twice]
New boot: https://openqa.suse.de/tests/22871713#step/boot_to_desktop/5 [`save_svirt_pty` only once]