### PR TITLE
Enable PackageHub repos if required for MU tests

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -211,6 +211,17 @@ sub run {
         zypper_call("rr sle-module-packagehub-subpackages:${version}::pool sle-module-packagehub-subpackages:${version}::update");
     }
 
+    # Enable PackageHub repos in case dependent packages are required.
+    # Note: avoid enabling by default as it may introduce new dependency issues,
+    # especially when LTSS repos are present.
+    if (get_var('QAM_ENABLE_PHUB_REPO')) {
+        my $version = get_var('VERSION');
+        my $arch = get_var('ARCH');
+        zypper_ar("http://dist.suse.de/ibs/SUSE/Products/SLE-Module-Packagehub-Subpackages/$version/$arch/product/",
+            name => "sle-module-packagehub-subpackages:${version}::pool");
+        zypper_ar("http://dist.suse.de/ibs/SUSE/Updates/SLE-Module-Packagehub-Subpackages/$version/$arch/update/",
+            name => "sle-module-packagehub-subpackages:${version}::update");
+    }
     my $zypper_version = script_output(q(rpm -q zypper|awk -F. '{print$2}'));
 
     zypper_call(q{mr -d $(zypper lr | awk -F '|' '/NVIDIA/ {print $2}')}, exitcode => [0, 3]);

--- a/variables.md
+++ b/variables.md
@@ -203,6 +203,7 @@ PXE_PRODUCT_NAME | string | false | Defines image name for PXE booting
 PXE_BOOT_TIME | integer | 120 | Approximate time that IPMI worker needs to load and execute PXE boot payload. Should be set in the IPMI worker configuration.
 QA_TESTSUITE | string | | Comma or semicolon separated a list of the automation cases' name, and these cases will be installed and triggered if you call "start_testrun" function from qa_run.pm
 QAM_MINIMAL | string | "full" or "small" | Full is adding patterns x11, gnome-basic, base, apparmor in minimal/install_patterns test. Small is just base.
+QAM_ENABLE_PHUB_REPO | boolean | false | Enable PackageHub repositories in case some package dependencies are required.
 RAIDLEVEL | integer | | Define raid level to be configured. Possible values: 0,1,5,6,10.
 REBOOT_TIMEOUT | integer | 0 | Set and handle reboot timeout available in YaST installer. 0 disables the timeout and needs explicit reboot confirmation.
 REGISTRY | string | docker.io | Registry to pull third-party container images from


### PR DESCRIPTION
1. PackageHub is not activated by default, we can enable the repos if some package dependency required.
2. However, sometimes enable the repos will cause new dependency problems especially ltss repos are there.
3. Add a variable here to enable them on demand.

- [Failed job](https://openqa.suse.de/tests/23009074)
- [Verification run](https://openqa.suse.de/tests/23029668)