### PR TITLE
All crash test deployment use same region and ssh

### DIFF
--- a/tests/sles4sap/crash/deploy.pm
+++ b/tests/sles4sap/crash/deploy.pm
@@ -96,10 +96,10 @@ sub run {
 
     if ($provider_type eq 'EC2') {
         my $instance_id = crash_deploy_aws(
-            region => get_var('PUBLIC_CLOUD_REGION'),
+            region => $provider->provider_client->region,
+            ssh_pub_key => $provider->ssh_key . ".pub",
             image_name => $provider->get_image_id(),
             image_owner => get_var('PUBLIC_CLOUD_EC2_ACCOUNT_ID', '679593333241'),
-            ssh_pub_key => $provider->ssh_key . ".pub",
             instance_type => get_required_var('PUBLIC_CLOUD_INSTANCE_TYPE'),
             address_range => $range{main_address_range},
             subnet_range => $range{subnet_address_range});
@@ -113,20 +113,21 @@ sub run {
           $self->{provider}->get_blob_uri(get_var('PUBLIC_CLOUD_IMAGE_LOCATION')) :
           $provider->get_image_id();
         crash_deploy_azure(
-            os => $os_ver,
             region => $provider->provider_client->region,
+            ssh_pub_key => $provider->ssh_key . ".pub",
+            os => $os_ver,
             address_range => $range{main_address_range},
             subnet_range => $range{subnet_address_range});
     }
     elsif ($provider_type eq 'GCE') {
         crash_deploy_gcp(
-            region => get_required_var('PUBLIC_CLOUD_REGION'),
+            region => $provider->provider_client->region,
+            ssh_pub_key => $provider->ssh_key . '.pub',
             availability_zone => get_required_var('PUBLIC_CLOUD_AVAILABILITY_ZONE'),
             project => get_required_var('PUBLIC_CLOUD_GOOGLE_PROJECT_ID'),
             image_name => $provider->get_image_id() =~ s/.*\///r,
             image_project => get_required_var('PUBLIC_CLOUD_IMAGE_PROJECT'),
             machine_type => get_var('PUBLIC_CLOUD_INSTANCE_TYPE', 'n1-standard-2'),
-            ssh_pub_key => $provider->ssh_key . '.pub',
             subnet_range => $range{subnet_address_range});
     }
     else {


### PR DESCRIPTION
Change the crash test deployment to use same ssh key and always get region from the PC provider pobject, across all the CSP.

- Loosely related to ticket: https://progress.opensuse.org/issues/202446

# Verification run:

 - sle-15-SP7-SapCloud-Gcp-Byos-x86_64-BuildLATEST_GCP_SLE15_7-crash_test  http://openqaworker15.qe.prg2.suse.org/tests/376107 :green_circle: 

 - sle-15-SP7-SapCloud-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_7-crash_test
http://openqaworker15.qe.prg2.suse.org/tests/376112 :green_circle: failure is later after the deployment

 - sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-crash_test http://openqaworker15.qe.prg2.suse.org/tests/376113
 -  http://openqaworker15.qe.prg2.suse.org/tests/376151 :green_circle: job failure is later in registration and not related to this change