### PR TITLE
Stop dlm resources before crm sbd commands

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -2069,7 +2069,7 @@ sub parse_sbd_metadata {
     my @val = ();
     my $metadata = {};
     my $device_name = "";
-    foreach my $line (split(/\n/, script_output('crm sbd configure show disk_metadata'))) {
+    foreach my $line (split(/\n/, script_output('crm sbd configure show disk_metadata', proceed_on_failure => 1))) {
         if ($line =~ /^==Dumping header on disk (\S+)/) {
             $device_name = $1;
         } elsif ($line =~ /Timeout\s+\((\w+)\)\s+\:\s+(\d+)/) {

--- a/tests/ha/add_sbd_device.pm
+++ b/tests/ha/add_sbd_device.pm
@@ -50,6 +50,7 @@ use Mojo::Base 'haclusterbasetest';
 use testapi;
 use lockapi;
 use hacluster;
+use version_utils qw(package_version_cmp);
 use Data::Dumper;
 
 sub run {
@@ -58,7 +59,10 @@ sub run {
     my $lun = get_lun;
 
     if (is_node(1)) {
+        my $crmsh_flag = (package_version_cmp(get_crmsh_version(), '5.1.0') >= 0);
+        assert_script_run("crm resource stop base-clone") if $crmsh_flag;
         assert_script_run("crm sbd device add $lun");
+        assert_script_run("crm resource start base-clone") if $crmsh_flag;
 
         # Check the sbd device is added into the configuration
         validate_script_output('crm sbd configure show disk_metadata', qr/$lun/);

--- a/tests/ha/change_sbd_metadata.pm
+++ b/tests/ha/change_sbd_metadata.pm
@@ -55,6 +55,7 @@ use Mojo::Base 'haclusterbasetest';
 use testapi;
 use lockapi;
 use hacluster;
+use version_utils qw(package_version_cmp);
 
 sub run {
     my $cluster_name = get_cluster_name;
@@ -67,9 +68,13 @@ sub run {
     # Need to get the orignial values before changing metadata, so barrier_wait is needed here.
     barrier_wait("CLUSTER_BEFORE_CHANGE_METADATA_$cluster_name");
 
-
-    # Configure the metadata
-    assert_script_run("crm sbd configure " . join(" ", map { "$_-timeout=" . ($metadata_config->{$_} + $change_num) } keys %$metadata_config)) if (is_node(1));
+    my $crmsh_flag = (package_version_cmp(get_crmsh_version(), '5.1.0') >= 0);
+    if (is_node(1)) {
+        assert_script_run("crm resource stop base-clone") if $crmsh_flag;
+        # Configure the metadata
+        assert_script_run("crm sbd configure " . join(" ", map { "$_-timeout=" . ($metadata_config->{$_} * $change_num) } keys %$metadata_config));
+        assert_script_run("crm resource start base-clone") if $crmsh_flag;
+    }
 
     barrier_wait("CLUSTER_AFTER_CHANGE_METADATA_$cluster_name");
 
@@ -77,14 +82,16 @@ sub run {
     my @new_sbd_conf = parse_sbd_metadata();
     my $new_metadata_config = $new_sbd_conf[0]->{metadata};
     foreach my $key (keys %$new_metadata_config) {
-        my $expected_val = $metadata_config->{$key} + $change_num;
+        my $expected_val = $metadata_config->{$key} * $change_num;
         die "The metadata $key is not changed as expected" if ($new_metadata_config->{$key} ne $expected_val);
     }
 
     barrier_wait("CLUSTER_CHECK_CHANGE_METADATA_$cluster_name");
 
+    assert_script_run("crm resource stop base-clone") if $crmsh_flag;
     # Recover metadata configuration
     assert_script_run("crm sbd configure " . join(" ", map { "$_-timeout=" . $metadata_config->{$_} } keys %$metadata_config)) if (is_node(1));
+    assert_script_run("crm resource start base-clone") if $crmsh_flag;
 }
 
 1;

--- a/tests/ha/remove_sbd_device.pm
+++ b/tests/ha/remove_sbd_device.pm
@@ -53,6 +53,7 @@ use Mojo::Base 'haclusterbasetest';
 use testapi;
 use lockapi;
 use hacluster;
+use version_utils qw(package_version_cmp);
 use Data::Dumper;
 
 sub run {
@@ -91,7 +92,10 @@ sub run {
     my $remove_dev = shift @sbd_devices;
 
     if (is_node(1)) {
+        my $crmsh_flag = (package_version_cmp(get_crmsh_version(), '5.1.0') >= 0);
+        assert_script_run("crm resource stop base-clone") if $crmsh_flag;
         assert_script_run("crm sbd device remove $remove_dev");
+        assert_script_run("crm resource start base-clone") if $crmsh_flag;
 
         # Check the remove result
         if (script_run("crm sbd configure show disk_metadata | grep -F '$remove_dev'")) {


### PR DESCRIPTION
This PR stops the `base-clone` command before running `crm sbd` commands, and restarts it after they finish. This is needed to account for changes in `crmsh 5.1.0` .

- Related ticket: https://jira.suse.com/browse/TEAM-11241
- Verification run: 
16.1: https://openqa.suse.de/tests/23044113
16.0: https://openqaworker15.qe.prg2.suse.org/tests/375046
