### PR TITLE
himmelblau: fix sed to match both "domain" and "domains" keys

### DIFF
--- a/tests/publiccloud/himmelblau.pm
+++ b/tests/publiccloud/himmelblau.pm
@@ -23,9 +23,9 @@ sub configure_himmelblau {
     my $CONFIG_FILE = "/etc/himmelblau/himmelblau.conf";
     my $ENABLE_DEBUG_LOGS = "true";
 
-    assert_script_run("sed -i -e 's/# domain =/domain = $allowed_domain/g' $CONFIG_FILE");
-    assert_script_run("sed -i -e 's/# pam_allow_groups =.*/pam_allow_groups = $allowed_user/g' $CONFIG_FILE");
-    assert_script_run("sed -i -e 's/# debug =.*/debug = $ENABLE_DEBUG_LOGS/g' $CONFIG_FILE");
+    assert_script_run("sed -ri 's/# (domains?) =.*/\\1 = $allowed_domain/g' $CONFIG_FILE");
+    assert_script_run("sed -i 's/# pam_allow_groups =.*/pam_allow_groups = $allowed_user/g' $CONFIG_FILE");
+    assert_script_run("sed -i 's/# debug =.*/debug = $ENABLE_DEBUG_LOGS/g' $CONFIG_FILE");
 
     record_info("Himmelblau configured");
 }


### PR DESCRIPTION
Use extended regex (-r) to capture the key name and support both "domain" and "domains" config variants. Also drop the unnecessary -e flag from the remaining sed calls.

Fixes https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25944

Verification run: https://openqa.opensuse.org/tests/6066787