### PR TITLE
Adapt test data for sle 160 grub timeout value

### DIFF
--- a/test_data/yam/agama_sle_extended_unattended_160.yaml
+++ b/test_data/yam/agama_sle_extended_unattended_160.yaml
@@ -36,4 +36,4 @@ repos:
     uri: https://download.opensuse.org/repositories/science/16.0/
     enabled: 'Yes'
     filter: name
-bootloader_timeout: '15'
+bootloader_timeout: '30'


### PR DESCRIPTION
##
### Adapt test data for sle 160 grub timeout value

- Related ticket: Quick PR
- Error jobs:
  - https://openqa.suse.de/tests/23201829/#step/validate_bootloader_timeout/7
  - https://openqa.suse.de/tests/23201828#step/validate_bootloader_timeout/1
- Needles: N/A
- Verification run: 
   - https://openqa.suse.de/tests/23214145

##