### PR TITLE
zdup/tdup: Set gpgkey option in .repo file

### DIFF
--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -107,6 +107,8 @@ sub run {
             $r .= "/\\\$basearch";
         }
         zypper_call("--no-gpg-checks ar \"$r\" repo$nr");
+        # Workaround to make zypper behaviour more like if it was download.o.o
+        script_run("echo \"gpgkey=$r/repodata/repomd.xml.key\" >> /etc/zypp/repos.d/repo$nr.repo");
         $nr++;
     }
     zypper_call '--gpg-auto-import-keys ref';

--- a/tests/transactional/tdup.pm
+++ b/tests/transactional/tdup.pm
@@ -28,6 +28,8 @@ sub run {
     my $nr = 1;
     foreach my $r (split(/,/, get_var('ZDUPREPOS', $defaultrepo))) {
         zypper_call("--no-gpg-checks ar \"$r\" repo$nr");
+        # Workaround to make zypper behaviour more like if it was download.o.o
+        script_run("echo \"gpgkey=$r/repodata/repomd.xml.key\" >> /etc/zypp/repos.d/repo$nr.repo");
         $nr++;
     }
 


### PR DESCRIPTION
If the URL contains download.opensuse.org, zypper invents the gpgkey= option itself. Here it needs to be set explicitly.

https://github.com/openSUSE/libzypp/blob/14f81f090cc5718c6fcab752b95106d81dbb9143/zypp/zypp/ng/workflows/repoinfowf.cc#L59

- Failure: https://openqa.opensuse.org/tests/6037008#step/zdup/8
- Verification run: https://openqa.opensuse.org/tests/6039792#step/zdup/10
