### PR TITLE
Add softfailure for bsc#1263772

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -2098,5 +2098,14 @@
             ]
         },
         "type": "ignore"
+    },
+    "bsc#1263772": {
+        "description": "Failed to start Run SUSEConnect --keepalive",
+        "products": {
+            "sle": [
+                "15-SP7"
+            ]
+        },
+        "type": "bug"
     }
 }


### PR DESCRIPTION
Add a softfailure for the known issue that `SUSEConnect --keepalive` fails to unblock maintenance updates.

This issue has already been [forced as softfailure in the past](https://openqa.suse.de/tests/23063397)

- Related failure: https://openqa.suse.de/tests/23141742#step/journal_check/2
- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1263772
- Verification run: https://openqa.suse.de/tests/23149270#step/journal_check/2
