### PR TITLE
Elemental3: fix package installation

### DIFF
--- a/tests/elemental3/generate_image.pm
+++ b/tests/elemental3/generate_image.pm
@@ -283,7 +283,7 @@ sub run {
         "run zypper addrepo --check --refresh ${totest_path}/standard elemental"
     );
     trup_call('--continue run zypper --gpg-auto-import-keys refresh');
-    install_package('elemental3ctl squashfs mtools xorriso', trup_apply => 1);
+    install_package('elemental3ctl squashfs mtools xorriso', trup_apply => 1, trup_continue => 1);
 
     # Use a crypted password
     my $hashpwd = script_output("openssl passwd -6 $rootpwd");


### PR DESCRIPTION
`trup_continue` option was missing in the previous commit.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/23048959#step/generate_image/56
- Verification run: http://10.168.203.102/tests/overview?distri=sle&version=16.0&build=71.88_os-rt-image&groupid=1
