### PR TITLE
xfstests: refactor loop device creation into lib/Kernel/block_dev.pm

### DIFF
--- a/lib/Kernel/block_dev.pm
+++ b/lib/Kernel/block_dev.pm
@@ -17,6 +17,8 @@ use testapi;
 our @EXPORT_OK = qw(
   is_block_device
   record_storage_info
+  create_loop_backing_file
+  attach_loop_device
 );
 
 =head2 is_block_device
@@ -52,6 +54,74 @@ sub record_storage_info {
     record_info('/dev disks',
         script_output('ls -l /dev/nvme* /dev/vd* /dev/sd*', proceed_on_failure => 1));
     record_info('by-id', script_output('ls -l /dev/disk/by-id', proceed_on_failure => 1));
+}
+
+=head2 create_loop_backing_file
+
+ create_loop_backing_file($path, $size, %opts);
+
+Creates a loop device backing file with proper Btrfs host handling.
+
+Arguments:
+  $path - Full path to the backing file (e.g., '/opt/xfstests/test_dev')
+  $size - Size specification (e.g., '5G', '1024M')
+  %opts - Optional parameters:
+    timeout => timeout in seconds (default: 300)
+
+This function creates an empty file, applies chattr +C to disable CoW and
+compression on Btrfs hosts (no-op on other filesystems), then uses fallocate
+to allocate the requested space.
+
+The chattr +C flag must be set on an empty file before data is written to
+prevent Btrfs host filesystem issues:
+  - CoW disabled: prevents physical space explosion during overwrites
+  - Compression disabled: ensures full physical space allocation
+  - Safe for all test filesystems (xfs, btrfs, ext4, overlay, nfs)
+
+Returns: nothing (dies on error via assert_script_run)
+
+=cut
+
+sub create_loop_backing_file {
+    my ($path, $size, %opts) = @_;
+    my $timeout = $opts{timeout} // 300;
+
+    assert_script_run("touch $path");
+    script_run("chattr +C $path 2>/dev/null || true");
+    assert_script_run("fallocate -l $size $path", $timeout);
+}
+
+=head2 attach_loop_device
+
+ attach_loop_device($backing_file, %opts);
+
+Attaches a loop device to a backing file and returns the loop device path.
+
+Arguments:
+  $backing_file - Path to the backing file
+  %opts - Optional parameters:
+    loop_dev => specific loop device path (e.g., '/dev/loop100')
+                If not provided, uses 'losetup -f' to find next free device
+    timeout  => timeout in seconds (default: 300)
+
+Returns: the loop device path (e.g., '/dev/loop0')
+
+=cut
+
+sub attach_loop_device {
+    my ($backing_file, %opts) = @_;
+    my $timeout = $opts{timeout} // 300;
+
+    if ($opts{loop_dev}) {
+        assert_script_run("losetup -P $opts{loop_dev} $backing_file", $timeout);
+        return $opts{loop_dev};
+    } else {
+        assert_script_run("losetup -fP $backing_file", $timeout);
+        my $output = script_output("losetup -j $backing_file");
+        my ($loop_dev) = $output =~ /^([^:]+):/;
+        die "Failed to parse loop device from: $output" unless $loop_dev;
+        return $loop_dev;
+    }
 }
 
 1;

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -28,6 +28,7 @@ use registration;
 use version_utils qw(is_transactional is_sle_micro is_sle);
 use Utils::Architectures 'is_ppc64le';
 use transactional;
+use Kernel::block_dev qw(create_loop_backing_file attach_loop_device);
 use List::Util 'sum';
 use rdma;
 
@@ -188,23 +189,11 @@ sub create_loop_device_by_rootsize {
     @filename = ('test_dev');
     foreach (1 .. $amount) { push(@filename, "scratch_dev$_"); }
 
-    my $use_dd_create = get_var('XFSTESTS_DD_CREATE_DISK', 0);
-
     my $i = 0;
     foreach (@filename) {
-        if ($use_dd_create) {
-            # chattr +C must be set on empty file to disable CoW/compression on Btrfs hosts
-            assert_script_run("touch $INST_DIR/$_");
-            script_run("chattr +C $INST_DIR/$_ 2>/dev/null || true");
-            my $size_mb = str_to_mb($loop_dev_size[$i]);
-            record_info('Loop device (dd)', "Creating $_ with dd: $loop_dev_size[$i] ($size_mb MB)");
-            assert_script_run("dd if=/dev/zero of=$INST_DIR/$_ bs=1M count=$size_mb conv=fsync status=progress", 1200);
-        } else {
-            assert_script_run("fallocate -l $loop_dev_size[$i] $INST_DIR/$_", 300);
-        }
-
+        create_loop_backing_file("$INST_DIR/$_", $loop_dev_size[$i]);
+        attach_loop_device("$INST_DIR/$_");
         $i++;
-        assert_script_run("losetup -fP $INST_DIR/$_", 300);
     }
     script_run("losetup -a");
     if ($para{fstype} =~ /overlay/) {
@@ -239,17 +228,8 @@ sub create_loop_device_by_rootsize {
         my $logdev = "/dev/loop100";
         my $logdev_name = "logdev";
 
-        if ($use_dd_create) {
-            # chattr +C must be set on empty file to disable CoW/compression on Btrfs hosts
-            assert_script_run("touch $INST_DIR/$logdev_name");
-            script_run("chattr +C $INST_DIR/$logdev_name 2>/dev/null || true");
-            record_info('Loop device (dd)', "Creating logdev with dd: 1G (1024 MB)");
-            assert_script_run("dd if=/dev/zero of=$INST_DIR/$logdev_name bs=1M count=1024 conv=fsync status=progress", 1200);
-        } else {
-            assert_script_run("fallocate -l 1G $INST_DIR/$logdev_name", 300);
-        }
-
-        assert_script_run("losetup -P $logdev $INST_DIR/$logdev_name", 300);
+        create_loop_backing_file("$INST_DIR/$logdev_name", '1G');
+        attach_loop_device("$INST_DIR/$logdev_name", loop_dev => $logdev);
         format_partition("$INST_DIR/$logdev_name", $para{fstype});
         script_run("echo export SCRATCH_LOGDEV=$logdev >> $CONFIG_FILE");
         script_run("echo export USE_EXTERNAL=yes >> $CONFIG_FILE");

--- a/variables.md
+++ b/variables.md
@@ -490,8 +490,7 @@ Variable        | Type      | Default value | Details
 ---             | ---       | ---           | ---
 XFSTEST_MKFS_OPTION | string | | BTRFS only, value=<options-in-mkfs>. Set the options in mkfs.btrfs. And also set it in xfstests runtime option BTRFS_MKFS_OPTIONS.
 XFSTESTS_LOGDEV | boolean | 0 | XFS only, value=0/1. enable log device in testing xfs
-XFSTESTS_LOOP_DEVICE | boolean | 0 | Create loop device for testing
-XFSTESTS_DD_CREATE_DISK | boolean | 0 | Use dd with chattr +C (NoCoW) to create loop device files with real physical space. On Btrfs hosts, this prevents: (1) compression of zero blocks making dd ineffective, (2) CoW-induced space explosion when fio writes random data, causing host ENOSPC/crash. chattr +C only affects host storage, not the filesystem inside loop device. Safe for all test types including btrfs. Slower than fallocate but essential for debugging ENOSPC tests like generic/299 on Btrfs hosts
+XFSTESTS_LOOP_DEVICE | boolean | 0 | Create loop device for testing with chattr +C to prevent CoW/compression issues on Btrfs hosts. Loop device files are created via lib/Kernel/block_dev.pm using touch + chattr +C + fallocate, which prevents physical space explosion during fio writes and host ENOSPC crashes
 XFSTESTS_ZONE_DEVICE | boolean | 0 | Create zoned device for testing
 XFSTESTS_XFS_REPAIR | boolean | 0 | XFS only, value=0/1. enable TEST_XFS_REPAIR_REBUILD=1 in xfstests log file local.config
 XFSTESTS_NFS_VERSION | string | 4.1 | NFS only, version of test target NFS. What's special is that set it with TLS-<nfsversion> will enable NFS over kTLS. And set it with krb5[pi]-<nfsversion> will enable NFS with kerberos5 mount option during tests


### PR DESCRIPTION
Extract loop device creation logic from xfstests/partition.pm into reusable functions in lib/Kernel/block_dev.pm to benefit other storage tests (blktests, future tests).

New functions:
- create_loop_backing_file(): touch + chattr +C + fallocate
- attach_loop_device(): losetup with optional specific device

Always use chattr +C on Btrfs hosts (not behind a flag) to prevent CoW/compression issues. This eliminates XFSTESTS_DD_CREATE_DISK which used dd - testing showed fallocate + chattr +C is sufficient and faster. (There is a VR to use fallocate replace dd, and run pass https://openqa.suse.de/tests/23161845#step/generic-299/61)

- Related ticket: https://progress.opensuse.org/issues/203208
- Verification run: https://openqa.suse.de/tests/23163439
