### PR TITLE
Don't handle to boot from harddisk on 16.0 on respined image

### DIFF
--- a/lib/grub_utils.pm
+++ b/lib/grub_utils.pm
@@ -62,7 +62,7 @@ Due to pre-installation setup, qemu boot order is always booting from CD-ROM.
 
 sub handle_installer_medium_bootup {
     return unless (check_var("BOOTFROM", "d") || (get_var('UEFI') && get_var('USBBOOT')));
-    return if (check_var("BOOTFROM", "c") && !(is_sle || is_leap("<16.1")));
+    return if (check_var("BOOTFROM", "c") && !(is_sle || is_leap("<16.0")));
     assert_screen 'inst-bootmenu', 180;
 
     # Layout of live is different from installation media


### PR DESCRIPTION

- Related failure: https://openqa.opensuse.org/tests/6029610#step/grub_test/2

- Needs https://github.com/os-autoinst/opensuse-jobgroups/pull/873

- VR: https://openqa.opensuse.org/tests/6039705 https://openqa.opensuse.org/tests/6039901