### PR TITLE
Add test for Apache SSL with PQC

### DIFF
--- a/data/security/openqa_agnostic/testApacheSSLPQC/apache_pqc_ssl_test.py
+++ b/data/security/openqa_agnostic/testApacheSSLPQC/apache_pqc_ssl_test.py
@@ -1,0 +1,144 @@
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+BASE_DIR = Path(__file__).parent
+KEY = BASE_DIR / "server_mldsa65.key"
+CRT = BASE_DIR / "server_mldsa65.crt"
+SERVER = "127.0.0.1:443"
+
+# Apache configuration paths
+APACHE_KEY = Path("/etc/apache2/ssl.key/server_mldsa65.key")
+APACHE_CRT = Path("/etc/apache2/ssl.crt/server_mldsa65.crt")
+VHOST_CONF = BASE_DIR / "pqc-ssl.conf"
+APACHE_VHOST = Path("/etc/apache2/vhosts.d/pqc-ssl.conf")
+
+# all ML-KEM algorithms
+MLKEM_VARIANTS = ["mlkem512", "mlkem768", "mlkem1024"]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def generate_certs():
+    """Generate ML-DSA-65 key and self-signed certificate, deploy them to Apache
+    directories, ensure SSL flag is set in sysconfig, stop firewalld, restart
+    Apache, and verify it is listening on port 443."""
+
+    # generate ML-DSA65 key
+    if not KEY.exists():
+        subprocess.run(
+            ["openssl", "genpkey", "-algorithm", "mldsa65", "-out", str(KEY)],
+            check=True,
+        )
+
+    # generate ML-DSA65 self-signed certificate
+    if not CRT.exists():
+        subprocess.run(
+            [
+                "openssl", "req", "-new", "-x509",
+                "-key", str(KEY), "-out", str(CRT),
+                "-days", "365",
+                "-subj", "/C=US/ST=Washington/L=Redmond/O=PQTest/CN=pqtest.local",
+                "-addext", "keyUsage=digitalSignature",
+                "-addext", "extendedKeyUsage=serverAuth",
+            ],
+            check=True,
+        )
+
+    # copy key/certificate to relevant Apache directories
+    subprocess.run(["cp", str(KEY), str(APACHE_KEY)], check=True)
+    subprocess.run(["cp", str(CRT), str(APACHE_CRT)], check=True)
+    # copy virtual host configuration
+    subprocess.run(["cp", str(VHOST_CONF), str(APACHE_VHOST)], check=True)
+
+    # make sure SSL is present (enabled) in Apache server flags
+    sysconfig = Path("/etc/sysconfig/apache2")
+    content = sysconfig.read_text()
+    match = re.search(r'^APACHE_SERVER_FLAGS="([^"]*)"', content, re.MULTILINE)
+    flags = match.group(1) if match else ""
+    if "SSL" not in flags.split():
+        new_flags = (flags + " SSL").strip()
+        subprocess.run(
+            [
+                "sed", "-i",
+                f's/^APACHE_SERVER_FLAGS=.*/APACHE_SERVER_FLAGS="{new_flags}"/',
+                str(sysconfig),
+            ],
+            check=True,
+        )
+
+    # stop firewall
+    subprocess.run(["systemctl", "stop", "firewalld"], check=True)
+    result = subprocess.run(
+        ["systemctl", "is-active", "firewalld"],
+        capture_output=True, text=True,
+    )
+    assert result.stdout.strip() == "inactive", (
+        f"firewalld is still running: {result.stdout.strip()}"
+    )
+
+    # (re)start Apache and make sure it's listening
+    subprocess.run(["systemctl", "restart", "apache2"], check=True)
+    result = subprocess.run(
+        ["ss", "-tlnp"],
+        capture_output=True, text=True, check=True,
+    )
+    assert ":443" in result.stdout, (
+        f"Apache is not listening on port 443:\n{result.stdout}"
+    )
+
+
+def _s_client_output(groups: str) -> str:
+    """Run openssl s_client against the server restricted to the given KEM group
+    and send a minimal HTTP/1.0 GET. Returns combined stdout and stderr."""
+    result = subprocess.run(
+        [
+            "openssl", "s_client",
+            "-connect", SERVER,
+            "-groups", groups,
+            "-CAfile", str(CRT),
+            "-servername", "pqtest.local",
+        ],
+        input="GET / HTTP/1.0\r\nHost: pqtest.local\r\n\r\n",
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("groups", MLKEM_VARIANTS)
+def test_pqc_handshake(groups):
+    """Verify the TLS handshake uses the expected ML-KEM group for key exchange
+    (checked in 'Negotiated TLS1.3 group' line) and ML-DSA-65 for the server
+    certificate signature (checked in 'Peer signature type' line)."""
+    output = _s_client_output(groups)
+    neg_group = next(
+        (l for l in output.splitlines() if "Negotiated TLS1.3 group" in l), ""
+    )
+    assert groups.upper() in neg_group or groups in neg_group, (
+        f"Expected {groups} in 'Negotiated TLS1.3 group' line:\n{neg_group}"
+    )
+    peer_sig = next(
+        (l for l in output.splitlines() if "Peer signature type" in l), ""
+    )
+    assert "mldsa65" in peer_sig.lower() or "ML-DSA-65" in peer_sig, (
+        f"Expected ML-DSA-65 in 'Peer signature type' line:\n{peer_sig}"
+    )
+
+
+@pytest.mark.parametrize("groups", MLKEM_VARIANTS)
+def test_https_200(groups):
+    """Verify the server returns HTTP 200 over a PQC TLS connection using curl.
+    curl -v verbose output (sent to stderr) is checked for 'HTTP/1.1 200 OK'."""
+    result = subprocess.run(
+        ["curl", "-k", "-v", "--curves", groups, "https://localhost:443"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=10,
+    )
+    assert "HTTP/1.1 200 OK" in result.stderr, (
+        f"Expected 'HTTP/1.1 200 OK' in curl output:\n{result.stderr}"
+    )

--- a/data/security/openqa_agnostic/testApacheSSLPQC/pqc-ssl.conf
+++ b/data/security/openqa_agnostic/testApacheSSLPQC/pqc-ssl.conf
@@ -1,0 +1,30 @@
+# Apache virtual host configuration file for SSL with ML-DSA key and ML-KEM key exchange algorithms
+<VirtualHost *:443>
+    ServerName pqtest.local
+    HostnameLookups Off
+    DocumentRoot /srv/www/htdocs
+    UseCanonicalName Off
+
+    <Directory "/srv/www/htdocs">
+        Options Indexes FollowSymLinks
+        AllowOverride None
+        <IfModule !mod_access_compat.c>
+            Require all granted
+        </IfModule>
+        <IfModule mod_access_compat.c>
+            Order allow,deny
+            Allow from all
+        </IfModule>
+    </Directory>
+
+    SSLEngine on
+    SSLCertificateFile     /etc/apache2/ssl.crt/server_mldsa65.crt
+    SSLCertificateKeyFile  /etc/apache2/ssl.key/server_mldsa65.key
+
+    Protocols h2 http/1.1
+
+    # restict protocol to v1.3 TLS, the only one which supports Post-Quantum Crypto
+    SSLProtocol            -all +TLSv1.3
+    # restrict group/curve negotiation strictly to pure Post-Quantum KEMs
+    SSLOpenSSLConfCmd      Curves mlkem512:mlkem768:mlkem1024
+</VirtualHost>

--- a/data/security/openqa_agnostic/testApacheSSLPQC/runtest
+++ b/data/security/openqa_agnostic/testApacheSSLPQC/runtest
@@ -1,0 +1,39 @@
+#!/bin/bash
+# METADATA_START
+# ---
+# test: Apache web server SSL post-quantum cryptography test using ML-DSA signature and ML-KEM key exchange algorithms
+# desc: Verifies that ML-DSA & ML-KEM post-quantum algorithms work through the Apache web server
+# steps:
+# - 1. Setup Apache
+#   - generate MLDSA65 key + certficate pair (self signed)
+#   - set up an Apache SSL virtual host with these keys and enforce TLS v1.3 and the 3 ML-KEM key exchange algorithms
+#     (see provided pqc-ssl.conf)
+#   - stop firewall if running
+#   - start Apache and check that it's listening
+# - 2. Test MLDSA65 algorithm with MLKEM512, MLKEM768 and MLKEM1024 key exchange algorithms
+#   - use openssl s_client to verify that we can establish a TLS v1.3 connection using the 3 ML-KEM algorithms
+#   - verify peer signature is MLDSA65
+#   - fetch default Apache web page with curl through TLS v1.3 connection, using the 3 ML-KEM algorithms
+# author: <mmilian@suse.com>
+# maintainer: QE Security <none@suse.de>
+# expected: no errors raised, connection succeed
+# platform: SLE16
+# tags: security post-quantum-crypto ssl apache python
+# ---
+# METADATA_END
+
+set -e
+
+# Source the helper script for argument handling
+source ../lib/helper.sh
+
+# Define files required for this test
+TEST_FILES=(apache_pqc_ssl_test.py)
+
+# Delegate argument processing to the helper
+handle_args "$0" "$@"
+
+# If the metadata flag is not provided, run the tests as usual.
+
+# run tests with pytest and generate junit xml results
+pytest apache_pqc_ssl_test.py --junitxml=results.xml

--- a/schedule/security/apachessl_pqc.yaml
+++ b/schedule/security/apachessl_pqc.yaml
@@ -1,0 +1,8 @@
+name: apachessl_pqc
+description: >
+  This is for the Apache SSL post-quantum cryptography test.
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - console/consoletest_setup
+  - security/oqa_agnostic/apachessl_pqc

--- a/tests/security/oqa_agnostic/apachessl_pqc.pm
+++ b/tests/security/oqa_agnostic/apachessl_pqc.pm
@@ -1,0 +1,60 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Run apache ssl post quantum python test
+# Maintainer: QE Security <none@suse.de>
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use security::agnosticTestRunner;
+use version_utils 'is_sle';
+use utils 'zypper_call';
+use Utils::Architectures 'is_s390x';
+
+sub run {
+    select_serial_terminal;
+    if (is_sle('<16')) {
+        record_info('SKIP', 'OpenSSL post quantum crypto tests are only available on SLE 16 and later');
+        return;
+    }
+
+    # prepare test environment
+    zypper_call 'in apache2';
+    my $apache_version = script_output('httpd -v');
+    record_info('Apache version', $apache_version);
+
+    zypper_call 'in python3-pytest';
+    my $pytest_version = script_output('pytest --version');
+    record_info('Pytest version', $pytest_version);
+
+    my $python_version = script_output('python3 --version');
+    record_info('Python version', $python_version);
+
+    if (is_s390x) {
+        zypper_call 'in openssl';
+    }
+
+    my $openssl_version = script_output('openssl --version');
+    record_info('OpenSSL version', $openssl_version);
+
+    # prepare test data
+    record_info('preparing test data');
+    my $data_url = data_url('security/openqa_agnostic/testApacheSSLPQC');
+    my $test_dir = '~/testApacheSSLPQC';
+    assert_script_run "mkdir -p $test_dir";
+    assert_script_run "curl -s -o $test_dir/pqc-ssl.conf $data_url/pqc-ssl.conf";
+
+    # run test
+    my $test = security::agnosticTestRunner->new({
+            language => 'python',
+            name => 'testApacheSSLPQC',
+            files => 'runtest apache_pqc_ssl_test.py'
+        }
+    );
+    $test->setup()->run_test()->parse_results()->cleanup();
+}
+
+1;


### PR DESCRIPTION
 OpenQA agnostic (python) test for verifying ML-DSA and ML-KEM
 post-quantum algorithms with Apache web server

- Related ticket: https://progress.opensuse.org/issues/194924
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=16.1&build=54.1&groupid=680
