### PR TITLE
bats/skopeo: Don't fail if we can't edit default.yaml

### DIFF
--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -57,7 +57,8 @@ sub run {
     $self->setup_pkgs(@pkgs);
 
     # Prevent https://github.com/containers/skopeo/issues/2718
-    run_command "sed -i '/sigstore-staging:/d' /etc/containers/registries.d/default.yaml";
+    # Note: This file is no longer present on podman v6.0 / skopeo v1.23
+    run_command "sed -i '/sigstore-staging:/d' /etc/containers/registries.d/default.yaml" if (script_run("test -f /etc/containers/registries.d/default.yaml") == 0);
 
     record_info("skopeo version", script_output("skopeo --version"));
     record_info("skopeo package version", script_output("rpm -q skopeo"));


### PR DESCRIPTION
The podman v6 suite doesn't come with this file anymore.

Failed job: https://openqa.opensuse.org/tests/6076003#step/skopeo/196
Verification run: https://openqa.opensuse.org/tests/6076006