### PR TITLE
clamav_upgrade: Install also libfreshclam* on 16+

### DIFF
--- a/tests/console/clamav_upgrade.pm
+++ b/tests/console/clamav_upgrade.pm
@@ -24,8 +24,7 @@ sub run {
 
     # Install the specific old versions
     my $libfreshclam = ($old_version =~ /^1\.5\./) ? "libfreshclam4" : "libfreshclam3";
-    my @pkgs = ("clamav", "clamav-milter", "libclamav12", "libclammspack0");
-    push(@pkgs, $libfreshclam) if (is_sle('<16.0'));
+    my @pkgs = ("clamav", "clamav-milter", "libclamav12", "libclammspack0", $libfreshclam);
     my $install_list = join(" ", map { "$_=$old_version" } @pkgs);
 
     zypper_call("in $install_list", timeout => 300);


### PR DESCRIPTION
libfreshclam4 is first installed as latest version not `$old_version`, then upgrade is done, but it will fail because it is not allowed to do downgrade by default `Solution 1: downgrade of libfreshclam4-1.5.3-160000.1.1.x86_64 to libfreshclam4-1.5.2-160000.1.1.x86_64`
I guess libfreshclam4 from PackageHub is out sooner than clamav* from SLE repo, that is creating this issue

- Related ticket: https://openqa.suse.de/tests/23229655#step/clamav_upgrade/19
- Verification run:
https://openqa.suse.de/tests/23229752 SLE 16
https://openqa.suse.de/tests/23230089 SLE 15-SP7
https://openqa.suse.de/tests/23230165 SLE 12-SP3