### PR TITLE
Add ipxe exit script support in selfinstall.pm

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -22,7 +22,7 @@ use Socket;
 use virt_autotest::utils;
 use Utils::Backends;
 
-our @EXPORT = qw(set_grub_on_vh switch_from_ssh_to_sol_console adjust_for_ipmi_xen set_pxe_efiboot ipmitool enable_sev_in_kernel add_kernel_options set_grub_terminal_and_timeout reconnect_when_ssh_console_broken set_ipxe_bootscript set_floppy_boot set_disk_boot);
+our @EXPORT = qw(set_grub_on_vh switch_from_ssh_to_sol_console adjust_for_ipmi_xen set_pxe_efiboot ipmitool enable_sev_in_kernel add_kernel_options set_grub_terminal_and_timeout reconnect_when_ssh_console_broken set_ipxe_bootscript set_floppy_boot set_disk_boot set_bootscript_hdd);
 
 #With the new ipmi backend, we only use the root-ssh console when the SUT boot up,
 #and no longer setup the real serial console for either kvm or xen.
@@ -550,6 +550,22 @@ sub reconnect_when_ssh_console_broken {
     script_run("uptime");
     script_run("ls -l /var/crash/");
     save_screenshot;
+}
+
+=head2 set_bootscript_hdd
+
+  set_bootscript_hdd()
+
+Call set_ipxe_bootscript to upload iPXE bootscript to exit network boot process.
+=cut
+
+sub set_bootscript_hdd {
+    my $bootscript = <<"END_BOOTSCRIPT";
+#!ipxe
+exit
+END_BOOTSCRIPT
+
+    set_ipxe_bootscript($bootscript);
 }
 
 =head2 set_ipxe_bootscript

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -133,15 +133,6 @@ END_BOOTSCRIPT
     set_ipxe_bootscript($bootscript);
 }
 
-sub set_bootscript_hdd {
-    my $bootscript = <<"END_BOOTSCRIPT";
-#!ipxe
-exit
-END_BOOTSCRIPT
-
-    set_ipxe_bootscript($bootscript);
-}
-
 sub set_bootscript_agama {
     my $host = get_required_var('SUT_IP');
     my $arch = get_required_var('ARCH');

--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -13,7 +13,7 @@ use Utils::Architectures qw(is_aarch64);
 use version_utils qw(is_leap_micro is_sle_micro);
 use utils;
 use Utils::Backends qw(is_ipmi);
-use ipmi_backend_utils qw(ipmitool);
+use ipmi_backend_utils qw(ipmitool set_bootscript_hdd);
 
 sub run {
     my ($self) = @_;
@@ -66,6 +66,11 @@ sub run {
         empty_usb_disks;
         ipmitool("chassis bootdev disk options=persistent,efiboot") for (0 .. 2);
     }
+
+    # Write exit to ipxe script to abort the network boot process and hands control back to the
+    # motherboard's BIOS or UEFI firmware, which then moves on to the next device in your boot
+    # order, namely almost always the local hard drive.
+    set_bootscript_hdd() if (is_ipxe_boot and get_var('IPXE_SET_HDD_BOOTSCRIPT'));
 }
 
 sub post_run_hook {


### PR DESCRIPTION
* **Move** ```set_bootscript_hdd``` to ```lib/ipmi_backend_utils.pm```.

* **Write** exit to ipxe script to abort the network boot process and hands control back to the motherboard's BIOS or UEFI firmware, which then moves on to the next device in your boot order, namely almost always the local hard drive after installation from ipxe finishes in ```tests/microos/selfinstall.pm‎```.

* **The** test suite level setting ```IPXE_SET_HDD_BOOTSCRIPT``` is used to control the functionality.

* **Verification Runs:**
  * [sle-16.1-Online-x86_64-Build48.1-snapshot-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23052353)
  * [sle-16.1-Online-x86_64-Build48.1-snapshot-gi-guest_developing-on-host_sles15sp7-kvm](https://openqa.suse.de/tests/23052354)
  * [sle-16.1-Online-x86_64-Build48.1-uefi-gi-guest_developing-on-host_sles16_0-kvm](https://openqa.suse.de/tests/23052356)
  * [sle-16.1-Base-SelfInstall-pxe-x86_64-Build10.51-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23052363)
  * [sle-16.1-Base-SelfInstall-pxe-x86_64-Build10.36-gi-guest_slem6dot2-on-host_developing-kvm](https://openqa.suse.de/tests/23028644)
  * [sle-16.1-Base-SelfInstall-pxe-x86_64-Build10.36-gi-guest_sles15sp7-on-host_developing-kvm](https://openqa.suse.de/tests/23052365)
  * [sle-16.1-Base-SelfInstall-pxe-x86_64-Build10.36-gi-guest_developing-on-host_developing-kvm with IPXE_SET_HDD_BOOTSCRIPT=1](https://openqa.suse.de/tests/23028640)
  * [sle-16.1-Base-SelfInstall-pxe-x86_64-Build10.36-gi-guest_slem6dot2-on-host_developing-kvm with IPXE_SET_HDD_BOOTSCRIPT=1](https://openqa.suse.de/tests/23028641)
  * [sle-16.1-Base-SelfInstall-pxe-x86_64-Build10.36-gi-guest_sles15sp7-on-host_developing-kvm with IPXE_SET_HDD_BOOTSCRIPT=1](https://openqa.suse.de/tests/23029231)
  * [verification run with pegasus which has ipxe boot at the top with IPXE_SET_HDD_BOOTSCRIPT=1](https://openqa.suse.de/tests/23052366)