### PR TITLE
Update bootloader timeout to 30 for profile

### DIFF
--- a/data/yam/agama/auto/lib/base.libsonnet
+++ b/data/yam/agama/auto/lib/base.libsonnet
@@ -2,7 +2,7 @@
   bootloader(bootloader, bootloader_timeout, bootloader_extra_kernel_params):: {
     [if bootloader || bootloader_timeout != '' || bootloader_extra_kernel_params != '' then 'bootloader']: std.prune({
       [if bootloader then 'stopOnBootMenu']: true,
-      [if bootloader_timeout then 'timeout']: 15,
+      [if bootloader_timeout then 'timeout']: 30,
       [if bootloader_extra_kernel_params != '' then 'extraKernelParams']: bootloader_extra_kernel_params,
     }),
   },


### PR DESCRIPTION
To fix issue: https://openqa.suse.de/tests/22883272#step/grub_test/4.
Update bootloader timeout to 30 for profile.

- Verification run: https://openqa.suse.de/tests/22884035#step/boot_agama/4
