### PR TITLE
Fix kubevirt migration test failure

### DIFF
--- a/tests/virt_autotest/kubevirt_tests_agent.pm
+++ b/tests/virt_autotest/kubevirt_tests_agent.pm
@@ -95,6 +95,7 @@ kubelet-arg:
   - cpu-manager-policy=static
   - kube-reserved=cpu=500m
   - system-reserved=cpu=500m
+nonroot-devices: true
 __END
 (exit \$?)");
 

--- a/tests/virt_autotest/kubevirt_tests_server.pm
+++ b/tests/virt_autotest/kubevirt_tests_server.pm
@@ -149,6 +149,9 @@ sub rke2_server_setup {
     assert_script_run('kubectl config view');
     assert_script_run('kubectl get nodes');
 
+    # Configure rke2-server service
+    assert_script_run("echo 'nonroot-devices: true' > /etc/rancher/rke2/config.yaml");
+
     # Create registries ready
     our $local_registry_fqdn = get_required_var("LOCAL_REGISTRY_FQDN");
     our $local_registry_ip = script_output("nslookup $local_registry_fqdn|sed -n '5,1p'|awk -F' ' '{print \$2}'");


### PR DESCRIPTION
To resolve this issue, just configuring CRI to dynamically assign device ownership inside containers based on the pod's securityContext UID/GID. It just requires to configure nonroot-devices in RKE2 which automatically sets "device_ownership_from_security_context = true" in the containerd config file. Setting "nonroot-devices: true" in RKE2 configuration (/etc/rancher/rke2/config.yaml) on all cluster nodes.

- Related ticket: https://progress.opensuse.org/issues/203025
- Verification run: https://openqa.suse.de/tests/23016071
