### PR TITLE
test(publiccloud): assert Azure UDR and cloud-init route propagation

### DIFF
--- a/data/publiccloud/cloud-init.yaml
+++ b/data/publiccloud/cloud-init.yaml
@@ -20,3 +20,4 @@ final_message: |
   timestamp: $timestamp
   datasource: $datasource
   uptime: $uptime
+

--- a/tests/publiccloud/cloud_netconfig.pm
+++ b/tests/publiccloud/cloud_netconfig.pm
@@ -72,6 +72,26 @@ sub run {
         die('There are no ARP neighbors on eth0') if ($instance->ssh_script_output("ip neighbor show dev eth0 | wc -l") == 0);
         die('There are no ARP neighbors on eth1') if ($instance->ssh_script_output("ip neighbor show dev eth1 | wc -l") == 0);
 
+        # Log cloud-init network config for debugging (bsc#1266868)
+        record_info('cloud-init network-config', $instance->ssh_script_output('sudo cat /var/lib/cloud/instance/network-config.json', proceed_on_failure => 1));
+
+        # Check that cloud-init contains the SUSE-specific _write_routes patch (bsc#1266868)
+        if ($instance->ssh_script_run('python3 -c "from cloudinit.distros.opensuse import Distro; assert hasattr(Distro, \'_write_routes\')"') != 0) {
+            record_soft_failure("bsc#1266868 - cloud-init is missing the SUSE-specific _write_routes patch");
+        }
+
+        # Check that cloud-init wrote the Azure UDR route to ifroute-eth0 (bsc#1266868)
+        my $udr_route = '172.25.25';
+        if ($instance->ssh_script_run("sudo grep -q $udr_route /etc/sysconfig/network/ifroute-eth0") != 0) {
+            record_soft_failure("bsc#1266868 - cloud-init did not write UDR route to /etc/sysconfig/network/ifroute-eth0");
+        }
+
+        # Check that cloud-netconfig programmed the Azure UDR route into the kernel (bsc#1267422)
+        my $custom_route = '172.25.25.0/24';
+        if ($instance->ssh_script_output("ip route show table all $custom_route | wc -l") == 0) {
+            record_soft_failure("bsc#1267422 - Custom UDR route $custom_route not found in routing tables");
+        }
+
         # Remove eth0 secondary address and eth1 default route and check if it reappears
         $instance->ssh_assert_script_run("sudo ip addr del $local_eth0_secondary_ip/24 dev eth0");
         $instance->ssh_assert_script_run("sudo ip route del default dev eth1");


### PR DESCRIPTION
Add checks for two related Azure networking bugs on SLES, both relying on the UDR (`172.25.25.0/24`) provisioned via [qac/infra#29](https://gitlab.suse.de/qac/infra/-/merge_requests/29):

**bsc#1266868 — cloud-init missing SUSE-specific `_write_routes` patch**

The SUSE downstream patch that writes `ifroute-*` files from cloud-init network config (read from Azure IMDS at boot) was dropped in cloud-init 25.x. Without it, custom Azure UDR routes delivered via IMDS are never written to `/etc/sysconfig/network/ifroute-eth0`.

Changes:
- Log `/var/lib/cloud/instance/network-config.json` for debugging
- Soft failure if the `_write_routes` method is missing from the installed cloud-init
- Soft failure if `ifroute-eth0` does not contain the UDR route `172.25.25.0/24`

**bsc#1267422 — cloud-netconfig not propagating Azure UDR routes into kernel routing tables**

`cloud-netconfig` should read the UDR from the Azure REST API and program it into the kernel routing table. Soft failure if `ip route show table all 172.25.25.0/24` returns nothing.

- Related: [bsc#1266868](https://bugzilla.suse.com/show_bug.cgi?id=1266868)
- Related: [bsc#1267422](https://bugzilla.suse.com/show_bug.cgi?id=1267422)
- Infrastructure change: https://gitlab.suse.de/qac/infra/-/merge_requests/29