### PR TITLE
feat: Tweak version adjustment introduced in edfce622

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -135,12 +135,15 @@ sub init_main {
         my $errors = verify_checksum();
         set_var('CHECKSUM_FAILED', $errors) if $errors;
     }
-    # allow scheduling jobs with e.g. `VERSION=16.0:gitea:pr:1234` instead of just `VERSION=16.0`
+    # allow scheduling jobs with e.g. `VERSION=16.0:git-1234` instead of just `VERSION=16.0`
     # note: This is useful because then jobs for individual submissions are not wrongly considered
     #       to be for consecutive builds and e.g. wrong bugref carry over is avoided.
     if (my $version = get_var('VERSION')) {
-        set_var('VERSION_ORIGINAL', $version);
-        set_var('VERSION', $version =~ s/:(?:(git|smelt)[-:])?(?:pr[-:])\d+$//rgi);
+        my $simplified_version = $version =~ s/:(?:(git|smelt)[-:])\d+$//rgi;
+        if ($version ne $simplified_version) {
+            set_var('VERSION_ORIGINAL', $version);
+            set_var('VERSION', $simplified_version);
+        }
     }
 }
 


### PR DESCRIPTION
* Do not require `:pr` suffix as this won't be used by qem-bot via https://github.com/openSUSE/qem-bot/pull/559/changes
* Set `VERSION_ORIGINAL` only if the version has changed

Related ticket: https://progress.opensuse.org/issues/202533