### PR TITLE
Fix counting kubevirt packages from specified repositary

### DIFF
--- a/tests/virt_autotest/kubevirt_tests_server.pm
+++ b/tests/virt_autotest/kubevirt_tests_server.pm
@@ -213,7 +213,7 @@ sub install_kubevirt_packages {
         # Check if at least one installed kubevirt package is from the incident repo
         my $pkgs_from_incident_repo;
         foreach (split(' ', $virt_manifests_pkgs), $virt_tests_pkg) {
-            $pkgs_from_incident_repo += 1 if (script_output("zypper info $_ | awk -F': ' '/^Repository/{print \$2}'") =~ /^TEST_/);
+            $pkgs_from_incident_repo += 1 if (script_output("zypper se -s $_ | grep '^i+'") =~ /TEST_[0-9]+/);
         }
         # Patch the kubevirt-operator manifest to use images from the SUSE internal registry
         my $incident_id = get_required_var('INCIDENT_ID');


### PR DESCRIPTION
The counting number of installed kubevirt packages from the incident repository is incorrect when the same version appears in system updates repository.

Failed run: https://openqa.suse.de/tests/22860505#step/kubevirt_tests_server/47

S  | Name               | Type    | Version             | Arch   | Repository
---+--------------------+---------+---------------------+--------+------------------------------------
i+ | kubevirt-manifests | package | 1.7.4-150700.3.24.2 | x86_64 | SLE-Module-Containers15-SP7-Updates
i+ | kubevirt-manifests | package | 1.7.4-150700.3.24.2 | x86_64 | TEST_0

- Related ticket: https://progress.opensuse.org/issues/202620
- Verification run: https://openqa.suse.de/tests/22862214
