### PR TITLE
Add low level support for multiple regions

### DIFF
--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Helper class for amazon connection and authentication
@@ -11,13 +11,45 @@ package publiccloud::aws_client;
 use Mojo::Base -base;
 use testapi;
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_sle);
 use publiccloud::utils;
 
-has region => sub { get_required_var('PUBLIC_CLOUD_REGION') };
+
+# Reference to a list of all regions specified via job variable/settings
+# At least one region is present from PUBLIC_CLOUD_REGION
+has _regions => sub {
+    my @list = (get_required_var('PUBLIC_CLOUD_REGION'));
+    if (my $alt = get_var('PUBLIC_CLOUD_ALTERNATE_REGIONS')) {
+        push @list, split(/\s*,\s*/, $alt);
+    }
+    return \@list;
+};
+
+# List of regions blacklisted by the user during the test execution.
+has _blacklisted_regions => sub { {} };
+
+# Setter for the blacklist. The test code can call this function
+# to add a region name to the blacklis; it usually happens
+# when a terraform deployment fails for a specific error.
+sub blacklist_region {
+    my ($self, $region) = @_;
+    $self->_blacklisted_regions->{$region} = 1;
+    return $self;    # allows chaining
+}
+
+# Getter, return the first not blacklisted region or die
+sub region {
+    my ($self) = @_;
+    my $blacklist = $self->_blacklisted_regions;
+    for my $r (@{$self->_regions}) {
+        return $r unless $blacklist->{$r};
+    }
+    die "No available regions — all blacklisted: " . join(', ', @{$self->_regions});
+}
+
+has username => sub { get_var('PUBLIC_CLOUD_USER', 'ec2-user') };
 has aws_account_id => undef;
 has container_registry => sub { get_var("PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY", 'suse-qec-testing') };
-has username => sub { get_var('PUBLIC_CLOUD_USER', 'ec2-user') };
 
 sub _check_credentials {
     my ($self) = @_;

--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -8,44 +8,11 @@
 # Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::aws_client;
-use Mojo::Base -base;
+use Mojo::Base 'publiccloud::client_base';
 use testapi;
 use utils;
 use version_utils qw(is_sle);
 use publiccloud::utils;
-
-
-# Reference to a list of all regions specified via job variable/settings
-# At least one region is present from PUBLIC_CLOUD_REGION
-has _regions => sub {
-    my @list = (get_required_var('PUBLIC_CLOUD_REGION'));
-    if (my $alt = get_var('PUBLIC_CLOUD_ALTERNATE_REGIONS')) {
-        push @list, split(/\s*,\s*/, $alt);
-    }
-    return \@list;
-};
-
-# List of regions blacklisted by the user during the test execution.
-has _blacklisted_regions => sub { {} };
-
-# Setter for the blacklist. The test code can call this function
-# to add a region name to the blacklis; it usually happens
-# when a terraform deployment fails for a specific error.
-sub blacklist_region {
-    my ($self, $region) = @_;
-    $self->_blacklisted_regions->{$region} = 1;
-    return $self;    # allows chaining
-}
-
-# Getter, return the first not blacklisted region or die
-sub region {
-    my ($self) = @_;
-    my $blacklist = $self->_blacklisted_regions;
-    for my $r (@{$self->_regions}) {
-        return $r unless $blacklist->{$r};
-    }
-    die "No available regions — all blacklisted: " . join(', ', @{$self->_regions});
-}
 
 has username => sub { get_var('PUBLIC_CLOUD_USER', 'ec2-user') };
 has aws_account_id => undef;

--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -8,44 +8,11 @@
 # Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::azure_client;
-use Mojo::Base -base;
+use Mojo::Base 'publiccloud::client_base';
 use testapi;
 use utils;
 use version_utils qw(is_sle);
 use publiccloud::utils;
-
-
-# Reference to a list of all regions specified via job variable/settings
-# At least one region is present from PUBLIC_CLOUD_REGION
-has _regions => sub {
-    my @list = (get_required_var('PUBLIC_CLOUD_REGION'));
-    if (my $alt = get_var('PUBLIC_CLOUD_ALTERNATE_REGIONS')) {
-        push @list, split(/\s*,\s*/, $alt);
-    }
-    return \@list;
-};
-
-# List of regions blacklisted by the user during the test execution.
-has _blacklisted_regions => sub { {} };
-
-# Setter for the blacklist. The test code can call this function
-# to add a region name to the blacklis; it usually happens
-# when a terraform deployment fails for a specific error.
-sub blacklist_region {
-    my ($self, $region) = @_;
-    $self->_blacklisted_regions->{$region} = 1;
-    return $self;    # allows chaining
-}
-
-# Getter, return the first not blacklisted region or die
-sub region {
-    my ($self) = @_;
-    my $blacklist = $self->_blacklisted_regions;
-    for my $r (@{$self->_regions}) {
-        return $r unless $blacklist->{$r};
-    }
-    die "No available regions — all blacklisted: " . join(', ', @{$self->_regions});
-}
 
 has username => sub { get_var('PUBLIC_CLOUD_USER', 'azureuser') };
 has subscription => sub { get_var('PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID') };

--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -11,12 +11,44 @@ package publiccloud::azure_client;
 use Mojo::Base -base;
 use testapi;
 use utils;
-use publiccloud::utils;
 use version_utils qw(is_sle);
+use publiccloud::utils;
 
-has subscription => sub { get_var('PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID') };
-has region => sub { get_required_var('PUBLIC_CLOUD_REGION') };
+
+# Reference to a list of all regions specified via job variable/settings
+# At least one region is present from PUBLIC_CLOUD_REGION
+has _regions => sub {
+    my @list = (get_required_var('PUBLIC_CLOUD_REGION'));
+    if (my $alt = get_var('PUBLIC_CLOUD_ALTERNATE_REGIONS')) {
+        push @list, split(/\s*,\s*/, $alt);
+    }
+    return \@list;
+};
+
+# List of regions blacklisted by the user during the test execution.
+has _blacklisted_regions => sub { {} };
+
+# Setter for the blacklist. The test code can call this function
+# to add a region name to the blacklis; it usually happens
+# when a terraform deployment fails for a specific error.
+sub blacklist_region {
+    my ($self, $region) = @_;
+    $self->_blacklisted_regions->{$region} = 1;
+    return $self;    # allows chaining
+}
+
+# Getter, return the first not blacklisted region or die
+sub region {
+    my ($self) = @_;
+    my $blacklist = $self->_blacklisted_regions;
+    for my $r (@{$self->_regions}) {
+        return $r unless $blacklist->{$r};
+    }
+    die "No available regions — all blacklisted: " . join(', ', @{$self->_regions});
+}
+
 has username => sub { get_var('PUBLIC_CLOUD_USER', 'azureuser') };
+has subscription => sub { get_var('PUBLIC_CLOUD_AZURE_SUBSCRIPTION_ID') };
 has credentials_file_content => undef;
 has container_registry => sub { get_var('PUBLIC_CLOUD_CONTAINER_IMAGES_REGISTRY', 'suseqectesting') };
 

--- a/lib/publiccloud/client_base.pm
+++ b/lib/publiccloud/client_base.pm
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Base helper class for public cloud connection clients
+#
+# Maintainer: QE-C team <qa-c@suse.de>
+
+package publiccloud::client_base;
+use Mojo::Base -base;
+use testapi;
+
+# Reference to a list of all regions specified via job variable/settings
+# At least one region is present from PUBLIC_CLOUD_REGION
+has _regions => sub {
+    my @list = (get_required_var('PUBLIC_CLOUD_REGION'));
+    if (my $alt = get_var('PUBLIC_CLOUD_ALTERNATE_REGIONS')) {
+        push @list, split(/\s*,\s*/, $alt);
+    }
+    return \@list;
+};
+
+# List of regions blacklisted by the user during the test execution.
+# The default must be a coderef (sub { {} }) and NOT a bare hashref ({}).
+# A bare {} is evaluated once at compile time and shared across all instances,
+# so blacklisting a region on one object would corrupt every other object.
+# Wrapping in sub {} makes Mojo::Base call it fresh for each new instance,
+# giving every object its own independent hash.
+has _blacklisted_regions => sub { {} };
+
+# Setter for the blacklist. The test code can call this function
+# to add a region name to the blacklis; it usually happens
+# when a terraform deployment fails for a specific error.
+sub blacklist_region {
+    my ($self, $region) = @_;
+    $self->_blacklisted_regions->{$region} = 1;
+    return $self;    # allows chaining
+}
+
+# Getter, return the first not blacklisted region or die
+sub region {
+    my ($self) = @_;
+    my $blacklist = $self->_blacklisted_regions;
+    for my $r (@{$self->_regions}) {
+        return $r unless $blacklist->{$r};
+    }
+    die "No available regions — all blacklisted: " . join(', ', @{$self->_regions});
+}
+
+1;

--- a/lib/publiccloud/client_base.pm
+++ b/lib/publiccloud/client_base.pm
@@ -21,31 +21,30 @@ has _regions => sub {
     return \@list;
 };
 
-# List of regions blacklisted by the user during the test execution.
+# List of disallowed regions during the test execution.
 # The default must be a coderef (sub { {} }) and NOT a bare hashref ({}).
 # A bare {} is evaluated once at compile time and shared across all instances,
-# so blacklisting a region on one object would corrupt every other object.
+# so disabling a region on one object would corrupt every other object.
 # Wrapping in sub {} makes Mojo::Base call it fresh for each new instance,
 # giving every object its own independent hash.
-has _blacklisted_regions => sub { {} };
+has _disallowed_regions => sub { {} };
 
-# Setter for the blacklist. The test code can call this function
-# to add a region name to the blacklis; it usually happens
+# Setter for the _dissallowed_regions. The test code can call this function
+# to add a region name to the disallowed list; it usually happens
 # when a terraform deployment fails for a specific error.
-sub blacklist_region {
+sub disable_region {
     my ($self, $region) = @_;
-    $self->_blacklisted_regions->{$region} = 1;
+    $self->_disallowed_regions->{$region} = 1;
     return $self;    # allows chaining
 }
 
-# Getter, return the first not blacklisted region or die
+# Getter, return the first not disallowed region or die
 sub region {
     my ($self) = @_;
-    my $blacklist = $self->_blacklisted_regions;
     for my $r (@{$self->_regions}) {
-        return $r unless $blacklist->{$r};
+        return $r unless $self->_disallowed_regions->{$r};
     }
-    die "No available regions — all blacklisted: " . join(', ', @{$self->_regions});
+    die "No available regions — all disabled: " . join(', ', @{$self->_regions});
 }
 
 1;

--- a/lib/publiccloud/gcp_client.pm
+++ b/lib/publiccloud/gcp_client.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright 2021 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
 # Summary: Helper class for google connection and authentication
@@ -11,7 +11,7 @@ package publiccloud::gcp_client;
 use Mojo::Base -base;
 use testapi;
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_sle);
 use publiccloud::utils;
 use Mojo::Util qw(b64_decode);
 use Mojo::JSON 'decode_json';
@@ -23,7 +23,39 @@ has storage_name => sub { get_var('PUBLIC_CLOUD_STORAGE_ACCOUNT', 'openqa-storag
 has project_id => sub { get_var('PUBLIC_CLOUD_GOOGLE_PROJECT_ID') };
 has account => sub { get_var('PUBLIC_CLOUD_GOOGLE_ACCOUNT') };
 has gcr_zone => sub { get_var('PUBLIC_CLOUD_GCR_ZONE', 'eu.gcr.io') };
-has region => sub { get_required_var('PUBLIC_CLOUD_REGION') };
+
+# Reference to a list of all regions specified via job variable/settings
+# At least one region is present from PUBLIC_CLOUD_REGION
+has _regions => sub {
+    my @list = (get_required_var('PUBLIC_CLOUD_REGION'));
+    if (my $alt = get_var('PUBLIC_CLOUD_ALTERNATE_REGIONS')) {
+        push @list, split(/\s*,\s*/, $alt);
+    }
+    return \@list;
+};
+
+# List of regions blacklisted by the user during the test execution.
+has _blacklisted_regions => sub { {} };
+
+# Setter for the blacklist. The test code can call this function
+# to add a region name to the blacklis; it usually happens
+# when a terraform deployment fails for a specific error.
+sub blacklist_region {
+    my ($self, $region) = @_;
+    $self->_blacklisted_regions->{$region} = 1;
+    return $self;    # allows chaining
+}
+
+# Getter, return the first not blacklisted region or die
+sub region {
+    my ($self) = @_;
+    my $blacklist = $self->_blacklisted_regions;
+    for my $r (@{$self->_regions}) {
+        return $r unless $blacklist->{$r};
+    }
+    die "No available regions — all blacklisted: " . join(', ', @{$self->_regions});
+}
+
 has availability_zone => sub { get_required_var('PUBLIC_CLOUD_AVAILABILITY_ZONE') };
 has username => sub { get_var('PUBLIC_CLOUD_USER', 'susetest') };
 

--- a/lib/publiccloud/gcp_client.pm
+++ b/lib/publiccloud/gcp_client.pm
@@ -8,7 +8,7 @@
 # Maintainer: QE-C team <qa-c@suse.de>
 
 package publiccloud::gcp_client;
-use Mojo::Base -base;
+use Mojo::Base 'publiccloud::client_base';
 use testapi;
 use utils;
 use version_utils qw(is_sle);
@@ -23,39 +23,6 @@ has storage_name => sub { get_var('PUBLIC_CLOUD_STORAGE_ACCOUNT', 'openqa-storag
 has project_id => sub { get_var('PUBLIC_CLOUD_GOOGLE_PROJECT_ID') };
 has account => sub { get_var('PUBLIC_CLOUD_GOOGLE_ACCOUNT') };
 has gcr_zone => sub { get_var('PUBLIC_CLOUD_GCR_ZONE', 'eu.gcr.io') };
-
-# Reference to a list of all regions specified via job variable/settings
-# At least one region is present from PUBLIC_CLOUD_REGION
-has _regions => sub {
-    my @list = (get_required_var('PUBLIC_CLOUD_REGION'));
-    if (my $alt = get_var('PUBLIC_CLOUD_ALTERNATE_REGIONS')) {
-        push @list, split(/\s*,\s*/, $alt);
-    }
-    return \@list;
-};
-
-# List of regions blacklisted by the user during the test execution.
-has _blacklisted_regions => sub { {} };
-
-# Setter for the blacklist. The test code can call this function
-# to add a region name to the blacklis; it usually happens
-# when a terraform deployment fails for a specific error.
-sub blacklist_region {
-    my ($self, $region) = @_;
-    $self->_blacklisted_regions->{$region} = 1;
-    return $self;    # allows chaining
-}
-
-# Getter, return the first not blacklisted region or die
-sub region {
-    my ($self) = @_;
-    my $blacklist = $self->_blacklisted_regions;
-    for my $r (@{$self->_regions}) {
-        return $r unless $blacklist->{$r};
-    }
-    die "No available regions — all blacklisted: " . join(', ', @{$self->_regions});
-}
-
 has availability_zone => sub { get_required_var('PUBLIC_CLOUD_AVAILABILITY_ZONE') };
 has username => sub { get_var('PUBLIC_CLOUD_USER', 'susetest') };
 

--- a/t/43_publiccloud_client.t
+++ b/t/43_publiccloud_client.t
@@ -1,0 +1,107 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Unit tests for the public cloud connection clients
+#   (publiccloud::aws_client, publiccloud::azure_client, publiccloud::gcp_client).
+#   The region / blacklist logic is shared via publiccloud::client_base, so every
+#   subtest exercises all three concrete clients to prove the inherited behaviour.
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+use testapi 'set_var';
+
+use publiccloud::aws_client;
+use publiccloud::azure_client;
+use publiccloud::gcp_client;
+use publiccloud::client_base;
+
+# The three cloud connection clients inherit the region/blacklist logic from
+# publiccloud::client_base. Running each check against all of them verifies the
+# shared behaviour through every concrete client.
+my @CLIENTS = qw(
+  publiccloud::aws_client
+  publiccloud::azure_client
+  publiccloud::gcp_client
+);
+
+sub _unset { for my $k (@_) { set_var($k, undef) } }
+
+subtest '[region] default returns PUBLIC_CLOUD_REGION' => sub {
+    set_var('PUBLIC_CLOUD_REGION', 'olympus-1');
+    # Also add alternate regions, even if the test does not use them.
+    # It proof they do not interfere the default.
+    set_var('PUBLIC_CLOUD_ALTERNATE_REGIONS', 'delphi-2 , ithaca-3,sparta-4');
+    for my $class (@CLIENTS) {
+        my $client = $class->new();
+        is $client->region, 'olympus-1', "$class returns the single configured region";
+    }
+    _unset('PUBLIC_CLOUD_REGION', 'PUBLIC_CLOUD_ALTERNATE_REGIONS');
+};
+
+subtest '[region] missing PUBLIC_CLOUD_REGION dies' => sub {
+    _unset('PUBLIC_CLOUD_REGION');
+    for my $class (@CLIENTS) {
+        my $client = $class->new();
+        dies_ok { $client->region } "$class dies when PUBLIC_CLOUD_REGION is not set";
+    }
+};
+
+subtest '[blacklist_region] ignore double blacklisting' => sub {
+    set_var('PUBLIC_CLOUD_REGION', 'olympus-1');
+    set_var('PUBLIC_CLOUD_ALTERNATE_REGIONS', 'delphi-2,ithaca-3');
+    my $ret;
+    for my $class (@CLIENTS) {
+        my $client = $class->new();
+        $client->blacklist_region('olympus-1');
+        is $client->region, 'delphi-2', "$class skips the single blacklisted region";
+
+        # Blacklist two times the same does not have any effect
+        $client->blacklist_region('olympus-1');
+        is $client->region, 'delphi-2', "$class skips the single blacklisted region";
+    }
+    _unset('PUBLIC_CLOUD_REGION', 'PUBLIC_CLOUD_ALTERNATE_REGIONS');
+};
+
+subtest '[blacklist_region] blacklisting is chainable' => sub {
+    set_var('PUBLIC_CLOUD_REGION', 'olympus-1');
+    set_var('PUBLIC_CLOUD_ALTERNATE_REGIONS', 'delphi-2,ithaca-3');
+    my $ret;
+    for my $class (@CLIENTS) {
+        my $client = $class->new();
+        $client->blacklist_region('olympus-1')->blacklist_region('delphi-2');
+        is $client->region, 'ithaca-3', "$class skips multiple blacklisted regions set via chaining";
+    }
+    _unset('PUBLIC_CLOUD_REGION', 'PUBLIC_CLOUD_ALTERNATE_REGIONS');
+};
+
+subtest '[region] dies when all regions are blacklisted' => sub {
+    set_var('PUBLIC_CLOUD_REGION', 'olympus-1');
+    set_var('PUBLIC_CLOUD_ALTERNATE_REGIONS', 'delphi-2');
+    for my $class (@CLIENTS) {
+        my $client = $class->new();
+        $client->blacklist_region('olympus-1')->blacklist_region('delphi-2');
+        throws_ok { $client->region } qr/No available regions/,
+          "$class dies with a descriptive error when every region is blacklisted";
+    }
+    _unset('PUBLIC_CLOUD_REGION', 'PUBLIC_CLOUD_ALTERNATE_REGIONS');
+};
+
+subtest '[blacklist_region] state is isolated per instance' => sub {
+    set_var('PUBLIC_CLOUD_REGION', 'olympus-1');
+    set_var('PUBLIC_CLOUD_ALTERNATE_REGIONS', 'delphi-2');
+    for my $class (@CLIENTS) {
+        my $first = $class->new();
+        my $second = $class->new();
+        $first->blacklist_region('olympus-1');
+        is $first->region, 'delphi-2', "$class first instance sees its own blacklist";
+        is $second->region, 'olympus-1', "$class second instance is not affected by the first (per-instance hash)";
+    }
+    _unset('PUBLIC_CLOUD_REGION', 'PUBLIC_CLOUD_ALTERNATE_REGIONS');
+};
+
+done_testing;

--- a/t/43_publiccloud_client.t
+++ b/t/43_publiccloud_client.t
@@ -5,7 +5,7 @@
 
 # Summary: Unit tests for the public cloud connection clients
 #   (publiccloud::aws_client, publiccloud::azure_client, publiccloud::gcp_client).
-#   The region / blacklist logic is shared via publiccloud::client_base, so every
+#   The region / disallow logic is shared via publiccloud::client_base, so every
 #   subtest exercises all three concrete clients to prove the inherited behaviour.
 
 use strict;
@@ -20,8 +20,7 @@ use publiccloud::azure_client;
 use publiccloud::gcp_client;
 use publiccloud::client_base;
 
-# The three cloud connection clients inherit the region/blacklist logic from
-# publiccloud::client_base. Running each check against all of them verifies the
+# Running each check against all of the CSP children classes verifies the
 # shared behaviour through every concrete client.
 my @CLIENTS = qw(
   publiccloud::aws_client
@@ -51,54 +50,54 @@ subtest '[region] missing PUBLIC_CLOUD_REGION dies' => sub {
     }
 };
 
-subtest '[blacklist_region] ignore double blacklisting' => sub {
+subtest '[disable_region] ignore double disabling' => sub {
     set_var('PUBLIC_CLOUD_REGION', 'olympus-1');
     set_var('PUBLIC_CLOUD_ALTERNATE_REGIONS', 'delphi-2,ithaca-3');
     my $ret;
     for my $class (@CLIENTS) {
         my $client = $class->new();
-        $client->blacklist_region('olympus-1');
-        is $client->region, 'delphi-2', "$class skips the single blacklisted region";
+        $client->disable_region('olympus-1');
+        is $client->region, 'delphi-2', "$class skips the single not allowed region";
 
-        # Blacklist two times the same does not have any effect
-        $client->blacklist_region('olympus-1');
-        is $client->region, 'delphi-2', "$class skips the single blacklisted region";
+        # Block two times the same does not have any effect
+        $client->disable_region('olympus-1');
+        is $client->region, 'delphi-2', "$class skips the single not allowed region";
     }
     _unset('PUBLIC_CLOUD_REGION', 'PUBLIC_CLOUD_ALTERNATE_REGIONS');
 };
 
-subtest '[blacklist_region] blacklisting is chainable' => sub {
+subtest '[disable_region] is chainable' => sub {
     set_var('PUBLIC_CLOUD_REGION', 'olympus-1');
     set_var('PUBLIC_CLOUD_ALTERNATE_REGIONS', 'delphi-2,ithaca-3');
     my $ret;
     for my $class (@CLIENTS) {
         my $client = $class->new();
-        $client->blacklist_region('olympus-1')->blacklist_region('delphi-2');
-        is $client->region, 'ithaca-3', "$class skips multiple blacklisted regions set via chaining";
+        $client->disable_region('olympus-1')->disable_region('delphi-2');
+        is $client->region, 'ithaca-3', "$class skips multiple disabled regions set via chaining";
     }
     _unset('PUBLIC_CLOUD_REGION', 'PUBLIC_CLOUD_ALTERNATE_REGIONS');
 };
 
-subtest '[region] dies when all regions are blacklisted' => sub {
+subtest '[region] dies when all regions are blocked' => sub {
     set_var('PUBLIC_CLOUD_REGION', 'olympus-1');
     set_var('PUBLIC_CLOUD_ALTERNATE_REGIONS', 'delphi-2');
     for my $class (@CLIENTS) {
         my $client = $class->new();
-        $client->blacklist_region('olympus-1')->blacklist_region('delphi-2');
+        $client->disable_region('olympus-1')->disable_region('delphi-2');
         throws_ok { $client->region } qr/No available regions/,
-          "$class dies with a descriptive error when every region is blacklisted";
+          "$class dies with a descriptive error when every region is disabled";
     }
     _unset('PUBLIC_CLOUD_REGION', 'PUBLIC_CLOUD_ALTERNATE_REGIONS');
 };
 
-subtest '[blacklist_region] state is isolated per instance' => sub {
+subtest '[disable_region] state is isolated per instance' => sub {
     set_var('PUBLIC_CLOUD_REGION', 'olympus-1');
     set_var('PUBLIC_CLOUD_ALTERNATE_REGIONS', 'delphi-2');
     for my $class (@CLIENTS) {
         my $first = $class->new();
         my $second = $class->new();
-        $first->blacklist_region('olympus-1');
-        is $first->region, 'delphi-2', "$class first instance sees its own blacklist";
+        $first->disable_region('olympus-1');
+        is $first->region, 'delphi-2', "$class first instance sees its own blocked list";
         is $second->region, 'olympus-1', "$class second instance is not affected by the first (per-instance hash)";
     }
     _unset('PUBLIC_CLOUD_REGION', 'PUBLIC_CLOUD_ALTERNATE_REGIONS');

--- a/variables.md
+++ b/variables.md
@@ -315,6 +315,7 @@ PUBLIC_AZURE_CLI_TEST | string | "vmss" | Azure CLI test names. This variable sh
 PUBLIC_CLOUD | boolean | false | All Public Cloud tests have this variable set to true. Contact: qa-c@suse.de
 PUBLIC_CLOUD_ACCNET | boolean | false | If set, az_accelerated_net test module is added to the job.
 PUBLIC_CLOUD_AHB_LT | string | "SLES_BYOS" | For Azure, it specifies the license type to change to (and test).
+PUBLIC_CLOUD_ALTERNATE_REGIONS | string | "" | Comma-separated list of fallback regions, appended after `PUBLIC_CLOUD_REGION`. The connection client exposes `region()` (returns the first non-disabled region) and `disable_region($region)` (marks a region unusable, e.g. after a deployment failure, so `region()` returns the next candidate). See `lib/publiccloud/client_base.pm`.
 PUBLIC_CLOUD_ARCH | string | "x86_64" | The architecture of created VM.
 PUBLIC_CLOUD_AVAILABILITY_ZONE | string | "" | The availability zone to use. Depends on `PUBLIC_CLOUD_REGION`. Only for GCE.
 PUBLIC_CLOUD_AZURE_IMAGE_DEFINITION | string | "" | Defines the image definition for uploading Arm64 images to the image gallery.


### PR DESCRIPTION
Add getter, setter and variables at client level for multiple regions and blacklisted regions.

- Related ticket: https://progress.opensuse.org/issues/202446

# Verification run:

## Azure
sle-micro-5.5-Azure-BYOS-Updates-x86_64-Build20260702-1-slem_basic az_Standard_B4ms
- http://openqa.suse.de/tests/23185820 :green_circle: 
- with some extra regions `PUBLIC_CLOUD_ALTERNATE_REGIONS="bandle, bidede,bum"` http://openqa.suse.de/tests/23188016 :green_circle: 

sle-16.0-Azure-BYOS-Maintenance-Images-x86_64-Build0496-publiccloud_img_proof az_Standard_B2s
- http://openqa.suse.de/tests/23188029 :green_circle: https://openqa.suse.de/tests/23188029/logfile?filename=serial_terminal.txt#line-123
-  http://openqa.suse.de/tests/23216990

sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-crash_test
- http://openqaworker15.qe.prg2.suse.org/tests/376116
- http://openqaworker15.qe.prg2.suse.org/tests/376117 :green_circle: region correctly used as before https://openqaworker15.qe.prg2.suse.org/tests/376117/logfile?filename=serial_terminal.txt#line-63

## AWS
 - sle-micro-5.5-EC2-BYOS-Updates-aarch64-Build20260702-1-slem_basic ec2_c6g.large -> http://openqa.suse.de/tests/23188033 :green_circle:  https://openqa.suse.de/tests/23188033/logfile?filename=serial_terminal.txt#line-47

## GCE
 - sle-micro-5.5-GCE-BYOS-Updates-x86_64-Build20260702-1-slem_basic@gce_n1_standard_2 -> http://openqa.suse.de/tests/23188041 :green_circle: https://openqa.suse.de/tests/23188041/logfile?filename=serial_terminal.txt#line-155

 - sle-15-SP6-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_6-qesap_gcp_angi_test -> http://openqaworker15.qe.prg2.suse.org/tests/376118  :green_circle: 
 