### PR TITLE
Differentiate TDX kernel check msg for different products

### DIFF
--- a/tests/virt_autotest/tdx_validation.pm
+++ b/tests/virt_autotest/tdx_validation.pm
@@ -122,10 +122,11 @@ sub check_tdx_features {
         }
     }
 
+    my $tdx_init_msg = is_sle('<16.1') ? 'virt/tdx: module initialized' : 'virt/tdx: TDX-Module initialized';
     my %dmesg_tdx_events = (
         'virt/tdx: BIOS enabled: private KeyID range' => 'TDX enabled and KeyIDs partitioned in BIOS',
         'allocated for PAMT' => 'PAMT memory successfully allocated',
-        'virt/tdx: module initialized' => 'TDX kernel module fully initialized'
+        $tdx_init_msg => 'TDX kernel module fully initialized'
     );
 
     # Get dmesg output


### PR DESCRIPTION
The TDX module initialization finish msg has changed for 16.1, so this PR handles that.

- Related ticket: https://progress.opensuse.org/issues/203100
- Verification run: 
  - 16.0 host tdx: https://openqa.suse.de/tests/23037214#
  - 16.1 host: https://openqa.suse.de/tests/23049051