### PR TITLE
containers: Remove xfails for bsc#1270423

### DIFF
--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -64,14 +64,6 @@ sub run_tests {
         # https://github.com/containers/podman/commit/f172ff789b14226b51cea39f9373e7de2a35905a
         "550-pause-process.bats::podman system migrate works with conmon being killed",
     ) if (is_ppc64le && !is_sle);
-    # NOTE: Remove when criu > 4.2-2.1
-    push @xfails, (
-        "520-checkpoint.bats::podman checkpoint - basic test",
-        "520-checkpoint.bats::podman checkpoint --file-locks",
-        "520-checkpoint.bats::podman checkpoint/restore ip and mac handling",
-        "520-checkpoint.bats::podman checkpoint/restore print IDs or raw input",
-        "520-checkpoint.bats::podman checkpoint/restore the latest container",
-    ) if (is_tumbleweed);
 
     my $ret = bats_tests($log_file, \%env, \@xfails, 6000);
 

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -49,22 +49,6 @@ sub run_tests {
         "run.bats::runc run [joining existing container namespaces]",
         "userns.bats::userns join other container userns",
     ) if (is_sle("<16") && $rootless);
-    # NOTE: Remove when criu > 4.2-2.1
-    push @xfails, (
-        "checkpoint.bats::checkpoint --lazy-pages and restore",
-        "checkpoint.bats::checkpoint --pre-dump and restore",
-        "checkpoint.bats::checkpoint and restore",
-        "checkpoint.bats::checkpoint and restore (bind mount, destination is symlink)",
-        "checkpoint.bats::checkpoint and restore (with --debug)",
-        "checkpoint.bats::checkpoint and restore in external network namespace",
-        "checkpoint.bats::checkpoint and restore with container specific CRIU config",
-        "checkpoint.bats::checkpoint and restore with nested bind mounts",
-        "checkpoint.bats::checkpoint and restore with netdevice",
-        "checkpoint.bats::checkpoint and restore with netdevice (bind mount, destination is symlink)",
-        "checkpoint.bats::checkpoint and restore with netdevice (with --debug)",
-        "checkpoint.bats::checkpoint then restore into a different cgroup (via --manage-cgroups-mode ignore)",
-        "checkpoint.bats::checkpoint/restore and exec",
-    ) if (is_tumbleweed);
 
     return bats_tests($log_file, \%env, \@xfails, 3000);
 }

--- a/tests/containers/containerd.pm
+++ b/tests/containers/containerd.pm
@@ -92,18 +92,6 @@ sub run {
     push @xfails, (
         "github.com/containerd/containerd/integration/client::TestImagePullSchema1",
     ) if (version->parse(numeric_version($version)) < version->parse("2.1.0"));
-    # NOTE: Remove when criu > 4.2-2.1
-    push @xfails, (
-        "github.com/containerd/containerd/integration/client::TestCheckpointLeaveRunning",
-        "github.com/containerd/containerd/integration/client::TestCheckpointOnPauseStatus",
-        "github.com/containerd/containerd/integration/client::TestCheckpointRestore",
-        "github.com/containerd/containerd/integration/client::TestCheckpointRestoreNewContainer",
-        "github.com/containerd/containerd/integration/client::TestCheckpointRestorePTY",
-        "github.com/containerd/containerd/integration/client::TestCheckpointRestoreWithImagePath",
-        "github.com/containerd/containerd/integration/client::TestContainerKillInitKillsChildWhenNotHostPid",
-        "github.com/containerd/containerd/integration/client::TestContainerKillInitPidHost",
-        "github.com/containerd/containerd/integration/client::TestContainerList",
-    ) if (is_tumbleweed);
 
     run_timeout_command "$env gotestsum --junitfile containerd.xml --format standard-verbose ./... -- -v -test.root &> containerd.txt", no_assert => 1, timeout => 900;
     upload_logs "containerd.txt";

--- a/tests/containers/podman_e2e.pm
+++ b/tests/containers/podman_e2e.pm
@@ -110,39 +110,6 @@ sub run {
         && version->parse(numeric_version($version)) >= version->parse("5.8.2")
         && version->parse(numeric_version($version)) < version->parse("6.0")
     );
-    # NOTE: Remove when criu > 4.2-2.1
-    push @xfails, (
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint --create-image with running container",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint a container started with --rm",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint a container with volumes",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint a running container by id",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint a running container by name",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint all running container",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint and restore container with --file-locks",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint and restore container with root file-system changes",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint and restore container with root file-system changes using --ignore-rootfs during checkpoint",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint and restore container with root file-system changes using --ignore-rootfs during restore",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint and restore container with same IP",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint and restore dev/shm content",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint and restore dev/shm content with --export and --import",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint and run exec in restored container",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint container with --pre-checkpoint",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint container with --pre-checkpoint and export (migration)",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint container with export (migration)",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint container with export (migration) and --ipc host",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint container with export and different compression algorithms",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint container with export and statistics",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint container with export and verify runtime",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint latest running container",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint with --leave-running",
-        "Libpod Suite::[It] Podman checkpoint podman pause a checkpointed container by id",
-        "Libpod Suite::[It] Podman checkpoint podman restore multiple containers from multiple checkpoint images",
-        "Libpod Suite::[It] Podman checkpoint podman restore multiple containers from single checkpoint image",
-        "Libpod Suite::[It] Podman checkpoint podman run with checkpoint image",
-        # Seen with crun:
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint container with export and verify non-default runtime",
-        "Libpod Suite::[It] Podman checkpoint podman checkpoint container with export and try to change the runtime",
-    ) if (is_tumbleweed);
 
     # Skip remoteintegration on SLES as it panics with:
     # Too many RemoteSocket collisions [PANICKED] Test Panicked


### PR DESCRIPTION
Remove xfails for https://bugzilla.suse.com/show_bug.cgi?id=1270423

Verification runs (tested with `TEST_REPOS=https://download.opensuse.org/repositories/home:/tiwai:/branches:/devel:/tools/openSUSE_Tumbleweed/home:tiwai:branches:devel:tools.repo`):
 - opensuse-Tumbleweed-DVD-x86_64-Build20260703-container_host_podman_testsuite_crun@uefi -> https://openqa.opensuse.org/tests/6075879
 - opensuse-Tumbleweed-DVD-x86_64-Build20260703-container_host_podman_testsuite@uefi -> https://openqa.opensuse.org/tests/6075880
 - opensuse-Tumbleweed-DVD-x86_64-Build20260703-container_host_runc_testsuite@uefi -> https://openqa.opensuse.org/tests/6075881
 - opensuse-Tumbleweed-DVD-x86_64-Build20260703-container_host_containerd_testsuite@uefi -> https://openqa.opensuse.org/tests/6075886
 - opensuse-Tumbleweed-DVD-x86_64-Build20260703-container_host_podman_e2e_crun@uefi -> https://openqa.opensuse.org/tests/6075887
 - opensuse-Tumbleweed-DVD-x86_64-Build20260703-container_host_podman_e2e@uefi -> https://openqa.opensuse.org/tests/6075888
