### PR TITLE
Kselftests: net: Remove network:utilities repo for SLE15

### DIFF
--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -187,9 +187,6 @@ sub install_dependencies
         if (is_tumbleweed()) {
             $netutils_repo = 'https://download.opensuse.org/repositories/network:/utilities/openSUSE_Factory/network:utilities.repo';
             $bench_repo = 'https://download.opensuse.org/repositories/benchmark/openSUSE_Factory/benchmark.repo';
-        } elsif (is_sle('<16')) {
-            $netutils_repo = 'https://download.opensuse.org/repositories/network:/utilities/15.6/network:utilities.repo';
-            $bench_repo = 'https://download.opensuse.org/repositories/benchmark/15.6/benchmark.repo';
         } elsif (is_sle('=16.0')) {
             $netutils_repo = 'https://download.opensuse.org/repositories/network:/utilities/16.0/network:utilities.repo';
             $bench_repo = 'https://download.opensuse.org/repositories/benchmark/16.0/benchmark.repo';


### PR DESCRIPTION
The repository has been removed and can't be used anymore.

- Related ticket: https://progress.opensuse.org/issues/203172
- Verification run: https://openqa.suse.de/tests/23116943 (failure is unrelated and has been reported)