### PR TITLE
Record bsc#1250320 soft-failure in wait_for_ssh_login for img_proof jobs

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -510,6 +510,17 @@ sub wait_for_ssh_login {
     ## ssh options to avoid issues with pipelining and host key validation
     my $ssh_opts = $self->ssh_opts() . ' -o ControlPath=none -o ConnectTimeout=10 -o strictHostKeyChecking=no -o UserKnownHostsFile=/dev/null';
     $self->ssh_script_retry("true", ssh_opts => $ssh_opts, retry => $retry, delay => $delay, fail_message => "ssh connection failed ($delay attempts in $timeout seconds)");
+
+    # bsc#1250320 - augenrules.service fails at startup on Hardened Images on 15-SP7.
+    # publiccloud_img_proof jobs don't run the check_services test module, where this
+    # known failure is already allowlisted, so record it here instead.
+    if (is_sle('=15-SP7') && is_hardened()) {
+        my $sysout = $self->ssh_script_output(cmd => 'sudo systemctl is-system-running', ssh_opts => $ssh_opts, proceed_on_failure => 1);
+        if ($sysout =~ m/degraded/) {
+            my $failed_svcs = $self->ssh_script_output(cmd => 'sudo systemctl --failed', ssh_opts => $ssh_opts, proceed_on_failure => 1);
+            record_soft_failure('bsc#1250320 - augenrules.service fails at startup on Hardened Images') if ($failed_svcs =~ m/augenrules/);
+        }
+    }
 }
 
 =head2 isok


### PR DESCRIPTION
Records a soft-failure for bsc#1250320 (augenrules.service failing on Hardened Images) in `wait_for_ssh_login`, since `publiccloud_img_proof` jobs skip the `check_services` test module where this known failure is otherwise allowlisted. Rebased onto master's `wait_for_ssh` refactor, which removed the `is-system-running`/degraded check this fix originally targeted — the string-match bug it fixed no longer exists in current code, so only the soft-failure recording is kept, reimplemented against the new `wait_for_ssh_login`.

* Related ticket: [bsc#1250320](https://bugzilla.suse.com/show_bug.cgi?id=1250320)
* Related failure: [openqa.suse.de/t23132251](https://openqa.suse.de/tests/23132251)
* Verification runs: [openqa.suse.de/t23563324](https://openqa.suse.de/tests/23563324) (QE-C, Azure Hardened img_proof), [openqa.suse.de/t23563325](https://openqa.suse.de/tests/23563325) (QE-C, EC2 Hardened img_proof), [openqa.suse.de/t23563326](https://openqa.suse.de/tests/23563326) (QE-SAP, GCE SLES4SAP)