### PR TITLE
Fix vmware image iso checksum verification

### DIFF
--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -169,11 +169,14 @@ sub run {
 
     ## Verify checksum of the copied images
     my $location = '/var/lib/libvirt/images/';
-    if (is_vmware) {
-        $location = get_var('BOOT_HDD_IMAGE') ? $vmware_openqa_datastore : $isodir;
-    }
+    $location = $vmware_openqa_datastore if (is_vmware);
     my $errors = verify_checksum $location;
-    record_info("Checksum", $errors, result => 'fail') if $errors;
+    if ($errors) {
+        record_info("Checksum", $errors, result => 'fail');
+        die "Checksum verification failed.";
+    } else {
+        record_info("Checksum matched", "", result => 'ok');
+    }
 
     # We need to use 'tablet' as a pointer device, i.e. a device
     # with absolute axis. That needs to be explicitely configured


### PR DESCRIPTION
It should verify the ISO checksum from datastore directory, not the ISO from NFS mount directory.

- Related ticket: https://progress.opensuse.org/issues/202704
- Verification run: https://openqa.suse.de/tests/22884313 (Correct ISO image)
                                https://openqa.suse.de/tests/22884239 (Corrupted ISO image)
