### PR TITLE
Feat: Add serial check for JeOS Firstboot

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -216,6 +216,16 @@ sub create_user_in_ui {
     $user_created = 1;
 }
 
+sub check_jeos_on_serial_terminal {
+    return if (wait_serial("JeOS Firstboot", no_regex => 1, timeout => 300));
+
+    if (is_sle("=16.1") && is_ppc64le) {
+        record_soft_failure("bsc#1260359 - No serial terminal on ppc64le");
+        return;
+    }
+    die "JeOS firstboot not detected on serial terminal";
+}
+
 sub run {
     my ($self) = @_;
     my $lang = get_var('JEOSINSTLANG', 'en_US');
@@ -240,6 +250,9 @@ sub run {
         # long timeout due to missing combustion/ignition config bsc#1210429
         $initial_screen_timeout = 420 if is_sle_micro;
     }
+
+    # Ensures the JeOS firstboot wizard is present on the serial terminal
+    check_jeos_on_serial_terminal() unless (is_sle("<15") || is_s390x || check_var('JEOS_CHECK_SERIAL', '0'));
 
     # https://github.com/openSUSE/jeos-firstboot/pull/82 welcome dialog is shown on all consoles
     # and configuration continues on console where *Start* has been pressed

--- a/variables.md
+++ b/variables.md
@@ -123,6 +123,7 @@ IPXE_SET_HDD_BOOTSCRIPT | boolean | false | Upload second IPXE boot script for b
 ISO_MAXSIZE | integer | | Max size of the iso, used in `installation/isosize.pm`.
 IS_MM_SERVER | boolean | | If set, run server-specific part of the multimachine job
 IS_MM_CLIENT | boolean | | If set, run client-specific part of the multimachine job
+JEOS_CHECK_SERIAL | boolean | true | Skip the check weather the JeOS Firstboot wizard shows up on the serial terminal
 K3S_SYMLINK | string | | Can be 'skip' or 'force'. Skips the installation of k3s symlinks to tools like kubectl or forces the creation of symlinks
 K3S_BIN_DIR | string | | If defined, install k3s to this provided directory instead of `/usr/local/bin/`
 K3S_CHANNEL | string | | Set the release channel to pick the k3s version from. Options include "stable", "latest" and "testing"


### PR DESCRIPTION
Checks if the JeOS Firstboot wizard shows up on the serial terminal unless disabled via `JEOS_CHECK_SERIAL=0`.

- Related tickets: [poo#203118](https://progress.opensuse.org/issues/203118) and [bsc#1260359](https://bugzilla.suse.com/show_bug.cgi?id=1260359)

### Verification runs

* [SLES 16.1 ppc64le](https://openqa.suse.de/tests/23140580)
* [SLES 16.1 aarch64](https://openqa.suse.de/tests/23140581)
* [SLES 16.1 x86_64](https://duck-norris.qe.suse.de/tests/249) (unrelated failure)
* [Tumbleweed x86_64](https://duck-norris.qe.suse.de/tests/250)
* [Tumbleweed aarch64](https://openqa.opensuse.org/tests/6059841) (unrelated failures)
* [SLES 12-SP5 x86_64](https://duck-norris.qe.suse.de/tests/251)
* [SLES 15-SP5 x86_64](https://duck-norris.qe.suse.de/tests/253)
* [SLES 15-SP7 x86_64](https://duck-norris.qe.suse.de/tests/252)
* [SLES 15-SP7 aarch64](https://openqa.suse.de/tests/23140582)
* [SLES 15-SP7 s390x](https://openqa.suse.de/tests/23140583)