### PR TITLE
containers: Add xfails for checkpoint tests on Tumbleweed with crun

### DIFF
--- a/tests/containers/podman_e2e.pm
+++ b/tests/containers/podman_e2e.pm
@@ -139,6 +139,9 @@ sub run {
         "Libpod Suite::[It] Podman checkpoint podman restore multiple containers from multiple checkpoint images",
         "Libpod Suite::[It] Podman checkpoint podman restore multiple containers from single checkpoint image",
         "Libpod Suite::[It] Podman checkpoint podman run with checkpoint image",
+        # Seen with crun:
+        "Libpod Suite::[It] Podman checkpoint podman checkpoint container with export and verify non-default runtime",
+        "Libpod Suite::[It] Podman checkpoint podman checkpoint container with export and try to change the runtime",
     ) if (is_tumbleweed);
 
     # Skip remoteintegration on SLES as it panics with:


### PR DESCRIPTION
The Linux kernel 7.1.0 dropped UDP-Lite and made other changes that break criu 4.2.  Upstream hasn't made a release yet, so we have to wait for a new release or adopt the Fedora patches for criu in OBS.

These were seen with crun.

Failed job: https://openqa.opensuse.org/tests/6073424

VR not needed as failures were extracted with tooling.