### PR TITLE
Fix agama install failure for vmware and hyperv tests

### DIFF
--- a/tests/yam/agama/agama_auto.pm
+++ b/tests/yam/agama/agama_auto.pm
@@ -15,7 +15,7 @@ use version_utils qw(is_vmware is_leap);
 
 sub run {
     my $self = shift;
-    select_console 'installation';
+    select_console 'installation' unless is_vmware() || is_hyperv();
     my $reboot_page = $testapi::distri->get_reboot();
     $reboot_page->expect_is_shown();
 


### PR DESCRIPTION
sle16.0 QU build installing on hyperv&vmware was failed during agama installation. 

- Related ticket: https://progress.opensuse.org/issues/203571
- Verification run: [default_svirt_sle16@svirt-vmware80](https://openqa.suse.de/tests/23200753)
                                [default_svirt_sle16@svirt-hyperv2025-uefi](https://openqa.suse.de/tests/23200656)
                                [default_svirt_sle16@svirt-hyperv2022-uefi](https://openqa.suse.de/tests/23200707)
