### PR TITLE
Add bootloader_start for s390x

### DIFF
--- a/schedule/security/yama.yaml
+++ b/schedule/security/yama.yaml
@@ -2,5 +2,11 @@ name: yama confinement framework
 description: >
   This is for the yama confinement framework
 schedule:
+  - '{{bootloader}}'
   - boot/boot_to_desktop
   - security/oqa_agnostic/yama
+conditional_schedule:
+  bootloader:
+    ARCH:
+      s390x:
+        - installation/bootloader_start


### PR DESCRIPTION
Add bootloader_start for s390x

- Related ticket: https://progress.opensuse.org/issues/196475
- Verification run: https://openqa.suse.de/tests/23017353#details