### PR TITLE
Disable az cli survey and telemetry messages

### DIFF
--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -52,6 +52,8 @@ sub init {
 
 sub az_login {
     my ($self) = @_;
+    # Remove survey and telemetry messages which can mangle JSON outputs.
+    assert_script_run('az config set core.survey_message=false core.collect_telemetry=no --only-show-errors --output json', timeout => 240);
     my $login_cmd = "while ! az login --service-principal -u \$ARM_CLIENT_ID -p \$ARM_CLIENT_SECRET -t \$ARM_TENANT_ID -o none 1>/dev/null 2>&1; do sleep 10; done";
 
     assert_script_run($login_cmd, timeout => 5 * 60);


### PR DESCRIPTION
Disable az cli survey and telemetry messages
It seems to be hard to see the "survey and telemetry messages" now but disable it is good.

- Related ticket: [TEAM-10989](https://jira.suse.com/browse/TEAM-10989) - Microsoft survey banner break az cli json output parsing
- Verification run:
https://openqa.suse.de/tests/23213638#step/qesap_configure/74 (15SP6 SAPHanaSR-ScaleUp-PerfOpt)
https://openqa.suse.de/tests/23213641#dependencies (15SP7 publiccloud_img_proof, this failure is not related to this PR)
https://openqa.suse.de/tests/23214078#step/upload_image/65 (15SP6 publiccloud_upload_img)
