### PR TITLE
Kselftests: NET: Tidy up dependency repositories

### DIFF
--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -208,16 +208,16 @@ sub install_dependencies
     }
 
     if ($collection =~ m{^net(/|$)}) {
-        my $netutils_repo, my $bench_repo;
+        my $version;
         if (is_tumbleweed()) {
-            $netutils_repo = 'https://download.opensuse.org/repositories/network:/utilities/openSUSE_Factory/network:utilities.repo';
-            $bench_repo = 'https://download.opensuse.org/repositories/benchmark/openSUSE_Factory/benchmark.repo';
-        } elsif (is_sle('=16.0')) {
-            $netutils_repo = 'https://download.opensuse.org/repositories/network:/utilities/16.0/network:utilities.repo';
-            $bench_repo = 'https://download.opensuse.org/repositories/benchmark/16.0/benchmark.repo';
+            $version = 'openSUSE_Factory';
+        } elsif (is_sle('>=16.0')) {
+            $version = '16.0';
         }
-        zypper_ar($netutils_repo) if $netutils_repo;
-        zypper_ar($bench_repo) if $bench_repo;
+        if ($version) {
+            # ipv6toolkit netsniff-ng ndisc6 dropwatch
+            zypper_ar("https://download.opensuse.org/repositories/network:/utilities/$version/network:utilities.repo", priority => 100);
+        }
 
         # install build deps
         install_package('clang libcap-devel libnuma-devel libmnl-devel python3-PyYAML python3-jsonschema', trup_apply => 1);


### PR DESCRIPTION
Only network:utilities repository is needed, the other packages are
available from already configured repositories. Note down the packages we
actually need from it. Lower its priority so that if some of the packages
are available from PackageHub or QA:Head, they are preferred.

Verification runs:
- https://openqa.suse.de/tests/23249471 15.7 ([failure expected](https://bugzilla.suse.com/show_bug.cgi?id=1269591))
- https://openqa.suse.de/tests/23249708 16.0
- https://openqa.suse.de/tests/23249845 16.1
- https://openqa.opensuse.org/tests/6082843 Tumbleweed ([failure unrelated](https://progress.opensuse.org/issues/202386#note-4))

