### PR TITLE
Add schedule file for agama_extended on 16

### DIFF
--- a/schedule/yam/agama_extended_160.yaml
+++ b/schedule/yam/agama_extended_160.yaml
@@ -1,0 +1,16 @@
+---
+name: agama_extended for SLES 160
+description: >
+  Perform interactive installation with the following additional test:
+    - Set static hostname via UI.
+    - Install packages gvim,rpm-build via profile.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/patch_agama_tests
+  - yam/validate/validate_self_update
+  - yam/agama/agama
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_hostname
+  - yam/validate/validate_connectivity
+  - yam/validate/validate_bootloader_timeout


### PR DESCRIPTION
##

### Add schedule file for agama_extended on 16.0
ntp related feature hasn't been applied on 16.0 yet, so we can't add ntp validation.

- Related ticket: 
  - Quick PR
- Related MR:
  - https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/855
- VR:
  - [sles_extended](https://openqa.suse.de/tests/23213587)


##
