### PR TITLE
blktests: add is_block_device to Kernel::block_dev and verify devices

### DIFF
--- a/lib/Kernel/block_dev.pm
+++ b/lib/Kernel/block_dev.pm
@@ -15,8 +15,27 @@ use warnings;
 use testapi;
 
 our @EXPORT_OK = qw(
+  is_block_device
   record_storage_info
 );
+
+=head2 is_block_device
+
+ is_block_device(@devices);
+
+Asserts that each device in the list exists as a block device. Dies if any
+device is not found, allowing the test to fail if a block device is not detected
+on the SUT.
+
+=cut
+
+sub is_block_device {
+    my (@devices) = @_;
+    for my $dev (@devices) {
+        assert_script_run("test -b $dev",
+            fail_message => "Block device $dev not found");
+    }
+}
 
 =head2 record_storage_info
 

--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -16,7 +16,7 @@ use LTP::WhiteList;
 use LTP::utils 'prepare_whitelist_environment';
 use package_utils 'install_package';
 use Utils::Logging qw(export_logs_basic save_and_upload_log);
-use Kernel::block_dev 'record_storage_info';
+use Kernel::block_dev qw(is_block_device record_storage_info);
 
 sub prepare_blktests_config {
     my ($devices, $test_case_dev_array) = @_;
@@ -64,6 +64,9 @@ sub run {
 
     record_storage_info();
     record_info('blktests cfg', script_output('cat /etc/blktests/config 2>/dev/null || true'));
+    # BLKTESTS_TEST_DEVS may be set to 'none' to let blktests use its own defaults,
+    # so skip the is_block_device check in such case
+    is_block_device(split(/\s+/, $devices)) if $devices ne 'none';
 
     my @tests = split(',', $tests);
     assert_script_run('cd /usr/lib/blktests');


### PR DESCRIPTION
Add is_block_device(@devices) to lib/Kernel/block_dev.pm to assert each device exists as a block device before tests run, failing early with a clear message if a device is missing.

Use it in blktests.pm to verify all BLKTESTS_TEST_DEVS entries exist, preventing silent test skips due to misconfigured NUMDISKS or HDDMODEL. Before this the test is marked as 'PASS' and it might be overlooked that in fact no test is run.

- Related ticket: https://progress.opensuse.org/issues/203073
- Verification run:
  - it should fail due to missing block devices: https://openqa.opensuse.org/tests/6047972
  - it should be ok: https://openqa.opensuse.org/tests/6047973 (clone from the same job)

see: https://progress.opensuse.org/issues/203073#note-10
Without this we would be having the problem like we had in nfs_stress_ng test module - happy green bubble doing nothing.
See: https://openqa.opensuse.org/tests/6046336
https://openqa.opensuse.org/tests/6046336#step/blktests/111