### PR TITLE
Fix Public Cloud migration from SLE 15-SP7 to SLE 16.0

### DIFF
--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -35,10 +35,10 @@ sub run {
         # LTSS should be disabled before the migration
         $instance->ssh_assert_script_run("sudo SUSEConnect -d -p SLES-LTSS/12.5/x86_64", timeout => 180);
 
-        $instance->ssh_assert_script_run("sudo zypper -n -p 110 ar -Gef " . get_required_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_12_SP5 Migration");
+        $instance->ssh_assert_script_run("sudo zypper -n -p 110 ar -Gef " . get_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_12_SP5 Migration") if (get_var("PUBLIC_CLOUD_DMS_REPO"));
         $instance->ssh_script_run("sudo zypper -n ref", timeout => 1800) if (is_ec2());
         $instance->ssh_assert_script_run("sudo timeout -k 15 $migration_timeout zypper -n in SLES15-Migration suse-migration-sle15-activation", timeout => $migration_timeout + 30);
-        $instance->ssh_assert_script_run("sudo zypper -n rr Migration", timeout => 900);
+        $instance->ssh_assert_script_run("sudo zypper -n rr Migration", timeout => 900) if (get_var("PUBLIC_CLOUD_DMS_REPO"));
         $instance->ssh_assert_script_run("sudo zypper refresh-services --force", timeout => 180);
 
         # Disable maintenance updates for the migration as directory is not available during it
@@ -65,10 +65,10 @@ sub run {
             $instance->ssh_assert_script_run(qq(echo -e "network:\\n    wicked2nm-continue-migration: true\\n" | sudo tee -a /etc/sle-migration-service.yml));
         }
 
-        $instance->ssh_assert_script_run("sudo zypper -n -p 110 ar -Gef " . get_required_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_15_SP7 Migration");
+        $instance->ssh_assert_script_run("sudo zypper -n -p 110 ar -Gef " . get_var("PUBLIC_CLOUD_DMS_REPO") . "SLE_15_SP7 Migration") if (get_var("PUBLIC_CLOUD_DMS_REPO"));
         $instance->ssh_script_run("sudo zypper -n ref", timeout => 1800) if (is_ec2());
         $instance->ssh_assert_script_run("sudo timeout -k 15 $migration_timeout zypper -n in SLES16-Migration suse-migration-sle16-activation", timeout => $migration_timeout + 30);
-        $instance->ssh_assert_script_run("sudo zypper -n rr Migration", timeout => 900);
+        $instance->ssh_assert_script_run("sudo zypper -n rr Migration", timeout => 900) if (get_var("PUBLIC_CLOUD_DMS_REPO"));
         $instance->ssh_assert_script_run("sudo zypper refresh-services --force", timeout => 180);
 
         # Disable maintenance updates for the migration as directory is not available during it

--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -46,11 +46,11 @@ sub run {
 
         # Reboot to run the migration
         $instance->softreboot(check_connectivity => 0, timeout => 3600);
-	$instance->wait_for_ssh();
+        $instance->wait_for_ssh();
         validate_version($instance);
         $instance->softreboot(check_connectivity => 0, timeout => 3600);
-	$instance->wait_for_ssh();
-	record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
+        $instance->wait_for_ssh();
+        record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
 
         # Re-enable maintenance updates for the migration
         $instance->ssh_script_run("sudo sudo sed -i 's/^enabled=0/enabled=1/' /etc/zypp/repos.d/SUSE_Maintenance_*");
@@ -84,11 +84,11 @@ sub run {
 
         # Reboot to run the migration
         $instance->softreboot(check_connectivity => 0, timeout => 3600);
-	$instance->wait_for_ssh();
+        $instance->wait_for_ssh();
         validate_version($instance);
         $instance->softreboot(check_connectivity => 0, timeout => 3600);
-	$instance->wait_for_ssh();
-	record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
+        $instance->wait_for_ssh();
+        record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
     }
 }
 

--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -15,7 +15,6 @@ use version_utils 'is_sle';
 use publiccloud::ssh_interactive "select_host_console";
 use publiccloud::utils qw(is_ec2 is_gce is_azure registercloudguest);
 
-
 sub run {
     my ($self, $args) = @_;
     my $migration_timeout = 2401;
@@ -42,7 +41,7 @@ sub run {
         $instance->ssh_assert_script_run("sudo zypper refresh-services --force", timeout => 180);
 
         # Disable maintenance updates for the migration as directory is not available during it
-        $instance->ssh_script_run("sudo sudo sed -i 's/^enabled=1/enabled=0/' /etc/zypp/repos.d/SUSE_Maintenance_*");
+        $instance->ssh_script_run("sudo sed -i 's/^enabled=1/enabled=0/' /etc/zypp/repos.d/SUSE_Maintenance_*");
 
         # Reboot to run the migration
         $instance->softreboot(check_connectivity => 0, timeout => 3600);
@@ -53,7 +52,7 @@ sub run {
         record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
 
         # Re-enable maintenance updates for the migration
-        $instance->ssh_script_run("sudo sudo sed -i 's/^enabled=0/enabled=1/' /etc/zypp/repos.d/SUSE_Maintenance_*");
+        $instance->ssh_script_run("sudo sed -i 's/^enabled=0/enabled=1/' /etc/zypp/repos.d/SUSE_Maintenance_*");
 
         # Try to install aws-cli and azure-cli as they were removed for the migration
         $instance->ssh_script_run("sudo zypper -n ref", timeout => 1800) if (is_ec2());
@@ -76,11 +75,38 @@ sub run {
         $instance->ssh_assert_script_run("sudo zypper refresh-services --force", timeout => 180);
 
         # Disable maintenance updates for the migration as directory is not available during it
-        $instance->ssh_script_run("sudo sudo sed -i 's/^enabled=1/enabled=0/' /etc/zypp/repos.d/SUSE_Maintenance_*");
+        $instance->ssh_script_run("sudo sed -i 's/^enabled=1/enabled=0/' /etc/zypp/repos.d/SUSE_Maintenance_*");
 
         my $arch = get_required_var('ARCH');
-        $instance->ssh_script_run("echo 'migration_product: SLES/16.0/$arch\\n' | sudo tee -a /etc/sle-migration-service.yml");
-        $instance->ssh_script_run("cat /etc/sle-migration-service.yml");
+
+        # Deregister modules with no SLE 16.0 equivalents on the cloud SMT.
+        # Each module needs two steps:
+        #   1. SUSEConnect -d  — server-side; prevents HTTP 422 from zypper migration.
+        #   2. zypper removeservice — local; prevents exit 104 (no provider found).
+        # Order matters: dependents before dependencies, as SUSEConnect -d rejects
+        # removal while dependent modules are still registered.
+        # sle-module-basesystem and sle-module-server-applications exist in 16.0 and are kept.
+        my @modules_to_remove = (
+            # Dependents first
+            ['sle-module-development-tools', 'Development_Tools_Module_x86_64'],
+            ['sle-module-legacy', 'Legacy_Module_x86_64'],
+            ['sle-module-systems-management', 'Systems_Management_Module_x86_64'],
+            ['sle-module-web-scripting', 'Web_and_Scripting_Module_x86_64'],
+            # Dependencies last
+            ['sle-module-desktop-applications', 'Desktop_Applications_Module_x86_64'],
+            ['sle-module-python3', 'Python_3_Module_x86_64'],
+        );
+        my @removed;
+        for my $entry (@modules_to_remove) {
+            my ($module, $svc) = @{$entry};
+            $instance->ssh_script_run("sudo SUSEConnect -d -p $module/15.7/$arch", timeout => 120);
+            my $ret = $instance->ssh_script_run("sudo zypper -n removeservice $svc", timeout => 120);
+            push @removed, $svc if $ret == 0;
+        }
+        record_info('Removed services', join("\n", @removed) || 'none');
+        record_info('SUSEConnect post-removal', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 120));
+
+        $instance->ssh_assert_script_run("echo 'migration_product: SLES/16.0/$arch' | sudo tee -a /etc/sle-migration-service.yml");
 
         # Reboot to run the migration
         $instance->softreboot(check_connectivity => 0, timeout => 3600);

--- a/tests/publiccloud/migration.pm
+++ b/tests/publiccloud/migration.pm
@@ -45,8 +45,12 @@ sub run {
         $instance->ssh_script_run("sudo sudo sed -i 's/^enabled=1/enabled=0/' /etc/zypp/repos.d/SUSE_Maintenance_*");
 
         # Reboot to run the migration
-        $instance->softreboot(timeout => 3600);
+        $instance->softreboot(check_connectivity => 0, timeout => 3600);
+	$instance->wait_for_ssh();
         validate_version($instance);
+        $instance->softreboot(check_connectivity => 0, timeout => 3600);
+	$instance->wait_for_ssh();
+	record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
 
         # Re-enable maintenance updates for the migration
         $instance->ssh_script_run("sudo sudo sed -i 's/^enabled=0/enabled=1/' /etc/zypp/repos.d/SUSE_Maintenance_*");
@@ -79,8 +83,12 @@ sub run {
         $instance->ssh_script_run("cat /etc/sle-migration-service.yml");
 
         # Reboot to run the migration
-        $instance->softreboot(timeout => 3600);
+        $instance->softreboot(check_connectivity => 0, timeout => 3600);
+	$instance->wait_for_ssh();
         validate_version($instance);
+        $instance->softreboot(check_connectivity => 0, timeout => 3600);
+	$instance->wait_for_ssh();
+	record_info('SUSEConnect', $instance->ssh_script_output("sudo SUSEConnect --status-text", timeout => 300));
     }
 }
 

--- a/variables.md
+++ b/variables.md
@@ -335,7 +335,7 @@ PUBLIC_CLOUD_CONTAINERS | boolean | false | If set, containers tests are added t
 PUBLIC_CLOUD_HIMMELBLAU | boolean | false | Scheduling variable for running the himmelblau tests.
 PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY | string | "" | Name for public cloud registry for the container images used on kubernetes tests.
 PUBLIC_CLOUD_CREDENTIALS_URL | string | "" | Base URL where to get the credentials from. This will be used to compose the full URL together with `PUBLIC_CLOUD_NAMESPACE`.
-PUBLIC_CLOUD_DMS_REPO | string | "" | The Repo URL for migration test.
+PUBLIC_CLOUD_DMS_REPO | string | "" | Optional. The Repo URL for migration test. If not set, migration packages will be installed from default repositories without adding a custom migration repository.
 PUBLIC_CLOUD_DOWNLOAD_TESTREPO | boolean | false | If set, it schedules `publiccloud/download_repos` job.
 PUBLIC_CLOUD_EC2_BOOT_MODE | string | "uefi-preferred" | The `--boot-mode` parameter for `ec2uploadimg` script. Available values: `legacy-bios`, `uefi`, `uefi-preferred` Currently unused variable. Use `git blame` to get context.
 PUBLIC_CLOUD_EC2_IPV6_ADDRESS_COUNT | string | 0 | How many IPv6 addresses should the instance have


### PR DESCRIPTION
The migration from SLE 15-SP7 to SLE 16.0 was failing because optional modules registered on the system (Desktop Applications, Web Scripting, DevTools, Legacy, Python3, Systems Management) have no equivalents in SLE 16.0 on the cloud SMT. This caused two failure modes: exit 104 (no provider found) when local zypper service files were still present, and HTTP 422 from the registration server when modules were still server-side activated. The fix deregisters each affected module in dependency order using `SUSEConnect -d` (server-side) followed by `zypper removeservice` (local), keeping `sle-module-basesystem` and `sle-module-server-applications` which do have 16.0 equivalents. Also fixes a pre-existing `sudo sudo` typo appearing three times in the file.

- Verification runs: [test 712 (passing)](https://pdostal-workbench.qe.prg2.suse.org/tests/712)