### PR TITLE
containers: Do not fail when uploading logs

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -576,14 +576,14 @@ sub bats_post_hook {
 
     my @logs = split /\s+/, script_output "ls";
     for my $log (@logs) {
-        upload_logs($log_dir . $log);
+        upload_logs($log_dir . $log, failok => 1);
     }
 
-    upload_logs('/proc/config.gz');
-    upload_logs('/var/log/audit/audit.log', log_name => "audit.txt");
+    upload_logs('/proc/config.gz', failok => 1);
+    upload_logs('/var/log/audit/audit.log', log_name => "audit.txt", failok => 1);
 
     write_sut_file('/tmp/commands.txt', join("\n", @commands));
-    upload_logs('/tmp/commands.txt');
+    upload_logs('/tmp/commands.txt', failok => 1);
 
     script_run('cd / ; rm -rf /tmp/logs');
 
@@ -633,7 +633,7 @@ sub bats_tests {
     my $ret = run_timeout_command($cmd, no_assert => 1, timeout => $timeout);
     script_run "mv report.xml $xmlfile";
 
-    upload_logs($tapfile);
+    upload_logs($tapfile, failok => 1);
     my @xfails = get_var("RUN_TESTS") ? () : @{$xfails};
     # Strip control chars from XML as they aren't quoted and we can't quote them as valid XML 1.1
     # because it's not supported in most XML libraries anyway. See https://bugs.python.org/issue43703

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -98,7 +98,7 @@ sub test_conformance {
     run_command 'cp /usr/bin/busybox-static tests/conformance/testdata/mount-targets/true';
     run_command 'docker rmi -f $(docker images -q) || true';
     run_timeout_command "TMPDIR=/var/tmp gotestsum --junitfile conformance.xml --format standard-verbose -- ./tests/conformance/... &> conformance.txt", no_assert => 1, timeout => 1200;
-    upload_logs "conformance.txt";
+    upload_logs "conformance.txt", failok => 1;
     die "Testsuite failed" if script_run("test -s conformance.xml");
     patch_junit "buildah", $version, "conformance.xml";
     parse_extra_log(XUnit => "conformance.xml");

--- a/tests/containers/bats/skopeo.pm
+++ b/tests/containers/bats/skopeo.pm
@@ -39,7 +39,7 @@ sub test_integration {
     install_gotestsum;
     run_command "cd integration";
     run_timeout_command "SKOPEO_BINARY=/usr/bin/skopeo gotestsum --junitfile integration.xml --format standard-verbose -- &> integration.txt", no_assert => 1, timeout => 300;
-    upload_logs "integration.txt";
+    upload_logs "integration.txt", failok => 1;
     die "Testsuite failed" if script_run("test -s integration.xml");
     patch_junit "skopeo", $skopeo_version, "integration.xml";
     parse_extra_log(XUnit => "integration.xml");

--- a/tests/containers/containerd.pm
+++ b/tests/containers/containerd.pm
@@ -71,7 +71,7 @@ sub critest {
     ) if (is_tumbleweed && is_aarch64);
 
     run_timeout_command "critest --ginkgo.junit-report critest.xml &> critest.txt", no_assert => 1, timeout => 300;
-    upload_logs "critest.txt";
+    upload_logs "critest.txt", failok => 1;
     die "Testsuite failed" if script_run("test -s critest.xml");
     patch_junit "containerd", $version, "critest.xml", @xfails;
     parse_extra_log(XUnit => "critest.xml", timeout => 180);
@@ -106,7 +106,7 @@ sub run {
     ) if (is_tumbleweed);
 
     run_timeout_command "$env gotestsum --junitfile containerd.xml --format standard-verbose ./... -- -v -test.root &> containerd.txt", no_assert => 1, timeout => 900;
-    upload_logs "containerd.txt";
+    upload_logs "containerd.txt", failok => 1;
     die "Testsuite failed" if script_run("test -s containerd.xml");
     patch_junit "containerd", $version, "containerd.xml", @xfails;
     parse_extra_log(XUnit => "containerd.xml", timeout => 180);

--- a/tests/containers/docker_buildx.pm
+++ b/tests/containers/docker_buildx.pm
@@ -86,7 +86,7 @@ sub run {
     ) if (is_sle);
 
     run_timeout_command "$env gotestsum --junitfile buildx.xml --format standard-verbose --packages=./tests &> buildx.txt", no_assert => 1, timeout => 1200;
-    upload_logs "buildx.txt";
+    upload_logs "buildx.txt", failok => 1;
     die "Testsuite failed" if script_run("test -s buildx.xml");
     patch_junit "docker-buildx", $version, "buildx.xml", @xfails;
     parse_extra_log(XUnit => "buildx.xml", timeout => 180);

--- a/tests/containers/docker_cli.pm
+++ b/tests/containers/docker_cli.pm
@@ -99,7 +99,7 @@ sub run {
     ) if ($firewall_backend eq "nftables");
 
     run_timeout_command "$env gotestsum --junitfile cli.xml ./e2e/... -- &> cli.txt", no_assert => 1, timeout => 3000;
-    upload_logs "cli.txt";
+    upload_logs "cli.txt", failok => 1;
     die "Testsuite failed" if script_run("test -s cli.xml");
     patch_junit "docker", $version, "cli.xml", @xfails;
     parse_extra_log(XUnit => "cli.xml", timeout => 180);

--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -68,7 +68,7 @@ sub test ($target) {
     );
 
     run_timeout_command "$env make $target &> $target.txt", no_assert => 1, timeout => 3600;
-    upload_logs "$target.txt";
+    upload_logs "$target.txt", failok => 1;
     assert_script_run "mv /tmp/report/report.xml $target.xml";
     die "Testsuite failed" if script_run("test -s $target.xml");
     patch_junit "docker-compose", $version, "$target.xml", @xfails;

--- a/tests/containers/docker_engine.pm
+++ b/tests/containers/docker_engine.pm
@@ -138,7 +138,7 @@ sub run {
         parse_extra_log(XUnit => "$report.xml", timeout => 180);
         run_command "popd";
     }
-    upload_logs("/var/tmp/report.txt");
+    upload_logs "/var/tmp/report.txt", failok => 1;
 }
 
 sub cleanup {

--- a/tests/containers/podman_e2e.pm
+++ b/tests/containers/podman_e2e.pm
@@ -152,7 +152,7 @@ sub run {
     my @targets = split('\s+', get_var('RUN_TESTS', $default_targets));
     foreach my $target (@targets) {
         run_timeout_command "$env make $target &> $target.txt", no_assert => 1, timeout => 3000;
-        upload_logs "$target.txt";
+        upload_logs "$target.txt", failok => 1;
         assert_script_run "mv report.xml $target.xml";
         die "Testsuite failed" if script_run("test -s $target.xml");
         patch_junit "podman", $version, "$target.xml", @xfails;

--- a/tests/containers/python_docker.pm
+++ b/tests/containers/python_docker.pm
@@ -82,7 +82,7 @@ sub test ($target) {
     );
 
     run_timeout_command "$env pytest $pytest_args tests/$target &> $target.txt", no_assert => 1, timeout => 3600;
-    upload_logs "$target.txt";
+    upload_logs "$target.txt", failok => 1;
     die "Testsuite failed" if script_run("test -s $target.xml");
     patch_junit "docker-py", $version, "$target.xml", @xfails;
     parse_extra_log(XUnit => "$target.xml", timeout => 180);

--- a/tests/containers/python_podman.pm
+++ b/tests/containers/python_podman.pm
@@ -52,7 +52,7 @@ sub test ($target) {
     my $pytest_args = "-vv --capture=tee-sys -o junit_logging=all --junit-xml $target.xml $ignore $deselect";
 
     run_timeout_command "$env pytest $pytest_args podman/tests/$target &> $target.txt", no_assert => 1, timeout => 3600;
-    upload_logs "$target.txt";
+    upload_logs "$target.txt", failok => 1;
     die "Testsuite failed" if script_run("test -s $target.xml");
     patch_junit "podman-py", $version, "$target.xml", @xfails;
     parse_extra_log(XUnit => "$target.xml", timeout => 180);


### PR DESCRIPTION
Unlike the logs uploaded via parse_extra_log(), these logs are just nice to have, so failure to upload is ok.

These tests are expensive and we can't afford the job to fail because the upload failed.

Failed job: https://openqa.opensuse.org/tests/6076749#step/podman_e2e/437

No VR needed.