### PR TITLE
Fix: Reset console after softreboot

### DIFF
--- a/tests/transactional/rebootmgr.pm
+++ b/tests/transactional/rebootmgr.pm
@@ -65,6 +65,7 @@ sub check_strategy_maint_window {
     # Trigger reboot and wait for maintenance window
     rbm_set_window '+2minutes', '1m';
     rbm_call 'reboot';
+    reset_consoles;
     rbm_check_status 2;
     die "System should be rebooting" unless wait_screen_change(undef, 180);
     process_reboot;


### PR DESCRIPTION
The new softreboot handling somehow breaks the console switching. As a workaround until we find a proper fix, we need to manually reset the console after a softreboot.

- Related ticket: https://progress.opensuse.org/issues/202980#note-5
- Verification runs: [16.1 Transactional images](https://openqa.suse.de/tests/23018654) | [MicroOS](https://openqa.opensuse.org/tests/6040050)
