### PR TITLE
Add is_ltss() helper based on lifecycle dates

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -7,12 +7,13 @@ use base Exporter;
 use Exporter;
 use strict;
 use warnings;
-use testapi qw(check_var get_var set_var script_output);
+use testapi qw(check_var get_var get_required_var set_var script_output);
 use version 'is_lax';
 use Carp 'croak';
 use Utils::Backends;
 use Utils::Architectures;
 use SemVer;
+use POSIX 'strftime';
 
 use constant {
     VERSION => [
@@ -67,6 +68,7 @@ use constant {
           has_selinux_by_default
           has_selinux
           is_wsl
+          is_ltss
         )
     ],
     BACKEND => [
@@ -1070,3 +1072,38 @@ Check if agama installation is being used
 sub is_agama {
     return (get_var('AGAMA') || get_var('INST_AUTO'));
 }
+
+=head2 is_ltss
+
+Returns true if the system is running on LTSS (Long Term Service Support)
+=cut
+
+sub is_ltss {
+    my $version = get_required_var('VERSION');
+    my $current_date = strftime("%Y%m%d", localtime);
+    # Product Support Lifecycle Dates defined at https://www.suse.com/lifecycle
+    my %general_ends = (
+        '15-SP7' => '20310731',
+        '16.0' => '20271130',
+        '16.1' => '20281130',
+        '16.2' => '20291130',
+        '16.3' => '20301130',
+        '16.4' => '20311130',
+        '16.5' => '20321130',
+        '16.6' => '20351130'
+    );
+    # Not valid for openSUSE products
+    return 0 if is_opensuse;
+
+    # All versions <=15-SP6 are already in LTSS
+    return 1 if is_sle('<=15-SP6');
+
+    # Die if version is not in the lifecycle table (including non-SLE products)
+    die "Version $version is not defined in LTSS lifecycle table.\nPlease update lib/version_utils.pm\n\n"
+      unless exists $general_ends{$version};
+
+    # Check if current date is past the lifecycle date
+    return $general_ends{$version} <= $current_date;
+}
+
+

--- a/t/01_version_utils.t
+++ b/t/01_version_utils.t
@@ -3,6 +3,7 @@ use warnings;
 use Test::More;
 use Test::Exception;
 use Test::Warnings;
+use Test::MockModule;
 
 use testapi qw(check_var get_var set_var);
 
@@ -249,6 +250,72 @@ subtest 'is_staging tests' => sub {
     ok is_staging, "foo is a staging project";
     isnt is_staging('bar'), 0, "bar is not this staging";
     is is_staging('foo'), 1, "foo is the current staging";
+};
+
+subtest 'is_ltss' => sub {
+    use version_utils 'is_ltss';
+    my $my_ver = Test::MockModule->new('version_utils', no_auto => 1);
+    my $my_fake_today;
+
+    $my_ver->redefine(strftime => sub { return $my_fake_today });
+
+    # Test 1: SLE 15-SP6 and older are always LTSS (regardless of date)
+    set_var('DISTRI', 'sle');
+    set_var('VERSION', '15-SP6');
+    $my_fake_today = '20260702';    # Today - way before LTSS
+    ok is_ltss(), "SLE 15-SP6 is LTSS even before lifecycle date";
+
+    set_var('VERSION', '15-SP5');
+    $my_fake_today = '20260702';
+    ok is_ltss(), "SLE 15-SP5 is LTSS";
+
+    set_var('VERSION', '12-SP5');
+    $my_fake_today = '20260702';
+    ok is_ltss(), "SLE 12-SP5 is LTSS";
+
+    # Test 2: Future versions before their lifecycle date
+    set_var('VERSION', '15-SP7');
+    $my_fake_today = '20310730';    # One day before 20310731
+    ok !is_ltss(), "SLE 15-SP7 is not yet LTSS (one day before)";
+
+    set_var('VERSION', '16.0');
+    $my_fake_today = '20271129';    # One day before 20271130
+    ok !is_ltss(), "SLE 16.0 is not yet LTSS (one day before)";
+
+    # Test 3: Future versions on their lifecycle date
+    set_var('VERSION', '15-SP7');
+    $my_fake_today = '20310731';    # Exactly on lifecycle date
+    ok is_ltss(), "SLE 15-SP7 is LTSS on lifecycle date";
+
+    set_var('VERSION', '16.0');
+    $my_fake_today = '20271130';    # Exactly on lifecycle date
+    ok is_ltss(), "SLE 16.0 is LTSS on lifecycle date";
+
+    # Test 4: Future versions after their lifecycle date
+    set_var('VERSION', '15-SP7');
+    $my_fake_today = '20310801';    # One day after 20310731
+    ok is_ltss(), "SLE 15-SP7 is LTSS (one day after)";
+
+    set_var('VERSION', '16.1');
+    $my_fake_today = '20321201';    # After 20281130
+    ok is_ltss(), "SLE 16.1 is LTSS (years after)";
+
+    # Test 5: Undefined SLE version should die
+    set_var('VERSION', '42.0');
+    dies_ok { is_ltss() } "SLE 42.0 (undefined version) should die";
+
+    # Test 6: openSUSE products return false (not LTSS)
+    set_var('DISTRI', 'opensuse');
+    set_var('VERSION', 'Tumbleweed');
+    ok !is_ltss(), "Tumbleweed is not LTSS";
+
+    set_var('DISTRI', 'microos');
+    set_var('VERSION', '6.0');
+    ok !is_ltss(), "MicroOS is not LTSS";
+
+    # Cleanup
+    set_var('DISTRI', undef);
+    set_var('VERSION', undef);
 };
 
 done_testing;


### PR DESCRIPTION
Detect LTSS products using hardcoded lifecycle end dates from https://www.suse.com/lifecycle instead of runtime variables. This avoids version bumps when products reach LTSS.

Versions <=15-SP6 are LTSS, future versions check against current date. Dies for undefined versions.

- Related ticket: https://progress.opensuse.org/issues/202185
- Verification runs:
  - [12-SP5 LTSS](https://openqa.suse.de/tests/23204468)
  - [15-SP6 LTSS](https://openqa.suse.de/tests/23167329)
  - [15-SP7 non-LTSS](https://openqa.suse.de/tests/23167330)
  - [16.1 non-LTSS](https://openqa.suse.de/tests/23167331)
  - [Tumbleweed](https://openqa.opensuse.org/tests/6064843)
  - [Leap 16.1](https://openqa.opensuse.org/tests/6074409)
