### PR TITLE
xfstests: collect more info for debugging

### DIFF
--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -95,7 +95,8 @@ sub log_create {
 
 sub collect_version {
     my $file = shift;
-    my $cmd = "(rpm -qa xfsprogs xfsdump btrfsprogs e2fsprogs coreutils util-linux kernel-default " . join(' ', @PACKAGES) . "; uname -r; rpm -qi kernel-default) | tee $file";
+    my $packs = "xfsprogs xfsdump btrfsprogs e2fsprogs coreutils util-linux kernel-default";
+    my $cmd = "(rpm -qa " . join(' ', ($packs, @PACKAGES)) . "; uname -r; rpm -qi kernel-default) | tee $file";
     script_run($cmd, proceed_on_failure => 1);
     upload_logs($file, timeout => 60, log_name => basename($file));
 }

--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -95,7 +95,7 @@ sub log_create {
 
 sub collect_version {
     my $file = shift;
-    my $cmd = "(rpm -qa xfsprogs xfsdump btrfsprogs e2fsprogs coreutils kernel-default " . join(' ', @PACKAGES) . "; uname -r; rpm -qi kernel-default) | tee $file";
+    my $cmd = "(rpm -qa xfsprogs xfsdump btrfsprogs e2fsprogs coreutils util-linux kernel-default " . join(' ', @PACKAGES) . "; uname -r; rpm -qi kernel-default) | tee $file";
     script_run($cmd, proceed_on_failure => 1);
     upload_logs($file, timeout => 60, log_name => basename($file));
 }

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -313,6 +313,10 @@ sub post_env_info {
     $size_info = $size_info . "QEMURAM       " . get_var("QEMURAM") . "\n";
     $size_info = $size_info . "\n" . script_output("df -h");
     record_info('Size', $size_info);
+
+    # record mounted filesystem info
+    my $mount_info = script_output("mount");
+    record_info('Mount', $mount_info);
 }
 
 sub format_with_options {


### PR DESCRIPTION
1. record util-linux version
2. record mounted filesystem
3. extract long Perl command into variable
Move a long cmd in collect_version() to a variable.
No behavior change - only reorganized code for maintainability and
shorter lines.

- Related ticket: https://progress.opensuse.org/issues/202668
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/22884139#step/partition/139
