### PR TITLE
pc_data_url: Make TEST_GIT_URL starting with "git@github.com:" work

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -721,6 +721,9 @@ sub pc_data_url {
     my $git_url = get_required_var("TEST_GIT_URL");
     my $commit = get_required_var("TEST_GIT_HASH");
 
+    # Convert the ssh URL "git@github.com:foobar" into "https://github.com/foobar" for curl/wget consumption
+    $git_url =~ s{^.*@([^:]+):}{https://$1/};
+
     # Strip .git suffix
     $git_url =~ s{\.git$}{};
 


### PR DESCRIPTION
Failed job:
https://pdostal-workbench.qe.prg2.suse.org/tests/730#step/prepare_instance/293

The job failed because `TEST_GIT_URL` in [vars.json](https://pdostal-workbench.qe.prg2.suse.org/tests/730/file/vars.json) contains `git@github.com:os-autoinst/os-autoinst-distri-opensuse.git`.  Other jobs pass because they use `https://` like [here](https://openqa.suse.de/tests/22803988/file/vars.json).

Tested locally with:
```
my $git_url = 'git@github.com:os-autoinst/os-autoinst-distri-opensuse.git';
$git_url =~ s{^.*@([^:]+):}{https://$1/};
print "$git_url\n";
```

Verification run: https://openqa.suse.de/tests/22874141