### PR TITLE
Add missing default scenarios to complete the test matrix for aarch64 and s390x

### DIFF
--- a/schedule/yam/agama_ppc64le.yaml
+++ b/schedule/yam/agama_ppc64le.yaml
@@ -8,6 +8,7 @@ schedule:
   - yam/agama/agama
   - installation/grub_test
   - installation/first_boot
+  - yam/validate/validate_selinux
   - yam/validate/validate_base_product
   - yam/validate/validate_product
   - yam/validate/validate_first_user

--- a/schedule/yam/agama_unattended.yaml
+++ b/schedule/yam/agama_unattended.yaml
@@ -7,6 +7,7 @@ schedule:
   - yam/agama/agama_auto
   - installation/grub_test
   - installation/first_boot
+  - yam/validate/validate_selinux
   - yam/validate/validate_base_product
   - yam/validate/validate_product
   - yam/validate/validate_connectivity

--- a/schedule/yam/agama_unattended_immutable.yaml
+++ b/schedule/yam/agama_unattended_immutable.yaml
@@ -7,6 +7,7 @@ schedule:
   - yam/agama/agama_auto
   - installation/grub_test
   - installation/first_boot
+  - yam/validate/validate_selinux
   - yam/validate/validate_base_product
   - yam/validate/validate_product
   - yam/validate/validate_connectivity

--- a/test_data/yam/agama_sle_media_161_immutable_s390x.yaml
+++ b/test_data/yam/agama_sle_media_161_immutable_s390x.yaml
@@ -1,0 +1,20 @@
+---
+os_release:
+  NAME: "SLES"
+  PRETTY_NAME: "SUSE Linux Enterprise Server %VERSION%"
+  VARIANT: "Micro"
+  VARIANT_ID: "transactional"
+  VERSION_ID: "%VERSION%"
+  ID: "sles"
+  ID_LIKE: 'suse opensuse sle-micro sl-micro microos opensuse-microos'
+  CPE_NAME: "cpe:/o:suse:sles:16:%VERSION%"
+  SUSE_SUPPORT_PRODUCT: "SUSE Linux Enterprise Server"
+repos:
+  - name: agama-0
+    alias: agama-0
+    uri: http://openqa.suse.de/assets/repo/SLES-16.1-Full-s390x-Build%BUILD%.install/install/
+    enabled: 'Yes'
+    filter: alias
+selinux:
+  status: enabled
+  mode: enforcing

--- a/test_data/yam/agama_sle_media_161_s390x.yaml
+++ b/test_data/yam/agama_sle_media_161_s390x.yaml
@@ -1,0 +1,20 @@
+---
+os_release:
+  NAME: "SLES"
+  PRETTY_NAME: "SUSE Linux Enterprise Server %VERSION%"
+  VARIANT: "Enterprise Server"
+  VARIANT_ID: "server"
+  VERSION_ID: "%VERSION%"
+  ID: "sles"
+  ID_LIKE: "suse opensuse"
+  CPE_NAME: "cpe:/o:suse:sles:16:%VERSION%"
+  SUSE_SUPPORT_PRODUCT: "SUSE Linux Enterprise Server"
+repos:
+  - name: agama-0
+    alias: agama-0
+    uri: http://openqa.suse.de/assets/repo/SLES-16.1-Full-s390x-Build%BUILD%.install/install/
+    enabled: 'Yes'
+    filter: alias
+selinux:
+  status: enabled
+  mode: enforcing


### PR DESCRIPTION
Add missing default scenarios to complete the test matrix for aarch64 and s390x and load validate_selinux for all of the default installation.

- Related ticket: 
  - https://progress.opensuse.org/issues/202959#note-10
- Verification run: 
  - [SLES16.1_Full](https://openqa.suse.de/tests/overview?flavor=Full&distri=sle&version=16.1&build=54.1&groupid=576) || [SLES_16.1_Online](https://openqa.suse.de/tests/overview?distri=sle&version=16.1&build=chcao_load_selinux) || [SLES16.0](https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=chcao_load_selinux)
- Related MR: 
  - https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/846