### PR TITLE
Enhance 'script_output_retry' to print more user friendly message

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -2154,8 +2154,6 @@ sub script_retry {
 
 Repeat command until expected result or timeout. Return the output of the command on success.
 
-C<$expect> refers to the expected command exit code and defaults to C<0>.
-
 C<$retry> refers to the number of retries and defaults to C<10>.
 
 C<$delay> is the time between retries and defaults to C<30>.
@@ -2186,7 +2184,7 @@ sub script_output_retry {
         my $ret = eval { script_output($exec, timeout => $timeout, proceed_on_failure => 0); };
         return $ret if ($ret);
         sleep $delay;
-        record_info('Retry', 'script_output failed, retrying.');
+        record_info("Retry", "Command:\n$cmd\nfailed, retrying.");
     }
     die($fail_msg) if $die;
 }


### PR DESCRIPTION
https://progress.opensuse.org/issues/202563

1. Show $cmd information when retry
2. Delete un-used args 'expect'


- Verification run: https://openqa.suse.de/tests/23139802
See https://openqa.suse.de/tests/23139802#step/t10_multi_networks_priority/455