### PR TITLE
agama: Add retry logic to go back to overview screen

### DIFF
--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -29,9 +29,18 @@ sub scroll_down {
 }
 
 sub back_to_overview {
-    assert_and_click('agama-overview-tab');
-    assert_screen('agama-overview-screen');
-    record_info('Back to overview');
+    for (my $tries = 0; $tries <= 5; $tries++) {
+        assert_and_click('agama-overview-tab');
+
+        if (check_screen('agama-overview-screen', 5)) {
+            record_info('Back to overview');
+            return;
+        }
+
+        diag "Failed to get to overview screen (# $tries)";
+    }
+
+    die "Max tries to return to overview screen reached";
 }
 
 sub has_product_selection {


### PR DESCRIPTION
On Leap 16.0 tests started to fail (about 50% rate) after changes introduced by
cada63486ee387ace00f9c4036c445212ddf4ec8 as if the webUI didn't register
the mouse click, which can be workarounded with a retry logic with a
limit, so it doesn't run forever

Failure: https://openqa.opensuse.org/tests/6031078#step/agama/12

VR:
- https://openqa.opensuse.org/tests/overview?build=maintenance_fix
