### PR TITLE
Change to use 'agama status' to check guest installation done

### DIFF
--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -2704,7 +2704,8 @@ sub verify_guest_agama_installation_done {
             return $self;
         }
         while ($_wait_timeout > 0) {
-            enter_cmd("timeout --kill-after=1 --signal=9 120 journalctl -u agama -u agama-web-server.service| grep -E \\\"Install phase done|Installation finished\\\"", timeout => 150);
+            my $check_install_finish = guest_is_sle($self->{guest_name}, '<16.1') ? "journalctl -u agama -u agama-web-server.service | grep -E 'Install phase done|Installation finished'" : "agama status --format json | jq '.installation' | grep succeeded";
+            enter_cmd("timeout --kill-after=1 --signal=9 120 $check_install_finish", timeout => 150);
             wait_still_screen(20);
             $_wait_timeout -= 20;
         }
@@ -2722,7 +2723,8 @@ sub verify_guest_agama_installation_done {
         $_ssh_command_options .= is_sle('16+') ? "-o PubkeyAcceptedAlgorithms=+ssh-ed25519 " : "-o PubkeyAcceptedAlgorithms=+ssh-rsa ";
         $_ssh_command_options .= "-i $_host_params{ssh_key_file}";
         while ($_wait_timeout > 0) {
-            if (script_run("timeout --kill-after=1 --signal=9 120 ssh $_ssh_command_options root\@$self->{guest_ipaddr} \"journalctl -u agama -u agama-web-server.service | grep -E \\\"Install phase done|Installation finished\\\"\"", timeout => 150) == 0) {
+            my $check_install_finish = guest_is_sle($self->{guest_name}, '<16.1') ? "journalctl -u agama -u agama-web-server.service | grep -E 'Install phase done|Installation finished'" : "agama status --format json | jq '.installation' | grep succeeded";
+            if (script_run("timeout --kill-after=1 --signal=9 120 ssh $_ssh_command_options root\@$self->{guest_ipaddr} \"$check_install_finish\"", timeout => 150) == 0) {
                 record_info("Guest $self->{guest_name} agama install phase done", "Guest $self->{guest_name} ip address is $self->{guest_ipaddr}");
                 $self->record_guest_installation_result('AGAMA_INSTALL_PHASE_DONE');
                 return $self;

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -285,7 +285,11 @@ sub is_pv_guest {
 }
 
 #Check if guest is SLE with optional filter for:
-#Version: <=12-sp3 =12-sp1 >11-sp1 >=15 15+ (>=15 and 15+ are equivalent)
+#Version: 16 =16.1 <16.0 16.1+ <=12-sp3 >=15 15+ (>=15 and 15+ are equivalent)
+#Examples of guest name:
+#   sles-16-1-64-kvm-hvm-uefi-agama-online-iso,
+#   sles_15_sp7_64_kvm_hvm_uefi-qcow2nvram,
+#   sles16efi_full-sev-es, sles15sp7-efi-sev-es
 #usage: guest_is_sle($guest_name, '<=12-sp2')
 sub guest_is_sle {
     my $guest_name = lc shift;
@@ -295,9 +299,15 @@ sub guest_is_sle {
     return 1 unless $query;
 
     # Version check
-    $guest_name =~ /sles-*(\d{2})(?:-*sp(\d))?/;
-    my $version = defined($2) ? "$1-sp$2" : "$1-sp0";
-    return check_version($query, $version, qr/\d{2}(?:-sp\d)?/);
+    $guest_name =~ /sles[-_]*(\d{2})(?:[-_]*(?:sp)?(\d+)|sp(\d+))?/;
+    my $major = $1;
+    my $sp = defined($2) ? $2 : (defined($3) ? $3 : 0);
+    my $version = "${major}.${sp}";
+    $query =~ s/[-_]*sp(\d+)/.$1/gi;
+    if ($query =~ /^\d+(?:\.\d+)?$/) {
+        $query = "=" . $query;
+    }
+    return check_version($query, $version, qr/\d{2}(?:\.\d+)?/);
 }
 
 


### PR DESCRIPTION
Follow https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25868 to fix agama installation failure on virt guest installation.

Related ticket: https://progress.opensuse.org/issues/202920


Verification run: 

[uefi-gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23018688#step/unified_guest_installation/308) 
[uefi-gi-guest_sles16_0-online-on-host_developing-kvm](https://openqa.suse.de/tests/23018691#step/unified_guest_installation/279) 
[uefi-gi-guest_developing-on-host_sles16_0-kvm](https://openqa.suse.de/tests/23018690#step/unified_guest_installation/415) 
[virt-bridge-setup-tool-on-host_developing-kvm](https://openqa.suse.de/tests/23018686#step/unified_guest_installation/310)
[arm test](https://openqa.suse.de/tests/23018988#)   //failed to validate as it failed before guest installation.
[snapshot-gi-guest_sles15sp7-on-host_developing-kvm](https://openqa.suse.de/tests/23028676)   //running

