### PR TITLE
ltp: add SKIP_KERNEL_UPDATE variable to skip update_kernel step

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -56,7 +56,7 @@ sub load_kernel_tests {
             get_var('ASSET_CHANGE_KERNEL_RPM')) {
             loadtest_kernel 'change_kernel';
         }
-        elsif (!get_var('LIBC_LIVEPATCH') && !is_jeos) {
+        elsif (!get_var('LIBC_LIVEPATCH') && !get_var('SKIP_KERNEL_UPDATE') && !is_jeos) {
             loadtest_kernel 'update_kernel';
         }
 


### PR DESCRIPTION
When INSTALL_LTP=git is used to build LTP from a custom git repo, update_kernel is loaded unconditionally even when the base image already has an appropriate kernel. Add SKIP_KERNEL_UPDATE=1 to allow skipping that step.

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
