### PR TITLE
containers: Make podman_quadlet not fatal

### DIFF
--- a/tests/containers/podman_quadlet.pm
+++ b/tests/containers/podman_quadlet.pm
@@ -183,4 +183,8 @@ sub post_fail_hook {
     cleanup();
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;


### PR DESCRIPTION
This failure shouldn't prevent the rest of the job from continuing:
https://openqa.suse.de/tests/22998126#step/podman_quadlet/121