### PR TITLE
kernel/post_process: skip groups where all tests are skipped

### DIFF
--- a/data/kernel/post_process
+++ b/data/kernel/post_process
@@ -54,6 +54,19 @@ generate_xunit_report() {
 	local error
 	error=$(check_for_errors "$dir")
 
+	local any_tests=0
+	for file in $(find ./results/$dir -type f); do
+		if ! is_not_run "$file"; then
+			any_tests=1
+			break
+		fi
+	done
+
+	if [[ $any_tests -eq 0 ]]; then
+		echo "Skipping group $dir: all tests were skipped"
+		return
+	fi
+
 	echo "<testsuite errors=\"$error\" name=\"$dir\">" > "./$results"
 
 	for file in $(find ./results/$dir -type f); do


### PR DESCRIPTION
When blktests runs a group (e.g. md) on a codestream that does not support it, every individual test file reports "status not run". Previously generate_xunit_report() still emitted an empty <testsuite> element for the group, which openQA parsed and displayed as a passing (but empty) result, making it look like the group ran successfully.

Add a pre-check loop: before writing any XML, verify that at least one test in the directory was actually executed. If all files carry "status not run" the function prints a diagnostic message and returns early without creating the results XML file, so parse_extra_log never sees the empty group.

This patch is prepared with AI as there is the bigger reffactor going on for blktests, liburing and other tests which will be running with the kernel generic runner. post_process shell is then treated as obsoleted and shall be removed in the near future.

Co-Authored-By: Claude

- Related ticket: https://progress.opensuse.org/issues/202815
- Verification run:
  - https://openqa.opensuse.org/tests/6031804 VR with md included to show an empty test group with all skipped tests is not rendered.
  Without this fix we have: https://openqa.suse.de/tests/22883269
<img width="1179" height="60" alt="image" src="https://github.com/user-attachments/assets/54277055-caeb-4e0b-b1ef-bb16ebc0b711" />


Regression VRs:
- https://openqa.suse.de/tests/22885437
- https://openqa.suse.de/tests/22885438
- https://openqa.suse.de/tests/22885439