### PR TITLE
revert: Allow including PR number in `VERSION`

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -135,13 +135,6 @@ sub init_main {
         my $errors = verify_checksum();
         set_var('CHECKSUM_FAILED', $errors) if $errors;
     }
-    # allow scheduling jobs with e.g. `VERSION=16.0:gitea:pr:1234` instead of just `VERSION=16.0`
-    # note: This is useful because then jobs for individual submissions are not wrongly considered
-    #       to be for consecutive builds and e.g. wrong bugref carry over is avoided.
-    if (my $version = get_var('VERSION')) {
-        set_var('VERSION_ORIGINAL', $version);
-        set_var('VERSION', $version =~ s/:(?:(git|smelt)[-:])?(?:pr[-:])\d+$//rgi);
-    }
 }
 
 sub loadtest {


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#25684 as it needs tweaking but we might need to change the whole approach anyway.

So I would revert it for now and only reintroduce it via https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25860 if we actually want/need it.