### PR TITLE
containers: Make most modules not fatal

### DIFF
--- a/tests/containers/container_suseconnect.pm
+++ b/tests/containers/container_suseconnect.pm
@@ -116,4 +116,8 @@ sub cleanup {
 sub post_run_hook { shift->cleanup() }
 sub post_fail_hook { shift->cleanup() }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;

--- a/tests/containers/firewall.pm
+++ b/tests/containers/firewall.pm
@@ -70,4 +70,8 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;

--- a/tests/containers/image.pm
+++ b/tests/containers/image.pm
@@ -111,4 +111,8 @@ sub run {
     $engine->cleanup_system_host();
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;

--- a/tests/containers/podman_artifact.pm
+++ b/tests/containers/podman_artifact.pm
@@ -59,3 +59,7 @@ sub post_run_hook {
     cleanup;
     $self->SUPER::post_run_hook;
 }
+
+sub test_flags {
+    return {fatal => 0};
+}

--- a/tests/containers/podman_ipv6.pm
+++ b/tests/containers/podman_ipv6.pm
@@ -93,4 +93,8 @@ sub post_fail_hook {
     shift->_cleanup();
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;

--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -255,4 +255,8 @@ sub post_fail_hook {
     shift->_cleanup();
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;

--- a/tests/containers/podman_network_cni.pm
+++ b/tests/containers/podman_network_cni.pm
@@ -79,4 +79,8 @@ sub run() {
 
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;

--- a/tests/containers/podman_pods.pm
+++ b/tests/containers/podman_pods.pm
@@ -130,4 +130,8 @@ sub post_fail_hook {
     $self->cleanup();
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;

--- a/tests/containers/privileged_mode.pm
+++ b/tests/containers/privileged_mode.pm
@@ -76,4 +76,8 @@ sub post_fail_hook {
     $self->cleanup();
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;

--- a/tests/containers/registry.pm
+++ b/tests/containers/registry.pm
@@ -91,4 +91,8 @@ sub run {
     $engine->cleanup_system_host();
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;

--- a/tests/containers/rootless_docker.pm
+++ b/tests/containers/rootless_docker.pm
@@ -85,4 +85,8 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;

--- a/tests/containers/secret.pm
+++ b/tests/containers/secret.pm
@@ -72,4 +72,8 @@ sub run {
     $engine->cleanup_system_host();
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;

--- a/tests/containers/skopeo.pm
+++ b/tests/containers/skopeo.pm
@@ -132,5 +132,9 @@ sub post_fail_hook {
     cleanup;
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;
 

--- a/tests/containers/third_party_images.pm
+++ b/tests/containers/third_party_images.pm
@@ -60,4 +60,8 @@ sub post_run_hook {
     upload_3rd_party_images_logs($self->{runtime});
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;


### PR DESCRIPTION
A failure in one module shouldn't deter openQA from running the rest of the tests.