### PR TITLE
Add metadata tool test module for EC2, Azure and GCE

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -48,6 +48,7 @@ sub load_maintenance_publiccloud_tests {
     } elsif (get_var('PUBLIC_CLOUD_LTP')) {
         loadtest 'publiccloud/run_ltp', run_args => $args;
     } elsif (get_var('PUBLIC_CLOUD_FUNCTIONAL')) {
+        loadtest('publiccloud/metadata', run_args => $args);
         loadtest('publiccloud/cloud_netconfig', run_args => $args);
         loadtest('publiccloud/suspending', run_args => $args) if (is_sle('15-SP6+'));
     } elsif (check_var('PUBLIC_CLOUD_AHB', 1)) {
@@ -143,6 +144,7 @@ sub load_latest_publiccloud_tests {
         } else {    # All test cases below require registration
             loadtest("publiccloud/registration", run_args => $args);
             if (get_var('PUBLIC_CLOUD_FUNCTIONAL')) {
+                loadtest('publiccloud/metadata', run_args => $args);
                 loadtest('publiccloud/cloud_netconfig', run_args => $args);
                 loadtest('publiccloud/suspending', run_args => $args) if (is_sle('15-SP6+'));
             } elsif (check_var('PUBLIC_CLOUD_AHB', 1)) {

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -3,7 +3,7 @@
 # Copyright 2019-2024 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Package: python3-ec2metadata iproute2 ca-certificates
+# Package: iproute2 ca-certificates
 # Summary: This is just bunch of random commands overviewing the public cloud instance
 # We just register the system, install random package, see the system and network configuration
 # This test module will fail at the end to prove that the test run will continue without rollback
@@ -24,10 +24,6 @@ sub run {
     assert_script_run("uname -a");
 
     assert_script_run("cat /etc/os-release");
-    if (is_ec2) {
-        script_run("ec2metadata --api latest --document | tee ec2metadata.txt");
-        upload_logs("ec2metadata.txt");
-    }
 
     assert_script_run("ps aux | nl");
 

--- a/tests/publiccloud/metadata.pm
+++ b/tests/publiccloud/metadata.pm
@@ -40,8 +40,9 @@ sub run {
         pc_zypper_call($instance, 'in python3-gcemetadata') unless $instance->ssh_script_run('rpm -q python3-gcemetadata') == 0;
         # Dump all instance metadata
         record_info('gcemetadata instance', $instance->ssh_script_output('gcemetadata --query instance'));
-        # XML output format
-        record_info('gcemetadata instance xml', $instance->ssh_script_output('gcemetadata --query instance --xml'));
+        # XML output format - skipped due to upstream gcemetadata bug: passing --xml with --query
+        # produces exactly 2 opts, triggering UnboundLocalError on 'outfile' in the gcemetadata script
+        record_info('gcemetadata instance xml', 'Skipped - upstream gcemetadata bug with --xml + --query');
         # Disk sub-device query
         record_info('gcemetadata disks', $instance->ssh_script_output('gcemetadata --query instance --disks --diskid 0'));
         # Network interface sub-device query

--- a/tests/publiccloud/metadata.pm
+++ b/tests/publiccloud/metadata.pm
@@ -1,0 +1,58 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: python3-ec2metadata python3-azuremetadata python3-gcemetadata
+# Summary: Test the cloud provider metadata CLI tools:
+#   ec2metadata on AWS, azuremetadata on Azure, gcemetadata on GCE
+#
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use publiccloud::utils qw(is_azure is_ec2 is_gce);
+use publiccloud::zypper qw(pc_zypper_call);
+
+sub run {
+    my ($self, $args) = @_;
+    my $instance = $args->{my_instance};
+
+    if (is_ec2) {
+        pc_zypper_call($instance, 'in python3-ec2metadata') unless $instance->ssh_script_run('rpm -q python3-ec2metadata') == 0;
+        # Dump all available fields
+        record_info('ec2metadata', $instance->ssh_script_output('ec2metadata'));
+        # Instance identity document (signed JSON with instanceId, region, accountId, etc.)
+        record_info('ec2metadata document', $instance->ssh_script_output('ec2metadata --api latest --document'));
+        # Individual fields available on all instance types
+        record_info('ec2metadata fields', $instance->ssh_script_output('ec2metadata --api latest --ami-id --instance-type --local-ipv4 --hostname'));
+    }
+    elsif (is_azure) {
+        pc_zypper_call($instance, 'in python3-azuremetadata') unless $instance->ssh_script_run('rpm -q python3-azuremetadata') == 0;
+        # Dump all available fields as plain text
+        record_info('azuremetadata', $instance->ssh_script_output('/usr/bin/azuremetadata'));
+        # JSON output format
+        record_info('azuremetadata json', $instance->ssh_script_output('/usr/bin/azuremetadata --json'));
+        # List available API versions
+        record_info('azuremetadata listapis', $instance->ssh_script_output('/usr/bin/azuremetadata --listapis'));
+        # Selected fields in XML format; --billingTag reads the disk tag from a block device, which requires root
+        record_info('azuremetadata detail', $instance->ssh_script_output('sudo /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature --xml'));
+    }
+    elsif (is_gce) {
+        pc_zypper_call($instance, 'in python3-gcemetadata') unless $instance->ssh_script_run('rpm -q python3-gcemetadata') == 0;
+        # Dump all instance metadata
+        record_info('gcemetadata instance', $instance->ssh_script_output('gcemetadata --query instance'));
+        # XML output format
+        record_info('gcemetadata instance xml', $instance->ssh_script_output('gcemetadata --query instance --xml'));
+        # Disk sub-device query
+        record_info('gcemetadata disks', $instance->ssh_script_output('gcemetadata --query instance --disks --diskid 0'));
+        # Network interface sub-device query
+        record_info('gcemetadata network', $instance->ssh_script_output('gcemetadata --query instance --network-interfaces --netid 0'));
+        # Dump all project metadata
+        record_info('gcemetadata project', $instance->ssh_script_output('gcemetadata --query project'));
+    }
+}
+
+sub test_flags {
+    return {};
+}
+
+1;

--- a/tests/publiccloud/metadata.pm
+++ b/tests/publiccloud/metadata.pm
@@ -53,7 +53,7 @@ sub run {
 }
 
 sub test_flags {
-    return {};
+    return {fatal => 0};
 }
 
 1;

--- a/tests/publiccloud/registration.pm
+++ b/tests/publiccloud/registration.pm
@@ -50,14 +50,6 @@ sub run {
     }
 }
 
-sub cleanup {
-    my ($self) = @_;
-    if (is_azure()) {
-        record_info('azuremetadata', $self->{run_args}->{my_instance}->ssh_script_output(cmd => "sudo /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature --xml"));
-    }
-    1;
-}
-
 sub test_flags {
     return {fatal => 1};
 }


### PR DESCRIPTION
Adds a new `tests/publiccloud/metadata.pm` test module that exercises the cloud provider metadata CLI tools: `ec2metadata` on AWS, `azuremetadata` on Azure, and `gcemetadata` on GCE. Each tool is installed via `pc_zypper_call` if not already present, and tested with multiple invocations covering plain output, XML/JSON formats, individual fields, and sub-device queries. The new module is scheduled before `cloud_netconfig` when `PUBLIC_CLOUD_FUNCTIONAL=1` in both `load_maintenance_publiccloud_tests` and `load_latest_publiccloud_tests`. The pre-existing `ec2metadata` call in `instance_overview` and the `azuremetadata` call in `registration`'s cleanup hook are removed since this dedicated module now covers them properly.

The `gcemetadata --query instance --xml` subtest is replaced with a `record_info` note due to an upstream bug in the `python3-gcemetadata` package: when exactly 2 opts are parsed, the script's shortcut branch assumes one of them is `--output`, leaving `outfile` unbound and crashing with `UnboundLocalError`. Confirmed on SLE 15-SP5 (x86_64) and SLE 15-SP7 (aarch64).

- Verification runs: [sle-12-SP5-EC2-BYOS-Updates.x86_64](https://pdostal-workbench.qe.prg2.suse.org/tests/795), [sle-15-SP7-Azure-BYOS-Updates.aarch64](https://pdostal-workbench.qe.prg2.suse.org/tests/797), [sle-15-SP4-GCE-BYOS-Updates.x86_64](https://pdostal-workbench.qe.prg2.suse.org/tests/853), [sle-15-SP6-EC2-BYOS-Updates.aarch64](https://pdostal-workbench.qe.prg2.suse.org/tests/830), [sle-15-SP6-GCE-BYOS-Updates.aarch64](https://pdostal-workbench.qe.prg2.suse.org/tests/859)

## Commits

- 0da4a11229 feat(publiccloud): Add metadata tool test module
- 8f35973650 fix(publiccloud/metadata): skip gcemetadata --xml due to upstream bug
- 309ce51385 fix(publiccloud/metadata): set fatal => 0 in test_flags

The commit 8f35973650 is a workaround for SUSE-Enceladus/gcemetadata#8