### PR TITLE
containers: Make podman_bci_systemd not fatal

### DIFF
--- a/tests/containers/podman_bci_systemd.pm
+++ b/tests/containers/podman_bci_systemd.pm
@@ -60,4 +60,8 @@ sub post_fail_hook {
     $self->cleanup();
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;


### PR DESCRIPTION
This failure shouldn't prevent the rest of the job from continuing:
https://openqa.suse.de/tests/22988025#step/podman_bci_systemd/54