### PR TITLE
Add openqa-agnostic java hashing test

### DIFF
--- a/data/security/openqa_agnostic/java_hashing/FipsJcaProviderTest.java
+++ b/data/security/openqa_agnostic/java_hashing/FipsJcaProviderTest.java
@@ -1,0 +1,89 @@
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.List;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+public class FipsJcaProviderTest {
+
+    private static final String FIPS_PROVIDER = "SunPKCS11-FIPS";
+    private static final byte[] SAMPLE = "test".getBytes(StandardCharsets.UTF_8);
+
+    private final List<String> results = new ArrayList<>();
+
+    void ok(String name) {
+        results.add("ok " + (results.size() + 1) + " - " + name);
+    }
+
+    void fail(String name, Exception e) {
+        results.add("not ok " + (results.size() + 1) + " - " + name);
+        results.add("  # " + e.getMessage().replace("\n", " "));
+    }
+
+    void run() throws Exception {
+        String fipsEnabled = Files.readString(Path.of("/proc/sys/crypto/fips_enabled")).trim();
+        if (!"1".equals(fipsEnabled)) {
+            results.add("ok 1 - kernel FIPS mode not enabled # SKIP");
+            return;
+        }
+        if (Security.getProvider(FIPS_PROVIDER) == null) {
+            results.add("ok 1 - " + FIPS_PROVIDER + " provider not registered # SKIP");
+            return;
+        }
+
+        // MD5 must be routed through the FIPS provider
+        try {
+            MessageDigest d = MessageDigest.getInstance("MD5");
+            if (!FIPS_PROVIDER.equals(d.getProvider().getName()))
+                throw new Exception("expected " + FIPS_PROVIDER + " got " + d.getProvider().getName());
+            ok("md5RoutedThroughFipsProvider");
+        } catch (Exception e) { fail("md5RoutedThroughFipsProvider", e); }
+
+        // Every MessageDigest the FIPS provider exposes must hash via it
+        Security.getProvider(FIPS_PROVIDER).getServices().stream()
+                .filter(s -> s.getType().equals("MessageDigest"))
+                .map(s -> s.getAlgorithm())
+                .sorted()
+                .forEach(algo -> {
+                    try {
+                        MessageDigest d = MessageDigest.getInstance(algo);
+                        if (!FIPS_PROVIDER.equals(d.getProvider().getName()))
+                            throw new Exception("wrong provider: " + d.getProvider().getName());
+                        if (d.digest(SAMPLE).length == 0)
+                            throw new Exception("empty digest");
+                        ok("MessageDigest " + algo);
+                    } catch (Exception e) { fail("MessageDigest " + algo, e); }
+                });
+
+        // Every Hmac* (non-PBE) the FIPS provider exposes must MAC via it
+        Security.getProvider(FIPS_PROVIDER).getServices().stream()
+                .filter(s -> s.getType().equals("Mac"))
+                .map(s -> s.getAlgorithm())
+                .filter(a -> a.startsWith("Hmac") && !a.startsWith("HmacPBE"))
+                .sorted()
+                .forEach(algo -> {
+                    try {
+                        Mac m = Mac.getInstance(algo);
+                        m.init(new SecretKeySpec(new byte[m.getMacLength()], algo));
+                        if (!FIPS_PROVIDER.equals(m.getProvider().getName()))
+                            throw new Exception("wrong provider: " + m.getProvider().getName());
+                        if (m.doFinal(SAMPLE).length == 0)
+                            throw new Exception("empty MAC");
+                        ok("Mac " + algo);
+                    } catch (Exception e) { fail("Mac " + algo, e); }
+                });
+    }
+
+    public static void main(String[] args) throws Exception {
+        FipsJcaProviderTest t = new FipsJcaProviderTest();
+        t.run();
+        // openQA TAP parser expects "filename.ext .." as first line
+        System.out.println("FipsJcaProviderTest.java ..");
+        System.out.println("1.." + t.results.size());
+        t.results.forEach(System.out::println);
+    }
+}

--- a/data/security/openqa_agnostic/java_hashing/runtest
+++ b/data/security/openqa_agnostic/java_hashing/runtest
@@ -1,0 +1,28 @@
+#!/bin/bash
+# METADATA_START
+# ---
+# test: java hashing
+# desc: Verifies SunPKCS11-FIPS JCA provider serves SHA/HMAC and routes MD5
+# steps:
+#   - assume kernel FIPS mode is enabled (/proc/sys/crypto/fips_enabled == 1)
+#   - assert MD5 is routed through SunPKCS11-FIPS provider
+#   - enumerate every MessageDigest the FIPS provider exposes; each must hash via SunPKCS11-FIPS
+#   - enumerate every Hmac* Mac the FIPS provider exposes; each must MAC via SunPKCS11-FIPS
+# author: <andrea.manzini@suse.com>
+# maintainer: QE Security <none@suse.de>
+# expected: results.tap reports all tests passed (or skipped if FIPS is off)
+# platform: SLE 16.1
+# tags: security java FIPS
+# ---
+# METADATA_END
+
+set -e
+source ../lib/helper.sh
+
+TEST_FILES=(FipsJcaProviderTest.java)
+handle_args "$0" "$@"
+
+ensure_command_available "javac"
+
+javac FipsJcaProviderTest.java
+java FipsJcaProviderTest > results.tap

--- a/lib/security/agnosticTestRunner.pm
+++ b/lib/security/agnosticTestRunner.pm
@@ -27,14 +27,24 @@ sub new {
     die "Attribute 'language' is mandatory" unless defined $args->{language};
 
     # check language support validity
-    die "Unsupported language '$args->{language}'. Supported languages are 'go' and 'python'" unless $args->{language} =~ /^(go|python)$/;
+    die "Unsupported language '$args->{language}'. Supported languages are 'go', 'python' and 'java'" unless $args->{language} =~ /^(go|python|java)$/;
 
     # Default values for attributes
     $args->{test_dir} //= '~/' . $args->{name};
-    $args->{result_file} //= '/tmp/' . lc($args->{name}) . '_results.xml';
+    $args->{result_format} //= $args->{language} eq 'java' ? 'TAP' : 'XUnit';
+    $args->{result_file} //= '/tmp/' . lc($args->{name}) . ($args->{language} eq 'java' ? '_results.tap' : '_results.xml');
     $args->{data_url_path} //= 'security/openqa_agnostic/' . $args->{name};
     $args->{run_command} //= 'runtest';
     return bless $args, $class;
+}
+
+sub latest_java_devel {
+    my $out = script_output(
+        q{zypper --terse -n se  'java-*-openjdk-devel'},
+        proceed_on_failure => 1);
+    my @majors = sort { $a <=> $b } ($out =~ /\bjava-(\d+)-openjdk-devel\b/g);
+    die 'No java-*-openjdk-devel package available in configured repos' unless @majors;
+    return "java-$majors[-1]-openjdk-devel";
 }
 
 sub setup {
@@ -46,10 +56,11 @@ sub setup {
 
     zypper_call 'in go gotestsum' if $self->{language} eq 'go';
     zypper_call 'in python3-pytest' if $self->{language} eq 'python';
+    zypper_call 'in ' . latest_java_devel() if $self->{language} eq 'java';
 
     assert_script_run 'mkdir -p ' . $self->{test_dir};
 
-    # Create lib directory and download the helper script
+    # Create lib directory and download shared helpers
     assert_script_run 'mkdir -p ' . $self->{test_dir} . '/../lib';
     my $helper_url = data_url('security/openqa_agnostic/lib/helper.sh');
     assert_script_run 'curl -s -o ' . $self->{test_dir} . '/../lib/helper.sh ' . $helper_url;
@@ -81,7 +92,8 @@ sub run_test {
     my $run_script = $self->{run_command};
     # Ensure run_command is treated as a path inside test_dir
     $run_script = "./$run_script" unless $run_script =~ m{^/|^\./};
-    my $command = 'cd ' . $self->{test_dir} . ' && chmod +x ' . $run_script . ' && ' . $run_script . ' && mv results.xml ' . $self->{result_file};
+    my $result_src = $self->{result_format} eq 'TAP' ? 'results.tap' : 'results.xml';
+    my $command = 'cd ' . $self->{test_dir} . ' && chmod +x ' . $run_script . ' && ' . $run_script . ' && mv ' . $result_src . ' ' . $self->{result_file};
     assert_script_run($command);
     # Prevent previous command from breaking the terminal, leaving it unusable for further testing
     enter_cmd('reset');
@@ -90,7 +102,7 @@ sub run_test {
 
 sub parse_results {
     my ($self) = @_;
-    parse_extra_log('XUnit', $self->{result_file});
+    parse_extra_log($self->{result_format}, $self->{result_file});
     return $self;
 }
 

--- a/schedule/security/fips/sle16/fips_ker_mode_java.yaml
+++ b/schedule/security/fips/sle16/fips_ker_mode_java.yaml
@@ -1,0 +1,9 @@
+name: fips_ker_mode_java
+description:    >
+    This is for OpenQA-agnostic FIPS testing of Java modules
+schedule:
+    - installation/bootloader_start
+    - boot/boot_to_desktop
+    - console/consoletest_setup
+    - fips/fips_setup
+    - security/oqa_agnostic/java_hashing

--- a/tests/security/oqa_agnostic/java_hashing.pm
+++ b/tests/security/oqa_agnostic/java_hashing.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Run 'java hashing' FIPS JCA provider test
+# Maintainer: QE Security <none@suse.de>
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use security::agnosticTestRunner;
+
+sub run {
+    select_serial_terminal;
+    my $test = security::agnosticTestRunner->new({
+            language => 'java',
+            name => 'java_hashing',
+        }
+    );
+
+    $test->setup()->run_test()->parse_results()->cleanup();
+}
+
+sub test_flags {
+    return {always_rollback => 0};
+}
+
+1;


### PR DESCRIPTION
By executing the `java_hashing` test module, we ensure that Java's cryptographic hashing functions correctly operate under strict `FIPS` policies on a newly provisioned environment.

the test contains also yaml metadata for test catalog:
```
$ ./runtest  -m
---
test: java hashing
desc: Verifies SunPKCS11-FIPS JCA provider serves SHA/HMAC and routes MD5
steps:
  - assume kernel FIPS mode is enabled (/proc/sys/crypto/fips_enabled == 1)
  - assert MD5 is routed through SunPKCS11-FIPS provider
  - enumerate every MessageDigest the FIPS provider exposes; each must hash via SunPKCS11-FIPS
  - enumerate every Hmac* Mac the FIPS provider exposes; each must MAC via SunPKCS11-FIPS
author: <andrea.manzini@suse.com>
maintainer: QE Security <none@suse.de>
expected: results.tap reports all tests passed (or skipped if FIPS is off)
platform: SLE 16.1
tags: security java FIPS
---
```

- Related ticket: https://progress.opensuse.org/issues/201474
- Needles: nope
- Verification runs:
  - https://openqa.suse.de/tests/22863810
  - https://openqa.suse.de/tests/22876286

