### PR TITLE
Setup new self-update test in Product Increment

### DIFF
--- a/schedule/yam/agama_self_update_unattended.yaml
+++ b/schedule/yam/agama_self_update_unattended.yaml
@@ -1,0 +1,18 @@
+---
+name: agama_self_update_unattended
+description: >
+  Default unattended installation after performing self update.
+schedule:
+  - yam/agama/boot_agama
+  - yam/validate/validate_self_update
+  - yam/agama/agama_auto
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_base_product
+  - yam/validate/validate_product
+  - yam/validate/validate_connectivity
+  - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
+  - yam/validate/validate_snapshots
+  - yam/validate/validate_registered_products
+  - console/validate_repos

--- a/schedule/yam/agama_self_update_unattended_ppc64le.yaml
+++ b/schedule/yam/agama_self_update_unattended_ppc64le.yaml
@@ -1,0 +1,18 @@
+---
+name: agama_self_update_unattended
+description: >
+  Default unattended installation after performing self update.
+schedule:
+  - yam/agama/boot_agama
+  - yam/validate/validate_self_update
+  - yam/agama/agama_auto
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_base_product
+  - yam/validate/validate_product
+  - yam/validate/validate_connectivity
+  - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
+  - yam/validate/validate_snapshots
+  - yam/validate/validate_registered_products
+  - console/validate_repos

--- a/schedule/yam/agama_self_update_unattended_s390x.yaml
+++ b/schedule/yam/agama_self_update_unattended_s390x.yaml
@@ -1,0 +1,19 @@
+---
+name: agama_self_update_unattended
+description: >
+  Default unattended installation after performing self update.
+schedule:
+  - yam/agama/boot_agama
+  - yam/validate/validate_self_update
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - yam/validate/validate_selinux
+  - yam/validate/validate_base_product
+  - yam/validate/validate_product
+  - yam/validate/validate_connectivity
+  - yam/validate/validate_first_user
+  - yam/validate/validate_snapshots
+  - yam/validate/validate_registered_products
+  - console/validate_repos

--- a/test_data/yam/agama_sle_self_update.yaml
+++ b/test_data/yam/agama_sle_self_update.yaml
@@ -1,0 +1,43 @@
+---
+os_release:
+  NAME: 'SLES'
+  PRETTY_NAME: 'SUSE Linux Enterprise Server %VERSION%'
+  VARIANT: 'Enterprise Server'
+  VARIANT_ID: 'server'
+  VERSION_ID: '%VERSION%'
+  ID: 'sles'
+  ID_LIKE: 'suse opensuse'
+  CPE_NAME: 'cpe:/o:suse:sles:16:%VERSION%'
+  SUSE_SUPPORT_PRODUCT: 'SUSE Linux Enterprise Server'
+repos:
+  - name: SLE-Product-SLES-%VERSION%
+    alias: SUSE_Linux_Enterprise_Server_%VERSION%_%ARCH%:SLE-Product-SLES-%VERSION%
+    uri: http://openqa.suse.de/assets/repo/SLES-%VERSION%-%ARCH%-Build%BUILD%/
+    enabled: 'Yes'
+    filter: name
+  - name: SLE-Product-SLES-%VERSION%-Debug
+    alias: SUSE_Linux_Enterprise_Server_%VERSION%_%ARCH%:SLE-Product-SLES-%VERSION%-Debug
+    uri: http://openqa.suse.de/assets/repo/SLES-%VERSION%-%ARCH%-Debug-Build%BUILD%/
+    enabled: 'No'
+    filter: name
+  - name: SLE-Product-SLES-%VERSION%-Source
+    alias: SUSE_Linux_Enterprise_Server_%VERSION%_%ARCH%:SLE-Product-SLES-%VERSION%-Source
+    uri: http://openqa.suse.de/assets/repo/SLES-%VERSION%-%ARCH%-Source-Build%BUILD%/
+    enabled: 'No'
+    filter: name
+  - name: NVIDIA-GPU-Compute-Toolkit-CUDA
+    alias: SUSE_Linux_Enterprise_Server_%VERSION%_%ARCH%:NVIDIA-GPU-Compute-Toolkit-CUDA
+    uri: https://static.scc.suse.com/repos/cuda/sles16/%ARCH%
+    enabled: 'No'
+    filter: name
+  - name: NVIDIA-Graphics-Drivers
+    alias: SUSE_Linux_Enterprise_Server_%VERSION%_%ARCH%:NVIDIA-Graphics-Drivers
+    uri: https://download.nvidia.com/suse/sle16
+    enabled: 'No'
+    filter: name
+selinux:
+  status: enabled
+  mode: enforcing
+products:
+  - SLES
+self_update_enabled: 1

--- a/test_data/yam/agama_sle_self_update_s390x_ppc64le.yaml
+++ b/test_data/yam/agama_sle_self_update_s390x_ppc64le.yaml
@@ -1,0 +1,33 @@
+---
+os_release:
+  NAME: 'SLES'
+  PRETTY_NAME: 'SUSE Linux Enterprise Server %VERSION%'
+  VARIANT: 'Enterprise Server'
+  VARIANT_ID: 'server'
+  VERSION_ID: '%VERSION%'
+  ID: 'sles'
+  ID_LIKE: 'suse opensuse'
+  CPE_NAME: 'cpe:/o:suse:sles:16:%VERSION%'
+  SUSE_SUPPORT_PRODUCT: 'SUSE Linux Enterprise Server'
+repos:
+  - name: SLE-Product-SLES-%VERSION%
+    alias: SUSE_Linux_Enterprise_Server_%VERSION%_%ARCH%:SLE-Product-SLES-%VERSION%
+    uri: http://openqa.suse.de/assets/repo/SLES-%VERSION%-%ARCH%-Build%BUILD%/
+    enabled: 'Yes'
+    filter: name
+  - name: SLE-Product-SLES-%VERSION%-Debug
+    alias: SUSE_Linux_Enterprise_Server_%VERSION%_%ARCH%:SLE-Product-SLES-%VERSION%-Debug
+    uri: http://openqa.suse.de/assets/repo/SLES-%VERSION%-%ARCH%-Debug-Build%BUILD%/
+    enabled: 'No'
+    filter: name
+  - name: SLE-Product-SLES-%VERSION%-Source
+    alias: SUSE_Linux_Enterprise_Server_%VERSION%_%ARCH%:SLE-Product-SLES-%VERSION%-Source
+    uri: http://openqa.suse.de/assets/repo/SLES-%VERSION%-%ARCH%-Source-Build%BUILD%/
+    enabled: 'No'
+    filter: name
+selinux:
+  status: enabled
+  mode: enforcing
+products:
+  - SLES
+self_update_enabled: 1

--- a/tests/yam/agama/agama.pm
+++ b/tests/yam/agama/agama.pm
@@ -47,6 +47,7 @@ sub run {
       " --agama-web-ui-package-version " . get_var('AGAMA_WEBUI_PACKAGE_VERSION') .
       " $test_options";
 
+    select_console 'install-shell';
     record_info("node cmd", $node_cmd);
     my $ret = script_run($node_cmd, timeout => 2400);
 

--- a/tests/yam/agama/agama_auto.pm
+++ b/tests/yam/agama/agama_auto.pm
@@ -15,6 +15,7 @@ use version_utils qw(is_vmware is_leap);
 
 sub run {
     my $self = shift;
+    select_console 'installation';
     my $reboot_page = $testapi::distri->get_reboot();
     $reboot_page->expect_is_shown();
 

--- a/tests/yam/validate/validate_self_update.pm
+++ b/tests/yam/validate/validate_self_update.pm
@@ -3,7 +3,7 @@
 # Copyright 2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: Validate that the self-update is performed by Agama via /etc/live-self-update/result
+# Summary: Validate that the self-update is performed by Agama via systemctl
 # Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
 
 use Mojo::Base 'consoletest';
@@ -12,6 +12,7 @@ use utils qw(systemctl);
 use scheduler qw(get_test_suite_data);
 
 sub run {
+    select_console 'install-shell';
     my $self_update_enabled = get_test_suite_data()->{self_update_enabled};
     if ($self_update_enabled) {
         my $retcode = script_output('cat /run/live-self-update/result');


### PR DESCRIPTION
Implements new self-update test for Product Increment workflow in Agama.
Adds console management, test scheduling, and validation for self-update functionality.

- Related ticket: https://progress.opensuse.org/issues/202470
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/835
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=PI-246.27&groupid=583
