### PR TITLE
update_kernel: Remove also 32bit LTP

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -444,7 +444,7 @@ sub cleanup_kernel_repos {
 
     # Remove LTP to avoid conflicts with the following install_ltp
     zypper_call('rm ltp ltp-stable', exitcode => [0, 104]);
-    script_run('rm -rf /opt/ltp');
+    script_run('rm -rf ' . get_ltproot(0) . ' ' . get_ltproot(1));
 }
 
 sub update_kgraft_under_load {


### PR DESCRIPTION
666ada051a removed only /opt/ltp, which is for 64bit package. ltp_{cve,syscalls}_m32 jobs use 32bit package which uses /opt/ltp-32. Remove both directories, using functions instead of hardcoding directories.

Follow-up: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25977
Follow-up: 666ada051a ("update_kernel: Allow reinstallation of KOTD")

VR: https://openqa.suse.de/tests/overview?build=LTP/remove-also-32bit