### PR TITLE
Feat: Add checks for Kernel-config for MinimalVM

### DIFF
--- a/schedule/jeos/sle/jeos-main.yaml
+++ b/schedule/jeos/sle/jeos-main.yaml
@@ -50,6 +50,7 @@ conditional_schedule:
 schedule:
     - '{{bootloader}}'
     - '{{wizard}}'
+    - jeos/kernel_config
     - jeos/image_info
     - jeos/record_machine_id
     - console/force_scheduled_tasks

--- a/schedule/jeos/sle/minimalvm-main.yaml
+++ b/schedule/jeos/sle/minimalvm-main.yaml
@@ -63,6 +63,7 @@ conditional_schedule:
 schedule:
     - '{{bootloader}}'
     - '{{wizard}}'
+    - jeos/kernel_config
     - jeos/image_info
     - jeos/minimalvm_image_checks
     - jeos/record_machine_id

--- a/tests/jeos/kernel_config.pm
+++ b/tests/jeos/kernel_config.pm
@@ -1,0 +1,21 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Verify kernel configuration
+# Maintainer: qa-c team <qa-c@suse.de>
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use version_utils;
+use Utils::Architectures;
+
+sub run {
+    my ($self) = @_;
+
+    # Check for bsc#1260359: Ensure there are no console= arguments on ppc64le for SLES
+    validate_script_output("grep GRUB_CMDLINE_LINUX_DEFAULT /etc/default/grub", sub { !m/console=/ }, fail_message => "Console= argument found in GRUB_CMDLINE_LINUX (bsc#1260359)") if (is_sle(">16.0") && is_ppc64le);
+}
+
+1;


### PR DESCRIPTION
Add a test module that allows to check the kernel configuration. As first test in this module we need to check the absense of console= parameters for ppc64le images on SLES.

- Related ticket: https://progress.opensuse.org/issues/203118
- Verification run: [SLES 16.1 ppc64le](https://openqa.suse.de/tests/23146958#step/kernel_config/1) | [SLES 16.1 x86_64](https://openqa.suse.de/tests/23146959#step/kernel_config/1)
