### PR TITLE
fix(utils): Make kill_timeout and retry_grace configurable in script_retry

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -687,7 +687,7 @@ sub terraform_destroy {
     my $terraform_timeout = get_var('TERRAFORM_TIMEOUT', TERRAFORM_TIMEOUT);
     # Retry 3 times with considerable delay. This has been introduced due to poo#95932 (RetryableError)
     # terraform keeps track of the allocated and destroyed resources, so its safe to run this multiple times.
-    my $ret = script_retry($cmd, retry => 9, delay => 180, timeout => $terraform_timeout, die => 0);
+    my $ret = script_retry($cmd, retry => 9, delay => 180, timeout => $terraform_timeout, die => 0, kill_timeout => 15, retry_grace => 45);
     unless (defined $ret) {
         if (is_serial_terminal()) {
             type_string(qq(\c\\));    # Send QUIT signal

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -2094,7 +2094,7 @@ sub svirt_host_basedir {
 
 =head2 script_retry
 
- script_retry($cmd, [expect => $expect], [retry => $retry], [delay => $delay], [timeout => $timeout], [die => $die]);
+ script_retry($cmd, [expect => $expect], [retry => $retry], [delay => $delay], [timeout => $timeout], [die => $die], [kill_timeout => $kill_timeout], [retry_grace => $retry_grace]);
 
 Repeat a command until the expected result is found or the overall timeout is
 hit.
@@ -2108,6 +2108,10 @@ C<$delay> is the time between retries and defaults to C<30>.
 C<$fail_message> is an optional error message in case of failure. Defaults to "Waiting for Godot".
 
 The command must return within C<$timeout> seconds (default: 30).
+
+C<$kill_timeout> is the number of seconds passed to C<timeout -k> (SIGKILL grace period after SIGTERM). Defaults to C<5>.
+
+C<$retry_grace> is the number of extra seconds C<script_run> waits beyond C<$timeout> to allow the shell to report the exit code after SIGKILL. Defaults to C<10>.
 
 If the command doesn't return C<$expect> after C<$retry> retries,
 this function will die, if C<$die> is set.
@@ -2127,6 +2131,8 @@ sub script_retry {
     my $option = $args{option} // '';
     my $die = $args{die} // 1;
     my $fail_msg = $args{fail_message} // "Waiting for Godot: $cmd";
+    my $kill_timeout = $args{kill_timeout} // 5;
+    my $retry_grace = $args{retry_grace} // 10;
     my $negate;
     # Exclamation mark needs to be moved before the timeout command, if present
     if (substr($cmd, 0, 1) eq "!") {
@@ -2134,11 +2140,12 @@ sub script_retry {
         $cmd =~ s/^\s+//;    # left trim spaces after the exclamation mark
         $negate = '!';
     }
-    my $exec = join ' ', grep { defined && length } ($negate, 'timeout -k 5', $option, $timeout, $cmd);
+    my $exec = join ' ', grep { defined && length } ($negate, "timeout -k $kill_timeout", $option, $timeout, $cmd);
     my $ret;
     for (1 .. $retry) {
-        # timeout for script_run must be larger than for the 'timeout ...' command
-        $ret = script_run($exec, ($timeout + 10));
+        # timeout for script_run must be larger than for the 'timeout ...' command  to give the shell more headroom to report the exit code after SIGKILL.
+        # to give the shell more headroom to report the exit code after SIGKILL
+        $ret = script_run($exec, ($timeout + $retry_grace));
         last if defined($ret) && $ret == $ecode;
 
         die($fail_msg) if $retry == $_ && $die == 1;

--- a/t/05_utils_auxiliary.t
+++ b/t/05_utils_auxiliary.t
@@ -43,6 +43,30 @@ subtest 'script_retry' => sub {
     $testapi->redefine('script_run', sub { ++$called; 1 });
     throws_ok { script_retry('false', retry => 3, delay => 0, timeout => .0001, fail_message => 'will fail') } qr/will fail/, 'expected to die on false';
     is $called, 3, 'command called multiple times on failing command';
+
+    # Test kill_timeout parameter is wired into the timeout -k command
+    my $actual_timeout;
+    $testapi->redefine('script_run', sub { $cmd = shift; $actual_timeout = shift; ++$called; 0 });
+    $called = 0;
+    is script_retry('true', delay => 0, retry => 1, timeout => 1, kill_timeout => 9), 0, 'script_retry with kill_timeout=9 succeeds';
+    is $cmd, 'timeout -k 9 1 true', 'kill_timeout is reflected in the timeout -k argument';
+
+    # Test retry_grace parameter is wired into the script_run timeout
+    $called = 0;
+    is script_retry('true', delay => 0, retry => 1, timeout => 2, retry_grace => 20), 0, 'script_retry with retry_grace=20 succeeds';
+    is $actual_timeout, 22, 'retry_grace is added to timeout for the script_run call (timeout + retry_grace)';
+
+    # Test that a script_run timeout exception (die) is propagated and retries do not mask it
+    my $throws_count = 0;
+    $testapi->redefine('script_run', sub { ++$throws_count; die "script_run timeout\n" });
+    throws_ok { script_retry('true', retry => 3, delay => 0, timeout => 1) } qr/script_run timeout/, 'script_run timeout exception propagates out of script_retry';
+    is $throws_count, 1, 'script_run is called once before the exception aborts the loop';
+
+    # Test that retries happen the expected number of times when kill_timeout and retry_grace are set
+    $called = 0;
+    $testapi->redefine('script_run', sub { ++$called; 1 });    # always fail (non-zero)
+    throws_ok { script_retry('false', retry => 4, delay => 0, timeout => 1, kill_timeout => 2, retry_grace => 5) } qr/Waiting for Godot/, 'dies after exhausting retries with custom kill_timeout and retry_grace';
+    is $called, 4, 'retried exactly retry times with kill_timeout and retry_grace set';
 };
 
 


### PR DESCRIPTION
Make the SIGKILL grace period (`kill_timeout`, passed to `timeout -k`) and the extra headroom given to `script_run` beyond the shell timeout (`retry_grace`) configurable parameters of `script_retry`, both defaulting to their previous hardcoded values (`5` and `10` respectively).

Set `kill_timeout => 15` and `retry_grace => 45` for the `tofu destroy` call in `terraform_destroy` to account for the command being observed hanging with no output for the full 1800s timeout.

* Related failure: https://openqa.suse.de/tests/23209031
* Verification run: https://pdostal-workbench.qe.prg2.suse.org/t1019