### PR TITLE
Disable GPG check for QA:/Head repos in transfer_repos

### DIFF
--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -85,6 +85,8 @@ sub run {
     }
     else {
         $instance->ssh_assert_script_run("sudo find $repodir -name *.repo -exec sed -i 's,http://download.suse.de/ibs/,$repodir,g' '{}' \\;");
+        # QA:/Head repos have an untrusted GPG key; disable gpgcheck in the .repo file before adding
+        $instance->ssh_assert_script_run("sudo grep -rl 'QA:/Head' $repodir | grep '\\.repo\$' | xargs -r sudo sed -i 's/^gpgcheck=.*/gpgcheck=0/'");
         $instance->ssh_assert_script_run("sudo find $repodir -name *.repo -exec zypper ar -p10 '{}' \\;");
         $instance->ssh_assert_script_run("sudo find $repodir -name *.repo -exec echo '{}' \\;");
     }


### PR DESCRIPTION
After transferring repos to the cloud instance and registering them via `zypper ar`, any `.repo` file whose content references `QA:/Head` is patched with `gpgcheck=0` **before** `zypper ar` reads it. This prevents zypper from prompting for GPG key acceptance (which defaults to reject in non-interactive mode) when building the repo cache.

- Failure being fixed: [openqa.suse.de/t23149331](https://openqa.suse.de/tests/23149331)
- Verification runs: [pdostal-workbench.qe.prg2.suse.org/t1015](https://pdostal-workbench.qe.prg2.suse.org/tests/1015)