### PR TITLE
aws_client: Use same work-around as azure_client

### DIFF
--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -46,7 +46,7 @@ sub init {
         # CAVEAT: Use the bash environment variables to prevent credential leaks.
         assert_script_run('printf "[default]\naws_access_key_id=$AWS_ACCESS_KEY_ID\naws_secret_access_key=$AWS_SECRET_ACCESS_KEY\nregion=$AWS_DEFAULT_REGION\n" > ~/.aws/credentials');
         # Work-around for https://bugzilla.suse.com/show_bug.cgi?id=1269510
-        assert_script_run('printf "[default]\nca_bundle = /var/lib/ca-certificates/ca-bundle.pem\n" > ~/.aws/config') if is_sle(">16.0");
+        script_run q(sed '/ca-certificates/s,\\\\$,--opt "\\\\--volume /etc/ssl:/etc/ssl:ro" \\\\,' /usr/bin/register_aws | bash) if is_sle(">16.0");
         script_run("PILOT_DEBUG=1 aws %silent --help");
     }
 


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/203514

Use same work-around done here:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25976/changes#diff-e5e5688638fdb55531f11ac8ed49a94bb3ebcdebbabca0476144522f0e9d36abR45-R46

Failed job: https://openqa.suse.de/tests/23175718#step/prepare_instance/164
Verification run: https://openqa.suse.de/tests/23185761