### PR TITLE
Add ignore for TDX not supported

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -2084,5 +2084,15 @@
             ]
         },
         "type": "bug"
+    },
+    "tdx-not-supported": {
+        "description": "virt/tdx: TDX not supported by the host platform",
+        "products": {
+            "sle": [
+                "16.0",
+                "16.1"
+            ]
+        },
+        "type": "ignore"
     }
 }


### PR DESCRIPTION
There is no point in failing the test runs for the message, that TDX is not supported. This is just an information message.

- Related failure: https://openqa.suse.de/tests/23004032#step/journal_check/23
- Related discussion: https://suse.slack.com/archives/C02DQJKULE4/p1782136077524129?thread_ts=1782116893.327789&cid=C02DQJKULE4
- Verification run: https://openqa.suse.de/tests/23004286
