### PR TITLE
Adapt the new Download logs in the Agama WebUI

### DIFF
--- a/lib/Yam/Agama/agama_base.pm
+++ b/lib/Yam/Agama/agama_base.pm
@@ -29,9 +29,8 @@ sub upload_agama_logs {
     save_and_upload_log('journalctl -b > /tmp/journal.log', "/tmp/journal.log", {timeout => 60});
 
     # logs from the UI saved by default to this path
-    if (script_run("test -f /root/Downloads/agama-logs.tar.gz") == 0) {
-        upload_logs("/root/Downloads/agama-logs.tar.gz", log_name => 'agama-logs-from-ui.tar.gz');
-    }
+    my $full_log_path = script_output("find /root/Downloads/ -name 'agama-logs*.tar.gz'");
+    upload_logs($full_log_path, log_name => 'agama-logs-from-ui.tar.gz') if $full_log_path;
 }
 
 sub upload_browser_automation_dumps {


### PR DESCRIPTION
## Summary
The downloaded filename now includes a timestamp e.g `agama-logs-2026-06-02-12T08-01-34-387Z.tar.gz` generated when the dialog is opened.

## 
## Adapt the new Download logs in the Agama WebUI
- Related ticket: 
  - https://progress.opensuse.org/issues/202713
- Related PR:
  - https://github.com/qe-installation-and-migration/agama-integration-test-webpack/pull/272
- VR:
  - [__sles_extended_dev dev/prod__](https://openqa.suse.de/tests/overview?build=hjluo_download_log_888&version=16.1&distri=sle)
  - [__sles_extended_dev QU__](https://openqa.suse.de/tests/overview?version=16.0&distri=sle&build=hjluo_download_log_888)
##