### PR TITLE
fix(himmelblau): set domain option

### DIFF
--- a/tests/publiccloud/himmelblau.pm
+++ b/tests/publiccloud/himmelblau.pm
@@ -23,7 +23,7 @@ sub configure_himmelblau {
     my $CONFIG_FILE = "/etc/himmelblau/himmelblau.conf";
     my $ENABLE_DEBUG_LOGS = "true";
 
-    assert_script_run("sed -i -e 's/# domains =/domains = $allowed_domain/g' $CONFIG_FILE");
+    assert_script_run("sed -i -e 's/# domain =/domain = $allowed_domain/g' $CONFIG_FILE");
     assert_script_run("sed -i -e 's/# pam_allow_groups =.*/pam_allow_groups = $allowed_user/g' $CONFIG_FILE");
     assert_script_run("sed -i -e 's/# debug =.*/debug = $ENABLE_DEBUG_LOGS/g' $CONFIG_FILE");
 


### PR DESCRIPTION
Update the test setup to edit the canonical domain option. This keeps configuration working after the example typo was fixed.

The `domains` parameter in the example configuration was a typo (albeit one which was aliased to the correct `domain` parameter, thus allowing the test to succeed). When the typo was corrected in the example himmelblau.conf, it broke the test setup.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1268646
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
