### PR TITLE
feat(boottime): Azure boottime data phase1

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -794,7 +794,7 @@ sub check_system_boottime() {
     if ($boottime > $max_boot_time) {
         if (is_azure()) {
             # Unreliable userspace boot time in Azure.
-            record_soft_failure("bsc#1262587 - openQA publiccloud tests have anomalous-high boot-time from systemd-analyze");
+            record_info("bsc#1262587", "Azure test high overall boottime - statistics collection value [sec]: " . $boottime);
         } else {
             # threshold exceeded
             die("System boot time overall $boottime is out of limit $max_boot_time");


### PR DESCRIPTION
Temporary modify the softailure into an harmless record_info on [bsc#1262587](https://bugzilla.suse.com/show_bug.cgi?id=1262587) events of Azure boottime anomalous values, for investigation purposes.

This PR is preparatory to next MR to activate bottime checks in Azure tests. 

- ref.tkt. https://progress.opensuse.org/issues/202686
