### PR TITLE
Improve CloudWatch agent shutdown before EC2 log download

### DIFF
--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -11,6 +11,7 @@ package publiccloud::ec2;
 use Mojo::Base 'publiccloud::provider';
 use Mojo::JSON 'decode_json';
 use testapi;
+use utils qw(random_string);
 use version_utils qw(is_transactional is_sle);
 use Utils::Architectures qw(is_aarch64);
 use publiccloud::utils qw(is_byos pc_data_url);
@@ -304,15 +305,24 @@ sub query_metadata {
 sub _disable_and_stop_ec2_cloudwatch_agent {
     my ($self, $instance) = @_;
 
-    $instance->ssh_assert_script_run("sudo systemctl disable --now amazon-cloudwatch-agent");
-    $instance->retry_ssh_command(
-        cmd => "! sudo systemctl is-active amazon-cloudwatch-agent",
-        timeout => 420,
-        retry => 6,
-        delay => 60
-    );
+    # systemctl is-enabled exits 4 when the unit file does not exist at all.
+    return if $instance->ssh_script_run("sudo systemctl is-enabled amazon-cloudwatch-agent") == 4;
 
-    sleep 3 * 60;    # wait for CloudWatch agent to flush logs
+    if ($instance->ssh_script_run("sudo systemctl is-active amazon-cloudwatch-agent") == 0) {
+        my $instance_id = $instance->instance_id;
+        my $region = $self->provider_client->region;
+        my $token = random_string(6) . '-vamoosed';
+        $instance->ssh_assert_script_run("echo 'openqa-cloudwatch-fence-$token' | sudo tee -a /var/log/dmesg");
+        $instance->ssh_script_retry(
+            "aws logs get-log-events --region '$region' --log-group-name '/ec2/logs/dmesg' " .
+              "--log-stream-name '$instance_id' --no-start-from-head --limit 10 " .
+              "--query 'events[*].message' --output text | grep -q '$token'",
+            retry => 6, delay => 5, timeout => 30
+        );
+        $instance->ssh_script_run("sudo systemctl disable --now amazon-cloudwatch-agent");
+    } else {
+        $instance->ssh_script_run("sudo systemctl disable amazon-cloudwatch-agent");
+    }
 }
 
 sub _fetch_ec2_cloudwatch_log_events {


### PR DESCRIPTION
The previous `_disable_and_stop_ec2_cloudwatch_agent` unconditionally ran `systemctl disable --now` (which fails with exit 1 on images that never had the agent installed) and used a blind 3-minute sleep to wait for log ingestion with no guarantee the data had actually reached CloudWatch. This replaces the sleep with a fence-token mechanism: a unique string is appended to `/var/log/dmesg` and the code polls CloudWatch via `ssh_script_retry` until the token appears in the log stream, confirming all prior events have been ingested. Images without the agent (unit file absent or inactive) are handled gracefully without errors.

- Verification runs: [destroy@ec2_m7g.large aarch64 Build:smelt:45033:dtb-armv7l](https://pdostal-workbench.qe.prg2.suse.org/tests/948), [destroy@64bit x86_64 Build20260625-1](https://pdostal-workbench.qe.prg2.suse.org/tests/949)