### PR TITLE
Fix test issues in podman v6 container suite

### DIFF
--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -76,7 +76,7 @@ sub run_tests {
 
     my $ret = bats_tests($log_file, \%env, \@xfails, 6000);
 
-    run_command "buildah prune -a -f";
+    run_command "STORAGE_DRIVER=$storage_driver buildah prune -a -f";
     cleanup_podman;
 
     return ($ret);

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -57,6 +57,11 @@ sub run_tests {
                 # due to https://github.com/containers/podman/issues/27246
                 "200-pod.bats::pod resource limits",
             ) if (version->parse(numeric_version($version)) >= version->parse("5.4.0"));
+            push @xfails, (
+                # These fail for root/local on podman v6.0.0 because we don't ship libcontainers-common
+                # with the storage driver set in storage.conf
+                "155-partial-pull.bats::zstd chunked does not modify image content",
+            ) if (version->parse(numeric_version($version)) >= version->parse("6.0.0"));
         }
     }
     push @xfails, (

--- a/tests/containers/podman_e2e.pm
+++ b/tests/containers/podman_e2e.pm
@@ -81,6 +81,7 @@ sub run {
         PODMAN_BINARY => "/usr/bin/podman",
         PODMAN_REMOTE_BINARY => "/usr/bin/podman-remote",
         QUADLET_BINARY => "/usr/libexec/podman/quadlet",
+        STORAGE_DRIVER => "overlay",
         TESTFLAGS => "--junit-report=report.xml",
     );
     my $env = join " ", map { "$_=$env{$_}" } sort keys %env;

--- a/tests/containers/podman_e2e.pm
+++ b/tests/containers/podman_e2e.pm
@@ -83,6 +83,7 @@ sub run {
         QUADLET_BINARY => "/usr/libexec/podman/quadlet",
         STORAGE_DRIVER => "overlay",
         TESTFLAGS => "--junit-report=report.xml",
+        TMPDIR => "/var/tmp",
     );
     my $env = join " ", map { "$_=$env{$_}" } sort keys %env;
 

--- a/tests/containers/podman_e2e.pm
+++ b/tests/containers/podman_e2e.pm
@@ -41,6 +41,8 @@ sub setup {
     # The tests expect an exact list of unqualified-search-registries containing "quay.io" and we ship:
     # unqualified-search-registries = ["registry.opensuse.org", "registry.suse.com", "docker.io"]
     run_command "rm -f /etc/containers/registries.conf.d/00-suse-registries.conf";
+    # Tests using --signature-policy /etc/containers/policy.json expect this file to exist
+    run_command "ln -sf /usr/share/containers/policy.json /etc/containers/policy.json" if script_run("test -f /etc/containers/policy.json");
 
     enable_docker;
 

--- a/tests/containers/podman_e2e.pm
+++ b/tests/containers/podman_e2e.pm
@@ -88,6 +88,7 @@ sub run {
     my @xfails = (
         'Libpod Suite::[It] Podman pod create podman pod create --restart=on-failure',
         'Libpod Suite::[It] Podman run memory podman run memory test on oomkilled container',
+        'Libpod Suite::[It] Verify podman containers.conf usage set .engine.remote=true',
     );
     push @xfails, (
         # Fixed in podman 5.6.1:
@@ -100,9 +101,6 @@ sub run {
         # Fails with "registry.access.redhat.com/*openshift*"
         'Libpod Suite::[It] Podman search podman search with wildcards',
     ) if (version->parse(numeric_version($version)) < version->parse("5.8.0"));
-    push @xfails, (
-        'Libpod Suite::[It] Verify podman containers.conf usage set .engine.remote=true',
-    ) if (get_var("ROOTLESS"));
     push @xfails, (
         # We can't backport https://github.com/containers/podman/pull/27775 and this test may fail with:
         # Command exited 125 as expected, but did not emit 'gateway 192.168.1.1 not in subnet 10.11.12.0/24'


### PR DESCRIPTION
Fix test issues in podman v6.0.0 and buildah v1.44.0.

Fixes:
- Symlink /etc/containers/policy.json to /usr/share/containers/ if not present.
- Make `.engine.remote=true` xfail also as root.
- Set `STORAGE_DRIVER` explicitly in the buildah & podman tests.
- podman_e2e: Set `TMPDIR` to avoid filling up /tmp which is tmpfs.
- bats/podman: Add xfail for podman v6.0.0+

### buildah
Failed job: https://openqa.opensuse.org/tests/6076744#step/buildah/396
Verification run: https://openqa.opensuse.org/tests/6076987#step/buildah/472

### podman bats
Failed job: https://openqa.opensuse.org/tests/6076747 (handled with xfail in last commit)
~Verification run: https://openqa.opensuse.org/tests/6077126~

### podman e2e:
Failed jobs:
 - w/ runc: https://openqa.opensuse.org/tests/6076749
 - w/ crun: https://openqa.opensuse.org/tests/6076750
 - w/ runc rootless: https://openqa.opensuse.org/tests/6076751
 - w/ crun rootless: https://openqa.opensuse.org/tests/6076752
 
Verification runs:
   - w/ runc: https://openqa.opensuse.org/tests/6077114
   - w/ crun: https://openqa.opensuse.org/tests/6077017
   - w/ runc rootless: https://openqa.opensuse.org/tests/6077018
   - w/ crun rootless: https://openqa.opensuse.org/tests/6077019

Note: The above VRs were done with these repos added to `TEST_REPOS` to fetch podman v6.0.0 & skopeo v1.23.0:
- https://download.opensuse.org/repositories/Virtualization:/containers/openSUSE_Tumbleweed/Virtualization:containers.repo 
- https://download.opensuse.org/repositories/home:/danishprakash:/branches:/Virtualization:/containers/openSUSE_Tumbleweed/home:danishprakash:branches:Virtualization:containers.repo
