### PR TITLE
refactor(java): use alljava.sh to export JAVA_HOME

### DIFF
--- a/tests/console/ant.pm
+++ b/tests/console/ant.pm
@@ -79,7 +79,12 @@ sub run {
     zypper_call 'in ant';
 
     # Set JAVA_HOME to the jdk installation directory
-    assert_script_run("export JAVA_HOME=`update-alternatives --list javac| awk -F 'java' '{split(\$0, a); print a[1]; exit}'`'java'");
+    assert_script_run 'ALL_JAVA=$(rpm -ql aaa_base | grep alljava.sh)';
+    # test workaround, normally alljava.sh should not be sourced manually, but
+    # $PROFILEREAD is already set and the test does not reboot the SUT. therefore
+    # alljava.sh is then sourced explicitly to set the java variables
+    assert_script_run '. ${ALL_JAVA}', timeout => 120;
+    assert_script_run 'env | grep -i java';
     assert_script_run("export ANT_HOME=/usr/share/ant");
 
     # Set up


### PR DESCRIPTION
Based on the findings in https://bugzilla.suse.com/show_bug.cgi?id=1269559

The tests were using update-alternatives to populate JAVA_HOME variable. The aaa_base package provides automatic detection by alljava.sh that we should use from now on.

- Related ticket: https://progress.opensuse.org/issues/203283

### Verification runs

* [16.1](https://babu-frik.qe.prg2.suse.org/tests/122#step/ant/8)
* [15-SP4](https://babu-frik.qe.prg2.suse.org/tests/117#step/ant/30)
* [15-SP7](https://babu-frik.qe.prg2.suse.org/tests/123#step/ant/9)
