### PR TITLE
Revert "Fix vmware image iso checksum verification"

### DIFF
--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -169,14 +169,11 @@ sub run {
 
     ## Verify checksum of the copied images
     my $location = '/var/lib/libvirt/images/';
-    $location = $vmware_openqa_datastore if (is_vmware);
-    my $errors = verify_checksum $location;
-    if ($errors) {
-        record_info("Checksum", $errors, result => 'fail');
-        die "Checksum verification failed.";
-    } else {
-        record_info("Checksum matched", "", result => 'ok');
+    if (is_vmware) {
+        $location = get_var('BOOT_HDD_IMAGE') ? $vmware_openqa_datastore : $isodir;
     }
+    my $errors = verify_checksum $location;
+    record_info("Checksum", $errors, result => 'fail') if $errors;
 
     # We need to use 'tablet' as a pointer device, i.e. a device
     # with absolute axis. That needs to be explicitely configured


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#25857, because sha512sum does not support concurrent execution.

`sha512sum: can't open '/vmfs/volumes/datastore2/openQA/SLES-16.1-Online-x86_64-Build48.1.install.iso': Device or resource busy`