### PR TITLE
Make SLES16.0 QU  guest migration work

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_full_repo.xml
+++ b/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_full_repo.xml
@@ -15,12 +15,13 @@
     <guest_domain_name/>
     <guest_memory>4096,maxmemory=8192</guest_memory>
     <guest_vcpus>2,maxvcpus=4</guest_vcpus>
-    <guest_cpumodel>host-model</guest_cpumodel>
+    <!-- According to bsc#1271635, SLES16.0 VM should use host-passthrough cpu to be migratable -->
+    <guest_cpumodel>mode=host-passthrough,check=none,migratable=on</guest_cpumodel>
     <guest_metadata/>
     <guest_boot_settings>loader=/usr/share/qemu/ovmf-x86_64-suse-4m-code.bin,loader.readonly=yes,loader.type=pflash,nvram.template=/usr/share/qemu/ovmf-x86_64-suse-4m-vars.bin,hd,bootmenu.enable=yes,menu=on</guest_boot_settings>
     <guest_xpath/>
     <guest_installation_automation_method>autoagama</guest_installation_automation_method>
-    <guest_installation_automation_platform></guest_installation_automation_platform>
+    <guest_installation_automation_platform/>
     <guest_installation_automation_file>sles_16_plus_kvm_hvm_guest_non_encrypted_storage_x86_64.jsonnet</guest_installation_automation_file>
     <guest_installation_method>location</guest_installation_method>
     <guest_installation_extra_args>live.password=ROOTPASSWORD#console=ttyS0,115200#loglevel=5#plymouth.enable=0#ignore_loglevel</guest_installation_extra_args>

--- a/lib/parallel_guest_migration_base.pm
+++ b/lib/parallel_guest_migration_base.pm
@@ -792,7 +792,8 @@ sub save_guest_asset {
     foreach my $_guest (split(/ /, $args{_guest})) {
         record_info("Save $_guest asset");
         my $_temp = 1;
-        $_temp = script_run("virsh $_uri dumpxml $_guest > $args{_confdir}/$_guest.xml");
+        # According to bsc#1271635, '--migratable' option should be used with 'virsh dumpxml' for migration.
+        $_temp = script_run("virsh $_uri dumpxml --migratable $_guest > $args{_confdir}/$_guest.xml");
         $_temp |= script_run("xmlstarlet ed --inplace --delete \"/domain/devices/interface/target\" $args{_confdir}/$_guest.xml");
         $_temp |= script_run("xmlstarlet ed --inplace --delete \"/domain/devices/interface/alias\" $args{_confdir}/$_guest.xml");
         $_temp |= script_run("xmlstarlet ed --inplace --delete \"/domain/devices/interface/source/\@portid\" $args{_confdir}/$_guest.xml");
@@ -1557,7 +1558,8 @@ sub do_guest_administration {
             "virsh $_uri list | grep \"guest .*running\"",
             "virsh $_uri save guest /tmp/guest_administration.chckpnt",
             "virsh $_uri restore /tmp/guest_administration.chckpnt",
-            "virsh $_uri dumpxml guest > /tmp/guest_administration.xml",
+            # According to bsc#1271635, '--migratable' option should be used with 'virsh dumpxml' for migration.
+            "virsh $_uri dumpxml guest --migratable > /tmp/guest_administration.xml",
             "virsh $_uri domxml-to-native --format native-format /tmp/guest_administration.xml > /tmp/guest_administration.cfg",
             "virsh $_uri shutdown guest",
             "virsh $_uri undefine guest --managed-save || virsh $_uri undefine guest --keep-nvram --managed-save",


### PR DESCRIPTION
* **According** to [this comment](https://bugzilla.suse.com/show_bug.cgi?id=1271635#c8
) in product bugs bsc#1271635, SLES16.0 VM should use ```host-passthrough``` cpu model for migration. So change cpu settings to ```mode=host-passthrough,check=none,migratable=on``` for guest profile ```SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_full_repo.xml```.

* **According** to [this comment](https://bugzilla.suse.com/show_bug.cgi?id=1271635#c10
) in product bug bsc#1271635, using ```--migratable``` with ```virsh dumpxml``` is more reasonable for guest migration operation.

* **Verification Runs:**
  * [sle-16.0-Full-x86_64-Build262.3-virt-guest-migration-developing-from-developing-to-developing-kvm](https://openqa.suse.de/tests/23654073)
  * [sle-16.1-Online-x86_64-Build60.3-virt-guest-migration-sle16-from-sle16-to-developing-kvm](https://openqa.suse.de/tests/23657251)
  * [sle-16.1-Online-x86_64-Build60.3-virt-guest-migration-developing-from-developing-to-developing-kvm](https://openqa.suse.de/tests/23689695)
  * [sle-15-SP7-Server-DVD-Incidents-VIRT-Core-x86_64-Build:smelt:45204:qemu-qam-kvm-migration](https://openqa.suse.de/tests/23689698)
  * [sle-15-SP7-Server-DVD-Incidents-VIRT-Core-x86_64-Build:smelt:45204:qemu-qam-xen-migration](https://openqa.suse.de/tests/23689584)
