### PR TITLE
Elemental3 add missing containers tests

### DIFF
--- a/tests/elemental3/generate_image.pm
+++ b/tests/elemental3/generate_image.pm
@@ -12,6 +12,7 @@ use Mojo::Base 'opensusebasetest';
 use testapi;
 use elemental3;
 use transactional qw(trup_call);
+use package_utils qw(install_package);
 use serial_terminal qw(select_serial_terminal);
 use Mojo::File qw(path);
 use utils qw(file_content_replace);
@@ -282,8 +283,7 @@ sub run {
         "run zypper addrepo --check --refresh ${totest_path}/standard elemental"
     );
     trup_call('--continue run zypper --gpg-auto-import-keys refresh');
-    trup_call('--continue pkg install elemental3ctl squashfs mtools xorriso');
-    trup_call('apply');
+    install_package('elemental3ctl squashfs mtools xorriso', trup_apply => 1);
 
     # Use a crypted password
     my $hashpwd = script_output("openssl passwd -6 $rootpwd");

--- a/tests/elemental3/test_framework.pm
+++ b/tests/elemental3/test_framework.pm
@@ -10,7 +10,7 @@ use testapi;
 use lockapi;
 use network_utils qw(get_default_dns is_running_in_isolated_network set_resolv);
 use serial_terminal qw(select_serial_terminal);
-use transactional qw(trup_call);
+use package_utils qw(install_package);
 use Utils::Git;
 
 sub run {
@@ -22,8 +22,11 @@ sub run {
     $branch //= 'main';
 
     # Add git/go package(s)
-    trup_call('pkg install git go kubernetes-client-provider', timeout => $timeout);
-    trup_call('apply');
+    install_package(
+        'git go kubernetes-client-provider',
+        timeout => $timeout,
+        trup_apply => 1
+    );
 
     # Configure ssh options
     my $ssh_dir = '/root/.ssh';

--- a/tests/elemental3/validate_container_image.pm
+++ b/tests/elemental3/validate_container_image.pm
@@ -9,9 +9,28 @@ use elemental3;
 use testapi;
 use serial_terminal qw(select_serial_terminal);
 
+sub extract_fileslist {
+    my %args = @_;
+
+    assert_script_run("$args{runtime} pull $args{uri}");
+    my $rootfs = script_output(
+        "$args{runtime} inspect -f '{{index .RootFS.Layers 0}}' $args{uri} | cut -d: -f2"
+    );
+
+    # Extract files from container
+    assert_script_run("$args{runtime} save $args{uri} -o $args{name}.tar");
+    assert_script_run("tar xvf $args{name}.tar");
+    my @files = script_output("tar tf $rootfs.tar");
+
+    # Record files list
+    record_info("$args{name} files", @files);
+
+    return (@files);
+}
+
 sub run {
     my $arch = get_required_var('ARCH');
-    my $container_type = get_required_var('TESTED_CONTAINER');
+    my $tested_container = get_required_var('TESTED_CONTAINER');
     my $k8s = get_var('K8S', 'null');
     my $runtime = get_required_var('CONTAINER_RUNTIMES');
     my $totest_path = get_required_var('TOTEST_PATH');
@@ -19,7 +38,8 @@ sub run {
     # No GUI, easier and quicker to use the serial console
     select_serial_terminal();
 
-    if ($container_type =~ /elemental/) {
+    if ($tested_container =~ /elemental/) {
+        # Basic tests of Elemental container image
         my $uri = get_container_uri(
             url => $totest_path,
             arch => $arch,
@@ -32,8 +52,8 @@ sub run {
 
         # Record the command version
         record_info('Elemental Version', script_output($cmd));
-    }
-    elsif ($container_type =~ /$k8s/) {
+    } elsif ($tested_container =~ /$k8s/) {
+        # Basic tests of K8s container image
         my $k8s_version_prefix = get_required_var('K8S_VERSION_PREFIX');
         my $uri = get_container_uri(
             url => $totest_path,
@@ -41,25 +61,37 @@ sub run {
             regex => ".*${k8s}-tar-\(${k8s_version_prefix}.*\)-\(.*\)"
         );
 
-        assert_script_run("$runtime pull $uri");
-        my $rootfs = script_output(
-            "$runtime inspect -f '{{index .RootFS.Layers 0}}' $uri | cut -d: -f2"
+        # Extract files list
+        my @files = extract_fileslist(name => $k8s, runtime => $runtime, uri => $uri);
+
+        die("Missing installer!") unless (join(' ', @files) =~ m/install\.sh/);
+    } elsif ($tested_container =~ /lcm/) {
+        # Basic tests of Lifecycle Manager container image
+        my $uri = get_container_uri(
+            url => $totest_path,
+            arch => $arch,
+            regex => ".*elemental-lifecycle-manager-\(.*\)-\(.*\)"
         );
 
-        # Extract files from container
-        assert_script_run("$runtime save $uri -o $k8s.tar");
-        assert_script_run("tar xvf $k8s.tar");
-        my $files_list = script_output("tar tf $rootfs.tar");
+        # Extract files list
+        my @files = extract_fileslist(name => 'lcm', runtime => $runtime, uri => $uri);
 
-        # Record files list
-        record_info("$k8s files", $files_list);
+        die("Missing raw image!") unless (join(' ', @files) =~ m/elemental-lifecycle-manager/);
+    } elsif ($tested_container =~ /longhorn/) {
+        # Basic tests of Longhorn container image
+        my $uri = get_container_uri(
+            url => $totest_path,
+            arch => $arch,
+            regex => ".*longhorn-\(.*\)-\(.*\)"
+        );
 
-        unless ($files_list =~ m/install.sh/) {
-            die("Missing installer!");
-        }
-    }
-    else {
-        die("Container type '$container_type' not supported!");
+        # Extract files list
+        my @files = extract_fileslist(name => 'longhorn', runtime => $runtime, uri => $uri);
+
+        die("Missing raw image!") unless (join(' ', @files) =~ m/longhorn_.*\.raw/);
+    } else {
+        # Not supported yet!
+        die("Container type '$tested_container' not supported!");
     }
 }
 


### PR DESCRIPTION
Add basic tests for container images `elemental-lifecycle-manager` and `longhorn`.

**NOTE:** https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25845 needs to be merged first!

- Related ticket: [CORE-612](https://jira.suse.com/browse/CORE-612) and [CORE-614](https://jira.suse.com/browse/CORE-614)
- Needles: N/A
- Verification runs: [elemental-image](http://10.116.2.38/tests/2432), [rke2-image](http://10.116.2.38/tests/2431), [lcm-image](http://10.116.2.38/tests/2428), [longhorn-image](http://10.116.2.38/tests/2430)
