### PR TITLE
Add PUBLIC_CLOUD_SKIP_INSTANCE_CHECKS variable

### DIFF
--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -48,7 +48,7 @@ sub run {
     $instance->wait_for_guestregister() if (is_ondemand);
 
     $instance->network_speed_test();
-    $instance->check_cloudinit() if (is_cloudinit_supported);
+    $instance->check_cloudinit() if (is_cloudinit_supported && !get_var('PUBLIC_CLOUD_SKIP_INSTANCE_CHECKS'));
     $instance->enable_kdump() if (get_var('PUBLIC_CLOUD_ENABLE_KDUMP'));
 
     $provider->initialize_logging($instance);

--- a/variables.md
+++ b/variables.md
@@ -397,6 +397,7 @@ PUBLIC_CLOUD_RESOURCE_GROUP | string | "qesaposd" | Allows to specify resource g
 PUBLIC_CLOUD_RESOURCE_NAME | string | "openqa-vm" | The name we use when creating our VM.
 PUBLIC_CLOUD_ROOT_DISK_SIZE | int |  | Set size of system disk in GiB for public cloud instance. Default size is 30 for Azure and 20 for GCE and EC2 
 PUBLIC_CLOUD_SCC_ENDPOINT | string | "registercloudguest" | Name of binary which will be used to register image . Except default value only possible value is "SUSEConnect" anything else will lead to test failure!
+PUBLIC_CLOUD_SKIP_INSTANCE_CHECKS | boolean | false | DO NOT ADD TO JOB GROUPS: Skip the instance checks running right after instance is created. Those includes failed service check and the cloud init check.
 PUBLIC_CLOUD_SKIP_MU | boolean | false | Run tests without downloading/applying maintenance updates.
 PUBLIC_CLOUD_SLES4SAP | boolean | false | If set, sles4sap test module is added to the job.
 PUBLIC_CLOUD_STORAGE_ACCOUNT | string | "" | Storage account used e.g. for custom disk and container images


### PR DESCRIPTION
Adds the `PUBLIC_CLOUD_SKIP_INSTANCE_CHECKS` boolean variable (default: false) to skip instance checks that run right after instance creation. When set, `check_cloudinit()` in `prepare_instance.pm` is skipped. The variable is marked "DO NOT ADD TO JOB GROUPS" and is intended for one-off use only.

* Verification run: [pdostal-workbench.qe.prg2.suse.org/t995](https://pdostal-workbench.qe.prg2.suse.org/tests/995#)
* Related ticket: [bsc#1267422](https://bugzilla.suse.com/show_bug.cgi?id=1267422)