### PR TITLE
Capture stderr in az_group_name_get and handle in callers

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -142,7 +142,9 @@ sub az_group_create(%args) {
 
 Get the name of all existing Resource Group in the current subscription.
 By default the output is an array of strings.
-Output can be modified using B<$args{query}>.
+Output is always an hash with `data` and `err` keys:
+`data` is the decode_json of the stdout. The internal data structure can change accordingly to what is provided via B<query>
+`err` is the stderr string if present, otherwise the key is missing.
 
 =over
 
@@ -153,13 +155,18 @@ Output can be modified using B<$args{query}>.
 
 sub az_group_name_get(%args) {
     $args{query} //= '[].name';
+    my $err_file = '/tmp/az_cli.err';
     my $az_cmd = join(' ',
         'az group list',
         "--query \"$args{query}\"",
         '-o json',
-        $SDAF_Azure_podman_flake_filter
+        "2> $err_file"
     );
-    return decode_json(script_output($az_cmd));
+    my $data = decode_json(script_output($az_cmd));
+    # Prepare return hash
+    my $result = { data => $data };
+    $result->{err} = script_output("cat $err_file 2>/dev/null || echo -n ''");
+    return $result;
 }
 
 =head2 az_group_delete

--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -26,7 +26,6 @@ Library to compose and run Azure cli commands
 our @EXPORT = qw(
   $SDAF_Azure_podman_flake_filter
   az_version
-  az_account_show
   az_group_create
   az_group_name_get
   az_group_delete
@@ -144,7 +143,7 @@ Get the name of all existing Resource Group in the current subscription.
 By default the output is an array of strings.
 Output is always an hash with `data` and `err` keys:
 `data` is the decode_json of the stdout. The internal data structure can change accordingly to what is provided via B<query>
-`err` is the stderr string if present, otherwise the key is missing.
+`err` is the stderr string, key is always present but it could have empty value.
 
 =over
 
@@ -164,7 +163,7 @@ sub az_group_name_get(%args) {
     );
     my $data = decode_json(script_output($az_cmd));
     # Prepare return hash
-    my $result = { data => $data };
+    my $result = {data => $data};
     $result->{err} = script_output("cat $err_file 2>/dev/null || echo -n ''");
     return $result;
 }
@@ -2497,30 +2496,6 @@ sub az_network_dns_zones_cleanup {
     for my $zone (@zones) {
         az_network_dns_zone_delete(resource_group => $args{resource_group}, zone_name => $zone);
     }
-}
-
-=head2 az_account_show
-
-
-Get account informations, by default the ID. By default the output is an strings.
-Output can be modified using B<$args{query}>.
-
-=over
-
-=item B<query> - Modify output filter using jmespath query. Default: 'id'
-
-=back
-=cut
-
-sub az_account_show {
-    my (%args) = @_;
-    $args{query} //= 'id';
-    my $az_cmd = join(' ', 'az account show',
-        "--query '$args{query}'",
-        '-o json',
-        $SDAF_Azure_podman_flake_filter
-    );
-    return decode_json(script_output($az_cmd));
 }
 
 =head2 az_role_definition_list

--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -831,7 +831,11 @@ az command line. Die in case of failure
 
 sub ipaddr2_deployment_sanity {
     my $rg = ipaddr2_azure_resource_group();
-    my $res = az_group_name_get();
+    my $result = az_group_name_get();
+    if ($result->{err}) {
+        record_info('AZ ERROR', $result->{err});
+    }
+    my $res = $result->{data};
     my $count = grep(/$rg/, @$res);
     die "There are not exactly one but $count resource groups with name $rg" unless $count == 1;
 

--- a/lib/sles4sap/qesap/azure.pm
+++ b/lib/sles4sap/qesap/azure.pm
@@ -71,9 +71,22 @@ sub qesap_az_get_resource_group {
     my (%args) = @_;
     my $job_id = get_var('QESAP_DEPLOYMENT_IMPORT', get_current_job_id());
     die "Could not determine job ID to find the resource group" unless defined $job_id;
-    my $all_rg = az_group_name_get();
+
+    # Get the hash result from the new API
+    my $result = az_group_name_get();
+
+    # Optional: check if there's an error and record it before proceeding
+    if (exists $result->{err} && $result->{err} ne '') {
+        record_info('QESAP AZ ERROR', $result->{err});
+    }
+
+    # Extract the array from the hash
+    my $all_rg = $result->{data};
+
+    # Filter the array
     my @selected_rg = grep(/$job_id/, @$all_rg);
     @selected_rg = grep(/$args{substring}/, @selected_rg) if ($args{substring});
+
     record_info('QESAP RG', $selected_rg[0] ? "result:$selected_rg[0]" : 'result:EMPTY');
     return $selected_rg[0];
 }

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -1078,9 +1078,7 @@ sub get_sdaf_resource_group {
     # Apply the filter: remove known noisy warnings
     if (exists $result->{err}) {
         # Define the filter regex based on the branch
-        my $is_sles16 = (get_var('SDAF_GIT_AUTOMATION_BRANCH', '') =~ /feature\/sles16/);
-        my $filter_regex = $is_sles16 ? qr/FutureWarning|Launching flake|self./ : qr/^$/;
-        $result->{err} =~ s/$filter_regex//g;
+        $result->{err} =~ s/.*(FutureWarning|Launching flake|self.).*//g;
         # Remove empty lines left behind by the filtering
         $result->{err} =~ s/^\s*\n//gm;
         record_info('AZ ERROR', "Error while fetching resource groups: $result->{err}") if ($result->{err} =~ /\S+/);

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -1071,8 +1071,22 @@ sub get_sdaf_resource_group {
     croak 'Missing mandatory argument "$args{deployment_id}"' unless $args{deployment_id};
     croak 'Missing mandatory argument "$args{resource_group_type}"' unless $args{resource_group_type};
 
-    my $query = "[?contains(name, '$args{resource_group_type}') && contains(name, '$args{deployment_id}')].name";
-    my $groups = az_group_name_get(query => $query);
+    # Capture the full hash returned by the new az_group_name_get
+    my $result = az_group_name_get(
+        query => "[?contains(name, '$args{resource_group_type}') && contains(name, '$args{deployment_id}')].name");
+
+    # Apply the filter: remove known noisy warnings
+    if (exists $result->{err}) {
+        # Define the filter regex based on the branch
+        my $is_sles16 = (get_var('SDAF_GIT_AUTOMATION_BRANCH', '') =~ /feature\/sles16/);
+        my $filter_regex = $is_sles16 ? qr/FutureWarning|Launching flake|self./ : qr/^$/;
+        $result->{err} =~ s/FutureWarning|Launching flake|self.//g;
+        # Remove empty lines left behind by the filtering
+        $result->{err} =~ s/^\s*\n//gm;
+        record_info('AZ ERROR', "Error while fetching resource groups: $result->{err}") if ($result->{err} =~ /\S+/);
+    }
+
+    my $groups = $result->{data};
     die "Zero or more than one resource groups found:\n" . join("\n", @$groups) unless (@$groups == 1);
     return $groups->[0];
 }

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -1080,7 +1080,7 @@ sub get_sdaf_resource_group {
         # Define the filter regex based on the branch
         my $is_sles16 = (get_var('SDAF_GIT_AUTOMATION_BRANCH', '') =~ /feature\/sles16/);
         my $filter_regex = $is_sles16 ? qr/FutureWarning|Launching flake|self./ : qr/^$/;
-        $result->{err} =~ s/FutureWarning|Launching flake|self.//g;
+        $result->{err} =~ s/$filter_regex//g;
         # Remove empty lines left behind by the filtering
         $result->{err} =~ s/^\s*\n//gm;
         record_info('AZ ERROR', "Error while fetching resource groups: $result->{err}") if ($result->{err} =~ /\S+/);

--- a/t/15_qesap_azure.t
+++ b/t/15_qesap_azure.t
@@ -16,7 +16,7 @@ set_var('QESAP_CONFIG_FILE', 'MARLIN');
 subtest '[qesap_az_get_resource_group] match job_id' => sub {
     my $qesap = Test::MockModule->new('sles4sap::qesap::azure', no_auto => 1);
     my $az_call = 0;
-    $qesap->redefine(az_group_name_get => sub { $az_call = 1; return ['BOAT1234'] });
+    $qesap->redefine(az_group_name_get => sub { $az_call = 1; return {data => ['BOAT1234']} });
     $qesap->redefine(get_current_job_id => sub { return '1234'; });
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
@@ -29,7 +29,7 @@ subtest '[qesap_az_get_resource_group] match job_id' => sub {
 subtest '[qesap_az_get_resource_group] substring' => sub {
     my $qesap = Test::MockModule->new('sles4sap::qesap::azure', no_auto => 1);
     my $az_call = 0;
-    $qesap->redefine(az_group_name_get => sub { $az_call = 1; return ['BOAT1234', 'CRAB1234'] });
+    $qesap->redefine(az_group_name_get => sub { $az_call = 1; return {data => ['BOAT1234', 'CRAB1234']} });
     $qesap->redefine(get_current_job_id => sub { return '1234'; });
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
@@ -42,7 +42,7 @@ subtest '[qesap_az_get_resource_group] substring' => sub {
 subtest '[qesap_az_get_resource_group] not match job_id' => sub {
     my $qesap = Test::MockModule->new('sles4sap::qesap::azure', no_auto => 1);
     my $az_call = 0;
-    $qesap->redefine(az_group_name_get => sub { $az_call = 1; return ['BOAT1234'] });
+    $qesap->redefine(az_group_name_get => sub { $az_call = 1; return {data => ['BOAT1234']} });
     $qesap->redefine(get_current_job_id => sub { return '3456'; });
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
@@ -55,7 +55,7 @@ subtest '[qesap_az_get_resource_group] not match job_id' => sub {
 subtest '[qesap_az_get_resource_group] match QESAP_DEPLOYMENT_IMPORT' => sub {
     my $qesap = Test::MockModule->new('sles4sap::qesap::azure', no_auto => 1);
     my $az_call = 0;
-    $qesap->redefine(az_group_name_get => sub { $az_call = 1; return ['BOAT1234'] });
+    $qesap->redefine(az_group_name_get => sub { $az_call = 1; return {data => ['BOAT1234']} });
     $qesap->redefine(get_current_job_id => sub { return '3456'; });
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
@@ -87,7 +87,7 @@ subtest '[qesap_az_get_resource_group] az integrate' => sub {
 
 subtest '[qesap_az_get_resource_group] die when job_id is undef' => sub {
     my $qesap = Test::MockModule->new('sles4sap::qesap::azure', no_auto => 1);
-    $qesap->redefine(az_group_name_get => sub { return ['BOAT1234']; });
+    $qesap->redefine(az_group_name_get => sub { return {data => ['BOAT1234']}; });
     # Mock get_current_job_id to return undef
     $qesap->redefine(get_current_job_id => sub { return undef; });
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });

--- a/t/20_sdaf_deployment_library.t
+++ b/t/20_sdaf_deployment_library.t
@@ -20,6 +20,8 @@ sub undef_variables {
       SDAF_GIT_AUTOMATION_REPO
       SDAF_GIT_TEMPLATES_REPO
       SDAF_DEPLOYMENT_ID
+      SDAF_ENV_CODE
+      PUBLIC_CLOUD_NAMESPACE
     );
     set_var($_, '') foreach @openqa_variables;
 }
@@ -55,12 +57,12 @@ subtest '[prepare_sdaf_project]' => sub {
 
     prepare_sdaf_project(%arguments);
 
+    undef_variables();
     # Check correct vnet codes
     is $vnet_checks{library}, '', 'Return library without vnet code';
     is $vnet_checks{deployer}, $arguments{deployer_vnet_code}, 'Return correct vnet code for deployer';
     is $vnet_checks{workload_zone}, $arguments{workload_vnet_code}, 'Return correct vnet code for workload zone';
     is $vnet_checks{sap_system}, $arguments{workload_vnet_code}, 'Return correct vnet code for sap SUT';
-    undef_variables();
 };
 
 subtest '[prepare_sdaf_project] Check directory creation' => sub {
@@ -89,10 +91,11 @@ subtest '[prepare_sdaf_project] Check directory creation' => sub {
     set_var('SDAF_GIT_AUTOMATION_BRANCH', 'latest');
 
     prepare_sdaf_project(%arguments);
+
+    undef_variables();
     is $mkdir_commands[0], 'mkdir -p /tmp/openqa_logs', 'Create logging directory';
     is $mkdir_commands[1], 'mkdir -p Azure_SAP_Automated_Deployment/WORKSPACES/DEPLOYER/LAB-SECE-DEP05-INFRASTRUCTURE',
       'Create workspace directory';
-    undef_variables;
 };
 
 subtest '[serial_console_diag_banner] ' => sub {
@@ -100,9 +103,12 @@ subtest '[serial_console_diag_banner] ' => sub {
     my @printed_lines;
     $ms_sdaf->noop(qw(wait_serial));
     $ms_sdaf->redefine(enter_cmd => sub { push(@printed_lines, $_[0]); return 1; });
+
     serial_console_diag_banner('Module: deploy_sdaf.pm');
+
     note("Banner:\n" . join("\n", @printed_lines));
     ok(grep(/Module: deploy_sdaf.pm/, @printed_lines), 'Banner must include message');
+
     dies_ok { serial_console_diag_banner() } 'Fail with missing test to be printed';
     dies_ok { serial_console_diag_banner('exeCuTing deploYment' x 6) } 'Fail with string exceeds max number of characters';
 };
@@ -163,14 +169,16 @@ subtest '[az_login] Get credentials from server' => sub {
             'PRD' => {client_id => 'Potato', client_secret => 'Patata', tenant_id => 'Zemiak', subscription_id => 'Batata'}
         }
     };
-    set_var('PUBLIC_CLOUD_NAMESPACE', 'sdaf');
-    set_var('SDAF_ENV_CODE', 'PRD');
 
     $ms_sdaf->noop(qw(record_info assert_script_run script_output));
     $ms_sdaf->redefine(get_credentials => sub { return $credentrials; });
     $ms_sdaf->redefine(write_sut_file => sub { $env_variable_file_content = $_[1]; });
+    set_var('PUBLIC_CLOUD_NAMESPACE', 'sdaf');
+    set_var('SDAF_ENV_CODE', 'PRD');
 
     az_login();
+
+    undef_variables();
     ok($env_variable_file_content =~ /export ARM_SUBSCRIPTION_ID=Batata/, 'File contains subscription id');
     ok($env_variable_file_content =~ /export ARM_CLIENT_SECRET=Patata/, 'File contains client secret');
     ok($env_variable_file_content =~ /export ARM_TENANT_ID=Zemiak/, 'File contains tenant id');
@@ -189,12 +197,12 @@ subtest '[az_login] Get credentials from OpenQA settings' => sub {
     $ms_sdaf->redefine(write_sut_file => sub { $env_variable_file_content = $_[1]; });
 
     az_login();
+
+    undef_variables();
     ok($env_variable_file_content =~ /export ARM_SUBSCRIPTION_ID=Peruna/, 'File contains subscription id');
     ok($env_variable_file_content =~ /export ARM_CLIENT_SECRET=Patata/, 'File contains client secret');
     ok($env_variable_file_content =~ /export ARM_TENANT_ID=Zemiak/, 'File contains tenant id');
     ok($env_variable_file_content =~ /export ARM_CLIENT_ID=Potato/, 'File contains client id');
-
-    undef_variables;
 };
 
 subtest '[sdaf_cleanup] Test correct usage' => sub {
@@ -215,7 +223,7 @@ subtest '[sdaf_cleanup] Test correct usage' => sub {
 subtest '[sdaf_cleanup] Test remover script failures' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
     my $force_group_delete;
-    $ms_sdaf->noop(qw( record_info script_output deployment_dir generate_resource_group_name ));
+    $ms_sdaf->noop(qw(script_output deployment_dir generate_resource_group_name ));
     $ms_sdaf->redefine(resource_group_exists => sub { return 'yes'; });
     $ms_sdaf->redefine(sdaf_destroy_resources => sub { $force_group_delete = 1; });
     $ms_sdaf->redefine(sdaf_execute_remover => sub { return 1; });
@@ -384,6 +392,7 @@ subtest '[sdaf_ssh_key_from_keyvault] Verify executed commands' => sub {
     $ms_sdaf->noop(qw(homedir record_info az_keyvault_secret_show));
 
     sdaf_ssh_key_from_keyvault(key_vault => 'SCV-70 White Base');
+
     note("\n --> " . join("\n --> ", @assert_script_run));
     ok(grep(/mkdir -p/, @assert_script_run), 'Create ssh directory');
     ok(grep(/touch/, @assert_script_run), 'Create ssh file');
@@ -408,6 +417,7 @@ subtest '[sdaf_deployment_reused]' => sub {
     $record_info_flag = undef;
     sdaf_deployment_reused(quiet => '1');
     ok(!$record_info_flag, 'Do not show "record_info" message with "quiet=>1"');
+    undef_variables();
 };
 
 subtest '[validate_components]' => sub {
@@ -479,7 +489,33 @@ subtest '[get_sdaf_resource_group]' => sub {
         resource_group_type => 'workload_zone'), 'Resource_group', 'Return exactly one RG';
 };
 
-subtest '[get_sdaf_resource_group]' => sub {
+subtest '[get_sdaf_resource_group] errors' => sub {
+    my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
+    $ms_sdaf->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', $_[0], ':', $_[1])); });
+    $ms_sdaf->redefine(az_group_name_get => sub { return {data => ['Resource_group'], err => ''}; });
+
+    is get_sdaf_resource_group(deployment_id => '123',
+        resource_group_type => 'workload_zone'), 'Resource_group', 'Return exactly one RG';
+};
+
+subtest '[get_sdaf_resource_group] flake errors' => sub {
+    my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
+    $ms_sdaf->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', $_[0], ':', $_[1])); });
+    $ms_sdaf->redefine(az_group_name_get => sub {
+            return {
+                data => ['Resource_group'],
+                err => "✓ Launching flake
+✓ Launching flake
+✓ Launching flake
+✓ Launching flake
+FutureWarning: some random message
+"}; });
+
+    is get_sdaf_resource_group(deployment_id => '123',
+        resource_group_type => 'workload_zone'), 'Resource_group', 'Return exactly one RG';
+};
+
+subtest '[get_sdaf_resource_group] missing args' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
     $ms_sdaf->noop('record_info');
     $ms_sdaf->redefine(az_group_name_get => sub { return {data => []}; });
@@ -520,12 +556,14 @@ subtest '[Check credentials] Long name regex ' => sub {
     });
 
     check_credentials();
+
+    undef_variables();
     for my $secret (@secrets_found) {
         ok(grep($secret, @expected_result), "Long secret '$secret' found in keyvault");
     }
     ok(!grep(/whale-id/, @secrets_found), 'Incorrect secret ID must be ommited');
-    undef_variables;
 };
+
 subtest '[Check credentials] Short name regex ' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
     my %credentials = (client_id => 'Potato', client_secret => 'Patata', tenant_id => 'Zemiak', subscription_id => 'Batata');
@@ -557,10 +595,11 @@ subtest '[Check credentials] Short name regex ' => sub {
     });
 
     check_credentials();
+
+    undef_variables();
     for my $secret (@secrets_found) {
         ok(grep($secret, @expected_result), "Short secret '$secret' found in keyvault");
     }
-    undef_variables;
 };
 
 subtest '[apply_no_cleanup_tag]' => sub {

--- a/t/20_sdaf_deployment_library.t
+++ b/t/20_sdaf_deployment_library.t
@@ -473,7 +473,7 @@ subtest '[sdaf_upload_logs]' => sub {
 subtest '[get_sdaf_resource_group]' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
     $ms_sdaf->noop('record_info');
-    $ms_sdaf->redefine(az_group_name_get => sub { return ['Resource_group']; });
+    $ms_sdaf->redefine(az_group_name_get => sub { return {data => ['Resource_group']}; });
 
     is get_sdaf_resource_group(deployment_id => '123',
         resource_group_type => 'workload_zone'), 'Resource_group', 'Return exactly one RG';
@@ -482,10 +482,10 @@ subtest '[get_sdaf_resource_group]' => sub {
 subtest '[get_sdaf_resource_group]' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
     $ms_sdaf->noop('record_info');
-    $ms_sdaf->redefine(az_group_name_get => sub { return []; });
+    $ms_sdaf->redefine(az_group_name_get => sub { return {data => []}; });
     dies_ok { get_sdaf_resource_group(deployment_id => '123', resource_group_type => 'workload_zone') } 'Fail with empty result';
 
-    $ms_sdaf->redefine(az_group_name_get => sub { return ['First_result', 'Oh_no-second_one']; });
+    $ms_sdaf->redefine(az_group_name_get => sub { return {data => ['First_result', 'Oh_no-second_one']}; });
     dies_ok { get_sdaf_resource_group(deployment_id => '123', resource_group_type => 'workload_zone') } 'Fail with more than one results';
 };
 

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -50,13 +50,52 @@ subtest '[az_group_create] missing args' => sub {
 subtest '[az_group_name_get]' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { push @calls, $_[0]; return '["Arlecchino","Truffaldino"]'; });
+
+    $azcli->redefine(script_output => sub {
+            my $cmd = shift;
+            push @calls, $cmd;
+
+            # Handle the az command
+            return '["Arlecchino","Truffaldino"]' if ($cmd =~ /az\s+.*/);
+
+            # Handle the cat command by matching 'cat /tmp/az_cli.err' (or similar)
+            return 'Mi son Arlechin batocio. Orbo de na recia e sordo da un ocio' if ($cmd =~ /cat\s+(\/tmp\/.*)/);
+
+            return 'INVALID';
+    });
 
     my $res = az_group_name_get();
 
     note("\n  -->  " . join("\n  -->  ", @calls));
+
     ok((any { /az group list/ } @calls), 'Correct composition of the main command');
-    ok((any { /Arlecchino/ } @$res), 'Correct result decoding');
+    ok((any { /cat \/tmp\/az_cli.err/ } @calls), 'The error file was read');
+    is_deeply($res->{data}, ["Arlecchino", "Truffaldino"], 'Data matches expected array');
+    is($res->{err}, 'Mi son Arlechin batocio. Orbo de na recia e sordo da un ocio', 'Error content correctly captured');
+};
+
+subtest '[az_group_name_get] empty stderr' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    my @calls;
+
+    $azcli->redefine(script_output => sub {
+            my $cmd = shift;
+            push @calls, $cmd;
+
+            # Handle the az command
+            return '["Arlecchino","Truffaldino"]' if ($cmd =~ /az\s+.*/);
+
+            # Handle the cat command by matching 'cat /tmp/az_cli.err' (or similar)
+            return '' if ($cmd =~ /cat\s+(\/tmp\/.*)/);
+
+            return 'INVALID';
+    });
+
+    my $res = az_group_name_get();
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+
+    is($res->{err}, '', 'Error empty content correctly captured');
 };
 
 subtest '[az_group_name_get] query' => sub {
@@ -64,7 +103,7 @@ subtest '[az_group_name_get] query' => sub {
     my @calls;
     $azcli->redefine(script_output => sub { push @calls, $_[0]; return '{"Arlecchino": "Truffaldino"}'; });
 
-    my $res = az_group_name_get(query => 'MASCHERA');
+    az_group_name_get(query => 'MASCHERA');
 
     note("\n  -->  " . join("\n  -->  ", @calls));
     ok((any { /--query.*MASCHERA/ } @calls), 'Correct composition of the query argument');
@@ -1584,18 +1623,6 @@ subtest '[az_network_dns_link_delete] Compose command' => sub {
     ok(grep(/--zone-name opensuse.org/, @calls), 'Check for argument "--zone-name"');
     ok(grep(/--name link_to_rg_vnet/, @calls), 'Check for argument "--name"');
     ok(grep(/--yes/, @calls), 'Check for autoapprove argument "--yes"');
-};
-
-subtest '[az_account_show]' => sub {
-    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
-    my @calls;
-    $azcli->redefine(script_output => sub { push @calls, $_[0]; return '"00000000-0000-0000-0000-000000000000"'; });
-
-    my $ret = az_account_show();
-
-    note("\n --> " . join("\n --> ", @calls));
-    ok((any { /az account show/ } @calls), 'Correct composition of the main command');
-    ok(($ret eq '00000000-0000-0000-0000-000000000000'), 'Ret is the expected value, of type string');
 };
 
 subtest '[az_role_definition_list]' => sub {


### PR DESCRIPTION
`az_group_name_get` decodes as json the all az cli ouput. Any stderr output from command execution (such as deprecation or future warnings) was captured leading to unrecognized output or json decoding failure.

This change updates `az_group_name_get` to redirect standard error to a temporary file and return a hash reference containing both the decoded `data` and the `err` string.

All current callers of `az_group_name_get` are updated to support this new hash structure:
- `ipaddr2_deployment_sanity` and `qesap_az_get_resource_group` extract the array from the `data` key and record any errors using `record_info`.
- `get_sdaf_resource_group` extracts `data`, filters out noisy non-critical stderr lines (e.g., "FutureWarning", "Launching flake") depending on the SDAF git automation branch, and logs any remaining error text.

- Related ticket: [TEAM-11276](https://jira.suse.com/browse/TEAM-11276)

# Verification run: 

## **SDAF**
- https://openqaworker15.qe.prg2.suse.org/tests/373874
- http://openqaworker15.qe.prg2.suse.org/tests/374117

## **HANASR**
- sle-15-SP7-Azure-SAP-PAYG-Incidents-x86_64  SAPHanaSR-ScaleUp-PerfOpt az_Standard_E4s_v3 -> 
http://openqaworker15.qe.prg2.suse.org/tests/374113

## **IPADDR2**
- sle-15-SP7-Azure-SAP-PAYG-Incidents-x86_64 ipaddr2 az_Standard_B1s -> http://openqaworker15.qe.prg2.suse.org/tests/374114

## **QE-SAP-DEPLOYMENT**
- sle-15-SP7-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-qesap_azure_ibsmirror_peering_test  ->  http://openqaworker15.qe.prg2.suse.org/tests/374115


