### PR TITLE
Kselftests: Add update_kernel to schedule if INSTALL_KOTD=1

### DIFF
--- a/schedule/kernel/run_kselftests.yaml
+++ b/schedule/kernel/run_kselftests.yaml
@@ -3,6 +3,7 @@ description:    >
     Generic scheduler for Linux kselftests
 schedule:
     - '{{boot}}'
+    - '{{update_kernel}}'
     - boot/boot_to_desktop
     - kernel/kselftests_prepare
     - kernel/kselftests_run
@@ -18,3 +19,7 @@ conditional_schedule:
         ARCH:
             s390x:
                 - installation/bootloader_zkvm
+    update_kernel:
+        INSTALL_KOTD:
+            '1':
+                - kernel/update_kernel


### PR DESCRIPTION
The user might want to test a specific kernel by means of setting KOTD_REPO and INSTALL_KOTD=1. If so, `update_kernel` module must be scheduled. Make it easier by adding a conditional in the relevant yaml file.

- Related ticket: N/A
- Verification run: https://openqa.suse.de/tests/23187752
