### PR TITLE
xfstests: Add XFSTESTS_DD_CREATE_DISK option to use dd for loop device creation

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -187,9 +187,23 @@ sub create_loop_device_by_rootsize {
     }
     @filename = ('test_dev');
     foreach (1 .. $amount) { push(@filename, "scratch_dev$_"); }
+
+    my $use_dd_create = get_var('XFSTESTS_DD_CREATE_DISK', 0);
+
     my $i = 0;
     foreach (@filename) {
-        assert_script_run("fallocate -l $loop_dev_size[$i++] $INST_DIR/$_", 300);
+        if ($use_dd_create) {
+            # chattr +C must be set on empty file to disable CoW/compression on Btrfs hosts
+            assert_script_run("touch $INST_DIR/$_");
+            script_run("chattr +C $INST_DIR/$_ 2>/dev/null || true");
+            my $size_mb = str_to_mb($loop_dev_size[$i]);
+            record_info('Loop device (dd)', "Creating $_ with dd: $loop_dev_size[$i] ($size_mb MB)");
+            assert_script_run("dd if=/dev/zero of=$INST_DIR/$_ bs=1M count=$size_mb conv=fsync status=progress", 1200);
+        } else {
+            assert_script_run("fallocate -l $loop_dev_size[$i] $INST_DIR/$_", 300);
+        }
+
+        $i++;
         assert_script_run("losetup -fP $INST_DIR/$_", 300);
     }
     script_run("losetup -a");
@@ -225,7 +239,16 @@ sub create_loop_device_by_rootsize {
         my $logdev = "/dev/loop100";
         my $logdev_name = "logdev";
 
-        assert_script_run("fallocate -l 1G $INST_DIR/$logdev_name", 300);
+        if ($use_dd_create) {
+            # chattr +C must be set on empty file to disable CoW/compression on Btrfs hosts
+            assert_script_run("touch $INST_DIR/$logdev_name");
+            script_run("chattr +C $INST_DIR/$logdev_name 2>/dev/null || true");
+            record_info('Loop device (dd)', "Creating logdev with dd: 1G (1024 MB)");
+            assert_script_run("dd if=/dev/zero of=$INST_DIR/$logdev_name bs=1M count=1024 conv=fsync status=progress", 1200);
+        } else {
+            assert_script_run("fallocate -l 1G $INST_DIR/$logdev_name", 300);
+        }
+
         assert_script_run("losetup -P $logdev $INST_DIR/$logdev_name", 300);
         format_partition("$INST_DIR/$logdev_name", $para{fstype});
         script_run("echo export SCRATCH_LOGDEV=$logdev >> $CONFIG_FILE");

--- a/variables.md
+++ b/variables.md
@@ -490,6 +490,7 @@ Variable        | Type      | Default value | Details
 XFSTEST_MKFS_OPTION | string | | BTRFS only, value=<options-in-mkfs>. Set the options in mkfs.btrfs. And also set it in xfstests runtime option BTRFS_MKFS_OPTIONS.
 XFSTESTS_LOGDEV | boolean | 0 | XFS only, value=0/1. enable log device in testing xfs
 XFSTESTS_LOOP_DEVICE | boolean | 0 | Create loop device for testing
+XFSTESTS_DD_CREATE_DISK | boolean | 0 | Use dd with chattr +C (NoCoW) to create loop device files with real physical space. On Btrfs hosts, this prevents: (1) compression of zero blocks making dd ineffective, (2) CoW-induced space explosion when fio writes random data, causing host ENOSPC/crash. chattr +C only affects host storage, not the filesystem inside loop device. Safe for all test types including btrfs. Slower than fallocate but essential for debugging ENOSPC tests like generic/299 on Btrfs hosts
 XFSTESTS_ZONE_DEVICE | boolean | 0 | Create zoned device for testing
 XFSTESTS_XFS_REPAIR | boolean | 0 | XFS only, value=0/1. enable TEST_XFS_REPAIR_REBUILD=1 in xfstests log file local.config
 XFSTESTS_NFS_VERSION | string | 4.1 | NFS only, version of test target NFS. What's special is that set it with TLS-<nfsversion> will enable NFS over kTLS. And set it with krb5[pi]-<nfsversion> will enable NFS with kerberos5 mount option during tests


### PR DESCRIPTION
This adds a new debug option XFSTESTS_DD_CREATE_DISK that allows using dd instead of fallocate to create loop device backing files.

Background:
When using fallocate, sparse files are created which don't occupy real physical space on the host filesystem. If the host filesystem runs out of space during test execution, the loop device will encounter ENOSPC errors when trying to allocate physical blocks. This can cause:
- Block layer 'critical space allocation error' messages
- XFS 'log recovery write I/O error -28' during mount
- Filesystem remounting read-only (EROFS) as self-protection
- Test failures that mask real kernel bugs

Changes:
- Add XFSTESTS_DD_CREATE_DISK environment variable (default: 0)
- Use dd with bs=1M, count=$size_mb when enabled
- Increase timeout to 1200s for dd operations (debug mode only)
- Apply to both test/scratch devices and logdev
- Keep fallocate timeout at 300s (unchanged)
- Applies to all filesystems using loop devices: xfs, btrfs, ext4, overlay
- Close CoW before dd to make sure that btrfs will not compress the dd operation



- Related ticket: https://progress.opensuse.org/issues/192976
- Verification run: https://openqa.suse.de/tests/23049584
