### PR TITLE
SDAF expand tags

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
@@ -489,8 +489,11 @@ Returns Hash of tag name and values to be applied on deployment resources.
 sub get_deployment_tags {
     my %tags = (
         deployed_by => get_var('SDAF_DEPLOYMENT_OWNER', 'OpenQA-SDAF-automation'),
-        openqa_instance => get_required_var('WORKER_HOSTNAME'),
-        deployment_id => get_current_job_id()
+        openqa_instance => get_var('WORKER_HOSTNAME', 'N/A'),
+        deployment_id => get_current_job_id(),
+        openqa_build => get_var('BUILD', 'N/A'),
+        deployment_scenario => get_var('SDAF_DEPLOYMENT_SCENARIO', 'N/A'),
+        openqa_created_date => Time::Piece->new->datetime()
     );
 
     $tags{no_cleanup_tag()} = '1' if get_var('SDAF_RETAIN_DEPLOYMENT');

--- a/t/26_deployment_connector.t
+++ b/t/26_deployment_connector.t
@@ -9,6 +9,7 @@ use testapi;
 use Data::Dumper;
 use Scalar::Util qw(reftype);
 use List::Util qw(any none);
+use Time::Piece;
 use sles4sap::sap_deployment_automation_framework::deployment_connector;
 
 sub undef_variables {
@@ -321,6 +322,8 @@ subtest '[get_deployment_tags] Check returned value' => sub {
     is $result{deployed_by}, 'Unit test', 'Apply "deployed_by" tag';
     is $result{openqa_instance}, 'OSD', 'Apply "openqa_instance" tag.';
     is $result{deployment_id}, '42', 'Apply "deployment_id" tag.';
+    ok(Time::Piece->strptime($result{openqa_created_date}, "%Y-%m-%dT%H:%M:%S"),
+        "Check date format in tag 'openqa_created_date: $result{openqa_created_date}'.");
     undef_variables;
 };
 


### PR DESCRIPTION
This PR adds more information about deployment in form of resource tags.
 This makes easier to identify origin of the deployment. 
 Added tags:
- openqa_build
- deployment_scenario
- openqa_created_date
 
Ticket: https://jira.suse.com/browse/TEAM-10974
VR:
https://openqaworker15.qe.prg2.suse.org/tests/374601#
Tags Deployer:
<img width="856" height="513" alt="image" src="https://github.com/user-attachments/assets/57f17ae2-96ed-4e68-a1d5-8886657bafe3" />

Tags workload zone:
<img width="830" height="492" alt="image" src="https://github.com/user-attachments/assets/6127cb54-c8d3-4651-8eb8-db254893643a" />

Tags sap systems:
<img width="839" height="514" alt="image" src="https://github.com/user-attachments/assets/f8d9d60b-7b75-4f77-84ae-86b707b1b5bf" />
