### PR TITLE
NVIDIA: Install newer cmake

### DIFF
--- a/lib/nvidia_utils.pm
+++ b/lib/nvidia_utils.pm
@@ -148,7 +148,10 @@ sub validate_cuda
     my $gcc_ver = get_var('NVIDIA_CUDA_GCC_VERSION');
     my $gcc_pkgs = $gcc_ver ? "gcc$gcc_ver gcc$gcc_ver-c++" : "";
 
-    zypper_call("install -l cmake git $gcc_pkgs cuda-toolkit vulkan-devel freeglut-devel Mesa-libEGL-devel", timeout => 1200);
+    zypper_call("install -l cmake python3-pip git $gcc_pkgs cuda-toolkit vulkan-devel freeglut-devel Mesa-libEGL-devel", timeout => 1200);
+    # Get an up-to-date cmake from PyPI instead of the distro package
+    assert_script_run('pip3 install -U cmake');
+    record_info('CMake Version', script_output('cmake --version'));
 
     # Query the GPU capabilities
     my $query = script_output('nvidia-smi --query-gpu=compute_cap --format=csv');

--- a/lib/nvidia_utils.pm
+++ b/lib/nvidia_utils.pm
@@ -41,7 +41,7 @@ sub get_nvidia_driver {
     my $branch = get_var('NVIDIA_DRIVER_BRANCH', 'G06');
     my $driver;
 
-    if ($args{variant} eq 'cuda') {
+    if (($args{variant} // '') eq 'cuda') {
         $driver = "nvidia-open-driver-${branch}-signed-cuda-kmp-default";
     } else {
         $driver = "nvidia-open-driver-${branch}-signed-kmp-default";
@@ -87,7 +87,7 @@ sub install
         zypper_call("remove --clean-deps @conflicting");
     }
 
-    if ($args{variant} eq 'cuda') {
+    if (($args{variant} // '') eq 'cuda') {
         $variant = $variant_cuda;
         zypper_call("remove --clean-deps $variant_std", exitcode => [0, 104]);
         zypper_call('rr nvidia');
@@ -104,8 +104,8 @@ sub install
     my $version = script_output("rpm -qa --queryformat '%{VERSION}\n' $variant | cut -d '_' -f1 | sort -u | tail -n 1");
     record_info("NVIDIA Version", $version);
 
-    my $workaround;
-    if ($version < 580 && $args{variant} eq 'cuda') {
+    my $workaround = '';
+    if ($version < 580 && ($args{variant} // '') eq 'cuda') {
         $workaround = "nvidia-persistenced == $version";
         record_soft_failure("bsc#1249098 - workaround for Nvidia driver dependency issue");
     }


### PR DESCRIPTION
The distro cmake predates knowledge of newer CUDA compiler releases and
their C++ standard support, so it fails to configure newer cuda-samples
targets (e.g. 9_CUDA_Tile, added in v13.3, requires C++20). Get an
up-to-date cmake from PyPI instead.

Also, fix a few warnings.

- Related ticket: https://progress.opensuse.org/issues/201828
- Verification run: https://openqa.suse.de/tests/23229699
