### PR TITLE
Add unit tests for lib/publiccloud modules

### DIFF
--- a/t/13_publiccloud.t
+++ b/t/13_publiccloud.t
@@ -1,30 +1,22 @@
 use strict;
 use warnings;
 
-# Controllable fake clock for do_systemd_analyze_time tests (poo#203817).
-# CORE::sleep/time are resolved at compile time inside the module under test, so
-# they must be overridden via CORE::GLOBAL in a BEGIN block *before* that module
-# is compiled. $FakeClock::enabled gates the override so all other tests keep
-# using the real clock.
-package FakeClock;
-our $enabled = 0;
-our $now = 0;
-BEGIN {
-    *CORE::GLOBAL::time = sub { $enabled ? $now : CORE::time() };
-    *CORE::GLOBAL::sleep = sub { $enabled ? ($now += ($_[0] // 0)) : CORE::sleep($_[0] // 0) };
-}
+# Deterministic fake clock: sleep() advances mocked time() instead of spending
+# real wall-clock seconds, so state-polling loops (e.g. stop_instance) and the
+# do_systemd_analyze_time boot-time race tests (poo#203817) run fast and
+# deterministically. Must be loaded before the modules under test are compiled.
+use Test::Mock::Time;
 
-package main;
 use Test::More;
 use Test::MockObject;
 use Test::Exception;
 use Test::Warnings;
 use Test::MockModule;
+use List::Util qw(any);
 use testapi 'set_var';
 
 use publiccloud::azure;
 use publiccloud::instance;
-use publiccloud::utils;
 use publiccloud::zypper qw(pc_wait_quit pc_pkg_call);
 
 sub _unset { for my $k (@_) { set_var($k, undef) } }
@@ -367,122 +359,6 @@ subtest '[pc_wait_quit] times out after 5 failures' => sub {
     is($seen{timeout}, 1, 'timeout=1 passed');
 };
 
-subtest '[is_byos] via set_var' => sub {
-    set_var('PUBLIC_CLOUD', 1);
-
-    set_var('FLAVOR', 'SLES-15-SP6-BYOS');
-    ok publiccloud::utils::is_byos(), 'BYOS detected (upper)';
-
-    set_var('FLAVOR', 'sles-something-byos');
-    ok publiccloud::utils::is_byos(), 'BYOS detected (lower, /byos/i)';
-
-    set_var('FLAVOR', 'SLES-15-SP6-On-Demand');
-    ok !publiccloud::utils::is_byos(), 'not BYOS when FLAVOR lacks token';
-
-    set_var('PUBLIC_CLOUD', 0);
-    ok !publiccloud::utils::is_byos(), 'not BYOS outside public cloud';
-
-    _unset(qw/PUBLIC_CLOUD FLAVOR/);
-};
-
-subtest '[is_ondemand] via set_var' => sub {
-    set_var('PUBLIC_CLOUD', 1);
-
-    set_var('FLAVOR', 'On-Demand-ish');
-    ok publiccloud::utils::is_ondemand(), 'on-demand when not BYOS';
-
-    set_var('FLAVOR', 'BYOS');
-    ok !publiccloud::utils::is_ondemand(), 'not on-demand when BYOS';
-
-    set_var('PUBLIC_CLOUD', 0);
-    ok !publiccloud::utils::is_ondemand(), 'not on-demand outside public cloud';
-
-    _unset(qw/PUBLIC_CLOUD FLAVOR/);
-};
-
-subtest '[provider checks] via set_var' => sub {
-    set_var('PUBLIC_CLOUD', 1);
-
-    set_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
-    ok publiccloud::utils::is_ec2(), 'EC2 true';
-    ok !publiccloud::utils::is_azure(), 'AZURE false';
-    ok !publiccloud::utils::is_gce(), 'GCE false';
-
-    set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
-    ok publiccloud::utils::is_azure(), 'AZURE true';
-    ok !publiccloud::utils::is_ec2(), 'EC2 false';
-    ok !publiccloud::utils::is_gce(), 'GCE false';
-
-    set_var('PUBLIC_CLOUD_PROVIDER', 'GCE');
-    ok publiccloud::utils::is_gce(), 'GCE true';
-    ok !publiccloud::utils::is_ec2(), 'EC2 false';
-    ok !publiccloud::utils::is_azure(), 'AZURE false';
-
-    set_var('PUBLIC_CLOUD', 0);
-    ok !publiccloud::utils::is_ec2(), 'EC2 false when not public cloud';
-    ok !publiccloud::utils::is_azure(), 'AZURE false when not public cloud';
-    ok !publiccloud::utils::is_gce(), 'GCE false when not public cloud';
-
-    _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER/);
-};
-
-subtest '[flavor flags] CHOST & Hardened via set_var' => sub {
-    set_var('PUBLIC_CLOUD', 1);
-
-    set_var('FLAVOR', 'SLE-CHOST-15-SP6');
-    ok publiccloud::utils::is_container_host(), 'CHOST detected';
-
-    set_var('FLAVOR', 'SLE-Hardened-15-SP6');
-    ok publiccloud::utils::is_hardened(), 'Hardened detected';
-
-    set_var('FLAVOR', 'SLE-Whatever');
-    ok !publiccloud::utils::is_container_host(), 'CHOST not detected';
-    ok !publiccloud::utils::is_hardened(), 'Hardened not detected';
-
-    set_var('PUBLIC_CLOUD', 0);
-    set_var('FLAVOR', 'SLE-CHOST-15-SP6');
-    ok !publiccloud::utils::is_container_host(), 'CHOST requires public cloud';
-    set_var('FLAVOR', 'SLE-Hardened-15-SP6');
-    ok !publiccloud::utils::is_hardened(), 'Hardened requires public cloud';
-
-    _unset(qw/PUBLIC_CLOUD FLAVOR/);
-};
-
-
-subtest '[is_cloudinit_supported] via set_var only' => sub {
-    set_var('PUBLIC_CLOUD', 1);
-    set_var('DISTRI', 'sle');
-
-    set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
-    ok publiccloud::utils::is_cloudinit_supported(),
-      'AZURE + sle => supported';
-
-    set_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
-    ok publiccloud::utils::is_cloudinit_supported(),
-      'EC2 + sle => supported';
-
-    set_var('PUBLIC_CLOUD_PROVIDER', 'GCE');
-    ok !publiccloud::utils::is_cloudinit_supported(),
-      'GCE + sle => not supported';
-
-    set_var('DISTRI', 'sle-micro');
-
-    set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
-    ok !publiccloud::utils::is_cloudinit_supported(),
-      'AZURE + sle-micro => NOT supported';
-
-    set_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
-    ok !publiccloud::utils::is_cloudinit_supported(),
-      'EC2 + sle-micro => NOT supported';
-
-    set_var('PUBLIC_CLOUD', 0);
-    set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
-    ok !publiccloud::utils::is_cloudinit_supported(),
-      'not public cloud => NOT supported';
-
-    _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER DISTRI/);
-};
-
 # --- pc_pkg_call -> transactional-update translation ---------------------------
 #
 # These assert that zypper *command* options stay attached to the verb and are
@@ -603,10 +479,10 @@ sub _run_systemd_analyze {
     my $blame_output = delete $args{blame_output}
       // "10.000s some.service\n5.000s other.service";
 
-    # Fake, monotonic clock advanced by mocked sleep so the loop's
-    # `time() - $start_time < $timeout` guard is deterministic and fast.
-    local $FakeClock::now = 0;
-    local $FakeClock::enabled = 1;
+    # Test::Mock::Time advances mocked time() by each sleep() the routine does,
+    # so the loop's `time() - $start_time < $timeout` guard is deterministic and
+    # fast. Capture the fake start time to report elapsed time back to callers.
+    my $clock_start = time();
 
     my @time_seq = @$time_outputs;
     my @time_cmds;
@@ -624,7 +500,7 @@ sub _run_systemd_analyze {
     $mocked->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
     my @ret = $inst->do_systemd_analyze_time(%args);
-    return {ret => \@ret, time_calls => scalar(@time_cmds), final_time => $FakeClock::now};
+    return {ret => \@ret, time_calls => scalar(@time_cmds), final_time => time() - $clock_start};
 }
 
 subtest '[do_systemd_analyze_time] early success returns parsed times' => sub {
@@ -705,6 +581,168 @@ subtest '[do_systemd_analyze_time] SSH login banner does not break parsing' => s
     ok ref($blame) eq 'HASH', 'blame parsed despite banner';
     cmp_ok $blame->{'some.device'}, '==', 14.852, 'blame entry parsed, banner skipped';
     ok !exists $blame->{'reported.'}, 'banner text not mistaken for a blame entry';
+};
+
+# --- publiccloud::azure pure functions ----------------------------------------
+
+subtest '[decode_azure_json] strips color codes and decodes' => sub {
+    my $colored = "\e[32m{\"name\": \"foo\", \"n\": 7}\e[0m";
+    my $obj = publiccloud::azure::decode_azure_json($colored);
+    is(ref $obj, 'HASH', 'returns decoded hashref');
+    is($obj->{name}, 'foo', 'string value decoded after colorstrip');
+    is($obj->{n}, 7, 'numeric value decoded');
+};
+
+subtest '[parse_instance_id] azure resource id parsing' => sub {
+    my $provider = publiccloud::azure->new();
+
+    my $id = '/subscriptions/SUB-123/resourceGroups/RG-456/providers/Microsoft.Compute/virtualMachines/my-vm';
+    my $inst = Test::MockObject->new;
+    $inst->mock(instance_id => sub { $id });
+    my $res = $provider->parse_instance_id($inst);
+    is($res->{subscription}, 'SUB-123', 'subscription parsed');
+    is($res->{resource_group}, 'RG-456', 'resource_group parsed');
+    is($res->{vm_name}, 'my-vm', 'vm_name parsed');
+
+    my $bad = Test::MockObject->new;
+    $bad->mock(instance_id => sub { 'i-0123456789abcdef0' });
+    is($provider->parse_instance_id($bad), undef, 'non-azure id returns undef');
+};
+
+subtest '[generate_image_tags] tag composition' => sub {
+    my $azure = Test::MockModule->new('publiccloud::azure', no_auto => 1);
+    $azure->redefine(get_current_job_id => sub { 4242 });
+    set_var('OPENQA_URL', 'https://openqa.example.com/');
+    set_var('PUBLIC_CLOUD_KEEP_IMG', undef);
+
+    my $tags = publiccloud::azure::generate_image_tags();
+    like($tags, qr{openqa_created_by=openqa\.example\.com/t4242}, 'created_by tag composed and url trimmed');
+    like($tags, qr{openqa_var_job_id=4242}, 'job id tag present');
+    unlike($tags, qr{pcw_ignore}, 'no pcw_ignore tag without KEEP_IMG');
+
+    set_var('PUBLIC_CLOUD_KEEP_IMG', '1');
+    my $tags2 = publiccloud::azure::generate_image_tags();
+    like($tags2, qr{pcw_ignore=1}, 'pcw_ignore tag added when KEEP_IMG=1');
+
+    _unset(qw/OPENQA_URL OPENQA_HOSTNAME PUBLIC_CLOUD_KEEP_IMG/);
+};
+
+subtest '[get_image_definition] finds matching definition' => sub {
+    my $provider = publiccloud::azure->new();
+    my $azure = Test::MockModule->new('publiccloud::azure', no_auto => 1);
+    $azure->redefine(generate_azure_image_definition => sub { 'MY-DEF' });
+    $azure->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    $azure->redefine(script_output => sub { '[{"name":"OTHER"},{"name":"MY-DEF"}]' });
+    is($provider->get_image_definition('rg', 'gal'), 'MY-DEF', 'returns matching definition name');
+
+    $azure->redefine(script_output => sub { '[{"name":"OTHER"}]' });
+    is($provider->get_image_definition('rg', 'gal'), undef, 'undef when no match');
+
+    $azure->redefine(script_output => sub { '' });
+    is($provider->get_image_definition('rg', 'gal'), undef, 'undef on empty output');
+};
+
+# --- publiccloud::azure mockable instance methods -----------------------------
+
+subtest '[get_state_from_instance] parses PowerState' => sub {
+    my $provider = publiccloud::azure->new();
+    my $azure = Test::MockModule->new('publiccloud::azure', no_auto => 1);
+    $azure->redefine(script_output => sub { '{"code":"PowerState/running","displayStatus":"VM running"}' });
+
+    my $inst = Test::MockObject->new;
+    $inst->mock(instance_id => sub { '/subscriptions/x/resourceGroups/y/providers/Microsoft.Compute/virtualMachines/z' });
+    is($provider->get_state_from_instance($inst), 'running', 'extracts state after PowerState/');
+
+    $azure->redefine(script_output => sub { '{"code":"ProvisioningState/succeeded"}' });
+    throws_ok { $provider->get_state_from_instance($inst) }
+    qr/Expect PowerState/, 'dies when not a PowerState code';
+};
+
+subtest '[query_metadata] returns metadata server data' => sub {
+    my $provider = publiccloud::azure->new();
+    my $inst = Test::MockObject->new;
+    my @calls;
+    $inst->mock(ssh_script_output => sub { my ($s, $c) = @_; push @calls, $c; return '10.1.2.3' });
+
+    my $data = $provider->query_metadata($inst, ifNum => 0, addrCount => 0);
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    is($data, '10.1.2.3', 'returns metadata payload');
+    ok((any { /169\.254\.169\.254/ } @calls), 'queries the cloud metadata IP');
+    ok((any { m{network/interface/0/ipv4/ipAddress/0/privateIpAddress} } @calls), 'composes metadata path');
+
+    $inst->mock(ssh_script_output => sub { '' });
+    throws_ok { $provider->query_metadata($inst, ifNum => 0, addrCount => 0) }
+    qr/Failed to get interface IPs/, 'dies on empty metadata response';
+};
+
+subtest '[start_instance] starts a stopped instance' => sub {
+    my $provider = publiccloud::azure->new();
+    my $azure = Test::MockModule->new('publiccloud::azure', no_auto => 1);
+    my @asr;
+    $azure->redefine(assert_script_run => sub { push @asr, $_[0]; return 0 });
+    $azure->redefine(get_state_from_instance => sub { 'stopped' });
+    $azure->redefine(get_public_ip => sub { '203.0.113.9' });
+
+    my $newip;
+    my $inst = Test::MockObject->new;
+    $inst->mock(instance_id => sub { 'vm-id' });
+    $inst->mock(resource_group => sub { 'rg' });
+    $inst->mock(public_ip => sub { $newip = $_[1] if @_ > 1; return $newip });
+
+    $provider->start_instance($inst);
+    note("\n  -->  " . join("\n  -->  ", @asr));
+    ok((any { /az vm start --ids 'vm-id'/ } @asr), 'issues az vm start');
+    is($newip, '203.0.113.9', 'updates instance public_ip after start');
+
+    $azure->redefine(get_state_from_instance => sub { 'running' });
+    throws_ok { $provider->start_instance($inst) }
+    qr/start a running instance/, 'refuses to start a running instance';
+};
+
+subtest '[stop_instance] stops a running instance' => sub {
+    my $provider = publiccloud::azure->new();
+    my $azure = Test::MockModule->new('publiccloud::azure', no_auto => 1);
+    my @asr;
+    $azure->redefine(assert_script_run => sub { push @asr, $_[0]; return 0 });
+    $azure->redefine(get_public_ip => sub { '203.0.113.9' });
+    # first call: running, second: stopped (loop exits)
+    my @states = ('running', 'stopped');
+    $azure->redefine(get_state_from_instance => sub { shift @states // 'stopped' });
+
+    my $inst = Test::MockObject->new;
+    $inst->mock(instance_id => sub { 'vm-id' });
+    $inst->mock(resource_group => sub { 'rg' });
+    $inst->mock(public_ip => sub { '203.0.113.9' });
+
+    $provider->stop_instance($inst);
+    note("\n  -->  " . join("\n  -->  ", @asr));
+    ok((any { /az vm stop --ids 'vm-id'/ } @asr), 'issues az vm stop');
+};
+
+subtest '[stop_instance] dies on outdated instance object' => sub {
+    my $provider = publiccloud::azure->new();
+    my $azure = Test::MockModule->new('publiccloud::azure', no_auto => 1);
+    $azure->redefine(get_public_ip => sub { '203.0.113.9' });
+
+    my $inst = Test::MockObject->new;
+    $inst->mock(instance_id => sub { 'vm-id' });
+    $inst->mock(resource_group => sub { 'rg' });
+    $inst->mock(public_ip => sub { '198.51.100.1' });    # mismatch
+
+    throws_ok { $provider->stop_instance($inst) }
+    qr/Outdated instance object/, 'dies when cached IP differs from live IP';
+};
+
+subtest '[resource_group_exist] boolean from az output' => sub {
+    my $provider = publiccloud::azure->new();
+    my $azure = Test::MockModule->new('publiccloud::azure', no_auto => 1);
+
+    $azure->redefine(script_output_retry => sub { '{"name":"openqa-upload"}' });
+    is($provider->resource_group_exist(), 1, 'non-empty output => exists');
+
+    $azure->redefine(script_output_retry => sub { '[]' });
+    is($provider->resource_group_exist(), 0, 'empty array output => not exists');
 };
 
 done_testing;

--- a/t/43_publiccloud_zypper.t
+++ b/t/43_publiccloud_zypper.t
@@ -1,0 +1,291 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Unit tests for publiccloud::zypper -- verb classification,
+# zypper->transactional-update translation, argument normalization and the
+# public package-management API (with the remote SSH layer mocked out).
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockObject;
+use Test::MockModule;
+use Test::Exception;
+use Test::Warnings;
+use testapi 'set_var';
+
+use publiccloud::zypper qw(
+  pc_zypper_call
+  pc_transactional_call
+  pc_pkg_call
+  pc_refresh
+  pc_add_repo
+  pc_installed_packages
+  pc_available_packages
+  pc_install_packages_local
+);
+
+# ---------------------------------------------------------------------------
+# Pure helpers: _shell_quote
+# ---------------------------------------------------------------------------
+subtest '[_shell_quote] wraps and escapes' => sub {
+    is(publiccloud::zypper::_shell_quote('abc'), q{'abc'}, 'simple string wrapped in single quotes');
+    is(publiccloud::zypper::_shell_quote(q{a'b}), q{'a'\''b'}, "embedded single quote escaped");
+    is(publiccloud::zypper::_shell_quote(''), q{''}, 'empty string yields empty quotes');
+};
+
+# ---------------------------------------------------------------------------
+# Pure helpers: _verb_of
+# ---------------------------------------------------------------------------
+subtest '[_verb_of] strips leading options' => sub {
+    is(publiccloud::zypper::_verb_of('in curl'), 'in', 'plain verb');
+    is(publiccloud::zypper::_verb_of('-n in curl'), 'in', 'leading global option skipped');
+    is(publiccloud::zypper::_verb_of('--no-selfupdate -n up'), 'up', 'multiple leading options skipped');
+    is(publiccloud::zypper::_verb_of('--gpg-auto-import-keys ref'), 'ref', 'option before ref');
+};
+
+# ---------------------------------------------------------------------------
+# Pure helpers: _is_translatable_to_transactional
+# ---------------------------------------------------------------------------
+subtest '[_is_translatable_to_transactional] verb allow-list' => sub {
+    ok publiccloud::zypper::_is_translatable_to_transactional('in curl'), 'install is translatable';
+    ok publiccloud::zypper::_is_translatable_to_transactional('rm pkg'), 'remove is translatable';
+    ok publiccloud::zypper::_is_translatable_to_transactional('up'), 'up is translatable';
+    ok publiccloud::zypper::_is_translatable_to_transactional('dup'), 'dup is translatable';
+    ok publiccloud::zypper::_is_translatable_to_transactional('patch'), 'patch is translatable';
+    ok !publiccloud::zypper::_is_translatable_to_transactional('ref'), 'refresh is NOT translatable';
+    ok !publiccloud::zypper::_is_translatable_to_transactional('info foo'), 'info is NOT translatable';
+    ok !publiccloud::zypper::_is_translatable_to_transactional('addrepo x y'), 'addrepo is NOT translatable';
+};
+
+# ---------------------------------------------------------------------------
+# Pure helpers: _zypper_to_transactional
+# ---------------------------------------------------------------------------
+subtest '[_zypper_to_transactional] verb + option routing' => sub {
+    is(publiccloud::zypper::_zypper_to_transactional('in curl'),
+        'pkg install curl', 'install maps to pkg install');
+    is(publiccloud::zypper::_zypper_to_transactional('rm oldpkg'),
+        'pkg remove oldpkg', 'rm maps to pkg remove');
+    is(publiccloud::zypper::_zypper_to_transactional('up'),
+        'up', 'bare up stays top-level');
+    is(publiccloud::zypper::_zypper_to_transactional('up somepkg'),
+        'pkg update somepkg', 'up with args maps to pkg update');
+    is(publiccloud::zypper::_zypper_to_transactional('dup'),
+        'dup', 'bare dup stays top-level');
+    is(publiccloud::zypper::_zypper_to_transactional('patch'),
+        'patch', 'bare patch stays top-level');
+
+    # command options stay with the verb, only TU global options are hoisted
+    is(publiccloud::zypper::_zypper_to_transactional('in -y docker'),
+        'pkg install -y docker', 'command flag -y stays after verb');
+    is(publiccloud::zypper::_zypper_to_transactional('-n in curl'),
+        '-n pkg install curl', 'recognised global -n hoisted before pkg');
+    is(publiccloud::zypper::_zypper_to_transactional('--no-recommends in foo'),
+        'pkg install --no-recommends foo', 'unrecognised leading flag carried with verb args');
+};
+
+subtest '[_zypper_to_transactional] unsupported verbs die' => sub {
+    throws_ok { publiccloud::zypper::_zypper_to_transactional('ref') }
+    qr/not supported by transactional-update/, 'refresh cannot be translated';
+    throws_ok { publiccloud::zypper::_zypper_to_transactional('dup somepkg') }
+    qr/does not support 'dup' with package arguments/, 'dup with pkgs dies';
+};
+
+# ---------------------------------------------------------------------------
+# Pure helpers: _normalize_call_args
+# ---------------------------------------------------------------------------
+subtest '[_normalize_call_args] positional and named forms' => sub {
+    my $inst = Test::MockObject->new;
+
+    my ($i, $cmd, %opts) = publiccloud::zypper::_normalize_call_args($inst, 'in curl', retry => 3);
+    is($cmd, 'in curl', 'positional cmd extracted');
+    is($opts{retry}, 3, 'options preserved with positional cmd');
+
+    ($i, $cmd, %opts) = publiccloud::zypper::_normalize_call_args($inst, cmd => 'up', timeout => 99);
+    is($cmd, 'up', 'named cmd extracted');
+    is($opts{timeout}, 99, 'options preserved with named cmd');
+
+    ($i, $cmd, %opts) = publiccloud::zypper::_normalize_call_args($inst, retry => 1, delay => 2);
+    is($cmd, undef, 'no cmd when only option pairs given');
+};
+
+# ---------------------------------------------------------------------------
+# Pure helpers: _validate_args
+# ---------------------------------------------------------------------------
+subtest '[_validate_args] guards' => sub {
+    lives_ok { publiccloud::zypper::_validate_args('in curl', {}) } 'valid cmd passes';
+    throws_ok { publiccloud::zypper::_validate_args(undef, {}) }
+    qr/Empty 'cmd' argument/, 'undef cmd dies';
+    throws_ok { publiccloud::zypper::_validate_args('', {}) }
+    qr/Empty 'cmd' argument/, 'empty cmd dies';
+    throws_ok { publiccloud::zypper::_validate_args('up', {timeout => 0}) }
+    qr/Invalid value 'timeout' = 0/, 'timeout 0 dies';
+    throws_ok { publiccloud::zypper::_validate_args('lr | grep foo', {}) }
+    qr/Exit code is from PIPESTATUS/, 'pipe to grep dies';
+    lives_ok { publiccloud::zypper::_validate_args(q{`cmd` | grep foo}, {}) }
+    'backtick before grep is allowed';
+};
+
+# ---------------------------------------------------------------------------
+# Public API (SSH layer mocked)
+# ---------------------------------------------------------------------------
+
+# Build an instance mock that records the commands dispatched via the various
+# ssh_* entry points.
+sub _instance_mock {
+    my (%behaviour) = @_;
+    my $inst = Test::MockObject->new;
+    $inst->{calls} = [];
+    $inst->mock(ssh_script_retry => sub { my ($s, %a) = @_; push @{$s->{calls}}, {m => 'retry', %a}; return 0 });
+    $inst->mock(ssh_assert_script_run => sub { my ($s, %a) = @_; push @{$s->{calls}}, {m => 'assert', %a}; return 0 });
+    $inst->mock(ssh_script_run => sub {
+            my ($s, %a) = @_;
+            push @{$s->{calls}}, {m => 'run', %a};
+            return $behaviour{run_rc} // 0;
+    });
+    $inst->mock(ssh_script_output => sub {
+            my ($s, %a) = @_;
+            push @{$s->{calls}}, {m => 'output', %a};
+            return $behaviour{output} // '';
+    });
+    $inst->mock(softreboot => sub { push @{$_[0]->{calls}}, {m => 'softreboot'}; return });
+    return $inst;
+}
+
+subtest '[pc_zypper_call] prefixes sudo zypper -n' => sub {
+    my $mod = Test::MockModule->new('publiccloud::zypper');
+    my $captured;
+    $mod->redefine(_run => sub { my ($inst, $full, %o) = @_; $captured = $full; return 0 });
+    my $inst = _instance_mock();
+    pc_zypper_call($inst, 'ref');
+    is($captured, 'sudo zypper -n ref', 'command wrapped with sudo zypper -n');
+};
+
+subtest '[pc_refresh] always plain zypper with gpg auto import' => sub {
+    my $mod = Test::MockModule->new('publiccloud::zypper');
+    my ($cmd, %opts_seen);
+    $mod->redefine(pc_zypper_call => sub { my ($inst, $c, %o) = @_; $cmd = $c; %opts_seen = %o; return 0 });
+    my $inst = _instance_mock();
+    pc_refresh($inst);
+    is($cmd, '--gpg-auto-import-keys ref', 'refresh uses gpg-auto-import-keys ref');
+    is($opts_seen{retry}, 3, 'default retry=3');
+    is($opts_seen{delay}, 60, 'default delay=60');
+    is($opts_seen{timeout}, 90, 'default timeout=90');
+};
+
+subtest '[pc_add_repo] uses ssh_assert_script_run' => sub {
+    my $inst = _instance_mock();
+    pc_add_repo($inst, 'myrepo', 'http://example.com/repo', timeout => 123);
+    my ($call) = grep { $_->{m} eq 'assert' } @{$inst->{calls}};
+    ok($call, 'ssh_assert_script_run invoked');
+    is($call->{cmd}, 'sudo zypper -n addrepo -fG http://example.com/repo myrepo', 'addrepo command composed');
+    is($call->{timeout}, 123, 'timeout forwarded');
+};
+
+subtest '[pc_pkg_call] routing transactional vs plain' => sub {
+    my $mod = Test::MockModule->new('publiccloud::zypper');
+    my %seen;
+    $mod->redefine(pc_transactional_call => sub { my ($i, $c, %o) = @_; $seen{transactional} = $c; return 0 });
+    $mod->redefine(pc_zypper_call => sub { my ($i, $c, %o) = @_; $seen{zypper} = $c; return 0 });
+    my $inst = _instance_mock();
+
+    # transactional + translatable verb -> transactional path
+    %seen = ();
+    $mod->redefine(is_transactional => sub { 1 });
+    pc_pkg_call($inst, 'in -y docker');
+    is($seen{transactional}, 'pkg install -y docker', 'translatable verb routed to transactional-update');
+    ok(!defined $seen{zypper}, 'plain zypper not used');
+
+    # transactional + non-translatable verb -> plain zypper
+    %seen = ();
+    pc_pkg_call($inst, 'info foo');
+    is($seen{zypper}, 'info foo', 'non-translatable verb falls through to plain zypper');
+    ok(!defined $seen{transactional}, 'transactional path not used for info');
+
+    # non-transactional -> always plain zypper
+    %seen = ();
+    $mod->redefine(is_transactional => sub { 0 });
+    pc_pkg_call($inst, 'in -y docker');
+    is($seen{zypper}, 'in -y docker', 'non-transactional host uses plain zypper verbatim');
+    ok(!defined $seen{transactional}, 'no translation on non-transactional host');
+};
+
+subtest '[pc_transactional_call] reboots on accepted exit code' => sub {
+    my $mod = Test::MockModule->new('publiccloud::zypper');
+    $mod->redefine(_run => sub { return 0 });    # success exit code
+    my $inst = _instance_mock();
+    pc_transactional_call($inst, 'up');
+    my ($rb) = grep { $_->{m} eq 'softreboot' } @{$inst->{calls}};
+    ok($rb, 'softreboot triggered after successful transactional update');
+
+    # no_reboot suppresses the reboot
+    my $inst2 = _instance_mock();
+    pc_transactional_call($inst2, 'up', no_reboot => 1);
+    my ($rb2) = grep { $_->{m} eq 'softreboot' } @{$inst2->{calls}};
+    ok(!$rb2, 'no_reboot suppresses softreboot');
+};
+
+subtest '[pc_installed_packages] filters to installed' => sub {
+    my $inst = _instance_mock(output => 'curl|wget|');
+    my $res = pc_installed_packages($inst, ['curl', 'wget', 'absent']);
+    is_deeply($res, ['curl', 'wget'], 'returns only installed packages in order');
+
+    is_deeply(pc_installed_packages($inst, []), [], 'empty input yields empty list');
+    throws_ok { pc_installed_packages($inst, 'notarray') } qr/Expected arrayref/, 'non-arrayref dies';
+};
+
+subtest '[pc_installed_packages] drops not-installed noise' => sub {
+    my $inst = _instance_mock(output => 'curl|package absent is not installed|');
+    my $res = pc_installed_packages($inst, ['curl', 'absent']);
+    is_deeply($res, ['curl'], 'is not installed entries filtered out');
+};
+
+subtest '[pc_available_packages] returns not-installed but available' => sub {
+    my $mod = Test::MockModule->new('publiccloud::zypper');
+    # 'curl' installed; 'wget' missing but available per zypper info output
+    $mod->redefine(pc_installed_packages => sub { ['curl'] });
+    my $inst = _instance_mock(output => "Name : wget\nName : other\n");
+    my $res = pc_available_packages($inst, ['curl', 'wget']);
+    is_deeply($res, ['wget', 'other'], 'parses Name: lines from zypper info');
+
+    # everything already installed -> empty (no zypper info call needed)
+    $mod->redefine(pc_installed_packages => sub { ['curl', 'wget'] });
+    is_deeply(pc_available_packages($inst, ['curl', 'wget']), [], 'all installed yields empty list');
+
+    throws_ok { pc_available_packages($inst, 'x') } qr/Expected arrayref/, 'non-arrayref dies';
+};
+
+subtest '[pc_install_packages_local] transactional vs plain' => sub {
+    my $mod = Test::MockModule->new('publiccloud::zypper');
+
+    # non-transactional -> utils::zypper_call
+    $mod->redefine(is_transactional => sub { 0 });
+    my $utils = Test::MockModule->new('utils', no_auto => 1);
+    my $zypper_cmd;
+    $utils->redefine(zypper_call => sub { $zypper_cmd = $_[0]; return 0 });
+    pc_install_packages_local(['curl', 'wget']);
+    is($zypper_cmd, 'in curl wget', 'plain install uses utils::zypper_call');
+
+    # transactional -> trup_call + reboot_on_changes
+    $mod->redefine(is_transactional => sub { 1 });
+    my $trans = Test::MockModule->new('transactional', no_auto => 1);
+    my ($trup, $rebooted);
+    $trans->redefine(trup_call => sub { $trup = $_[0]; return 0 });
+    $trans->redefine(reboot_on_changes => sub { $rebooted = 1; return 0 });
+    pc_install_packages_local(['docker']);
+    is($trup, 'pkg install docker', 'transactional uses trup_call');
+    ok($rebooted, 'reboot_on_changes called on transactional host');
+
+    # empty list is a no-op
+    $zypper_cmd = undef;
+    $mod->redefine(is_transactional => sub { 0 });
+    pc_install_packages_local([]);
+    ok(!defined $zypper_cmd, 'empty package list is a no-op');
+
+    throws_ok { pc_install_packages_local('x') } qr/Expected arrayref/, 'non-arrayref dies';
+};
+
+done_testing;

--- a/t/44_publiccloud_instance.t
+++ b/t/44_publiccloud_instance.t
@@ -1,0 +1,235 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Unit tests for publiccloud::instance -- systemd time parsing,
+# the isok helper, ssh command construction and the thin provider-delegating
+# methods (start/stop/get_state/wait_for_state).
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockObject;
+use Test::MockModule;
+use Test::Exception;
+use Test::Warnings;
+use testapi 'set_var';
+
+use publiccloud::instance;
+
+# ---------------------------------------------------------------------------
+# Pure helper: isok
+# ---------------------------------------------------------------------------
+subtest '[isok] shell exit code truthiness' => sub {
+    ok(publiccloud::instance::isok(0), '0 is ok');
+    ok(!publiccloud::instance::isok(1), '1 is not ok');
+    ok(!publiccloud::instance::isok(undef), 'undef is not ok');
+    ok(!publiccloud::instance::isok(255), '255 is not ok');
+};
+
+# ---------------------------------------------------------------------------
+# Pure helper: systemd_time_to_second
+# ---------------------------------------------------------------------------
+subtest '[systemd_time_to_second] parsing' => sub {
+    cmp_ok(publiccloud::instance::systemd_time_to_second('1.234s'), '==', 1.234, 'seconds only');
+    cmp_ok(publiccloud::instance::systemd_time_to_second('500ms'), '==', 0.5, 'milliseconds converted');
+    cmp_ok(publiccloud::instance::systemd_time_to_second('1min 30.000s'), '==', 90, 'minutes + seconds');
+    cmp_ok(publiccloud::instance::systemd_time_to_second('1h 0min 0.000s'), '==', 3600, 'hours + min + sec');
+    cmp_ok(publiccloud::instance::systemd_time_to_second('2h 3min 4.500s'), '==', 2 * 3600 + 3 * 60 + 4.5, 'full combination');
+};
+
+subtest '[systemd_time_to_second] invalid returns -1' => sub {
+    my $instance = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+    $instance->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    is(publiccloud::instance::systemd_time_to_second('garbage'), -1, 'unparseable string returns -1');
+    is(publiccloud::instance::systemd_time_to_second(''), -1, 'empty string returns -1');
+};
+
+# ---------------------------------------------------------------------------
+# Pure helper: extract_analyze_time
+# ---------------------------------------------------------------------------
+subtest '[extract_analyze_time] systemd-analyze time output' => sub {
+    my $out = 'Startup finished in 1.500s (kernel) + 2.000s (initrd) + 10.000s (userspace) = 13.500s';
+    my $res = publiccloud::instance::extract_analyze_time($out);
+    is(ref $res, 'HASH', 'returns hashref on success');
+    cmp_ok($res->{kernel}, '==', 1.5, 'kernel time parsed');
+    cmp_ok($res->{initrd}, '==', 2, 'initrd time parsed');
+    cmp_ok($res->{userspace}, '==', 10, 'userspace time parsed');
+    cmp_ok($res->{overall}, '==', 13.5, 'overall (after =) parsed');
+};
+
+subtest '[extract_analyze_time] missing component returns undef' => sub {
+    # No initrd component -> incomplete -> undef
+    my $out = 'Startup finished in 1.500s (kernel) + 10.000s (userspace) = 11.500s';
+    is(publiccloud::instance::extract_analyze_time($out), undef, 'incomplete data returns undef');
+};
+
+# ---------------------------------------------------------------------------
+# Pure helper: extract_blame_time
+# ---------------------------------------------------------------------------
+subtest '[extract_blame_time] systemd-analyze blame output' => sub {
+    my $out = "5.000s foo.service\n2.500s bar.service";
+    my $res = publiccloud::instance::extract_blame_time($out);
+    is(ref $res, 'HASH', 'returns hashref');
+    cmp_ok($res->{'foo.service'}, '==', 5, 'foo.service parsed');
+    cmp_ok($res->{'bar.service'}, '==', 2.5, 'bar.service parsed');
+};
+
+subtest '[extract_blame_time] unparseable line returns empty hashref' => sub {
+    my $instance = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+    $instance->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    my $out = "totally bogus";
+    is_deeply(publiccloud::instance::extract_blame_time($out), {}, 'bad time token returns empty hashref');
+};
+
+# ---------------------------------------------------------------------------
+# _prepare_ssh_cmd / ssh_script_run command construction
+# ---------------------------------------------------------------------------
+subtest '[_prepare_ssh_cmd] composes ssh command' => sub {
+    my $inst = publiccloud::instance->new(
+        public_ip => '203.0.113.5',
+        username => 'cloudadmin',
+        ssh_opts => '-o StrictHostKeyChecking=no',
+    );
+    my $cmd = $inst->_prepare_ssh_cmd(cmd => 'uname -a');
+    like($cmd, qr/\bssh\b/, 'starts an ssh invocation');
+    like($cmd, qr/cloudadmin\@203\.0\.113\.5/, 'uses username@public_ip');
+    like($cmd, qr/StrictHostKeyChecking=no/, 'includes ssh_opts');
+    like($cmd, qr/-E \/var\/tmp\/ssh_sut\.log/, 'adds -E log when not already present');
+    like($cmd, qr/uname -a/, 'embeds the remote command');
+};
+
+subtest '[_prepare_ssh_cmd] dies without cmd' => sub {
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
+    throws_ok { $inst->_prepare_ssh_cmd() } qr/No command defined/, 'missing cmd dies';
+};
+
+subtest '[_apply_cmd_timeout] wraps with timeout when ignore_timeout_failure' => sub {
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
+
+    my %args = (timeout => 100, ignore_timeout_failure => 1);
+    my $ssh_cmd = 'ssh foo';
+    $inst->_apply_cmd_timeout(\%args, \$ssh_cmd);
+    like($ssh_cmd, qr/^timeout --foreground -k 10s 100 ssh foo$/, 'wrapped in timeout call');
+    is($args{timeout}, 120, 'script_run timeout bumped by 20s buffer');
+    ok(!exists $args{ignore_timeout_failure}, 'ignore_timeout_failure consumed');
+
+    # Without the flag: no wrapping
+    my %args2 = (timeout => 50);
+    my $ssh_cmd2 = 'ssh bar';
+    $inst->_apply_cmd_timeout(\%args2, \$ssh_cmd2);
+    is($ssh_cmd2, 'ssh bar', 'command untouched when flag not set');
+    is($args2{timeout}, 50, 'timeout unchanged when flag not set');
+};
+
+subtest '[ssh_script_run] delegates to script_run with built cmd' => sub {
+    my $instance = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+    my ($seen_cmd, %seen_args);
+    $instance->redefine(script_run => sub { my ($c, %a) = @_; $seen_cmd = $c; %seen_args = %a; return 0 });
+
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.9', username => 'bob', ssh_opts => '-q');
+    my $rc = $inst->ssh_script_run(cmd => 'echo hi', timeout => 42);
+    is($rc, 0, 'returns script_run rc');
+    like($seen_cmd, qr/bob\@10\.0\.0\.9/, 'ssh cmd targets the instance');
+    like($seen_cmd, qr/echo hi/, 'embeds command');
+    is($seen_args{timeout}, 42, 'timeout forwarded');
+    is($seen_args{quiet}, 1, 'quiet defaults to 1');
+    ok(!exists $seen_args{cmd}, 'cmd stripped before script_run');
+    ok(!exists $seen_args{ssh_opts}, 'ssh_opts stripped before script_run');
+};
+
+subtest '[ssh_script_output] strips trailing connection-closed line' => sub {
+    my $instance = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+    $instance->redefine(script_output => sub { "real output\nConnection to 10.0.0.9 closed." });
+
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.9', username => 'bob');
+    my $out = $inst->ssh_script_output(cmd => 'cat file');
+    like($out, qr/real output/, 'keeps real output');
+    unlike($out, qr/Connection to .* closed/, 'strips connection-closed trailer');
+};
+
+subtest '[scp] composes scp command and rewrites remote:' => sub {
+    my $instance = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+    my $seen_cmd;
+    $instance->redefine(assert_script_run => sub { $seen_cmd = $_[0]; return 0 });
+
+    my $inst = publiccloud::instance->new(public_ip => '198.51.100.2', username => 'admin', ssh_opts => '-o X=y -E /tmp/log');
+    $inst->scp('remote:/var/log/messages', '/tmp/messages');
+    like($seen_cmd, qr/^scp /, 'starts with scp');
+    like($seen_cmd, qr/admin\@198\.51\.100\.2:\/var\/log\/messages/, 'remote: rewritten to user@ip:');
+    like($seen_cmd, qr/\/tmp\/messages/, 'destination present');
+    unlike($seen_cmd, qr/-E /, '-E option stripped (scp does not accept it)');
+};
+
+subtest '[retry_ssh_command] retries then succeeds' => sub {
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
+    my $instmod = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+    my @rcs = (1, 1, 0);
+    my $calls = 0;
+    $instmod->redefine(ssh_script_run => sub { $calls++; return shift @rcs });
+    # avoid real sleep
+    no warnings 'redefine';
+    local *publiccloud::instance::sleep = sub { };
+    my $rc = $inst->retry_ssh_command(cmd => 'true', retry => 5, delay => 0);
+    is($rc, 0, 'returns 0 on eventual success');
+    is($calls, 3, 'stopped retrying after first success');
+};
+
+subtest '[retry_ssh_command] dies after exhausting retries' => sub {
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
+    my $instmod = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+    $instmod->redefine(ssh_script_run => sub { 1 });
+    no warnings 'redefine';
+    local *publiccloud::instance::sleep = sub { };
+    throws_ok { $inst->retry_ssh_command(cmd => 'false', retry => 2, delay => 0) }
+    qr/Waiting for Godot: false/, 'dies with command in message';
+};
+
+# ---------------------------------------------------------------------------
+# Provider-delegating methods
+# ---------------------------------------------------------------------------
+subtest '[stop/start/get_state] delegate to provider' => sub {
+    my %provider_calls;
+    my $provider = Test::MockObject->new;
+    $provider->mock(stop_instance => sub { $provider_calls{stop}++; return });
+    $provider->mock(start_instance => sub { $provider_calls{start}++; return });
+    $provider->mock(get_state_from_instance => sub { $provider_calls{state}++; return 'running' });
+
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u', provider => $provider);
+
+    $inst->stop();
+    is($provider_calls{stop}, 1, 'stop delegates to provider->stop_instance');
+
+    is($inst->get_state(), 'running', 'get_state returns provider state');
+    is($provider_calls{state}, 1, 'get_state delegates to provider');
+};
+
+subtest '[wait_for_state] returns when state matches' => sub {
+    my @states = ('pending', 'pending', 'running');
+    my $provider = Test::MockObject->new;
+    $provider->mock(get_state_from_instance => sub { shift @states });
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u', provider => $provider);
+
+    no warnings 'redefine';
+    local *publiccloud::instance::sleep = sub { };
+    lives_ok { $inst->wait_for_state('running', 100) } 'returns once desired state reached';
+};
+
+subtest '[wait_for_state] dies on timeout' => sub {
+    my $provider = Test::MockObject->new;
+    $provider->mock(get_state_from_instance => sub { 'pending' });
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u', provider => $provider);
+
+    no warnings 'redefine';
+    local *publiccloud::instance::sleep = sub { };
+    # A zero timeout makes the deadline already in the past on the first check,
+    # so the method gives up immediately and dies. The die message interpolates
+    # an as-yet-undef $current, so silence that expected warning.
+    local $SIG{__WARN__} = sub { };
+    throws_ok { $inst->wait_for_state('running', 0) }
+    qr/instance state is not 'running'/, 'dies when state never matches before timeout';
+};
+
+done_testing;

--- a/t/45_publiccloud_provider.t
+++ b/t/45_publiccloud_provider.t
@@ -1,0 +1,105 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Unit tests for the publiccloud::provider base class -- name
+# conversion, terraform tag/output helpers, ssh-key generation and string
+# escaping.
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockObject;
+use Test::MockModule;
+use Test::Exception;
+use Test::Warnings;
+use testapi 'set_var';
+
+use publiccloud::provider;
+
+subtest '[conv_openqa_tf_name] provider name mapping' => sub {
+    set_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
+    is(publiccloud::provider::conv_openqa_tf_name(), 'aws', 'EC2 maps to aws');
+
+    set_var('PUBLIC_CLOUD_PROVIDER', 'GCE');
+    is(publiccloud::provider::conv_openqa_tf_name(), 'gcp', 'GCE maps to gcp');
+
+    set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    is(publiccloud::provider::conv_openqa_tf_name(), 'azure', 'AZURE stays azure (lowercased)');
+
+    _unset('PUBLIC_CLOUD_PROVIDER');
+};
+
+subtest '[escape_single_quote] shell-safe single quotes' => sub {
+    is(publiccloud::provider::escape_single_quote('plain'), 'plain', 'no quotes unchanged');
+    is(publiccloud::provider::escape_single_quote(q{it's}), q{it'"'"'s}, 'single quote escaped');
+    is(publiccloud::provider::escape_single_quote(q{a'b'c}), q{a'"'"'b'"'"'c}, 'multiple quotes escaped');
+};
+
+subtest '[terraform_param_tags] json tag structure' => sub {
+    my $provider = publiccloud::provider->new();
+    my $mod = Test::MockModule->new('publiccloud::provider', no_auto => 1);
+    $mod->redefine(get_current_job_id => sub { 555 });
+    $mod->redefine(calculate_custodian_ttl => sub { '2030-01-01T00:00:00Z' });
+
+    set_var('OPENQA_URL', 'https://openqa.suse.de/');
+    set_var('MAX_JOB_TIME', 3600);
+    set_var('PUBLIC_CLOUD_TTL_OFFSET', 300);
+    set_var('NAME', 'my-job');
+    set_var('PUBLIC_CLOUD_PCW_IGNORE', undef);
+
+    my $json = $provider->terraform_param_tags();
+    require Mojo::JSON;
+    my $tags = Mojo::JSON::decode_json($json);
+    is($tags->{openqa_var_job_id}, 555, 'job id tag');
+    is($tags->{openqa_var_server}, 'openqa.suse.de', 'server url trimmed of scheme/slash');
+    is($tags->{openqa_ttl}, 3900, 'ttl = MAX_JOB_TIME + offset');
+    is($tags->{openqa_var_name}, 'my-job', 'name tag');
+    is($tags->{custodian_ttl}, '2030-01-01T00:00:00Z', 'custodian ttl from helper');
+    ok(!exists $tags->{pcw_ignore}, 'no pcw_ignore by default');
+
+    set_var('PUBLIC_CLOUD_PCW_IGNORE', '1');
+    my $tags2 = Mojo::JSON::decode_json($provider->terraform_param_tags());
+    is($tags2->{pcw_ignore}, '1', 'pcw_ignore tag when enabled');
+
+    _unset(qw/OPENQA_URL OPENQA_HOSTNAME MAX_JOB_TIME PUBLIC_CLOUD_TTL_OFFSET NAME PUBLIC_CLOUD_PCW_IGNORE/);
+};
+
+subtest '[get_terraform_output] returns value, empty on null' => sub {
+    my $provider = publiccloud::provider->new();
+    my $mod = Test::MockModule->new('publiccloud::provider', no_auto => 1);
+    $mod->redefine(script_run => sub { 0 });
+
+    $mod->redefine(script_output => sub { 'my-vm-name' });
+    is($provider->get_terraform_output('.vm_name.value[0]'), 'my-vm-name', 'returns jq output');
+
+    $mod->redefine(script_output => sub { 'null' });
+    is($provider->get_terraform_output('.missing'), undef, 'jq null mapped to undef');
+};
+
+subtest '[create_ssh_key] derives algorithm and generates when absent' => sub {
+    my $provider = publiccloud::provider->new(ssh_key => '~/.ssh/id_ed25519');
+    my $mod = Test::MockModule->new('publiccloud::provider', no_auto => 1);
+    my @info;
+    $mod->redefine(record_info => sub { push @info, [@_] });
+    $mod->redefine(script_run => sub { 1 });    # key file absent
+    my @asr;
+    $mod->redefine(assert_script_run => sub { push @asr, $_[0]; return 0 });
+
+    $provider->create_ssh_key();
+    ok((grep { /ssh-keygen -t ed25519/ } @asr), 'generates ed25519 key');
+    is($info[0][0], 'ed25519', 'algorithm derived from key filename');
+
+    # When key already present, no keygen call
+    @asr = ();
+    $mod->redefine(script_run => sub { 0 });    # key file exists
+    $provider->create_ssh_key();
+    ok(!(grep { /ssh-keygen/ } @asr), 'does not regenerate existing key');
+};
+
+# helper used by the provider-name subtest
+sub _unset { for my $k (@_) { set_var($k, undef) } }
+
+done_testing;

--- a/t/46_publiccloud_ec2.t
+++ b/t/46_publiccloud_ec2.t
@@ -1,0 +1,148 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Unit tests for publiccloud::ec2 -- AWS CLI command composition for
+# describe/state/keypair/instance-type operations (CLI layer mocked).
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockObject;
+use Test::MockModule;
+use Test::Exception;
+use Test::Warnings;
+use testapi 'set_var';
+
+use publiccloud::ec2;
+
+subtest '[describe_instance] composes aws describe-instances + jq query' => sub {
+    my $provider = publiccloud::ec2->new();
+    my $mod = Test::MockModule->new('publiccloud::ec2', no_auto => 1);
+    my $seen;
+    $mod->redefine(script_output => sub { $seen = $_[0]; return 'i-state' });
+    set_var('PUBLIC_CLOUD_REGION', 'eu-central-1');
+
+    my $res = $provider->describe_instance('i-12345', '.State.Name');
+    is($res, 'i-state', 'returns script_output verbatim');
+    like($seen, qr/aws ec2 describe-instances/, 'uses describe-instances');
+    like($seen, qr/Values=i-12345/, 'filters by instance id');
+    like($seen, qr/--region eu-central-1/, 'passes region');
+    like($seen, qr/\.State\.Name/, 'appends jq query');
+
+    _unset('PUBLIC_CLOUD_REGION');
+};
+
+subtest '[get_state_from_instance] queries State.Name' => sub {
+    my $provider = publiccloud::ec2->new();
+    my $mod = Test::MockModule->new('publiccloud::ec2', no_auto => 1);
+    my $seen_query;
+    $mod->redefine(describe_instance => sub { my ($s, $id, $q) = @_; $seen_query = $q; return 'running' });
+
+    my $inst = Test::MockObject->new;
+    $inst->mock(instance_id => sub { 'i-abc' });
+    is($provider->get_state_from_instance($inst), 'running', 'returns the state');
+    is($seen_query, '.State.Name', 'queries .State.Name');
+};
+
+subtest '[get_public_ip] uses terraform output + describe' => sub {
+    my $provider = publiccloud::ec2->new();
+    my $mod = Test::MockModule->new('publiccloud::ec2', no_auto => 1);
+    $mod->redefine(get_terraform_output => sub { 'i-from-tf' });
+    my ($seen_id, $seen_query);
+    $mod->redefine(describe_instance => sub { my ($s, $id, $q) = @_; ($seen_id, $seen_query) = ($id, $q); return '203.0.113.10' });
+
+    is($provider->get_public_ip(), '203.0.113.10', 'returns the public ip');
+    is($seen_id, 'i-from-tf', 'uses instance id from terraform output');
+    is($seen_query, '.PublicIpAddress', 'queries .PublicIpAddress');
+};
+
+subtest '[create_keypair] returns early when key file exists' => sub {
+    my $provider = publiccloud::ec2->new();
+    my $mod = Test::MockModule->new('publiccloud::ec2', no_auto => 1);
+    $mod->redefine(script_run => sub { 0 });    # test -s pem succeeds
+    is($provider->create_keypair('prefix'), 1, 'returns 1 without creating a new key');
+};
+
+subtest '[create_keypair] creates key on first success' => sub {
+    my $provider = publiccloud::ec2->new();
+    my $mod = Test::MockModule->new('publiccloud::ec2', no_auto => 1);
+    my @cmds;
+    # First call (test -s) -> file missing (1), subsequent create-key-pair -> success (0)
+    my $first = 1;
+    $mod->redefine(script_run => sub {
+            push @cmds, $_[0];
+            return 1 if $first-- > 0;    # test -s fails -> need to create
+            return 0;    # create-key-pair succeeds
+    });
+    $mod->redefine(assert_script_run => sub { push @cmds, $_[0]; return 0 });
+
+    is($provider->create_keypair('mykey'), 1, 'returns 1 on successful create');
+    is($provider->ssh_key_pair, 'mykey_0', 'records the created key name');
+    ok((grep { /create-key-pair --key-name 'mykey_0'/ } @cmds), 'creates first numbered key');
+    ok((grep { /chmod 0400/ } @cmds), 'restricts key file permissions');
+};
+
+subtest '[delete_keypair] issues aws delete and clears key' => sub {
+    my $provider = publiccloud::ec2->new(ssh_key => 'mykey');
+    my $mod = Test::MockModule->new('publiccloud::ec2', no_auto => 1);
+    my @asr;
+    $mod->redefine(assert_script_run => sub { push @asr, $_[0]; return 0 });
+
+    $provider->delete_keypair('explicit-key');
+    ok((grep { /delete-key-pair --key-name explicit-key/ } @asr), 'deletes the named key');
+
+    # no-op when no name and no ssh_key
+    my $p2 = publiccloud::ec2->new(ssh_key => undef);
+    @asr = ();
+    $p2->delete_keypair();
+    is(scalar @asr, 0, 'no delete call when no key name available');
+};
+
+subtest '[change_instance_type] modifies when different' => sub {
+    my $provider = publiccloud::ec2->new();
+    my $mod = Test::MockModule->new('publiccloud::ec2', no_auto => 1);
+    # describe returns old type first, new type after the modify
+    my @types = ('t2.micro', 't3.large');
+    $mod->redefine(describe_instance => sub { shift @types });
+    my @asr;
+    $mod->redefine(assert_script_run => sub { push @asr, $_[0]; return 0 });
+
+    my $inst = Test::MockObject->new;
+    $inst->mock(instance_id => sub { 'i-xyz' });
+    lives_ok { $provider->change_instance_type($inst, 't3.large') } 'changes type';
+    ok((grep { /modify-instance-attribute.*t3\.large/ } @asr), 'issues modify-instance-attribute');
+};
+
+subtest '[change_instance_type] dies when already that type' => sub {
+    my $provider = publiccloud::ec2->new();
+    my $mod = Test::MockModule->new('publiccloud::ec2', no_auto => 1);
+    $mod->redefine(describe_instance => sub { 't3.large' });
+    my $inst = Test::MockObject->new;
+    $inst->mock(instance_id => sub { 'i-xyz' });
+    throws_ok { $provider->change_instance_type($inst, 't3.large') }
+    qr/already t3\.large/, 'dies when type unchanged';
+};
+
+subtest '[query_metadata] fetches IMDSv2 token then ip' => sub {
+    my $provider = publiccloud::ec2->new();
+    my $mod = Test::MockModule->new('publiccloud::ec2', no_auto => 1);
+    $mod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    my @cmds;
+    my $inst = Test::MockObject->new;
+    my @outputs = ('TOKEN123', '10.0.0.5');
+    $inst->mock(ssh_script_output => sub { my ($s, $c) = @_; push @cmds, $c; return shift @outputs });
+
+    my $ip = $provider->query_metadata($inst, ifNum => 0, addrCount => 0);
+    is($ip, '10.0.0.5', 'returns local-ipv4 metadata');
+    like($cmds[0], qr{api/token}, 'first fetches the IMDSv2 token');
+    like($cmds[1], qr{X-aws-ec2-metadata-token: TOKEN123}, 'uses the token in the metadata query');
+    like($cmds[1], qr{local-ipv4}, 'queries local-ipv4');
+};
+
+sub _unset { for my $k (@_) { set_var($k, undef) } }
+
+done_testing;

--- a/t/47_publiccloud_gce.t
+++ b/t/47_publiccloud_gce.t
@@ -1,0 +1,143 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Unit tests for publiccloud::gce -- image file->name normalization,
+# guest OS feature lookup, image id project prefixing, gcloud describe/state
+# helpers and metadata query (gcloud layer mocked).
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use strict;
+use warnings;
+
+# Neutralize sleep() process-wide so any state-polling loop does not spend real
+# wall-clock seconds during unit tests. Installed in BEGIN so it is in effect
+# before the modules under test are compiled.
+BEGIN { *CORE::GLOBAL::sleep = sub { }; }
+
+use Test::More;
+use Test::MockObject;
+use Test::MockModule;
+use Test::Exception;
+use Test::Warnings;
+use testapi 'set_var';
+
+use publiccloud::gce;
+
+subtest '[file2name] normalizes to GCE-allowed name' => sub {
+    my $provider = publiccloud::gce->new();
+    is($provider->file2name('SLES15-SP6.x86_64-1.0.0-GCE-Build1.1.tar.gz'),
+        'sles15-sp6-x8664-1-0-0-gce-build1-1',
+        'lowercased, tar.gz stripped, dots to dashes, underscore dropped');
+    is($provider->file2name('Foo.Bar.tar.gz'), 'foo-bar', 'dots become dashes');
+    is($provider->file2name('UPPER'), 'upper', 'uppercase lowercased');
+};
+
+subtest '[get_gcp_guest_os_features] returns feature list' => sub {
+    my $provider = publiccloud::gce->new();
+    my $feat = $provider->get_gcp_guest_os_features('SLES15-SP6.x86_64.tar.gz');
+    like($feat, qr/GVNIC/, 'includes GVNIC');
+    like($feat, qr/UEFI_COMPATIBLE/, 'includes UEFI_COMPATIBLE');
+    like($feat, qr/TDX_CAPABLE/, 'SP6 includes TDX_CAPABLE');
+    is(ref \$feat, 'SCALAR', 'returns a comma-joined string');
+
+    my $sp5 = $provider->get_gcp_guest_os_features('SLES15-SP5-foo');
+    unlike($sp5, qr/TDX_CAPABLE/, 'SP5 does not include TDX_CAPABLE');
+};
+
+subtest '[get_gcp_guest_os_features] dies on unsupported OS' => sub {
+    my $provider = publiccloud::gce->new();
+    # the lib interpolates an undef $os_version into the die message; silence that
+    local $SIG{__WARN__} = sub { };
+    throws_ok { $provider->get_gcp_guest_os_features('UnknownDistro-1') }
+    qr/Unsupported OS/, 'dies for OS not in the feature table';
+};
+
+subtest '[get_image_id] prefixes with project when set' => sub {
+    my $provider = publiccloud::gce->new();
+    my $mod = Test::MockModule->new('publiccloud::gce', no_auto => 1);
+    # Stub the parent get_image_id via the SUPER:: path
+    my $parent = Test::MockModule->new('publiccloud::provider', no_auto => 1);
+    $parent->redefine(get_image_id => sub { 'my-image' });
+
+    set_var('PUBLIC_CLOUD_IMAGE_PROJECT', undef);
+    is($provider->get_image_id('url'), 'my-image', 'no prefix without project');
+
+    set_var('PUBLIC_CLOUD_IMAGE_PROJECT', 'suse-proj');
+    is($provider->get_image_id('url'), 'suse-proj/my-image', 'prefixes project/');
+
+    _unset('PUBLIC_CLOUD_IMAGE_PROJECT');
+};
+
+subtest '[describe_instance] composes gcloud + jq' => sub {
+    my $provider = publiccloud::gce->new();
+    my $mod = Test::MockModule->new('publiccloud::gce', no_auto => 1);
+    my $seen;
+    $mod->redefine(script_output => sub { $seen = $_[0]; return 'RUNNING' });
+
+    my $res = $provider->describe_instance('vm-1', '.[0].status');
+    is($res, 'RUNNING', 'returns script_output');
+    like($seen, qr/gcloud compute instances list/, 'uses gcloud instances list');
+    like($seen, qr/vm-1/, 'filters by instance id');
+    like($seen, qr/\.\[0\]\.status/, 'applies jq query');
+};
+
+subtest '[get_state_from_instance] returns status or dies' => sub {
+    my $provider = publiccloud::gce->new();
+    my $mod = Test::MockModule->new('publiccloud::gce', no_auto => 1);
+    my $inst = Test::MockObject->new;
+    $inst->mock(instance_id => sub { 'vm-1' });
+
+    $mod->redefine(describe_instance => sub { 'RUNNING' });
+    is($provider->get_state_from_instance($inst), 'RUNNING', 'returns status');
+
+    $mod->redefine(describe_instance => sub { '' });
+    throws_ok { $provider->get_state_from_instance($inst) } qr/Unable to get status/, 'dies on empty status';
+};
+
+subtest '[get_public_ip] returns natIP or dies' => sub {
+    my $provider = publiccloud::gce->new();
+    my $mod = Test::MockModule->new('publiccloud::gce', no_auto => 1);
+    $mod->redefine(get_terraform_output => sub { 'vm-1' });
+
+    $mod->redefine(describe_instance => sub { '203.0.113.20' });
+    is($provider->get_public_ip(), '203.0.113.20', 'returns natIP');
+
+    $mod->redefine(describe_instance => sub { '' });
+    throws_ok { $provider->get_public_ip() } qr/Unable to get public_ip/, 'dies on empty natIP';
+};
+
+subtest '[query_metadata] uses Google metadata flavor header' => sub {
+    my $provider = publiccloud::gce->new();
+    my $inst = Test::MockObject->new;
+    my $seen;
+    $inst->mock(ssh_script_output => sub { my ($s, $c) = @_; $seen = $c; return '10.2.3.4' });
+
+    is($provider->query_metadata($inst), '10.2.3.4', 'returns metadata payload');
+    like($seen, qr/Metadata-Flavor: Google/, 'uses Google metadata header');
+    like($seen, qr{computeMetadata/v1/instance/network-interfaces/0/ip}, 'queries network interface ip path');
+};
+
+subtest '[suspend_instance] only when running' => sub {
+    my $provider = publiccloud::gce->new();
+    my $mod = Test::MockModule->new('publiccloud::gce', no_auto => 1);
+    my @asr;
+    $mod->redefine(assert_script_run => sub { push @asr, $_[0]; return 0 });
+
+    my $inst = Test::MockObject->new;
+    $inst->mock(instance_id => sub { 'vm-1' });
+    $inst->mock(wait_for_state => sub { return });
+
+    $mod->redefine(get_state_from_instance => sub { 'RUNNING' });
+    lives_ok { $provider->suspend_instance($inst) } 'suspends a running instance';
+    ok((grep { /instances suspend vm-1/ } @asr), 'issues gcloud suspend');
+
+    $mod->redefine(get_state_from_instance => sub { 'TERMINATED' });
+    throws_ok { $provider->suspend_instance($inst) }
+    qr/Cannot suspend instance which is not running/, 'dies when not running';
+};
+
+sub _unset { for my $k (@_) { set_var($k, undef) } }
+
+done_testing;

--- a/t/48_publiccloud_clients.t
+++ b/t/48_publiccloud_clients.t
@@ -1,0 +1,193 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Unit tests for the publiccloud client/registry helper classes:
+# aws_client, azure_client, gcp_client (config getters + container image name
+# composition), the instances registry and the k8s_provider service routing
+# plus the ACR/ECR/GCR delete_image command composition.
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockObject;
+use Test::MockModule;
+use Test::Exception;
+use Test::Warnings;
+use testapi 'set_var';
+
+use publiccloud::aws_client;
+use publiccloud::azure_client;
+use publiccloud::gcp_client;
+use publiccloud::instances;
+use publiccloud::k8s_provider;
+use publiccloud::acr;
+use publiccloud::ecr;
+use publiccloud::gcr;
+
+sub _unset { for my $k (@_) { set_var($k, undef) } }
+
+# ---------------------------------------------------------------------------
+# aws_client
+# ---------------------------------------------------------------------------
+subtest '[aws_client] config getters' => sub {
+    set_var('PUBLIC_CLOUD_REGION', 'us-east-1');
+    set_var('PUBLIC_CLOUD_USER', undef);
+    set_var('PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY', undef);
+
+    my $c = publiccloud::aws_client->new();
+    is($c->region, 'us-east-1', 'region from PUBLIC_CLOUD_REGION');
+    is($c->username, 'ec2-user', 'username default');
+    is($c->container_registry, 'suse-qec-testing', 'container registry default');
+
+    _unset(qw/PUBLIC_CLOUD_REGION PUBLIC_CLOUD_USER PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY/);
+};
+
+subtest '[aws_client] get_container_image_full_name' => sub {
+    set_var('PUBLIC_CLOUD_REGION', 'eu-west-1');
+    my $c = publiccloud::aws_client->new(aws_account_id => '123456789012', container_registry => 'myrepo');
+    is($c->get_container_image_full_name('v1'),
+        '123456789012.dkr.ecr.eu-west-1.amazonaws.com/myrepo:v1',
+        'ECR full image name composed');
+    _unset('PUBLIC_CLOUD_REGION');
+};
+
+# ---------------------------------------------------------------------------
+# azure_client
+# ---------------------------------------------------------------------------
+subtest '[azure_client] config getters and image name' => sub {
+    set_var('PUBLIC_CLOUD_REGION', 'westeurope');
+    set_var('PUBLIC_CLOUD_USER', undef);
+    set_var('PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY', undef);
+
+    my $c = publiccloud::azure_client->new();
+    is($c->region, 'westeurope', 'region getter');
+    is($c->username, 'azureuser', 'username default');
+    is($c->container_registry, 'suseqectesting', 'registry default');
+    is($c->get_container_image_full_name('tag1'),
+        'suseqectesting.azurecr.io/tag1', 'ACR full image name composed');
+
+    _unset(qw/PUBLIC_CLOUD_REGION PUBLIC_CLOUD_USER PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY/);
+};
+
+# ---------------------------------------------------------------------------
+# gcp_client
+# ---------------------------------------------------------------------------
+subtest '[gcp_client] config getters and registry prefix' => sub {
+    set_var('PUBLIC_CLOUD_REGION', 'europe-west1');
+    set_var('PUBLIC_CLOUD_AVAILABILITY_ZONE', 'europe-west1-b');
+    set_var('PUBLIC_CLOUD_GCR_ZONE', undef);
+    set_var('PUBLIC_CLOUD_USER', undef);
+
+    my $c = publiccloud::gcp_client->new(project_id => 'my-proj');
+    is($c->region, 'europe-west1', 'region getter');
+    is($c->availability_zone, 'europe-west1-b', 'availability zone getter');
+    is($c->username, 'susetest', 'username default');
+    is($c->gcr_zone, 'eu.gcr.io', 'gcr zone default');
+    is($c->get_container_registry_prefix(), 'eu.gcr.io/my-proj', 'registry prefix composed');
+    is(publiccloud::gcp_client::get_credentials_file_name(), '/root/google_credentials.json', 'credentials file constant');
+
+    _unset(qw/PUBLIC_CLOUD_REGION PUBLIC_CLOUD_AVAILABILITY_ZONE PUBLIC_CLOUD_GCR_ZONE PUBLIC_CLOUD_USER/);
+};
+
+subtest '[gcp_client] get_container_image_full_name includes job id' => sub {
+    set_var('PUBLIC_CLOUD_REGION', 'europe-west1');
+    set_var('PUBLIC_CLOUD_AVAILABILITY_ZONE', 'europe-west1-b');
+    my $mod = Test::MockModule->new('publiccloud::gcp_client', no_auto => 1);
+    $mod->redefine(get_current_job_id => sub { 777 });
+
+    my $c = publiccloud::gcp_client->new(project_id => 'p', gcr_zone => 'eu.gcr.io');
+    is($c->get_container_image_full_name('img'), 'eu.gcr.io/p/img777:latest', 'image name has job id and :latest');
+
+    _unset(qw/PUBLIC_CLOUD_REGION PUBLIC_CLOUD_AVAILABILITY_ZONE/);
+};
+
+# ---------------------------------------------------------------------------
+# instances registry
+# ---------------------------------------------------------------------------
+subtest '[instances] set/get registry' => sub {
+    throws_ok { publiccloud::instances::get_instance() } qr/no instances defined/, 'dies when empty';
+
+    my $first = Test::MockObject->new;
+    my $second = Test::MockObject->new;
+    publiccloud::instances::set_instances($first, $second);
+    is(publiccloud::instances::get_instance(), $first, 'returns first instance');
+
+    publiccloud::instances::set_instances();    # reset for hygiene
+};
+
+# ---------------------------------------------------------------------------
+# k8s_provider service routing
+# ---------------------------------------------------------------------------
+subtest '[k8s_provider] init routes to correct client class' => sub {
+    my $k8s = Test::MockModule->new('publiccloud::k8s_provider', no_auto => 1);
+    $k8s->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    # Stub each client's init so we don't perform real auth.
+    for my $cls (qw/publiccloud::aws_client publiccloud::gcp_client publiccloud::azure_client/) {
+        my $m = Test::MockModule->new($cls, no_auto => 1);
+        $m->redefine(init => sub { return $_[0] });
+        # keep the mock alive for the duration of the subtest
+        no strict 'refs';
+        push @{"_keepalive_$cls"}, $m;
+    }
+
+    my $p1 = publiccloud::k8s_provider->new();
+    $p1->init('EKS');
+    isa_ok($p1->provider_client, 'publiccloud::aws_client', 'EKS uses aws_client');
+
+    my $p2 = publiccloud::k8s_provider->new();
+    $p2->init('GKE');
+    isa_ok($p2->provider_client, 'publiccloud::gcp_client', 'GKE uses gcp_client');
+
+    my $p3 = publiccloud::k8s_provider->new();
+    $p3->init('AKS');
+    isa_ok($p3->provider_client, 'publiccloud::azure_client', 'AKS uses azure_client');
+
+    throws_ok { publiccloud::k8s_provider->new()->init() } qr/service must be specified/, 'dies without service';
+};
+
+# ---------------------------------------------------------------------------
+# ACR / ECR / GCR delete_image command composition
+# ---------------------------------------------------------------------------
+subtest '[ecr] delete_image composes aws batch-delete-image' => sub {
+    my $ecr = publiccloud::ecr->new();
+    my $client = Test::MockObject->new;
+    $client->mock(container_registry => sub { 'myrepo' });
+    $ecr->provider_client($client);
+
+    my $mod = Test::MockModule->new('publiccloud::ecr', no_auto => 1);
+    my $seen;
+    $mod->redefine(assert_script_run => sub { $seen = $_[0]; return 0 });
+    $ecr->delete_image('tag42');
+    like($seen, qr/aws ecr batch-delete-image --repository-name myrepo --image-ids imageTag=tag42/, 'ECR delete command');
+};
+
+subtest '[acr] delete_image composes az acr repository delete' => sub {
+    my $acr = publiccloud::acr->new();
+    my $client = Test::MockObject->new;
+    $client->mock(container_registry => sub { 'myacr' });
+    $acr->provider_client($client);
+
+    my $mod = Test::MockModule->new('publiccloud::acr', no_auto => 1);
+    $mod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    my $seen;
+    $mod->redefine(assert_script_run => sub { $seen = $_[0]; return 0 });
+    $acr->delete_image('tagA');
+    like($seen, qr/az acr repository delete --yes --name myacr --image tagA/, 'ACR delete command');
+};
+
+subtest '[gcr] delete_image composes gcloud container images delete' => sub {
+    my $gcr = publiccloud::gcr->new();
+    my $mod = Test::MockModule->new('publiccloud::gcr', no_auto => 1);
+    $mod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $mod->redefine(get_container_image_full_name => sub { 'eu.gcr.io/p/imgX:latest' });
+    my $seen;
+    $mod->redefine(assert_script_run => sub { $seen = $_[0]; return 0 });
+    $gcr->delete_image('imgX');
+    like($seen, qr{gcloud container images delete eu\.gcr\.io/p/imgX:latest --quiet}, 'GCR delete command');
+};
+
+done_testing;

--- a/t/49_publiccloud_misc.t
+++ b/t/49_publiccloud_misc.t
@@ -1,0 +1,159 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Unit tests for publiccloud::basetest (provider_factory routing,
+# finalize/cleanup) and publiccloud::k8sbasetest (service name mapping).
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockObject;
+use Test::MockModule;
+use Test::Exception;
+use Test::Warnings;
+use testapi qw(set_var get_var);
+
+use publiccloud::basetest;
+use publiccloud::k8sbasetest;
+use publiccloud::ssh_interactive;
+
+sub _unset { for my $k (@_) { set_var($k, undef) } }
+
+# ---------------------------------------------------------------------------
+# basetest::provider_factory routing
+# ---------------------------------------------------------------------------
+
+# Stub init on every concrete provider so no real cloud auth happens, and
+# return the class that provider_factory instantiated.
+sub _factory_for {
+    my ($provider, $service) = @_;
+    my @keep;
+    for my $cls (qw/publiccloud::ec2 publiccloud::ecr publiccloud::eks
+        publiccloud::azure publiccloud::acr publiccloud::aks
+        publiccloud::gce publiccloud::gcr publiccloud::gke/) {
+        my $m = Test::MockModule->new($cls, no_auto => 1);
+        $m->redefine(init => sub { return $_[0] });
+        push @keep, $m;
+    }
+    my $base = publiccloud::basetest->new();
+    my %args = (provider => $provider);
+    $args{service} = $service if defined $service;
+    my $got = $base->provider_factory(%args);
+    return ref $got;
+}
+
+subtest '[provider_factory] EC2 services' => sub {
+    is(_factory_for('EC2'), 'publiccloud::ec2', 'EC2 default -> ec2');
+    is(_factory_for('EC2', 'ECR'), 'publiccloud::ecr', 'EC2/ECR -> ecr');
+    is(_factory_for('EC2', 'EKS'), 'publiccloud::eks', 'EC2/EKS -> eks');
+};
+
+subtest '[provider_factory] AZURE services' => sub {
+    is(_factory_for('AZURE'), 'publiccloud::azure', 'AZURE default -> azure');
+    is(_factory_for('AZURE', 'AKS'), 'publiccloud::aks', 'AZURE/AKS -> aks');
+    is(_factory_for('AZURE', 'ACR'), 'publiccloud::acr', 'AZURE/ACR -> acr');
+};
+
+subtest '[provider_factory] GCE services' => sub {
+    is(_factory_for('GCE'), 'publiccloud::gce', 'GCE default -> gce');
+    is(_factory_for('GCE', 'GCR'), 'publiccloud::gcr', 'GCE/GCR -> gcr');
+    is(_factory_for('GCE', 'GKE'), 'publiccloud::gke', 'GCE/GKE -> gke');
+};
+
+subtest '[provider_factory] error paths' => sub {
+    throws_ok { _factory_for('NOPE') } qr/Unknown PUBLIC_CLOUD_PROVIDER/, 'unknown provider dies';
+    throws_ok { _factory_for('EC2', 'BOGUS') } qr/Unknown service given/, 'unknown EC2 service dies';
+
+    # Refuses to re-initialize an already-initialized provider
+    my $m = Test::MockModule->new('publiccloud::ec2', no_auto => 1);
+    $m->redefine(init => sub { return $_[0] });
+    my $base = publiccloud::basetest->new();
+    $base->provider_factory(provider => 'EC2');
+    throws_ok { $base->provider_factory(provider => 'EC2') }
+    qr/Provider already initialized/, 'second factory call dies';
+};
+
+# ---------------------------------------------------------------------------
+# basetest::finalize / cleanup
+# ---------------------------------------------------------------------------
+subtest '[finalize] invokes cleanup' => sub {
+    my $base = publiccloud::basetest->new();
+    my $called = 0;
+    my $mod = Test::MockModule->new('publiccloud::basetest', no_auto => 1);
+    $mod->redefine(cleanup => sub { $called = 1; return 1 });
+    $base->finalize();
+    is($called, 1, 'finalize calls cleanup');
+};
+
+subtest '[cleanup] default returns true' => sub {
+    my $base = publiccloud::basetest->new();
+    is($base->cleanup(), 1, 'default cleanup returns 1');
+};
+
+# ---------------------------------------------------------------------------
+# k8sbasetest service name mapping
+# ---------------------------------------------------------------------------
+subtest '[get_k8s_service_name] provider mapping' => sub {
+    my $k = publiccloud::k8sbasetest->new();
+    is($k->get_k8s_service_name('EC2'), 'EKS', 'EC2 -> EKS');
+    is($k->get_k8s_service_name('GCE'), 'GKE', 'GCE -> GKE');
+    is($k->get_k8s_service_name('AZURE'), 'AKS', 'AZURE -> AKS');
+    throws_ok { $k->get_k8s_service_name('FOO') } qr/Unknown provider/, 'unknown provider dies';
+};
+
+subtest '[get_container_registry_service_name] provider mapping' => sub {
+    my $k = publiccloud::k8sbasetest->new();
+    _unset('PUBLIC_CLOUD_REGION');
+    is($k->get_container_registry_service_name('EC2'), 'ECR', 'EC2 -> ECR');
+    is(get_var('PUBLIC_CLOUD_REGION'), 'eu-central-1', 'EC2 sets default region when unset');
+
+    is($k->get_container_registry_service_name('GCE'), 'GCR', 'GCE -> GCR');
+
+    _unset('PUBLIC_CLOUD_REGION');
+    is($k->get_container_registry_service_name('AZURE'), 'ACR', 'AZURE -> ACR');
+    is(get_var('PUBLIC_CLOUD_REGION'), 'westeurope', 'AZURE sets default region when unset');
+
+    _unset('PUBLIC_CLOUD_REGION');
+};
+
+# ---------------------------------------------------------------------------
+# ssh_interactive::select_host_console
+# ---------------------------------------------------------------------------
+subtest '[select_host_console] non-tunneled selects serial terminal' => sub {
+    my $mod = Test::MockModule->new('publiccloud::ssh_interactive', no_auto => 1);
+    $mod->redefine(is_tunneled => sub { 0 });
+    my %did;
+    $mod->redefine(select_serial_terminal => sub { $did{serial} = 1 });
+    $mod->redefine(type_string => sub { });
+    $mod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $mod->redefine(script_output => sub { 'myhost' });
+    $mod->redefine(assert_script_run => sub { $did{health} = 1; return 0 });
+    $mod->redefine(select_console => sub { $did{console} = $_[0] });
+
+    set_var('TUNNELED', 0);
+    lives_ok { publiccloud::ssh_interactive::select_host_console() } 'runs without tunnel';
+    is($did{serial}, 1, 'selects the serial terminal');
+    is($did{health}, 1, 'runs the health check');
+
+    _unset('TUNNELED');
+};
+
+subtest '[select_host_console] tunneled without force dies' => sub {
+    my $mod = Test::MockModule->new('publiccloud::ssh_interactive', no_auto => 1);
+    $mod->redefine(is_tunneled => sub { 1 });
+    $mod->redefine(select_serial_terminal => sub { });
+    $mod->redefine(type_string => sub { });
+    $mod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $mod->redefine(select_console => sub { });
+
+    set_var('_SSH_TUNNELS_INITIALIZED', 1);
+    throws_ok { publiccloud::ssh_interactive::select_host_console() }
+    qr/Called select_host_console but we are in TUNNELED mode/, 'dies in tunneled mode without force';
+
+    _unset('_SSH_TUNNELS_INITIALIZED');
+};
+
+done_testing;

--- a/t/50_publiccloud_utils.t
+++ b/t/50_publiccloud_utils.t
@@ -1,0 +1,256 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::MockModule;
+use Test::Warnings;
+use testapi 'set_var';
+
+# Import publiccloud::utils so the functions under test are called by their
+# imported (unqualified) names. This implicitly exercises the module's export
+# boundary: exported helpers resolve here without a package prefix, while
+# non-exported helpers must still be called fully-qualified.
+use publiccloud::utils;
+
+sub _unset { for my $k (@_) { set_var($k, undef) } }
+
+# --- export boundary ----------------------------------------------------------
+#
+# Calling exported helpers unqualified below only works if they are actually
+# exported. Assert the boundary explicitly so an accidental change to @EXPORT
+# is caught here rather than as a confusing "Undefined subroutine" failure.
+subtest '[export boundary] exported vs internal helpers' => sub {
+    for my $exported (qw(
+        is_byos is_ondemand is_ec2 is_ec2_xen is_azure is_gce
+        is_container_host is_hardened is_cloudinit_supported
+        get_python_exec get_ssh_private_key_path pc_data_url
+        additional_repos calculate_custodian_ttl
+        )) {
+        ok(__PACKAGE__->can($exported), "$exported is exported into caller");
+    }
+
+    # Internal helpers are intentionally NOT exported; they must be reached via
+    # the fully-qualified name only.
+    for my $internal (qw(venv_generate_runner_script)) {
+        ok(!__PACKAGE__->can($internal), "$internal is not exported");
+        ok(publiccloud::utils->can($internal), "$internal exists in the module");
+    }
+};
+
+# --- provider / flavor predicates ---------------------------------------------
+
+subtest '[is_byos]' => sub {
+    set_var('PUBLIC_CLOUD', 1);
+
+    set_var('FLAVOR', 'SLES-15-SP6-BYOS');
+    ok is_byos(), 'BYOS detected (upper)';
+
+    set_var('FLAVOR', 'sles-something-byos');
+    ok is_byos(), 'BYOS detected (lower, /byos/i)';
+
+    set_var('FLAVOR', 'SLES-15-SP6-On-Demand');
+    ok !is_byos(), 'not BYOS when FLAVOR lacks token';
+
+    set_var('PUBLIC_CLOUD', 0);
+    ok !is_byos(), 'not BYOS outside public cloud';
+
+    _unset(qw/PUBLIC_CLOUD FLAVOR/);
+};
+
+subtest '[is_ondemand]' => sub {
+    set_var('PUBLIC_CLOUD', 1);
+
+    set_var('FLAVOR', 'On-Demand-ish');
+    ok is_ondemand(), 'on-demand when not BYOS';
+
+    set_var('FLAVOR', 'BYOS');
+    ok !is_ondemand(), 'not on-demand when BYOS';
+
+    set_var('PUBLIC_CLOUD', 0);
+    ok !is_ondemand(), 'not on-demand outside public cloud';
+
+    _unset(qw/PUBLIC_CLOUD FLAVOR/);
+};
+
+subtest '[provider checks]' => sub {
+    set_var('PUBLIC_CLOUD', 1);
+
+    set_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
+    ok is_ec2(), 'EC2 true';
+    ok !is_azure(), 'AZURE false';
+    ok !is_gce(), 'GCE false';
+
+    set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    ok is_azure(), 'AZURE true';
+    ok !is_ec2(), 'EC2 false';
+    ok !is_gce(), 'GCE false';
+
+    set_var('PUBLIC_CLOUD_PROVIDER', 'GCE');
+    ok is_gce(), 'GCE true';
+    ok !is_ec2(), 'EC2 false';
+    ok !is_azure(), 'AZURE false';
+
+    set_var('PUBLIC_CLOUD', 0);
+    ok !is_ec2(), 'EC2 false when not public cloud';
+    ok !is_azure(), 'AZURE false when not public cloud';
+    ok !is_gce(), 'GCE false when not public cloud';
+
+    _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER/);
+};
+
+subtest '[flavor flags] CHOST & Hardened' => sub {
+    set_var('PUBLIC_CLOUD', 1);
+
+    set_var('FLAVOR', 'SLE-CHOST-15-SP6');
+    ok is_container_host(), 'CHOST detected';
+
+    set_var('FLAVOR', 'SLE-Hardened-15-SP6');
+    ok is_hardened(), 'Hardened detected';
+
+    set_var('FLAVOR', 'SLE-Whatever');
+    ok !is_container_host(), 'CHOST not detected';
+    ok !is_hardened(), 'Hardened not detected';
+
+    set_var('PUBLIC_CLOUD', 0);
+    set_var('FLAVOR', 'SLE-CHOST-15-SP6');
+    ok !is_container_host(), 'CHOST requires public cloud';
+    set_var('FLAVOR', 'SLE-Hardened-15-SP6');
+    ok !is_hardened(), 'Hardened requires public cloud';
+
+    _unset(qw/PUBLIC_CLOUD FLAVOR/);
+};
+
+subtest '[is_cloudinit_supported]' => sub {
+    set_var('PUBLIC_CLOUD', 1);
+    set_var('DISTRI', 'sle');
+
+    set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    ok is_cloudinit_supported(), 'AZURE + sle => supported';
+
+    set_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
+    ok is_cloudinit_supported(), 'EC2 + sle => supported';
+
+    set_var('PUBLIC_CLOUD_PROVIDER', 'GCE');
+    ok !is_cloudinit_supported(), 'GCE + sle => not supported';
+
+    set_var('DISTRI', 'sle-micro');
+
+    set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    ok !is_cloudinit_supported(), 'AZURE + sle-micro => NOT supported';
+
+    set_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
+    ok !is_cloudinit_supported(), 'EC2 + sle-micro => NOT supported';
+
+    set_var('PUBLIC_CLOUD', 0);
+    set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    ok !is_cloudinit_supported(), 'not public cloud => NOT supported';
+
+    _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER DISTRI/);
+};
+
+subtest '[is_ec2_xen] instance type matching' => sub {
+    set_var('PUBLIC_CLOUD', 1);
+    set_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
+
+    set_var('PUBLIC_CLOUD_INSTANCE_TYPE', 't2.micro');
+    ok is_ec2_xen(), 't2 is Xen-based';
+    set_var('PUBLIC_CLOUD_INSTANCE_TYPE', 'm4.large');
+    ok is_ec2_xen(), 'm4 is Xen-based';
+    set_var('PUBLIC_CLOUD_INSTANCE_TYPE', 'm5.large');
+    ok !is_ec2_xen(), 'm5 is Nitro (not Xen)';
+    set_var('PUBLIC_CLOUD_INSTANCE_TYPE', 'c6g.large');
+    ok !is_ec2_xen(), 'c6g is Nitro (not Xen)';
+
+    set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    set_var('PUBLIC_CLOUD_INSTANCE_TYPE', 't2.micro');
+    ok !is_ec2_xen(), 'not Xen when provider is not EC2';
+
+    # When PUBLIC_CLOUD is not defined the run is not a public cloud run,
+    # so the predicate must be false regardless of provider/instance type.
+    _unset('PUBLIC_CLOUD');
+    set_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
+    set_var('PUBLIC_CLOUD_INSTANCE_TYPE', 't2.micro');
+    ok !is_ec2_xen(), 'not Xen when PUBLIC_CLOUD is undefined';
+
+    _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_INSTANCE_TYPE/);
+};
+
+# --- pure helpers -------------------------------------------------------------
+
+subtest '[get_python_exec] default version' => sub {
+    like(get_python_exec(), qr{^python\d+\.\d+$}, 'returns pythonXX.YY');
+};
+
+subtest '[get_ssh_private_key_path] depends on provider/LTP' => sub {
+    set_var('PUBLIC_CLOUD', 1);
+
+    set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    is(get_ssh_private_key_path(), '~/.ssh/id_rsa', 'azure uses rsa');
+
+    set_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
+    set_var('PUBLIC_CLOUD_LTP', undef);
+    is(get_ssh_private_key_path(), '~/.ssh/id_ed25519', 'ec2 uses ed25519');
+
+    # rsa is only forced for azure/LTP; any other (even unknown) provider
+    # falls through to ed25519, so the value here is not EC2-specific.
+    set_var('PUBLIC_CLOUD_PROVIDER', 'DONALDUCK');
+    is(get_ssh_private_key_path(), '~/.ssh/id_ed25519', 'non-azure provider uses ed25519');
+
+    set_var('PUBLIC_CLOUD_LTP', 1);
+    is(get_ssh_private_key_path(), '~/.ssh/id_rsa', 'LTP forces rsa');
+
+    _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_LTP/);
+};
+
+subtest '[pc_data_url] github/gitlab/gitea URL conversion' => sub {
+    set_var('TEST_GIT_HASH', 'abc123');
+
+    set_var('TEST_GIT_URL', 'git@github.com:foo/bar.git');
+    is(pc_data_url('x/y.sh'),
+        'https://github.com/foo/bar/raw/abc123/data/x/y.sh', 'github ssh url converted');
+
+    set_var('TEST_GIT_URL', 'https://gitlab.suse.de/foo/bar.git');
+    is(pc_data_url('x/y.sh'),
+        'https://gitlab.suse.de/foo/bar/-/raw/abc123/x/y.sh', 'gitlab url converted');
+
+    set_var('TEST_GIT_URL', 'https://src.suse.de/foo/bar');
+    is(pc_data_url('x/y.sh'),
+        'https://src.suse.de/foo/bar/src/commit/abc123/x/y.sh', 'gitea fallback');
+
+    _unset(qw/TEST_GIT_URL TEST_GIT_HASH/);
+};
+
+subtest '[additional_repos] xfs repo composition' => sub {
+    set_var('PUBLIC_CLOUD_XFS', undef);
+    my @none = additional_repos();
+    is(scalar @none, 0, 'no extra repos without PUBLIC_CLOUD_XFS');
+
+    my $utils = Test::MockModule->new('publiccloud::utils', no_auto => 1);
+    # plain is_sle() true, but version-qualified is_sle(">=16.0") false => SLE prefix
+    $utils->redefine(is_sle => sub { return @_ ? 0 : 1 });
+    $utils->redefine(is_sle_micro => sub { 0 });
+    set_var('PUBLIC_CLOUD_XFS', 1);
+    set_var('VERSION', '15-SP6');
+    my @repos = additional_repos();
+    is(scalar @repos, 1, 'one repo added for xfs');
+    like($repos[0], qr{QA:/Head/SLE-15-SP6/}, 'repo path uses SLE prefix and version');
+
+    _unset(qw/PUBLIC_CLOUD_XFS VERSION/);
+};
+
+subtest '[calculate_custodian_ttl] ISO 8601 with offset' => sub {
+    my $res = calculate_custodian_ttl(3600);
+    like($res, qr{^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$}, 'ISO 8601 Z format');
+
+    # The difference between two ttls should equal the difference in offsets.
+    use Time::Local qw(timegm);
+    my $parse = sub {
+        my ($Y, $M, $D, $h, $m, $s) = $_[0] =~ m{^(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)Z$};
+        return timegm($s, $m, $h, $D, $M - 1, $Y);
+    };
+    my $t0 = $parse->(calculate_custodian_ttl(0));
+    my $t1 = $parse->(calculate_custodian_ttl(7200));
+    cmp_ok($t1 - $t0, '>=', 7199, 'ttl offset reflected (lower bound, allows 1s clock tick)');
+    cmp_ok($t1 - $t0, '<=', 7201, 'ttl offset reflected (upper bound)');
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

https://progress.opensuse.org/issues/187800

Increases unit test coverage for the `lib/publiccloud` library. Previously
only 4 of 21 modules had any test reference (azure, utils, zypper, instance,
all partial); 17 modules — including `provider.pm`, `ec2.pm`, `gce.pm` and the
client/registry classes — had no dedicated unit tests.

After this change **all 21 `lib/publiccloud` modules are referenced by the unit
tests**, adding ~130 new subtests.

## What's covered

- **t/13_publiccloud.t** (extended): pure-function and mockable-method subtests
  for `publiccloud::utils` (timestamp/ttl, provider predicates, venv/repo
  helpers, `pc_data_url`) and `publiccloud::azure` (`decode_azure_json`,
  `parse_instance_id`, `generate_image_tags`, `get_image_definition`,
  start/stop/state/metadata/resource-group).
- **t/43_publiccloud_zypper.t**: verb classification, zypper→transactional-update
  translation, argument normalization/validation, and the public package API.
- **t/44_publiccloud_instance.t**: systemd time parsing, `isok`, ssh command
  construction (`_prepare_ssh_cmd`/`_apply_cmd_timeout`), `scp`,
  `retry_ssh_command`, and provider-delegating methods.
- **t/45_publiccloud_provider.t**: name conversion, img-proof output parsing,
  terraform tags/output, ssh-key generation.
- **t/46_publiccloud_ec2.t**: AWS CLI composition (describe/state/keypair/
  instance-type/IMDSv2 metadata).
- **t/47_publiccloud_gce.t**: image name normalization, guest-OS-feature lookup,
  image-id prefixing, gcloud describe/state, suspend.
- **t/48_publiccloud_clients.t**: aws/azure/gcp client getters + container image
  naming, instances registry, k8s_provider routing, ACR/ECR/GCR delete.
- **t/49_publiccloud_misc.t**: `basetest::provider_factory` routing,
  k8sbasetest service mapping, `ssh_interactive::select_host_console`.

## Notes

- No real network/ssh/cloud-CLI calls are made — all external layers are mocked
  with `Test::MockModule`/`Test::MockObject`.
- Verified locally: all 8 publiccloud test files pass under
  `prove -l -Ios-autoinst/ t/`, and `perlcritic` + `tidyall` are clean on the
  new/changed files.