### PR TITLE
Add regex to match new zypper output on 15-SP7

### DIFF
--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -51,7 +51,7 @@ sub run {
         push(@sappatterns, 'sles_sap_HAAPP', 'sles_sap_HADB') if is_sle('16+');
     }
 
-    my $base_pattern = is_sle('15+') ? 'patterns-server-enterprise-sap_server' : 'patterns-sles-sap_server';
+    my $base_pattern = is_sle('15+') ? '(patterns-server-enterprise-sap_server|pattern:sap_server)' : 'patterns-sles-sap_server';
     $base_pattern = '(patterns-sap-base_sap_server|pattern:sles_sap_base_sap_server)' if (is_sle('16+'));
 
     zypper_enable_install_dvd;


### PR DESCRIPTION
On a new zypper version provided on 15-SP7, the output of `zypper info -t pattern sap_server` has changed from ` i+ | patterns-server-enterprise-sap_server | package | Required ` to
`i+ | pattern:sap_server  | pattern | Required`
So we need to adjust our regex.
Since this test module also run on MU, there is no newer version zypper, so we add regex.

Relate: https://jira.suse.com/browse/TEAM-11358

VRs:
YAST migration job: https://openqa.suse.de/tests/23127908# 

SAP MU job: https://openqa.suse.de/tests/23127910

