### PR TITLE
Increase timeout value 4 registercloudguest --clean

### DIFF
--- a/tests/sles4sap/sap_deployment_automation_framework/configure_deployer.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/configure_deployer.pm
@@ -53,7 +53,7 @@ sub run {
     my @cleanup_retries = (1 .. 3);
     my $cleanup_rc;
     while (shift @cleanup_retries) {
-        $cleanup_rc = script_run('sudo registercloudguest --clean');
+        $cleanup_rc = script_run('sudo registercloudguest --clean', timeout => 180);
         last unless $cleanup_rc;
     }
     die 'Registration cleanup attempts failed' if $cleanup_rc;


### PR DESCRIPTION
Increase timeout value for registercloudguest --clean
All SDAF test cases failed on timed out today, the default value is `90s`, so increase it to `180s`. 
for example: https://openqaworker15.qe.prg2.suse.org/tests/376537#step/configure_deployer/29
```
# Test died: command 'sudo registercloudguest --clean' timed out at /usr/lib/os-autoinst/testapi.pm line 997.
	testapi::script_run("sudo registercloudguest --clean") called at /var/lib/openqa/pool/56/os-autoinst-distri-opensuse/tests/sles4sap/sap_deployment_automation_framework/configure_deployer.pm line 56
```

- Related ticket: It is a simple fix so no ticket.
- Verification run: 
https://openqaworker15.qe.prg2.suse.org/tests/376622#step/configure_deployer/27 (the test step passed as usual)