### PR TITLE
Remove redundant --verbose flag from gitlint hook

### DIFF
--- a/.githooks.config
+++ b/.githooks.config
@@ -1,3 +1,3 @@
 [hook "commit-message-linter"]
     event = commit-msg
-    command = gitlint --verbose --msg-filename 
+    command = gitlint --msg-filename 


### PR DESCRIPTION
The `--verbose` flag in `.githooks.config` was making gitlint *less* verbose than its default. By default gitlint runs at triple verbosity (equivalent to `-vvv`); passing a single `--verbose` reduces it to one level.

- Related: #25698