### PR TITLE
Use string comparison to ensure correct result

### DIFF
--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -286,7 +286,8 @@ sub prepare_ssh_key {
 
     $self->reveal_myself;
     # Use the unified ssh keys, or guests can't be reused by different hosts
-    unless (script_run("[[ -f $_host_params{ssh_key_file}.pub ]]") == 0 and script_output("cat $_host_params{ssh_key_file}.pub", proceed_on_failure => 1) != '') {
+    unless (script_run("[[ -f $_host_params{ssh_key_file}.pub ]]") == 0 and script_output("cat $_host_params{ssh_key_file}.pub", proceed_on_failure => 1) ne '') {
+        record_info("Re-generate non-existent or empty ssh key file $_host_params{ssh_key_file}.pub");
         assert_script_run("ssh-keygen -f $_host_params{ssh_key_file} -q -P \"\" <<<y");
     }
     assert_script_run("chmod 600 $_host_params{ssh_key_file} $_host_params{ssh_key_file}.pub");


### PR DESCRIPTION
* **Switch** to use string comparison ``ne`` for comparing output from subroutine ```script_output``` which really outputs strings. Using arithmetic comparison ```!=``` may deliver unexpected results, for example, non-empty output will be treated as empty like [this one](https://openqa.suse.de/tests/23104307#step/unified_guest_installation/41).

* **Add** ```record_info``` to explicitly display information about overwriting non-existent or empty ssh key file.

* **Verification Runs:**
  * [sle-16.1-Online-x86_64-Build54.1-uefi-gi-full-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23215543)
  * [sle-16.1-Online-x86_64-Build54.1-uefi-gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23215544)
  * [sle-16.1-Base-SelfInstall-pxe-x86_64-Build10.55-gi-guest_slem6dot2-on-host_developing-kvm](https://openqa.suse.de/tests/23215606)
  * [sle-16.1-Online-x86_64-Build54.1-immutable-gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23215597)
  * [An example of re-generating ssh key file](https://openqa.suse.de/tests/23226602#step/unified_guest_installation/41)