### PR TITLE
Change to use $self->{guest_version} to determine guest version

### DIFF
--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -2704,7 +2704,9 @@ sub verify_guest_agama_installation_done {
             return $self;
         }
         while ($_wait_timeout > 0) {
-            my $check_install_finish = guest_is_sle($self->{guest_name}, '<16.1') ? "journalctl -u agama -u agama-web-server.service | grep -E 'Install phase done|Installation finished'" : "agama status --format json | jq '.installation' | grep succeeded";
+            my $check_install_finish = ($self->{guest_version} eq '16.0')
+              ? "journalctl -u agama -u agama-web-server.service | grep -E 'Install phase done|Installation finished'"
+              : "agama status --format json | jq '.installation' | grep succeeded";
             enter_cmd("timeout --kill-after=1 --signal=9 120 $check_install_finish", timeout => 150);
             wait_still_screen(20);
             $_wait_timeout -= 20;
@@ -2723,7 +2725,9 @@ sub verify_guest_agama_installation_done {
         $_ssh_command_options .= is_sle('16+') ? "-o PubkeyAcceptedAlgorithms=+ssh-ed25519 " : "-o PubkeyAcceptedAlgorithms=+ssh-rsa ";
         $_ssh_command_options .= "-i $_host_params{ssh_key_file}";
         while ($_wait_timeout > 0) {
-            my $check_install_finish = guest_is_sle($self->{guest_name}, '<16.1') ? "journalctl -u agama -u agama-web-server.service | grep -E 'Install phase done|Installation finished'" : "agama status --format json | jq '.installation' | grep succeeded";
+            my $check_install_finish = ($self->{guest_version} eq '16.0')
+              ? "journalctl -u agama -u agama-web-server.service | grep -E 'Install phase done|Installation finished'"
+              : "agama status --format json | jq '.installation' | grep succeeded";
             if (script_run("timeout --kill-after=1 --signal=9 120 ssh $_ssh_command_options root\@$self->{guest_ipaddr} \"$check_install_finish\"", timeout => 150) == 0) {
                 record_info("Guest $self->{guest_name} agama install phase done", "Guest $self->{guest_name} ip address is $self->{guest_ipaddr}");
                 $self->record_guest_installation_result('AGAMA_INSTALL_PHASE_DONE');


### PR DESCRIPTION
Change to use $self->{guest_version} to determine guest version as $self->{guest_version} is more acurate than guest_is_sle()

It is the cleaner version of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25872

Related ticket: https://progress.opensuse.org/issues/202920

Verification run:

[virt-bridge-setup-tool-on-host_developing-kvm](https://openqa.suse.de/tests/23037056#step/unified_guest_installation/308)
[uefi-gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23029633#step/unified_guest_installation/308) 
[snapshot-gi-guest_developing-online-on-host_sles16_0-kvm](https://openqa.suse.de/tests/23033234#step/unified_guest_installation/415)
[snapshot-gi-guest_sles16_0-online-on-host_developing-kvm](https://openqa.suse.de/tests/23033235)  
[uefi-gi-guest_sles15sp7-on-host_developing-kvm](https://openqa.suse.de/tests/23048864) 
