### PR TITLE
SDAF apply workaround for iSCSI registration

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/ansible.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/ansible.pm
@@ -21,6 +21,7 @@ use sles4sap::sap_deployment_automation_framework::naming_conventions;
 our @EXPORT = qw(
   sdaf_execute_playbook
   sdaf_register_byos
+  ansible_execute_command
 );
 
 

--- a/tests/sles4sap/sap_deployment_automation_framework/os_preparation.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/os_preparation.pm
@@ -104,6 +104,16 @@ sub run {
                 sdaf_config_root_dir => $sdaf_config_root_dir,
                 scc_reg_code => get_required_var('SCC_REGCODE_SLES4SAP'))
               if is_byos() || get_var('PUBLIC_CLOUD_FORCE_REGISTRATION');
+
+            # Register iSCSI servers as a temporary workaround for GH#35
+            record_soft_failure('gh#35 - Register iSCSI manually') if check_var('SDAF_FENCING_MECHANISM', 'sbd');
+            ansible_execute_command(
+                command => 'sudo registercloudguest --clean && sudo registercloudguest --force-new',
+                host_group => $sap_sid . "_ISCSI",
+                sdaf_config_root_dir => $sdaf_config_root_dir,
+                sap_sid => $sap_sid,
+                verbose => 1
+            ) if check_var('SDAF_FENCING_MECHANISM', 'sbd');
         }
         # Stop execution with SAP SUT OS setup - App installation is done after maintenance updates are applied
         last if ($playbook_options->{playbook_filename} =~ /playbook_02_os_sap_specific_config/);


### PR DESCRIPTION
There is an issue with iSCSI registration. This PR adds manual registration step for iSCSI servers.

Ticket: https://github.com/sdaf-suse/sap-automation/issues/35
Verification run: https://openqaworker15.qe.prg2.suse.org/tests/373715#live
