### PR TITLE
Add Trento container rebuild smoke test module

### DIFF
--- a/data/trento/certificate.yaml
+++ b/data/trento/certificate.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Derived from hack/cert-manager/certificate.tpl.yaml in
+# https://github.com/trento-project/helm-charts, with the issuer pointing at
+# the self-signed one suitable for an ephemeral test environment.
+# ${TRENTO_NAMESPACE} and ${TRENTO_WEB_ORIGIN} are replaced by the test.
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: trento-certificate
+  namespace: ${TRENTO_NAMESPACE}
+
+spec:
+  secretName: trento-tls
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+
+  commonName: ${TRENTO_WEB_ORIGIN}
+  dnsNames:
+  - ${TRENTO_WEB_ORIGIN}

--- a/data/trento/ingress-tls-values.yaml
+++ b/data/trento/ingress-tls-values.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Derived from hack/cert-manager/override-values.tpl.yaml in
+# https://github.com/trento-project/helm-charts, with the self-signed issuer
+# and with the TLS secret pinned to the ingress hostname, so Traefik serves
+# the cert-manager certificate instead of its own default one.
+# ${TRENTO_WEB_ORIGIN} is replaced by the test.
+
+trento-web:
+  ingress:
+    hosts:
+      - host: ${TRENTO_WEB_ORIGIN}
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls:
+      - secretName: trento-tls
+        hosts:
+          - ${TRENTO_WEB_ORIGIN}
+    annotations:
+      cert-manager.io/cluster-issuer: selfsigned-issuer
+
+trento-wanda:
+  ingress:
+    hosts:
+      - host: ${TRENTO_WEB_ORIGIN}
+        paths:
+          - path: /wanda
+            pathType: ImplementationSpecific
+    tls:
+      - secretName: trento-tls
+        hosts:
+          - ${TRENTO_WEB_ORIGIN}
+    annotations:
+      cert-manager.io/cluster-issuer: selfsigned-issuer
+
+trento-mcp-server:
+  ingress:
+    hosts:
+      - host: ${TRENTO_WEB_ORIGIN}
+        paths:
+          - path: /mcp
+            pathType: ImplementationSpecific
+    tls:
+      - secretName: trento-tls
+        hosts:
+          - ${TRENTO_WEB_ORIGIN}
+    annotations:
+      cert-manager.io/cluster-issuer: selfsigned-issuer

--- a/data/trento/selfsigned-issuer.yaml
+++ b/data/trento/selfsigned-issuer.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Taken from hack/cert-manager/selfsigned-issuer.yaml in
+# https://github.com/trento-project/helm-charts
+
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}

--- a/lib/trento.pm
+++ b/lib/trento.pm
@@ -1,0 +1,182 @@
+# SUSE's openQA tests
+#
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Helper functions for Trento tests
+# Maintainer: Trento team <trento-developers@suse.com>
+
+package trento;
+
+use base Exporter;
+use Exporter;
+use strict;
+use warnings;
+use Carp qw(croak);
+use testapi;
+use package_utils 'install_package';
+use utils qw(file_content_replace script_retry);
+
+our @EXPORT = qw(
+  setup_trento_ingress_tls
+  trento_helm_set_options
+  trento_helm_values_image_path_from_image
+  trento_wait_for_crd_established
+);
+
+sub _image_name_from_reference {
+    my ($image) = @_;
+    die 'Argument <image> missing or empty' unless defined $image && $image ne '';
+
+    $image =~ s/(?:[:@][^\/:@]+)$//;
+    $image =~ s{.*/}{};
+
+    return $image;
+}
+
+sub trento_helm_values_image_path_from_image {
+    my ($image) = @_;
+    my $image_name = _image_name_from_reference($image);
+    my %helm_values_image_path = (
+        'trento-web' => 'trento-web',
+        'trento-wanda' => 'trento-wanda',
+        'trento-checks' => 'trento-wanda.checks',
+        'mcp-server-trento' => 'trento-mcp-server');
+
+    die "No Helm values mapping found for image: $image_name"
+      unless $helm_values_image_path{$image_name};
+
+    return $helm_values_image_path{$image_name};
+}
+
+sub trento_helm_set_options {
+    my (%args) = @_;
+    foreach (qw(hostname admin_password)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
+
+    my @set = (
+        'trento-mcp-server.enabled=true',
+        'prometheus.enabled=false',
+    );
+    my @set_string = (
+        "global.trentoWeb.origin=$args{hostname}",
+        "trento-web.adminUser.password=$args{admin_password}",
+    );
+
+    my $options = '';
+    $options .= " --set $_" for @set;
+    # Single quotes: a $ in the password would be expanded inside double ones.
+    $options .= qq{ --set-string '$_'} for @set_string;
+
+    return $options;
+}
+
+sub trento_wait_for_crd_established {
+    my (%args) = @_;
+    foreach (qw(kubeconfig name)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
+
+    script_retry(
+        join(' ',
+            'env',
+            $args{kubeconfig},
+            qq{kubectl get crd "$args{name}"},
+            q{-o go-template='{{range .status.conditions}}{{if eq .type "Established"}}{{.status}}{{end}}{{end}}' 2>/dev/null | grep -q True}),
+        timeout => $args{timeout} // 30,
+        retry => $args{retry} // 60,
+        delay => $args{delay} // 6);
+}
+
+sub _install_cert_manager {
+    my (%args) = @_;
+
+    script_retry(
+        join(' ',
+            'env',
+            $args{kubeconfig},
+            'helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager',
+            qq{--version "$args{version}"},
+            '--namespace cert-manager',
+            '--create-namespace',
+            '--set crds.enabled=true',
+            '--wait'),
+        timeout => 600,
+        retry => 3,
+        delay => 30);
+    trento_wait_for_crd_established(kubeconfig => $args{kubeconfig}, name => 'certificates.cert-manager.io');
+    trento_wait_for_crd_established(kubeconfig => $args{kubeconfig}, name => 'clusterissuers.cert-manager.io');
+    assert_script_run("$args{kubeconfig} kubectl wait --for=condition=available --timeout=300s --all deployments -n cert-manager", timeout => 330);
+}
+
+sub _checkout_helm_charts_repository {
+    my (%args) = @_;
+
+    assert_script_run(qq{rm -rf "$args{target_dir}"});
+    script_retry(
+        join(' ',
+            'git clone --depth 1 --filter=blob:none --no-checkout',
+            qq{"$args{repository}"},
+            qq{"$args{target_dir}"}),
+        timeout => 300,
+        retry => 3,
+        delay => 30);
+    assert_script_run(
+        join(' ',
+            qq{git -C "$args{target_dir}"},
+            'sparse-checkout set --no-cone .github/scripts/helm-upgrade-smoke-test.sh',
+            qq{&& git -C "$args{target_dir}"},
+            qq{fetch --depth 1 origin "$args{ref}"},
+            qq{&& git -C "$args{target_dir}"},
+            'checkout --detach FETCH_HEAD'),
+        timeout => 300);
+    record_info('Helm charts', script_output('git -C "' . $args{target_dir} . '" --no-pager log -1 --oneline'));
+}
+
+sub _prepare_tls_termination_files {
+    my (%args) = @_;
+
+    my $issuer_file = '/root/trento-selfsigned-issuer.yaml';
+    my $certificate_file = '/root/trento-certificate.yaml';
+    my $values_file = '/root/trento-ingress-tls-values.yaml';
+
+    assert_script_run('curl -f -o ' . $issuer_file . ' ' . data_url('trento/selfsigned-issuer.yaml'));
+    assert_script_run('curl -f -o ' . $certificate_file . ' ' . data_url('trento/certificate.yaml'));
+    assert_script_run('curl -f -o ' . $values_file . ' ' . data_url('trento/ingress-tls-values.yaml'));
+
+    file_content_replace($certificate_file,
+        '\$\{TRENTO_NAMESPACE\}' => $args{namespace},
+        '\$\{TRENTO_WEB_ORIGIN\}' => $args{hostname});
+    file_content_replace($values_file, '\$\{TRENTO_WEB_ORIGIN\}' => $args{hostname});
+
+    return ($issuer_file, $certificate_file, $values_file);
+}
+
+sub setup_trento_ingress_tls {
+    my (%args) = @_;
+    foreach (qw(hostname namespace kubeconfig)) { croak "Missing mandatory $_ argument" unless $args{$_}; }
+
+    my $cert_manager_version = get_var('CERT_MANAGER_VERSION', 'v1.20.2');
+    my $helm_charts_repo = get_var('TRENTO_HELM_CHARTS_REPO', 'https://github.com/trento-project/helm-charts.git');
+    my $helm_charts_ref = get_var('TRENTO_HELM_CHARTS_REF', 'main');
+    my $helm_charts_dir = '/root/trento-helm-charts';
+    my $smoke_test_script = "$helm_charts_dir/.github/scripts/helm-upgrade-smoke-test.sh";
+
+    install_package('git-core', timeout => 600);
+
+    _install_cert_manager(kubeconfig => $args{kubeconfig}, version => $cert_manager_version);
+    _checkout_helm_charts_repository(
+        repository => $helm_charts_repo,
+        ref => $helm_charts_ref,
+        target_dir => $helm_charts_dir);
+    assert_script_run(qq{test -f "$smoke_test_script"});
+
+    my ($issuer_file, $certificate_file, $tls_values_file) = _prepare_tls_termination_files(
+        hostname => $args{hostname},
+        namespace => $args{namespace});
+    assert_script_run(qq{$args{kubeconfig} kubectl apply -f "$issuer_file"}, timeout => 120);
+    assert_script_run("$args{kubeconfig} kubectl wait --for=condition=Ready --timeout=300s clusterissuer/selfsigned-issuer", timeout => 330);
+    assert_script_run(qq{$args{kubeconfig} kubectl apply -f "$certificate_file"}, timeout => 120);
+    assert_script_run("$args{kubeconfig} kubectl wait --for=condition=Ready --timeout=300s certificate/trento-certificate", timeout => 330);
+
+    return ($tls_values_file, $smoke_test_script);
+}
+
+1;

--- a/schedule/trento/trento_container_tests.yaml
+++ b/schedule/trento/trento_container_tests.yaml
@@ -1,0 +1,11 @@
+---
+name: trento_container_tests
+description: >
+  Maintainer: Trento team <trento-developers@suse.com>
+  Trento container rebuild validation on a pre-installed SLES for SAP 15 SP7
+  openQA VM. The test deploys Trento Server on K3s with the Helm chart,
+  injects the rebuilt container image under test, and validates Web, Wanda,
+  login, and MCP endpoints.
+schedule:
+  - boot/boot_to_desktop
+  - trento/trento

--- a/tests/trento/trento.pm
+++ b/tests/trento/trento.pm
@@ -1,0 +1,125 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Smoke test for Trento container images
+# Packages: trento-web-image trento-wanda-image trento-checks-image mcp-server-trento-image
+# Maintainer: Trento team <trento-developers@suse.com>
+
+use Mojo::Base 'containers::basetest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use containers::helm;
+use containers::k8s qw(gather_k8s_logs install_k3s);
+use package_utils 'install_package';
+use trento;
+use utils qw(random_string script_retry systemctl);
+
+sub run {
+    select_serial_terminal;
+
+    my $helm_chart = get_var('HELM_CHART', 'oci://registry.suse.com/trento/trento-server');
+    my $image = get_required_var('CONTAINER_IMAGE_TO_TEST');
+    my $helm_values_image_path = trento_helm_values_image_path_from_image($image);
+    set_var('HELM_VALUES_IMAGE_PATH', $helm_values_image_path);
+
+    my $trento_server_hostname = get_var('TRENTO_SERVER_HOSTNAME', 'localhost');
+    my $admin_password = get_var('TRENTO_ADMIN_PASSWORD');
+    $admin_password = random_string(undef, 12) if (!defined $admin_password || $admin_password eq '');
+    die 'TRENTO_ADMIN_PASSWORD must contain at least 8 characters' if length($admin_password) < 8;
+    die 'TRENTO_ADMIN_PASSWORD must not contain single quotes, they break shell quoting' if $admin_password =~ /'/;
+    my $admin_user = get_var('TRENTO_ADMIN_USER', 'admin');
+    my $helm_release = get_var('TRENTO_HELM_RELEASE', 'trento-server');
+
+    my $trento_ingress_url = get_var('TRENTO_INGRESS_URL', "https://$trento_server_hostname");
+    my $kubeconfig = 'KUBECONFIG=/etc/rancher/k3s/k3s.yaml';
+    my $trento_namespace = 'default';
+
+    record_info('Chart', "Installing Trento chart under test: $helm_chart");
+    record_info('Image', "Overriding $helm_values_image_path.image with $image");
+
+    # The chart creates Traefik Middleware objects, so keep Traefik enabled
+    # during k3s installation (install_k3s disables it by default).
+    set_var('K3S_ENABLE_TRAEFIK', 1);
+    install_package('curl', timeout => 600);
+    install_k3s();
+    # install_k3s returns early if k3s is already present, so ensure it's
+    # started — reinstalling on top of a running instance re-registers the node
+    # under the current hostname while the previous Node object survives in the
+    # datastore, leaving a stale NotReady node whose pods stay Terminating.
+    systemctl('start k3s', timeout => 180) if script_run('systemctl is-active --quiet k3s');
+    if (script_run('command -v helm') == 0) {
+        record_info('helm', 'helm already present in the image, reusing it');
+    }
+    else {
+        assert_script_run('curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-4 | bash', timeout => 600);
+    }
+    script_retry("env $kubeconfig kubectl get nodes -o name | grep -q '^node/'", timeout => 180, retry => 10, delay => 10);
+    assert_script_run("$kubeconfig kubectl wait --for=condition=Ready node --all --timeout=300s", timeout => 330);
+
+    # The chart creates Traefik Middleware objects, so wait for Traefik CRDs and deployment.
+    trento_wait_for_crd_established(kubeconfig => $kubeconfig, name => 'middlewares.traefik.io');
+    script_retry("env $kubeconfig kubectl -n kube-system get deploy traefik", timeout => 180, retry => 30, delay => 6);
+    assert_script_run("$kubeconfig kubectl -n kube-system rollout status deploy/traefik --timeout=180s", timeout => 200);
+
+    assert_script_run(qq{getent hosts "$trento_server_hostname" || echo "127.0.0.1 $trento_server_hostname" >> /etc/hosts});
+
+    # Reuse the upstream helper manifests to enable cert-manager-backed ingress TLS.
+    my ($tls_values_file, $smoke_test_script) = setup_trento_ingress_tls(
+        kubeconfig => $kubeconfig,
+        hostname => $trento_server_hostname,
+        namespace => $trento_namespace);
+
+    my $chart = helm_get_chart($helm_chart);
+    my ($set_options, $helm_options) = helm_configure_values(get_var('HELM_CONFIG'), split_image_registry => 0);
+    $set_options .= trento_helm_set_options(hostname => $trento_server_hostname, admin_password => $admin_password);
+    $helm_options .= qq{ -f "$tls_values_file"};
+
+    # Install Trento Server with the rebuilt image and ingress TLS values.
+    my $helm_cmd = join(' ',
+        'env',
+        $kubeconfig,
+        'helm upgrade --install',
+        $set_options,
+        qq{"$helm_release"},
+        qq{"$chart"},
+        $helm_options);
+    script_retry($helm_cmd, timeout => 900, retry => 5, delay => 15);
+
+    # Wait for chart workloads before validating endpoints.
+    assert_script_run(
+        "$kubeconfig bash -c 'for w in \$(kubectl get deploy,statefulset -o name); do kubectl rollout status \"\$w\" --timeout=900s; done'",
+        timeout => 930);
+    assert_script_run("$kubeconfig kubectl wait --for=condition=Ready pods --all --timeout=900s", timeout => 930);
+    assert_script_run(qq{$kubeconfig helm status "$helm_release"}, timeout => 120);
+
+    # Run the upstream smoke test through the TLS ingress.
+    my $smoke_test_cmd = join(' ',
+        'env',
+        $kubeconfig,
+        qq{INGRESS_HOST="$trento_server_hostname"},
+        qq{WEB_BASE_URL="$trento_ingress_url"},
+        qq{WANDA_BASE_URL="$trento_ingress_url/wanda"},
+        qq{MCP_BASE_URL="$trento_ingress_url/mcp"},
+        qq{TEST_USERNAME="$admin_user"},
+        # Single quotes: a $ in the password would be expanded inside double ones.
+        qq{TEST_PASSWORD='$admin_password'},
+        'bash',
+        qq{"$smoke_test_script"});
+    script_retry($smoke_test_cmd, timeout => 300, retry => 3, delay => 15);
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    my $kubeconfig = 'KUBECONFIG=/etc/rancher/k3s/k3s.yaml';
+
+    record_info('Pods', script_output("$kubeconfig kubectl get pods -A -o wide", proceed_on_failure => 1));
+    gather_k8s_logs();
+}
+
+sub test_flags {
+    return {fatal => 0};
+}
+1;

--- a/variables.md
+++ b/variables.md
@@ -567,3 +567,18 @@ TEMPLATE | string | default | Template to use to build the OS image
 TEST_GROUP | string | qetestgroup | Test group to create and use
 TEST_USER | string | qetest | Test user to create and use
 TOTEST_PATH | string | | Path where the ToTest artifacts could be found
+
+### Trento specific variables
+
+Following variables are relevant for Trento container tests.
+
+Variable        | Type      | Default value | Details
+---             | ---       | ---           | ---
+CERT_MANAGER_VERSION | string | v1.20.2 | cert-manager chart version used for ingress TLS
+TRENTO_ADMIN_PASSWORD | string | random 12 character password | Admin password for Trento Web, generated when unset
+TRENTO_ADMIN_USER | string | admin | Admin user for Trento Web
+TRENTO_HELM_CHARTS_REF | string | main | Git ref of the Trento helm-charts repository to check out
+TRENTO_HELM_CHARTS_REPO | string | https://github.com/trento-project/helm-charts.git | Repository providing the upstream smoke test script
+TRENTO_HELM_RELEASE | string | trento-server | Name of the Helm release
+TRENTO_INGRESS_URL | string | https://$TRENTO_SERVER_HOSTNAME | Base URL used to reach Trento through the ingress
+TRENTO_SERVER_HOSTNAME | string | localhost | Hostname used for the ingress and the TLS certificate


### PR DESCRIPTION
## Overview

Add an openQA smoke test for rebuilt Trento container images.

The new schedule deploys Trento Server on a pre-installed SLES for SAP openQA VM using k3s and the Trento Helm chart. The test injects the rebuilt container image under test into the corresponding chart values path and verifies that the deployment is usable through the configured ingress.

The test setup also enables a more realistic ingress scenario by installing cert-manager, applying the cert-manager manifests shipped in `data/trento/`, and configuring Traefik-backed TLS termination with a self-signed issuer suitable for the ephemeral test environment.

Validation is performed through the upstream Trento Helm chart smoke test script. It checks Web and Wanda readiness, logs in with the configured admin user, verifies the authenticated profile endpoint, and exercises the MCP endpoint through the HTTPS ingress.

## Implementation details

- Add `schedule/trento/trento_container_tests.yaml`.
- Add `tests/trento/trento.pm` to install k3s/Helm, deploy the Trento chart, override the rebuilt image under test, wait for workloads, and run the upstream smoke test.
- Add `lib/trento.pm` with Trento-specific helpers for image-to-values mapping, Helm options, cert-manager/TLS setup, sparse checkout of the upstream smoke test script, and robust CRD readiness waits.
- Add the cert-manager `ClusterIssuer`, the `Certificate`, and the ingress TLS Helm values under `data/trento/`, derived from the upstream `hack/cert-manager` templates and adapted to the self-signed issuer.
- Use an autogenerated admin password by default while still allowing `TRENTO_ADMIN_PASSWORD` to override it.
- Keep `HELM_CHART`, `TRENTO_SERVER_HOSTNAME`, `TRENTO_INGRESS_URL`, `TRENTO_HELM_CHARTS_REPO`, and `TRENTO_HELM_CHARTS_REF` configurable.
