### PR TITLE
hpc/ww4: Update test with new expected behavior

### DIFF
--- a/tests/hpc/ww4.pm
+++ b/tests/hpc/ww4.pm
@@ -89,6 +89,8 @@ sub run ($self) {
     assert_script_run "wwctl overlay build";
     # Refresh repositories inside the container
     validate_script_output("echo 'zypper -n refresh && echo warewulf-container-refreshed' | wwctl container shell warewulf-container", sub { m/warewulf-container-refreshed/ });
+    # Restart dnsmasq to apply newly configured compute nodes, expected behavior documented in bsc#1269035
+    systemctl 'restart dnsmasq';
     barrier_wait('WWCTL_READY');
     record_info 'WWCTL_READY', strftime("\%H:\%M:\%S", localtime);
     mutex_unlock 'ww4_ready';

--- a/tests/hpc/ww4.pm
+++ b/tests/hpc/ww4.pm
@@ -66,7 +66,7 @@ sub run ($self) {
 
     $rt = (assert_script_run "wwctl container import $hpc_container warewulf-container", timeout => 320) ? 1 : 0;
     test_case('Container pull', 'ww4', $rt);
-    $rt = (assert_script_run "wwctl profile set -y --image warewulf-container") ? 1 : 0;
+    $rt = (assert_script_run "wwctl profile set -y --image warewulf-container default") ? 1 : 0;
     test_case('Profile', 'ww4', $rt);
     assert_script_run "wwctl profile set -y default --netname default --netmask 255.255.255.0 --gateway 192.168.10.100";
     assert_script_run "wwctl profile list -a";


### PR DESCRIPTION
Recent update of warewulf4 package changed its behavior and we need to update test scenario:
1. warewulf4 now needs explicit definition of default profile
2. warewulf4 has changed behavior (bsc#1269035) and dnsmasq must be restarted to apply configuration for newly added nodes

- Related ticket: https://progress.opensuse.org/issues/203043
- Needles: none
- Verification run:
- 15-SP7 https://openqa.suse.de/tests/overview?build=czerw%2Fos-autoinst-distri-opensuse%2325890&distri=sle&version=15-SP7
