### PR TITLE
helm: Remove soft-failure for resolved bsc#1268876

### DIFF
--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -53,12 +53,7 @@ sub run {
         if ($k8s_backend eq "EC2") {
             add_suseconnect_product(get_addon_fullname('pcm')) if is_sle("<16");
             my $aws_cli_pkg = is_sle(">16.0") ? 'aws-cli-cmd' : 'aws-cli';
-            my $rc = zypper_call("in jq $aws_cli_pkg", exitcode => [0, 104], timeout => 300);
-            if ($rc && is_sle(">16.0")) {
-                # https://src.suse.de/products/SLFO/pulls/4071
-                record_soft_failure("ssd#products/SLFO#4071 - New packages: aws-cli-cmd, az-cli-cmd");
-                return;
-            }
+            zypper_call("in jq $aws_cli_pkg", timeout => 300);
 
             # publiccloud::aws_client needs to demand PUBLIC_CLOUD_REGION due to other places where
             # we don't want to have defaults and want tests to fail when region is not defined
@@ -75,12 +70,7 @@ sub run {
             add_suseconnect_product(get_addon_fullname('pcm'), (is_sle('=12-sp5') ? '12' : undef)) if is_sle("<16");
             add_suseconnect_product(get_addon_fullname('phub')) if is_sle('=12-sp5');
             my $az_cli_pkg = is_sle(">16.0") ? 'az-cli-cmd' : 'azure-cli';
-            my $rc = zypper_call("in jq $az_cli_pkg", exitcode => [0, 104], timeout => 300);
-            if ($rc && is_sle(">16.0")) {
-                # https://src.suse.de/products/SLFO/pulls/4071
-                record_soft_failure("ssd#products/SLFO#4071 - New packages: aws-cli-cmd, az-cli-cmd");
-                return;
-            }
+            zypper_call("in jq $az_cli_pkg", timeout => 300);
 
             # publiccloud::azure_client needs to demand PUBLIC_CLOUD_REGION due to other places where
             # we don't want to have defaults and want tests to fail when region is not defined


### PR DESCRIPTION
Remove soft-failure for resolved https://bugzilla.suse.com/show_bug.cgi?id=1268876

Note: ssd#products/SLFO#4071 was the wrong tag for it. 

Related discussion: https://suse.slack.com/archives/C02ACGUEN82/p1782231982593789?thread_ts=1782229487.600789&cid=C02ACGUEN82

Verification runs:
- 16.0: https://openqa.suse.de/tests/23022064
- 16.1: https://openqa.suse.de/tests/23022065 (failing, waiting for next build)