### PR TITLE
Workaround flaky scroll in Agama authentication screen

### DIFF
--- a/tests/installation/agama.pm
+++ b/tests/installation/agama.pm
@@ -28,6 +28,13 @@ sub scroll_down {
     send_key "ctrl-down";
 }
 
+sub scroll_up {
+    # We need to click on an empty space so we can press arrow up
+    mouse_set(850, 630);
+    mouse_click;
+    send_key "ctrl-up";
+}
+
 sub back_to_overview {
     for (my $tries = 0; $tries <= 5; $tries++) {
         assert_and_click('agama-overview-tab');
@@ -85,6 +92,9 @@ sub agama_set_root_password_screen {
 
         # Click the accept button to confirm changes, we use "enter" in agama_define_user_screen
         assert_and_click('agama-user-accept-button');
+
+        scroll_up();
+
         assert_screen('agama-auth-changes-applied');
     }
 }


### PR DESCRIPTION
Accepting the changes for root in the "Authentication" screen will
scroll to the top of the screen, but seems to not be always the case,
and the screen can end back to where it was, somewhere in between or
on the right place

VR: [TW build](https://openqa.opensuse.org/tests/overview?result=passed&machine=uefi-3G&distri=opensuse&version=Tumbleweed&build=poo203262)
