### PR TITLE
helm: Apply work-around for gh#OSInside/flake-pilot#80

### DIFF
--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -54,6 +54,13 @@ sub run {
             add_suseconnect_product(get_addon_fullname('pcm')) if is_sle("<16");
             my $aws_cli_pkg = is_sle(">16.0") ? 'aws-cli-cmd' : 'aws-cli';
             zypper_call("in jq $aws_cli_pkg", timeout => 300);
+            if (is_sle(">16.0")) {
+                # Wrap aws to suppress flake-pilot stderr noise
+                # https://github.com/OSInside/flake-pilot/issues/80
+                my $aws_bin = script_output("command -v aws");
+                assert_script_run("printf '#!/bin/sh\\nexec $aws_bin %%silent \"\$\@\"\\n' > /usr/local/bin/aws && chmod +x /usr/local/bin/aws");
+                assert_script_run('export PATH=/usr/local/bin:$PATH');
+            }
 
             # publiccloud::aws_client needs to demand PUBLIC_CLOUD_REGION due to other places where
             # we don't want to have defaults and want tests to fail when region is not defined

--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -78,6 +78,15 @@ sub run {
             add_suseconnect_product(get_addon_fullname('phub')) if is_sle('=12-sp5');
             my $az_cli_pkg = is_sle(">16.0") ? 'az-cli-cmd' : 'azure-cli';
             zypper_call("in jq $az_cli_pkg", timeout => 300);
+            if (is_sle(">16.0")) {
+                # Wrap az to suppress flake-pilot stderr noise
+                # https://github.com/OSInside/flake-pilot/issues/80
+                my $az_bin = script_output("command -v az");
+                assert_script_run("printf '#!/bin/sh\\nexec $az_bin %%silent \"\$\@\"\\n' > /usr/local/bin/az && chmod +x /usr/local/bin/az");
+                assert_script_run('export PATH=/usr/local/bin:$PATH');
+            }
+
+            # publiccloud::aws_client needs to demand PUBLIC_CLOUD_REGION due to other places where
 
             # publiccloud::azure_client needs to demand PUBLIC_CLOUD_REGION due to other places where
             # we don't want to have defaults and want tests to fail when region is not defined


### PR DESCRIPTION
Wrap the aws & az commands with `%silent` on SLE 16.1+ to suppress flake-pilot noise.  See https://github.com/OSInside/flake-pilot/issues/80

Failed job: https://openqa.suse.de/tests/23166739#step/helm_EC2/104
Verification run: https://openqa.suse.de/tests/23169992
