### PR TITLE
lklfuse: softfail on bsc#1256466

### DIFF
--- a/tests/kernel/usb_drive.pm
+++ b/tests/kernel/usb_drive.pm
@@ -69,6 +69,10 @@ sub run {
         install_package 'lklfuse';
         assert_script_run "usermod -a -G disk bernhard";
 
+        if (script_run('which fusermount3') != 0) {
+            record_soft_failure "bsc#1256466 - missing dependency for fuse3 in libfuse3";
+            install_package 'fuse3';
+        }
         select_user_serial_terminal;
         $mountpoint = "/home/bernhard/mount";
         $file = "/home/bernhard/file";


### PR DESCRIPTION
Allow to continue running in case we don't have fuse3 package installed as dependency of libfuse3.
In case fusermount3 is missing, record a softfail and install the package.

Allow to run the tests anyway while we wait for the fix to propagate into the product.

- Related ticket: https://progress.opensuse.org/issues/202785
- Verification run: https://openqa.suse.de/tests/23034574
