### PR TITLE
blktests: add running kernel info to the template

### DIFF
--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -47,7 +47,7 @@ sub run {
     my $test_case_dev_array = get_var('BLKTESTS_TEST_CASE_DEV_ARRAY');
 
     record_info('KERNEL', script_output('rpm -qi kernel-default'));
-    save_and_upload_log('rpm -qi kernel-default', 'kernel_bug_report.txt');
+    save_and_upload_log('(rpm -qi kernel-default; uname -a)', 'kernel_bug_report.txt');
 
     #QA repo is added with lower prio in order to avoid possible problems
     #with some packages provided in both, tested product and qa repo; example: fio


### PR DESCRIPTION
- Verification run: https://openqa.suse.de/tests/23194154

So in short the template should now have:
https://openqa.suse.de/tests/23194154/file/blktests-kernel_bug_report.txt

instead of:
https://openqa.suse.de/tests/23104893/file/blktests-kernel_bug_report.txt