### PR TITLE
Kselftests: Post-process single-test runs like full collections

### DIFF
--- a/tests/kernel/kselftests_run.pm
+++ b/tests/kernel/kselftests_run.pm
@@ -48,7 +48,11 @@ sub run {
     $self->{tests} = [@tests];
     die 'No tests to run.' unless @tests > 0;
 
-    my $test_opt = @tests > 1 ? '--per-test-log' : '';
+    # Always use --per-test-log so each test's subtest output goes to its own
+    # /tmp/<test> file and the summary only holds the top-level results. This
+    # keeps a single, uniform post-processing path for both single and multiple
+    # tests (see post_process).
+    my $test_opt = '--per-test-log';
     if (@selected == @available && !@skip) {
         # No tests were selected nor skipped, run full collection
         $test_opt .= " --collection $collection";
@@ -108,13 +112,8 @@ sub post_run_hook {
     my ($self) = @_;
     $self->SUPER::post_run_hook;
 
-    my ($ktap, $softfails, $hardfails);
     my @tests = @{$self->{tests}};
-    if (@tests > 1) {
-        ($ktap, $softfails, $hardfails) = post_process(collection => $self->{collection}, tests => \@tests);
-    } else {
-        ($ktap, $softfails, $hardfails) = post_process_single(collection => $self->{collection}, test => $tests[0]);
-    }
+    my ($ktap, $softfails, $hardfails) = post_process(collection => $self->{collection}, tests => \@tests);
 
     chomp @{$ktap};
     write_sut_file('/tmp/kselftest.tap.txt', join("\n", grep { /\S/ } @{$ktap}));


### PR DESCRIPTION
When only one test is selected via KSELFTEST_TESTS, the run is post-processed through a separate path that emits the KTAP for a single test directly. For collections whose subtest output needs a specialized parser, such as livepatch, that parser intentionally drops the TAP header, plan and top-level result lines. Without the surrounding post_process step to restore them, the uploaded KTAP is reduced to bare comment lines, which openQA cannot turn into per-test result details. The consequence is that a single-test job shows no post-processed details at all, while the same test inside a full-collection run does.

Always request per-test logs from the runner and route every run through post_process, regardless of how many tests are selected. This keeps a single, uniform post-processing path that produces a complete KTAP document with proper headers and top-level results, so single-test jobs report the same details as full-collection jobs.

Related ticket: N/A
Verification runs:
- https://openqa.opensuse.org/tests/6071593 (before)
- https://openqa.opensuse.org/tests/6071606 (after)
