### PR TITLE
Add synce4l gspd packages for precision timing for RAN use cases

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -253,6 +253,7 @@ sub load_common_tests {
     # breaking most later modules.
     # Skip the test if setups don't support snapshot rollback due to bsc#1266277
     loadtest 'console/year_2038_detection' unless (is_s390x || is_bootloader_sdboot || get_var('QEMU_DISABLE_SNAPSHOTS'));
+    loadtest 'console/synce4l_gpsd' if (is_sle_micro('>=6.2'));
 }
 
 

--- a/schedule/functional/sle16/extra_tests_textmode2.yaml
+++ b/schedule/functional/sle16/extra_tests_textmode2.yaml
@@ -34,5 +34,6 @@ schedule:
     - console/zypper_log_packages
     - console/rabbitmq
     - console/libxslt
+    - console/synce4l_gpsd
     - network/samba/samba_adcli
     - shutdown/shutdown

--- a/schedule/qam/16/mau-extra-tests.yaml
+++ b/schedule/qam/16/mau-extra-tests.yaml
@@ -13,6 +13,7 @@ schedule:
   - console/cron
   - console/mta
   - console/sudo
+  - console/synce4l_gpsd
   - x11/evolution/evolution_prepare_servers
   - console/mutt
   - network/samba/server

--- a/tests/console/synce4l_gpsd.pm
+++ b/tests/console/synce4l_gpsd.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright 2012-2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: synce4l gpsd
+# Summary: Test case for Precision Timing packages (synce4l and gpsd)
+# Maintainer: qe-core <qe-core@suse.com>
+
+use Mojo::Base 'consoletest';
+use testapi;
+use version_utils;
+use utils;
+use package_utils 'install_package';
+
+sub run {
+    my ($self) = @_;
+
+    $self->select_serial_terminal;
+
+    record_info("Install", "Installing precision timing packages");
+    install_package('synce4l gpsd', trup_reboot => 1);
+
+    record_info("Version Check", "Verifying updated upstream versions for Granite Rapids compatibility");
+
+    # Verify synce4l is at least version 1.1.0
+    my $synce_version = script_output("rpm -q --queryformat '%{VERSION}' synce4l");
+    if (zypper_version_cmp($synce_version, '1.1.0') >= 0) {
+        record_info("synce4l version is modern: $synce_version");
+    } else {
+        die "Unexpected synce4l version! Found: $synce_version. Expected >= 1.1.0";
+    }
+
+    # Verify gpsd version is at least 3.27
+    my $gpsd_version = script_output("rpm -q --queryformat '%{VERSION}' gpsd");
+    if (zypper_version_cmp($gpsd_version, '3.27.5') >= 0) {
+        record_info("gpsd version is modern: $gpsd_version");
+    } else {
+        die "Unexpected gpsd version! Found: $gpsd_version. Expected >= 3.27.5";
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Add synce4l gspd packages for precision timing for RAN use cases

- Related ticket: https://progress.opensuse.org/issues/197960
- Verification run: https://openqa.suse.de/tests/overview?build=tinawang123%2Fos-autoinst-distri-opensuse%23synce4l_gspd&
