### PR TITLE
Support 'dot' in virt guest name

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -290,6 +290,7 @@ sub is_pv_guest {
 #   sles-16-1-64-kvm-hvm-uefi-agama-online-iso,
 #   sles_15_sp7_64_kvm_hvm_uefi-qcow2nvram,
 #   sles16efi_full-sev-es, sles15sp7-efi-sev-es
+#   sles-16dot1-aarch64-kvm-uefi
 #usage: guest_is_sle($guest_name, '<=12-sp2')
 sub guest_is_sle {
     my $guest_name = lc shift;
@@ -298,16 +299,22 @@ sub guest_is_sle {
     return 0 unless $guest_name =~ /sle/;
     return 1 unless $query;
 
+    # Replace "dot" with hyphen (eg. sles-16dot1 -> sles-16-1)
+    $guest_name =~ s/(\d+)dot(\d+)/$1-$2/g;
+
     # Version check
-    $guest_name =~ /sles[-_]*(\d{2})(?:[-_]*(?:sp)?(\d+)|sp(\d+))?/;
-    my $major = $1;
-    my $sp = defined($2) ? $2 : (defined($3) ? $3 : 0);
-    my $version = "${major}.${sp}";
-    $query =~ s/[-_]*sp(\d+)/.$1/gi;
-    if ($query =~ /^\d+(?:\.\d+)?$/) {
-        $query = "=" . $query;
+    if ($guest_name =~ /sles[-_]*(\d{2})(?:[-_]*(?:sp)?(?!(?:64|x86|aarch|efi|kvm)\b)(\d+)|sp(\d+))?/) {
+        my $major = $1;
+        my $sp = defined($2) ? $2 : (defined($3) ? $3 : 0);
+        my $version = "${major}.${sp}";
+        $query =~ s/[-_]*sp(\d+)/.$1/gi;
+        if ($query =~ /^\d+(?:\.\d+)?$/) {
+            $query = "=" . $query;
+        }
+        return check_version($query, $version, qr/\d{2}(?:\.\d+)?/);
     }
-    return check_version($query, $version, qr/\d{2}(?:\.\d+)?/);
+
+    return 0;
 }
 
 


### PR DESCRIPTION
Support this kind of guest name in `guest_is_sle()`:

```
sles-16dot1-aarch64-kvm-uefi-traditional-agama-online-iso
```

- Related ticket: https://progress.opensuse.org/issues/203082
- Verification run: only run a test on OSD because it can be locally verified more easily

[sle-15-SP5-Server-DVD-Incidents-VIRT-Kernel-x86_64-Build:666666:none-qam-kvm-install-and-sriov-test](https://openqa.suse.de/tests/23049333#step/sriov_network_card_pci_passthrough/606) 

local validation results:
```
Testing Guest: sles-16-aarch64-kvm-hvm-uefi-agama-online-iso
Query:        >=16.0
  -> Passing to check_version: query='>=16.0', parsed_version='16.0'
Result:       TRUE (MATCH)
------------------------------------------------------------
Testing Guest: sles-16-0-64-kvm-hvm-uefi-agama-online-iso
Query:        >=15
  -> Passing to check_version: query='>=15', parsed_version='16.0'
Result:       TRUE (MATCH)
------------------------------------------------------------
Testing Guest: sles-16-0-64-kvm-hvm-uefi-agama-online-iso
Query:        >=16.0
  -> Passing to check_version: query='>=16.0', parsed_version='16.0'
Result:       TRUE (MATCH)
------------------------------------------------------------
Testing Guest: sles-16-0-64-kvm-hvm-uefi-agama-online-iso
Query:        <16.1
  -> Passing to check_version: query='<16.1', parsed_version='16.0'
Result:       TRUE (MATCH)
------------------------------------------------------------
Testing Guest: sles-16-0-64-kvm-hvm-uefi-agama-online-iso
Query:        16+
  -> Passing to check_version: query='16+', parsed_version='16.0'
Result:       TRUE (MATCH)
------------------------------------------------------------
Testing Guest: sles-16-0-64-kvm-hvm-uefi-agama-online-iso
Query:        >=16
  -> Passing to check_version: query='>=16', parsed_version='16.0'
Result:       TRUE (MATCH)
------------------------------------------------------------
Testing Guest: sles-16-0-64-kvm-hvm-uefi-agama-online-iso
Query:        <=16
  -> Passing to check_version: query='<=16', parsed_version='16.0'
Result:       FALSE (NO MATCH)
------------------------------------------------------------
Testing Guest: sles-16-1-64-kvm-hvm-uefi-agama-online-iso-qcow2nvram
Query:        =16.1
  -> Passing to check_version: query='=16.1', parsed_version='16.1'
Result:       TRUE (MATCH)
------------------------------------------------------------
Testing Guest: sles-16-1-64-kvm-hvm-uefi-agama-online-iso-qcow2nvram
Query:        <16.1
  -> Passing to check_version: query='<16.1', parsed_version='16.1'
Result:       FALSE (NO MATCH)
------------------------------------------------------------
Testing Guest: sles-16dot1-aarch64-kvm-uefi-traditional-agama-online-iso
Query:        =16.1
  -> Passing to check_version: query='=16.1', parsed_version='16.1'
Result:       TRUE (MATCH)
------------------------------------------------------------
Testing Guest: sles-16-64-kvm-hvm-sev-es-agama-online-iso
Query:        =16.0
  -> Passing to check_version: query='=16.0', parsed_version='16.0'
Result:       TRUE (MATCH)
------------------------------------------------------------
Testing Guest: sles-12-sp5-64-fv-uefi-xen
Query:        =16+
  -> Passing to check_version: query='=16+', parsed_version='12.5'
Result:       FALSE (NO MATCH)
------------------------------------------------------------
Testing Guest: sles_15_sp7_64_kvm_hvm_uefi-qcow2nvram
Query:        =15-sp7
  -> Passing to check_version: query='=15.7', parsed_version='15.7'
Result:       TRUE (MATCH)
------------------------------------------------------------
Testing Guest: sles16efi_full-sev-es
Query:        >=16.0
  -> Passing to check_version: query='>=16.0', parsed_version='16.0'
Result:       TRUE (MATCH)
------------------------------------------------------------
Testing Guest: sles15sp7-efi-sev-es
Query:        15sp7
  -> Passing to check_version: query='=15.7', parsed_version='15.7'
Result:       TRUE (MATCH)
------------------------------------------------------------
Testing Guest: sles15sp7-efi-sev-es
Query:        <=15-SP4
  -> Passing to check_version: query='<=15.4', parsed_version='15.7'
Result:       FALSE (NO MATCH)
------------------------------------------------------------
Testing Guest: sles15sp5
Query:        15-sp3+
  -> Passing to check_version: query='15.3+', parsed_version='15.5'
Result:       TRUE (MATCH)
------------------------------------------------------------
```
