### PR TITLE
containers: Avoid DockerHub rate-limits on docker-buildx & docker-compose upstream tests

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -179,6 +179,11 @@ sub configure_docker {
     }
     run_command qq(echo 'DOCKER_OPTS="$docker_opts"' > /etc/sysconfig/docker);
     record_info "DOCKER_OPTS", $docker_opts;
+    # Configure the default buildkitd config so BuildKit workers that don't receive
+    # an explicit --buildkitd-config (e.g. custom builders in compose e2e tests) also
+    # pull through our mirror instead of hitting docker.io directly.
+    run_command "mkdir -p /etc/buildkit";
+    write_sut_file("/etc/buildkit/buildkitd.toml", qq([registry."docker.io"]\n  mirrors = ["http://$registry"]\n\n[registry."http://$registry"]\n  insecure = true\n));
     run_command "systemctl restart docker";
     run_command "export DOCKER_HOST=tcp://localhost:$port";
     if ($args{tls}) {

--- a/tests/containers/docker_buildx.pm
+++ b/tests/containers/docker_buildx.pm
@@ -17,6 +17,7 @@ use Utils::Architectures;
 use containers::bats;
 
 my $version;
+my $mirror_dir = "/var/tmp/buildkit-registry-mirror";
 
 sub setup {
     my $self = shift;
@@ -38,6 +39,26 @@ sub setup {
     record_info "docker-buildx version", $version;
 
     patch_sources "buildx", $version, "tests";
+
+    # The buildx test framework starts its own local distribution registry as a BuildKit
+    # mirror (via BUILDKIT_REGISTRY_MIRROR_DIR).  By default it generates a plain registry
+    # config (no pull-through), so images not pre-seeded in the mirror fall back to
+    # docker.io directly and hit rate limits.  Pre-seed a config.yaml that makes the
+    # local registry a pull-through proxy backed by our mirror; the framework skips
+    # writing its own config.yaml when one already exists.
+    my $registry = get_var("REGISTRY", "3.126.238.126:5000");
+    run_command "mkdir -p $mirror_dir/data";
+    write_sut_file("$mirror_dir/config.yaml", <<END_YAML);
+version: 0.1
+loglevel: debug
+storage:
+    filesystem:
+        rootdirectory: $mirror_dir/data
+http:
+    addr: 127.0.0.1:0
+proxy:
+    remoteurl: http://$registry
+END_YAML
 }
 
 sub run {
@@ -47,6 +68,7 @@ sub run {
     select_serial_terminal;
 
     my %env = (
+        BUILDKIT_REGISTRY_MIRROR_DIR => $mirror_dir,
         TZ => "UTC",
     );
     my $env = join " ", map { "$_=\"$env{$_}\"" } sort keys %env;


### PR DESCRIPTION
The Docker daemon's `--registry-mirror` option is ignored by BuildKit workers because they manage their own image store independently of dockerd.

For compose e2e tests that create custom buildx builders without an explicit `--buildkitd-config`, write a default buildkitd.toml so those builders inherit the mirror.

For buildx integration tests, the upstream test framework spins up a local distribution registry as a BuildKit mirror but only writes its config.yaml if one doesn't already exist.  Pre-seed BUILDKIT_REGISTRY_MIRROR_DIR with a config.yaml that enables pull-through proxying to our mirror, so the local registry forwards cache misses to our mirror instead of falling back to docker.io and hitting 429 rate limits.

Failed job: https://openqa.opensuse.org/tests/6041053
Verification run: https://openqa.opensuse.org/tests/6043110