### PR TITLE
Cretate YAMLs and adjust tests for SLE16.1 immutable

### DIFF
--- a/schedule/security/sle16_transactional/fde_misc_qcow.yaml
+++ b/schedule/security/sle16_transactional/fde_misc_qcow.yaml
@@ -1,0 +1,14 @@
+name: fde_misc_qcow
+description: >
+  Test fde misc using preinstalled qcow2 images in immutable mode
+schedule:
+  - installation/bootloader_uefi
+  - jeos/firstrun
+  - transactional/host_config
+  - console/suseconnect_scc
+  - microos/services_enabled
+  - transactional/disable_timers
+  - security/selinux/selinux_setup
+  - security/tpm2/tpm2_verify_presence
+  - security/tpm2/tpm2_fail_key_unsealing
+  - security/fde_regenerate_key

--- a/schedule/security/sle16_transactional/fips_ker_mode_tests_crypt_core_qcow.yaml
+++ b/schedule/security/sle16_transactional/fips_ker_mode_tests_crypt_core_qcow.yaml
@@ -1,0 +1,34 @@
+name: fips_ker_mode_tests_crypt_core_qcow
+description: >
+  Test fips_ker_mode_tests_crypt_core using preinstalled qcow2 images in immutable mode
+schedule:
+  - '{{boot}}'
+  - jeos/firstrun
+  - transactional/host_config
+  - console/suseconnect_scc
+  - microos/services_enabled
+  - transactional/disable_timers
+  - security/selinux/selinux_setup
+  - fips/fips_setup
+  - fips/openssl/openssl_fips_alglist
+  - fips/openssl/openssl_fips_hash
+  - fips/openssl/openssl_fips_cipher
+  - console/openssl_alpn
+  - fips/gnutls/gnutls_base_check
+  - fips/gnutls/gnutls_server
+  - fips/gnutls/gnutls_client
+  - fips/openssl/openssl_pubkey_rsa
+  - fips/openssl/openssl_pubkey_dsa
+  - fips/openssl/openssl_fips_dhparam
+  - fips/openssh/openssh_fips
+  - console/sshd
+  - console/ssh_cleanup
+conditional_schedule:
+  boot:
+    ARCH:
+      s390x:
+        - installation/bootloader_start
+      aarch64:
+        - installation/bootloader_uefi
+      x86_64:
+        - installation/bootloader_uefi

--- a/tests/fips/openssh/openssh_fips.pm
+++ b/tests/fips/openssh/openssh_fips.pm
@@ -21,6 +21,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils 'zypper_call';
 use version_utils qw(is_sle is_transactional is_sle_micro);
+use package_utils 'install_package';
 
 sub is_older_product {
     return 1 if is_sle('<16');
@@ -35,8 +36,8 @@ sub run {
     my $current_ver = script_output("rpm -q --qf '%{version}\n' openssh");
     record_info("openssh version", "Current openssh package version: $current_ver");
 
-    # this package is not available on SL Micro
-    zypper_call('in expect') unless is_transactional;
+    # expect package is not available on SL Micro
+    install_package('expect', trup_apply => 1) unless is_sle_micro;
 
     # on Tumbleweed sshd is not active by default:
     # ensure sshd is installed and started before trying to connect

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -324,7 +324,7 @@ sub run {
     }
 
     # Only execute this block on SLE Micro 6.0+ when using the encrypted image.
-    if (get_var('FLAVOR') =~ m/-encrypted/i) {
+    if (get_var('FLAVOR') =~ m/-encrypted/i || get_var('ENCRYPTED')) {
         # Select FDE with pass and tpm
         assert_screen "alp-fde-pass-tpm";
         # with the latest ALP 9.2/SLEM 3.4 build, this step takes more time than usual.

--- a/tests/security/tpm2/tpm2_verify_presence.pm
+++ b/tests/security/tpm2/tpm2_verify_presence.pm
@@ -8,11 +8,12 @@
 use Mojo::Base 'opensusebasetest';
 use serial_terminal 'select_serial_terminal';
 use testapi;
-
+use package_utils 'install_package';
 
 sub run {
     select_serial_terminal;
 
+    install_package('fde-tools', trup_continue => 1, trup_reboot => 1);
     my $out = script_output('fdectl tpm-present', proceed_on_failure => 1);
     record_info('TPM output', $out);
 


### PR DESCRIPTION
Cretate YAMLs and adjust tests for SLE16.1 immutable in order to run it.

- Related ticket: https://progress.opensuse.org/issues/201411
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=16.1&build=10.55&groupid=611 (please do ignore x86 non UEFI, also for additional fails of s390x and TPM will be created a ticket)

Feel free to suggest more VRs.