### PR TITLE
Record md5sum value of assets

### DIFF
--- a/tests/shutdown/svirt_upload_assets.pm
+++ b/tests/shutdown/svirt_upload_assets.pm
@@ -30,6 +30,12 @@ sub extract_assets {
     enter_cmd("$cmd && echo OK");
     assert_screen('svirt-asset-upload-hdd-image-converted', 3000);
 
+    # Record md5sum value of the asset
+    record_info('md5sum value', 'please check the value in next page');
+    enter_cmd("md5sum $image_storage/$name && echo 'MD5SUMOK'");
+    assert_screen('svirt-asset-upload-md5sum-check');
+    enter_cmd("clear");
+
     # Upload the image as a private asset; do the upload verification
     # on your own - hence the following assert_screen().
     upload_asset("$image_storage/$name", 1, 1);


### PR DESCRIPTION
We can double confirm if anything changed for assets in case some hdd images are not bootable

Sample failed job: https://openqa.suse.de/tests/23149878#step/boot_to_desktop/9

```
+ mount -o remount,ro /sysroot
[  200.373068][   T26] BTRFS error (device vda2): bdev /dev/vda2 errs: wr 0, rd 0, flush 0, corrupt 22, gen 0
[  200.373074][   T26] BTRFS error (device vda2): bdev /dev/vda2 errs: wr 0, rd 0, flush 0, corrupt 23, gen 0
[  200.373078][   T26] BTRFS error (device vda2): bdev /dev/vda2 errs: wr 0, rd 0, flush 0, corrupt 24, gen 0
[  200.373083][   T26] BTRFS error (device vda2): bdev /dev/vda2 errs: wr 0, rd 0, flush 0, corrupt 25, gen 0
[  200.373130][   T26] BTRFS error (device vda2): bdev /dev/vda2 errs: wr 0, rd 0, flush 0, corrupt 26, gen 0
[  200.373184][   T26] BTRFS error (device vda2): bdev /dev/vda2 errs: wr 0, rd 0, flush 0, corrupt 27, gen 0
/sysroot/usr/share/grub2/zipl-refresh: line 10: /sysroot/usr/bin/sync: Input/output error
[  200.373482][   T26] BTRFS error (device vda2): bdev /dev/vda2 errs: wr 0, rd 0, flush 0, corrupt 28, gen 0
[  200.373528][   T26] BTRFS error (device vda2): bdev /dev/vda2 errs: wr 0, rd 0, flush 0, corrupt 29, gen 0
/sysroot/usr/share/grub2/zipl-refresh: line 10: /sysroot/usr/bin/sync: Input/output error

[  200.374777] dracut-pre-pivot[544]: Warning: Not continuing
[  200.374870] dracut-pre-pivot[544]: Warning:
         Starting Dracut Emergency Shell...

Generating "/run/initramfs/rdsosreport.txt"


Entering emergency mode. Exit the shell to continue.
Type "journalctl" to view system logs.
You might want to save "/run/initramfs/rdsosreport.txt" to a USB stick or /boot
after mounting them and attach it to a bug report.


Enter root password for system maintenance
(or press Control-D to continue): 
```

- Verification run: 
[sle16](https://openqa.suse.de/tests/23214152#step/svirt_upload_assets/8)
[sle15](https://openqa.suse.de/tests/23214377#step/svirt_upload_assets/8)
[sle12](https://openqa.suse.de/tests/23214490#step/svirt_upload_assets/8)