### PR TITLE
Fix regression in assert_script_run usage

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -1197,9 +1197,8 @@ sub az_nic_create(%args) {
             '--subnet', $args{subnet},
             '--network-security-group', $args{nsg},
             '--private-ip-address-version IPv4',
-            '--public-ip-address', $args{pubip_name}),
-        $SDAF_Azure_podman_flake_filter
-    );
+            '--public-ip-address', $args{pubip_name},
+            $SDAF_Azure_podman_flake_filter));
 }
 
 =head2 az_nic_get


### PR DESCRIPTION
Fix regression introduced by 37cfb48. The new variable was not added within the join() that result it to be interpreted as a separater assert_script_run argument, as a zero time timeout. Fix just move the SDAF variable within the join() to be correctly used to compose the command line string.

Related to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25641

- Related ticket: https://jira.suse.com/browse/TEAM-11370

# Verification run:
 - sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-crash_test -> http://openqaworker15.qe.prg2.suse.org/tests/376114 :green_circle: 