### PR TITLE
Fix aws-cli jobs on latest SLES 16.1

### DIFF
--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -45,6 +45,8 @@ sub init {
         assert_script_run('mkdir -p ~/.aws');
         # CAVEAT: Use the bash environment variables to prevent credential leaks.
         assert_script_run('printf "[default]\naws_access_key_id=$AWS_ACCESS_KEY_ID\naws_secret_access_key=$AWS_SECRET_ACCESS_KEY\nregion=$AWS_DEFAULT_REGION\n" > ~/.aws/credentials');
+        # Work-around for https://bugzilla.suse.com/show_bug.cgi?id=1269510
+        assert_script_run('printf "[default]\nca_bundle = /var/lib/ca-certificates/ca-bundle.pem\n" > ~/.aws/config') if is_sle(">16.0");
         script_run("PILOT_DEBUG=1 aws %silent --help");
     }
 

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -192,7 +192,7 @@ sub create_ssh_key {
     record_info($alg, "The $alg key will be generated.");
     if (script_run('test -f ' . $self->ssh_key) != 0) {
         assert_script_run('SSH_DIR=`dirname ' . $self->ssh_key . '`; mkdir -p $SSH_DIR');
-        assert_script_run('ssh-keygen -t ' . $alg . ' -q -N "" -C "" -m pem -f ' . $self->ssh_key);
+        assert_script_run('ssh-keygen -t ' . $alg . ' -q -N "" -C ""' . ($alg eq 'rsa' ? ' -m pem' : '') . ' -f ' . $self->ssh_key);
     }
 }
 


### PR DESCRIPTION
This PR:
- Adds work-around for https://bugzilla.suse.com/show_bug.cgi?id=1269510
- Use PEM format for RSA keys only as recent OpenSSH versions reject the legacy PEM format and force the RFC-4716 format for ED25519 keys instead.

Failed job: https://openqa.suse.de/tests/23166401#step/aws_cli/32
Verification run: https://openqa.suse.de/tests/23166457
