### PR TITLE
[VT]: Update sle16.1 snapshot test to use native qcow2 loader and nvram

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_x86_64_agama_online_iso_on_16_1_lower_host_qcow2_nvram.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_x86_64_agama_online_iso_on_16_1_lower_host_qcow2_nvram.xml
@@ -1,42 +1,46 @@
 <?xml version="1.0"?>
 <guest>
     <guest_os_name>sles</guest_os_name>
-    <guest_version>15-sp7</guest_version>
-    <guest_version_major>15</guest_version_major>
-    <guest_version_minor>7</guest_version_minor>
+    <guest_version>16.1</guest_version>
+    <guest_version_major>16</guest_version_major>
+    <guest_version_minor>1</guest_version_minor>
     <guest_os_word_length>64</guest_os_word_length>
     <guest_build/>
     <host_hypervisor_uri/>
     <host_virt_type>kvm</host_virt_type>
     <guest_virt_type>hvm</guest_virt_type>
-    <guest_machine_type/>
+    <guest_machine_type>q35</guest_machine_type>
     <guest_arch>x86_64</guest_arch>
     <guest_name/>
     <guest_domain_name/>
     <guest_memory>4096,maxmemory=8192</guest_memory>
     <guest_vcpus>2,maxvcpus=4</guest_vcpus>
-    <guest_cpumodel/>
+    <guest_cpumodel>host-model</guest_cpumodel>
     <guest_metadata/>
+    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-suse-4m-code.bin,loader.readonly=yes,loader.type=pflash,nvram.template=/usr/share/qemu/ovmf-x86_64-suse-4m-qcow2-vars.bin,nvram.templateFormat=qcow2,hd,bootmenu.enable=yes,menu=on</guest_boot_settings>
     <guest_xpath/>
-    <guest_installation_automation_method>autoyast</guest_installation_automation_method>
-    <guest_installation_automation_platform/>
-    <guest_installation_automation_file>sles_15_plus_kvm_hvm_guest_graphical_x86_64.xml</guest_installation_automation_file>
-    <guest_installation_method>location</guest_installation_method>
-    <guest_installation_extra_args>sshd=1#sshpassword=ROOTPASSWORD#console=ttyS0,115200n8#textmode=1</guest_installation_extra_args>
+    <guest_installation_automation_method>autoagama</guest_installation_automation_method>
+    <guest_installation_automation_platform></guest_installation_automation_platform>
+    <guest_installation_automation_file>sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet</guest_installation_automation_file>
+    <guest_installation_method>directkernel</guest_installation_method>
+    <guest_installation_extra_args/>
     <guest_installation_wait/>
     <guest_installation_method_others/>
-    <guest_installation_media>http://openqa.suse.de/assets/repo/fixed/SLE-15-SP7-Full-x86_64-GM-Media1/</guest_installation_media>
-    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-suse-4m-code.qcow2,loader.readonly=yes,loader.type=pflash,nvram.template=/usr/share/qemu/ovmf-x86_64-suse-4m-vars.qcow2,nvram.templateFormat=qcow2,hd,bootmenu.enable=yes,menu=on</guest_boot_settings>
-    <guest_secure_boot>true</guest_secure_boot>
-    <guest_os_variant/>
+    <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.1-Online-x86_64-Build12345.install.iso</guest_installation_media>
+    <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.1-Online-x86_64-Build12345.install/</guest_installation_fine_grained_media>
+    <guest_installation_fine_grained_repos/>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args_overwrite/>
+    <guest_installation_fine_grained_others/>
+    <guest_os_variant>sles16</guest_os_variant>
     <guest_storage_path/>
     <guest_storage_type>disk</guest_storage_type>
     <guest_storage_format>qcow2</guest_storage_format>
     <guest_storage_label>gpt</guest_storage_label>
-    <guest_storage_size/>
+    <guest_storage_size>40</guest_storage_size>
     <guest_storage_backing_path/>
     <guest_storage_backing_format/>
-    <guest_storage_others/>
+    <guest_storage_others>driver.name=qemu,target.dev=vda,target.bus=virtio,bus=virtio,cache=none</guest_storage_others>
     <guest_network_type>bridge</guest_network_type>
     <guest_network_mode>bridge</guest_network_mode>
     <guest_network_device/>
@@ -90,7 +94,7 @@
     <guest_default_target>graphical</guest_default_target>
     <guest_do_registration>true</guest_do_registration>
     <guest_registration_server/>
-    <guest_registration_username>www@suse.com</guest_registration_username>
+    <guest_registration_username/>
     <guest_registration_password/>
-    <guest_registration_extensions>sle-module-legacy#sle-module-basesystem#sle-module-server-applications#sle-module-desktop-applications#sle-module-web-scripting</guest_registration_extensions>
+    <guest_registration_extensions/>
 </guest>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_x86_64_agama_online_iso_qcow2_nvram.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_1_traditional_64_kvm_hvm_x86_64_agama_online_iso_qcow2_nvram.xml
@@ -17,7 +17,7 @@
     <guest_vcpus>2,maxvcpus=4</guest_vcpus>
     <guest_cpumodel>host-model</guest_cpumodel>
     <guest_metadata/>
-    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-suse-4m-code.bin,loader.readonly=yes,loader.type=pflash,nvram.template=/usr/share/qemu/ovmf-x86_64-suse-4m-qcow2-vars.bin,nvram.templateFormat=qcow2,hd,bootmenu.enable=yes,menu=on</guest_boot_settings>
+    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-suse-4m-code.qcow2,loader.readonly=yes,loader.type=pflash,nvram.template=/usr/share/qemu/ovmf-x86_64-suse-4m-vars.qcow2,nvram.templateFormat=qcow2,hd,bootmenu.enable=yes,menu=on</guest_boot_settings>
     <guest_xpath/>
     <guest_installation_automation_method>autoagama</guest_installation_automation_method>
     <guest_installation_automation_platform></guest_installation_automation_platform>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso_qcow2_nvram.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso_qcow2_nvram.xml
@@ -17,7 +17,7 @@
     <guest_vcpus>4,maxvcpus=8</guest_vcpus>
     <guest_cpumodel>host-model</guest_cpumodel>
     <guest_metadata/>
-    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-suse-4m-code.bin,loader.readonly=yes,loader.type=pflash,nvram.template=/usr/share/qemu/ovmf-x86_64-suse-4m-qcow2-vars.bin,nvram.templateFormat=qcow2,hd,bootmenu.enable=yes,menu=on</guest_boot_settings>
+    <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-suse-4m-code.qcow2,loader.readonly=yes,loader.type=pflash,nvram.template=/usr/share/qemu/ovmf-x86_64-suse-4m-vars.qcow2,nvram.templateFormat=qcow2,hd,bootmenu.enable=yes,menu=on</guest_boot_settings>
     <guest_xpath/>
     <guest_installation_automation_method>autoagama</guest_installation_automation_method>
     <guest_installation_automation_platform></guest_installation_automation_platform>

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2735,7 +2735,7 @@ sub load_sles16_mu_virt_tests {
         loadtest "virtualization/universal/install_update_package";
 
         #Feature test specific preparation steps on host before vm installation
-        if (check_var('ENABLE_SNAPSHOTS', '1')) {
+        if (check_var('ENABLE_SNAPSHOTS', '1') && is_sle('=16.0')) {
             loadtest "virt_autotest/prepare_nvram_for_snapshot";
         }
     }

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -862,10 +862,15 @@ sub create_guest {
             record_info("Boot Firmware", "Guest $name configured for EFI sev_es boot");
         }
         if ($guest->{boot_firmware} && $guest->{boot_firmware} eq 'efi-with-qcow2-based-nvram') {
-            # Need to match with SNAPSHOT_NVRAM_TEMPLATE_SRC and SNAPSHOT_NVRAM_TEMPLATE_NEW settings
-            $virtinstall .= " --boot loader=/usr/share/qemu/ovmf-x86_64-suse-4m-code.bin,loader.readonly=yes,"
-              . "loader.type=pflash,nvram.template=/usr/share/qemu/ovmf-x86_64-suse-4m-qcow2-vars.bin,"
-              . "nvram.templateFormat=qcow2,hd,bootmenu.enable=yes,menu=on";
+            if (is_sle('>=16.1')) {
+                $virtinstall .= " --boot loader=/usr/share/qemu/ovmf-x86_64-suse-4m-code.qcow2,loader.readonly=yes,"
+                  . "loader.type=pflash,nvram.template=/usr/share/qemu/ovmf-x86_64-suse-4m-vars.qcow2,";
+            } else {
+                # Need to match with SNAPSHOT_NVRAM_TEMPLATE_SRC and SNAPSHOT_NVRAM_TEMPLATE_NEW settings
+                $virtinstall .= " --boot loader=/usr/share/qemu/ovmf-x86_64-suse-4m-code.bin,loader.readonly=yes,"
+                  . "loader.type=pflash,nvram.template=/usr/share/qemu/ovmf-x86_64-suse-4m-qcow2-vars.bin,";
+            }
+            $virtinstall .= "nvram.templateFormat=qcow2,hd,bootmenu.enable=yes,menu=on";
             record_info("Boot Firmware", "Guest $name configured with EFI bootloader and qcow2 based nvram for snapshot test");
         }
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -913,7 +913,7 @@ elsif (get_var("VIRT_AUTOTEST")) {
         # Skip reset_partition for s390x due to there just be 42Gib disk space for each s390x LPAR
         loadtest "virt_autotest/reset_partition" if is_x86_64 && get_var('VIRT_PRJ1_GUEST_INSTALL') && !get_var('LTSS');
         loadtest "virt_autotest/reboot_and_wait_up_normal" if !is_registered_sles && get_var('REPO_0_TO_INSTALL');
-        loadtest "virt_autotest/prepare_nvram_for_snapshot" if get_var("ENABLE_SNAPSHOT") && is_x86_64 && get_var("VIRT_UEFI_GUEST_INSTALL");
+        loadtest "virt_autotest/prepare_nvram_for_snapshot" if get_var("ENABLE_SNAPSHOT") && is_x86_64 && get_var("VIRT_UEFI_GUEST_INSTALL") && is_sle('<16.1');
         loadtest "virt_autotest/download_guest_assets" if get_var("SKIP_GUEST_INSTALL") && is_x86_64;
     }
     if (get_var("VIRT_PRJ1_GUEST_INSTALL")) {

--- a/schedule/virt_autotest/sle16_guest_installation.yaml
+++ b/schedule/virt_autotest/sle16_guest_installation.yaml
@@ -33,6 +33,15 @@ conditional_schedule:
   prepare_nvram_for_snapshot:
     ENABLE_SNAPSHOT:
       1:
+        - '{{prepare_nvram_for_snapshot_DEV_version}}'
+        - '{{prepare_nvram_for_snapshot_QU_version}}'
+  prepare_nvram_for_snapshot_DEV_version:
+    VERSION_TO_INSTALL:
+      '16.0':
+        - virt_autotest/prepare_nvram_for_snapshot
+  prepare_nvram_for_snapshot_QU_version:
+    VERSION:
+      '16.0':
         - virt_autotest/prepare_nvram_for_snapshot
   virt_bridge_setup_test:
     ENABLE_VIRT_BRIDGE_SETUP_TEST:


### PR DESCRIPTION
There are some recent ovmf package changes. Based on this, we need to do snapshot test differently as below shown:
- For 16.1+, we can directly use the newly provided ovmf-.*-{vars,code}.qcow2 for snapshot test uefi vms. 
- For 16.0, need to continue the existing way to convert ovmf-.*-vars.bin to qcow2 format for uefi vms.
- For sle15spx, no such special things needed at all for legacy vms, but need ovmf conversion for uefi vms.

Given the different automation implementation and VERSION or VERSION_TO_INSTALL settings for MU, QU, developing, we should handle them differently:
- for MU: update logic to only do ovmf conversion for VERSION=16.0 staging test and use ovmf parameters differently for 16.0 and 16.1+
- for QU: update yaml schedule, to load ovmf conversion for VERSION=16.0 snapshot test
- for Developing: update yaml schedule, to load ovmf conversion for VERSION_TO_INSTALL<=16.0 snapshot tests

This PR fulfills above changes.


- Related ticket: https://progress.opensuse.org/issues/200369

- Relevant job group yaml change: https://gitlab.suse.de/qa-testsuites/openqa-job-group-yaml/-/merge_requests/406/diffs

- Verification run: 
Developing:
  - [#23138967](https://openqa.suse.de/tests/23138967#) sle-16.1-Online-x86_64-Build54.1-snapshot-gi-guest_developing-online-on-host_sles16_0-kvm@alice-suse_os-autoinst-distri-opensuse_alice_update-snapshot-test@64bit-ipmi-uefi
  - [#23138970](https://openqa.suse.de/tests/23138970#) sle-16.1-Online-x86_64-Build54.1-snapshot-gi-guest_developing-on-host_sles15sp7-kvm@alice-suse_os-autoinst-distri-opensuse_alice_update-snapshot-test@64bit-ipmi-legacy-boot
  - [#23138998](https://openqa.suse.de/tests/23138998#) sle-16.1-Online-x86_64-Build54.1-snapshot-gi-guest_developing-on-host_developing-kvm@alice-suse_os-autoinst-distri-opensuse_alice_update-snapshot-test@64bit-ipmi-uefi
  - [#23130777](https://openqa.suse.de/tests/23130777#) sle-16.1-Online-x86_64-Build54.1-snapshot-gi-guest_sles15sp7-on-host_developing-kvm@alice-suse_os-autoinst-distri-opensuse_alice_update-snapshot-test@64bit-ipmi-uefi
  - [#23130778](https://openqa.suse.de/tests/23130778#) sle-16.1-Online-x86_64-Build54.1-snapshot-gi-guest_sles16_0-online-on-host_developing-kvm@alice-suse_os-autoinst-distri-opensuse_alice_update-snapshot-test@64bit-ipmi-uefi
  
  MU:
  - [#23140419](https://openqa.suse.de/tests/23140419#) sle-15-SP6-Server-DVD-Incidents-VIRT-Core-x86_64-Build:smelt:123456:none-qam-kvm-install-and-features-test@alice-suse_os-autoinst-distri-opensuse_alice_update-snapshot-test@64bit-ipmi-legacy-large-mem
  - [#23140420](https://openqa.suse.de/tests/23140420#) sle-16.0-VIRT-Core-Updates-Staging-x86_64-Build:smelt:123456:none-qam-kvm-install-and-snapshot-test@alice-suse_os-autoinst-distri-opensuse_alice_update-snapshot-test@64bit-ipmi-uefi-large-mem 
  
  QU: 
  - [#23141746](https://openqa.suse.de/tests/23141746#) sle-16.0-Online-x86_64-Build245.4-snapshot-gi-guest_developing-on-host_developing-kvm@alice-suse_os-autoinst-distri-opensuse_alice_update-snapshot-test@64bit-ipmi-uefi