### PR TITLE
Increase crm cluster bootstrap timeouts to prevent join failures

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -1411,12 +1411,14 @@ sub ipaddr2_cluster_create(%args) {
 
     ipaddr2_ssh_internal(id => 1,
         cmd => 'sudo crm cluster init -y --name DONALDUCK',
+        timeout => 300,
         bastion_ip => $args{bastion_ip});
 
     my $join_str = $args{rootless} ? USER . '@' : "";
     $join_str .= ipaddr2_get_internal_vm_private_ip(id => 1);
     ipaddr2_ssh_internal(id => 2,
         cmd => "sudo crm cluster join -y -c $join_str",
+        timeout => 300,
         bastion_ip => $args{bastion_ip});
 
     ipaddr2_ssh_internal(id => 1,


### PR DESCRIPTION
Increase the timeout for Pacemaker cluster initialization and join operations on the SUT internal VMs to 300 seconds (5 minutes). Seems like that in SLES 16.0, the python3-based crmsh package stack result in longer execution time.
This is more prominent in constrained B1s VM hardware instances used by ipaddr2 tests.


- Related ticket: https://jira.suse.com/browse/TEAM-11080


# Verification
- sle-16.0-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE16.0-ipaddr2_azure_test@az_Standard_B1s -> http://openqaworker15.qe.prg2.suse.org/tests/374116 :green_circle: 