### PR TITLE
Fix agama storage failure by slight format change and udevadm settle

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
+++ b/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
@@ -30,11 +30,11 @@ local agama_product_mode = if transactional == '1' then 'immutable' else 'standa
             size: '120 GiB'
           },
           {
-            filesystem: { path: '/var/lib/libvirt/images/', type: 'xfs' }
-          },
-          {
             filesystem: { path: 'swap' },
             size: '4 GiB'
+          },
+          {
+            filesystem: { path: '/var/lib/libvirt/images', type: 'xfs' }
           }
         ]
       }
@@ -62,9 +62,14 @@ local agama_product_mode = if transactional == '1' then 'immutable' else 'standa
           #!/usr/bin/env bash
           for i in `lsblk -n -l -o NAME -d -e 7,11,254`
               do wipefs -af /dev/$i
-              sleep 1
-              sync
+              # The following 4 lines work around Agama race condition on NVMe devices.
+              # See bsc#1269730 and PR#25926
+              partprobe /dev/$i 2>/dev/null
+              blockdev --rereadpt /dev/$i 2>/dev/null
           done
+          udevadm settle --timeout=30
+          sync
+          sleep 2
         |||
       }
     ],


### PR DESCRIPTION

Related ticket: https://progress.opensuse.org/issues/203091

to fix the host installation failure: eg. https://openqa.suse.de/tests/23104736
```
Jun 28 17:24:30 <6> sshd-session[6865]: pam_unix(sshd:session): session opened for user root(uid=0) by root(uid=0)
Jun 28 17:24:30 <6> bash[6850]:    0 |  Pre-Init  |0000000000| OS Boot | Installation started () | Asserted
Jun 28 17:24:31 <6> bash[7004]: Received a response with unexpected ID 0 vs. 131
Jun 28 17:24:31 <6> bash[7004]:    0 |  Pre-Init  |0000000000| OS Boot | Installation failed () | Asserted
Jun 28 17:24:31 <3> agama-web-server[4008]: agama-manager/src/service.rs:902: Installation failed: It is not possible to install the system because there are some pending issues: {Storage: [Issue { class: "proposal", description: "Cannot calculate a valid storage setup with the current configuration", details: None }]}.
Jun 28 17:24:31 <5> agama-web-server[4008]: agama-server/src/web/service.rs:140: response for 1924145348610: 500 Internal Server Error 1.376687617s
Jun 28 17:24:31 <3> agama-web-server[4008]: /home/abuild/rpmbuild/BUILD/agama-22+118.d762c9b0a-build/agama/vendor/tower-http-0.6.8/src/trace/on_failure.rs:93: response failed
Jun 28 17:24:31 <5> agama-web-server[4008]: agama-server/src/web/service.rs:140: response for 6757048708497420: 200 OK 1.339088279s
Jun 28 17:24:31 <6> agama-web-server[4008]: /home/abuild/rpmbuild/BUILD/agama-22+118.d762c9b0a-build/agama/vendor/tower-http-0.6.8/src/trace/on_eos.rs:105: end of stream
Jun 28 17:24:31 <6> agama-autoinstall[5987]: Error: Error:
Jun 28 17:24:31 <6> agama-autoinstall[5987]: Internal server error
Jun 28 17:24:31 <6> agama-autoinstall[5987]: Details:
Jun 28 17:24:31 <6> agama-autoinstall[5987]: It is not possible to install the system because there are some pending issues: {Storage: [Issue { class: "proposal", description: "Cannot calculate a valid storage setup with the current configuration", details: None }]}.
Jun 28 17:24:31 <5> systemd[1]: src/core/unit.c(unit_log_process_exit):6114: agama-autoinstall.service: Main process exited, code=exited, status=1/FAILURE
Jun 28 17:24:31 <4> systemd[1]: src/core/unit.c(unit_log_failure):6072: agama-autoinstall.service: Failed with result 'exit-code'.
```

The storage failure did not happen at all times. Based on the latest 2 builds(the data is not enough), It happened at a approximately 15% frequency on some of the machines with NVMe disks(pegasus and galactica only). It is likely a race condition, sometimes agama handles harddisk before they are completely ready.

udevadm settle --timeout=30 is the key of the change, to make sure udev is settled before agama installation.

Filed [bug#1269730](https://bugzilla.suse.com/show_bug.cgi?id=1269730) on this failure. The PR will work as a workaround instead of a fix. This piece of information has been updated to the changes.

Verification run:  

9 tests on baremetal machines with NVME disks: 
https://openqa.suse.de/tests/23115216    //`kaylee`
https://openqa.suse.de/tests/23115221    https://openqa.suse.de/tests/23116917    //`river`
https://openqa.suse.de/tests/23115913    https://openqa.suse.de/tests/23116876    //`pagasus`
https://openqa.suse.de/tests/23115916     https://openqa.suse.de/tests/23116878   //`galactica`
https://openqa.suse.de/tests/23116902   //`bare-metal1`
https://openqa.suse.de/tests/23116010   //`bare-metal2`


1 test on a machine without nvme disks:
https://openqa.suse.de/tests/23115218
