### PR TITLE
TW & Leap: Use validate_selinux by default

### DIFF
--- a/schedule/install/agama_install.yaml
+++ b/schedule/install/agama_install.yaml
@@ -17,5 +17,5 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - '{{opensuse_welcome}}'
-  - console/system_prepare
+  - yam/validate/validate_selinux
   - shutdown/shutdown

--- a/test_data/opensuse/agama_default.yml
+++ b/test_data/opensuse/agama_default.yml
@@ -1,0 +1,4 @@
+---
+selinux:
+  status: enabled
+  mode: enforcing


### PR DESCRIPTION
Needs `YAML_TEST_DATA=test_data/opensuse/agama_default.yml` on testsuites.

VR: https://openqa.opensuse.org/tests/overview?distri=opensuse&build=validate_selinux
