### PR TITLE
agama_reboot: Add timeout to installation finish check

### DIFF
--- a/tests/installation/agama_reboot.pm
+++ b/tests/installation/agama_reboot.pm
@@ -43,7 +43,7 @@ sub verify_agama_auto_install_done_cmdline {
     my $timeout = get_var('AGAMA_INSTALL_TIMEOUT', '480');
     while ($timeout > 0) {
         my $check_install_finish = is_sle('<16.1') ? "journalctl -u agama -u agama-web-server.service | grep -E 'Install phase done|Installation finished'" : "agama status --format json | jq '.installation' | grep succeeded";
-        if (script_run("$check_install_finish") == 0) {
+        if (script_run("$check_install_finish", timeout => 60) == 0) {
             record_info("agama install phase done", script_output('agama config show'));
             return;
         }


### PR DESCRIPTION
Fix poo#203064: Default timeout 30s is not enough for some bare metal
machines. Time out for installation check is now 60s.

Failure: https://openqa.suse.de/tests/23021616#step/agama_reboot/7

Issues started with recent change in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25868. Which is using different commands to check installation phase.

- Related ticket: https://progress.opensuse.org/issues/203064
- Needles: none
- Verification run: https://openqa.suse.de/tests/23021918
