### PR TITLE
blktests: Enable md tests for scsi and NVMes including tests `atomic writes on stacked devices`

### DIFF
--- a/lib/Kernel/block_dev.pm
+++ b/lib/Kernel/block_dev.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright 2025 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Summary: Utilities for block and storage device handling in kernel tests.
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package Kernel::block_dev;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use warnings;
+use testapi;
+
+our @EXPORT_OK = qw(
+  record_storage_info
+);
+
+=head2 record_storage_info
+
+ record_storage_info();
+
+Records block device layout into the openQA test log as a diagnostic snapshot.
+
+=cut
+
+sub record_storage_info {
+    record_info('devices', script_output(
+            'lsblk -p -o NAME,TYPE,SIZE,MODEL,SERIAL,TRAN,MOUNTPOINT',
+            proceed_on_failure => 1));
+    record_info('/dev disks',
+        script_output('ls -l /dev/nvme* /dev/vd* /dev/sd*', proceed_on_failure => 1));
+    record_info('by-id', script_output('ls -l /dev/disk/by-id', proceed_on_failure => 1));
+}
+
+1;

--- a/schedule/storage/blktests.yaml
+++ b/schedule/storage/blktests.yaml
@@ -6,12 +6,14 @@ vars:
     VIDEOMODE: text
     VIRTIO_CONSOLE: 1
     QEMUCPUS: 4
-    NUMDISKS: 5
+    NUMDISKS: 7
     HDDMODEL_1: virtio-blk
     HDDMODEL_2: nvme
     HDDMODEL_3: nvme
     HDDMODEL_4: scsi-hd
     HDDMODEL_5: scsi-hd
+    HDDMODEL_6: nvme
+    HDDMODEL_7: nvme
     DUMP_MEMORY_ON_FAIL: 1
     BOOT_HDD_IMAGE: 1
 

--- a/schedule/storage/blktests.yaml
+++ b/schedule/storage/blktests.yaml
@@ -6,14 +6,6 @@ vars:
     VIDEOMODE: text
     VIRTIO_CONSOLE: 1
     QEMUCPUS: 4
-    NUMDISKS: 7
-    HDDMODEL_1: virtio-blk
-    HDDMODEL_2: nvme
-    HDDMODEL_3: nvme
-    HDDMODEL_4: scsi-hd
-    HDDMODEL_5: scsi-hd
-    HDDMODEL_6: nvme
-    HDDMODEL_7: nvme
     DUMP_MEMORY_ON_FAIL: 1
     BOOT_HDD_IMAGE: 1
 

--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -18,13 +18,16 @@ use package_utils 'install_package';
 use Utils::Logging qw(export_logs_basic save_and_upload_log);
 
 sub prepare_blktests_config {
-    my ($devices) = @_;
+    my ($devices, $test_case_dev_array) = @_;
 
     if ($devices eq 'none') {
         record_info('INFO', 'No specific tests device selected');
     } else {
         script_run("echo TEST_DEVS=\\($devices\\) > /etc/blktests/config");
         record_info('INFO', "$devices");
+    }
+    if ($test_case_dev_array) {
+        script_run("echo '$test_case_dev_array' >> /etc/blktests/config");
     }
 }
 
@@ -40,6 +43,7 @@ sub run {
     my $trtypes = get_var('BLKTESTS_TRTYPES');
     my $md_kver = get_var('BLKTESTS_MD_KVER');
     my $issues = get_var('BLKTESTS_KNOWN_ISSUES');
+    my $test_case_dev_array = get_var('BLKTESTS_TEST_CASE_DEV_ARRAY');
 
     record_info('KERNEL', script_output('rpm -qi kernel-default'));
     save_and_upload_log('rpm -qi kernel-default', 'kernel_bug_report.txt');
@@ -55,7 +59,7 @@ sub run {
     my $log_dir = '/var/log/blktests';
     assert_script_run("mkdir -p ${log_dir}/results");
 
-    prepare_blktests_config($devices);
+    prepare_blktests_config($devices, $test_case_dev_array);
 
     my @tests = split(',', $tests);
     assert_script_run('cd /usr/lib/blktests');
@@ -181,6 +185,13 @@ For blktests, C<test_variant> matches C<BLKTESTS_TRTYPES>.
 
 Optional. Value passed to C<./check --quick>. If unset, C<--quick> is not
 passed and all tests run regardless of their C<QUICK> flag.
+
+=head2 BLKTESTS_TEST_CASE_DEV_ARRAY
+
+Optional. A bash assignment appended verbatim to the blktests config file.
+Required for tests using C<test_device_array()>, such as C<md/003>. Example:
+
+  BLKTESTS_TEST_CASE_DEV_ARRAY='TEST_CASE_DEV_ARRAY[md/003]="/dev/nvme0n1 /dev/nvme1n1 /dev/nvme2n1 /dev/nvme3n1"'
 
 =head2 BLKTESTS_MD_KVER
 

--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -38,6 +38,7 @@ sub run {
     my $quick = get_var('BLKTESTS_QUICK');
     my $exclude = get_var('BLKTESTS_EXCLUDE');
     my $trtypes = get_var('BLKTESTS_TRTYPES');
+    my $md_kver = get_var('BLKTESTS_MD_KVER');
     my $issues = get_var('BLKTESTS_KNOWN_ISSUES');
 
     record_info('KERNEL', script_output('rpm -qi kernel-default'));
@@ -77,11 +78,12 @@ sub run {
 
     $exclude = join(' ', map { "--exclude=$_" } @exclude);
     $trtypes = "NVMET_TRTYPES=\"$trtypes\" " if $trtypes;
+    $md_kver = "BLKTESTS_MD_KVER=\"$md_kver\" " if $md_kver;
 
     foreach my $i (@tests) {
         my $config = $devices eq 'none' ? '' : '-c /etc/blktests/config';
         my $quick_arg = $quick ? "--quick=$quick" : '';
-        script_run("${trtypes} ./check $config -o ${log_dir}/results $quick_arg $exclude $i", 1200);
+        script_run("${trtypes}${md_kver}./check $config -o ${log_dir}/results $quick_arg $exclude $i", 1200);
     }
 
     script_run("cd ${log_dir}");
@@ -179,6 +181,14 @@ For blktests, C<test_variant> matches C<BLKTESTS_TRTYPES>.
 
 Optional. Value passed to C<./check --quick>. If unset, C<--quick> is not
 passed and all tests run regardless of their C<QUICK> flag.
+
+=head2 BLKTESTS_MD_KVER
+
+Optional. Overrides the minimum kernel version required by the md test group,
+passed as C<BLKTESTS_MD_KVER> to C<./check>. Useful for distro kernels that
+backport md atomic write support to an older base version. Example:
+
+  BLKTESTS_MD_KVER=6 12 0
 
 =head2 BLKTESTS_TRTYPES
 

--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -16,6 +16,7 @@ use LTP::WhiteList;
 use LTP::utils 'prepare_whitelist_environment';
 use package_utils 'install_package';
 use Utils::Logging qw(export_logs_basic save_and_upload_log);
+use Kernel::block_dev 'record_storage_info';
 
 sub prepare_blktests_config {
     my ($devices, $test_case_dev_array) = @_;
@@ -60,6 +61,9 @@ sub run {
     assert_script_run("mkdir -p ${log_dir}/results");
 
     prepare_blktests_config($devices, $test_case_dev_array);
+
+    record_storage_info();
+    record_info('blktests cfg', script_output('cat /etc/blktests/config 2>/dev/null || true'));
 
     my @tests = split(',', $tests);
     assert_script_run('cd /usr/lib/blktests');


### PR DESCRIPTION
Add HDDMODEL_6 and HDDMODEL_7 as nvme. md/003 requires at least 4 NVMe devices in TEST_DEV_ARRAY to test atomic writes with MD devices.
Move device handling into kernel-yamls -> various tests require various devices, so its better to handle them there. Even various sle code streams might require various set of devices (i.e. md tests).
The test use new blktests rpm which adds md tests + downstream patch which allows to override upstream kernel requirement for the `atomic writes on md` from 6.14 to a set value. Our tests sets that to 6.12.

- Related ticket: https://progress.opensuse.org/issues/203073
- Verification run:
  - sle16.1 md tests including NVMe 4 devices: https://openqa.suse.de/tests/23063472
    - notable changes: 
      - https://openqa.suse.de/tests/23063472#step/blktests/69
      - https://openqa.suse.de/tests/23063472#step/blktests/78
      - new: `# Test messages # md::002::description	test md atomic writes`
      - new:`nvme0n1_nvme1n1_nvme2n1_nvme3n1: # Test messages # md::003::description	test md atomic writes for NVMe drives`
  - sle16.1: regression check for `blktests_block`: https://openqa.suse.de/tests/23063894
  - sle16.1: regression check for: `nvme`: https://openqa.suse.de/tests/23065603
  - sle16.1: regression check for: `nvme_tcp`: https://openqa.suse.de/tests/23065612
  - sle16.1: regression check for: `nvme_fc`: https://openqa.suse.de/tests/23065607
  - sle16.1: regression check for: `nvme_rdma`: https://openqa.suse.de/tests/23065610 (known bug: https://bugzilla.suse.com/show_bug.cgi?id=1268465)

- sle16.0:
  - `blktests`: https://openqa.suse.de/tests/23066643 (loop/009 tends to fail these days. see: https://progress.opensuse.org/issues/203112)
  - `blktests_block`: https://openqa.suse.de/tests/23066645
  - `nvme`: https://openqa.suse.de/tests/23066650
  - `nvme_tcp`: https://openqa.suse.de/tests/23066662
  - `nvme_fc`: https://openqa.suse.de/tests/23066657
  - `nvme_rdma`: https://openqa.suse.de/tests/23066657