### PR TITLE
fix(publiccloud): derive kernel-devel package via rpm query format, not string parsing

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -46,13 +46,15 @@ sub install_build_deps {
     # Remove kernel-default-devel from the list of dependencies since matching kernel version kernel-<flavor>-devel-<ver> package will be added.
     @deps = grep { $_ ne 'kernel-default-devel' } @deps;
 
+    # Query rpm's NAME/VERSION/RELEASE tags directly for the package owning
+    # the running kernel's config file, instead of parsing free-form `rpm -qf`
+    # output. The previous sed/cut/awk chain assumed the package name always
+    # splits cleanly into kernel-<flavor>-<version>, which is not guaranteed
+    # and produced an invalid 'kernel--devel-<version>' package on some SUTs.
+    my $kernel_pkg_name = $instance->ssh_script_output(cmd => q{rpm -qf --qf '%{NAME}' /boot/config-$(uname -r)});
+    my $kernel_pkg_ver = $instance->ssh_script_output(cmd => q{rpm -qf --qf '%{VERSION}-%{RELEASE}' /boot/config-$(uname -r)});
     # Sample value: kernel-default-devel-6.12.0-160000.27.1
-    my $kernel_devel_pkg = $instance->ssh_script_output(cmd => q{
-        rpm -qf /boot/config-$(uname -r) \
-        | sed -r 's/\.[^.]*$//' \
-        | cut -d- -f2- \
-        | awk -F- '{print "kernel-" $1 "-devel-" substr($0, index($0,$2))}'
-    });
+    my $kernel_devel_pkg = "${kernel_pkg_name}-devel-${kernel_pkg_ver}";
 
     push @deps, $kernel_devel_pkg;
 


### PR DESCRIPTION
## Problem

\`install_build_deps()\` in \`tests/publiccloud/run_ltp.pm\` derives the
\`kernel-<flavor>-devel-<version>\` package to install by piping the
free-form output of \`rpm -qf /boot/config-$(uname -r)\` through a
\`sed | cut | awk\` chain. This assumes the package name owning the
config file always splits cleanly into \`kernel-<flavor>-<version>-<release>\`.

On at least one SUT this assumption broke and the pipeline silently
produced the invalid package name \`kernel--devel-6.4.0-150700.53.34.1\`
(empty flavor field), which doesn't exist in any repo. \`zypper\` then
failed the whole \`install --no-recommends ...\` call, failing the
\`run_ltp\` module entirely — unrelated to the actual package/incident
under test.

Observed on openqa.suse.de job 21728418 (publiccloud_ltp,
\`smelt:43604:systemd\` incident test run):

\`\`\`
Test died: typing command 'ssh ... sudo zypper -n install --no-recommends
autoconf automake gcc git-core libopenssl-devel make
kernel--devel-6.4.0-150700.53.34.1' timed out
\`\`\`

Reproduced the exact malformed output locally:

\`\`\`
$ echo "kernel--6.4.0-150700.53.34.1.x86_64" \
  | sed -r 's/\.[^.]*$//' | cut -d- -f2- \
  | awk -F- '{print "kernel-" $1 "-devel-" substr($0, index($0,$2))}'
kernel--devel-6.4.0-150700.53.34.1
\`\`\`

## Fix

Query rpm's \`NAME\`/\`VERSION\`/\`RELEASE\` tags directly via \`rpm -qf --qf\`
instead of parsing free-form output, which is robust regardless of how
the kernel package name is structured.

## Test

No dedicated unit test exists for this module. Verified the new
\`rpm -qf --qf '%{NAME}'\` / \`'%{VERSION}-%{RELEASE}'\` approach produces
the same sample value documented in the code comment
(\`kernel-default-devel-6.12.0-160000.27.1\`) for normal kernel flavors,
and no longer depends on the position of dashes/dots in the package
NVRA string. \`perltidy\` reports no formatting changes needed.


VR: https://openqa.suse.de/tests/23234752#live