### PR TITLE
Avoid misleading ipaddr2 fail record_info

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -1347,7 +1347,7 @@ sub ipaddr2_ssh_internal(%args) {
         return $ret if (defined $ret && $ret == 0);
         record_info("Failed $_ time",
             "Command $command failed with exit code " . ($ret // 'undef'),
-            result => 'fail');
+            result => 'fail') unless $args{no_assert};
     }
     die "Command $command failed with exit code " . ($ret // 'undef') unless $args{no_assert};
     return $ret;


### PR DESCRIPTION
Do not print record_info in when no_assert => 1 as the exit code is expected not to be zero.

# Verification run:
- sle-15-SP7-SapCloud-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_7-ipaddr2_azure_test -> http://openqaworker15.qe.prg2.suse.org/tests/376712 :green_circle: no more confusing tails from record_info https://openqaworker15.qe.prg2.suse.org/tests/376712#step/registration/23
- sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-ipaddr2_azure_test -> http://openqaworker15.qe.prg2.suse.org/tests/376711 :green_circle:  https://openqaworker15.qe.prg2.suse.org/tests/376711#step/registration/11