### PR TITLE
Update the bootloader timeout for 16.0 testdata in full

### DIFF
--- a/test_data/yam/agama_sle_extended_full_unattended.yaml
+++ b/test_data/yam/agama_sle_extended_full_unattended.yaml
@@ -5,7 +5,7 @@ files:
     mode: '644'
     owner: 'root'
     sha256sum: '5f925f748a27b757853767477ec0e0e6f04b1727f3607c7f622a2a1e4bd2a0e5'
-bootloader_timeout: '15'
+bootloader_timeout: '30'
 repos:
   - name: 'SUSE Linux Enterprise Server %VERSION%'
     alias: SLES


### PR DESCRIPTION
To fix this issue:
https://openqa.suse.de/tests/23185265#step/validate_bootloader_timeout/7. In the profile, the bootloader_timeout is set as 30, so need to update the testdata.

- Verification run:  [x86_64](https://openqa.suse.de/tests/23200032#) || [aarch64](https://openqa.suse.de/tests/23200024)
