### PR TITLE
Remove persistence on PC AWS CloudWatch

### DIFF
--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -435,10 +435,6 @@ sub _install_ec2_cloudwatch_agent
 
     $self->_install_dmesg_capture_to_log($instance);
 
-    $instance->ssh_assert_script_run("sudo mkdir -p /etc/systemd/journald.conf.d");
-    $instance->ssh_assert_script_run("echo -e '[Journal]\\nStorage=persistent' | sudo tee /etc/systemd/journald.conf.d/persistent.conf");
-    $instance->ssh_assert_script_run("sudo systemctl restart systemd-journald");
-
     my $arch = is_aarch64() ? "arm64" : "amd64";
 
     my $rpm_file = "amazon-cloudwatch-agent.rpm";


### PR DESCRIPTION
As CloudWatch logging was introduced on all AWS
tests the persistence setting broke journalctl test.

For the sake of simplicity the persistence was removed in all cases.
There was certain corner case that rendered persistence setting needed,
however, there are more chances of persistence setting introducing
issues like this than that corner case.

- Related ticket: https://progress.opensuse.org/issues/202524
- Verification run: https://openqa.suse.de/tests/22862319