### PR TITLE
Create br0 in preparation phase for immutable system

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -149,6 +149,7 @@ our @EXPORT = qw(
   dump_tasktrace
   show_all_disks
   render_scc_url
+  query_installed_packages
 );
 
 our @EXPORT_OK = qw(
@@ -3809,6 +3810,25 @@ sub render_scc_url {
     my $scc_url = get_var('SCC_URL', 'https://scc.suse.com');
     $scc_url =~ s/$test_build/$main_build/g if is_disk_image;
     return $scc_url;
+}
+
+=head2 query_installed_packages
+
+  query_installed_packages(packages => 'package1,package2,package3')
+
+Query whether provided packages are all installed by using 'rpm -q'. Return 1 if
+all packages are already installed or 0 if any of them is not installed. The only
+argument is packages which accepts list of package names separated by comma.
+=cut
+
+sub query_installed_packages {
+    my %args = @_;
+    $args{packages} //= '';
+
+    croak('No packages to be checked') if (!$args{packages});
+    my $ret = 0;
+    $ret |= script_run("rpm -q $_") foreach (split(/,/, $args{packages}));
+    return ($ret ? 0 : 1);
 }
 
 1;

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -21,9 +21,9 @@ use Data::Dumper;
 use XML::Writer;
 use IO::File;
 use Carp;
-use utils 'script_retry';
+use utils qw(script_retry query_installed_packages);
 use upload_system_log 'upload_supportconfig_log';
-use version_utils qw(is_sle is_alp is_opensuse);
+use version_utils qw(is_sle is_alp is_opensuse is_transactional);
 use Utils::Architectures;
 use virt_autotest::utils;
 use virt_autotest::common;
@@ -106,8 +106,13 @@ sub create_host_bridge_nm {
     my $config_path = "/etc/NetworkManager/system-connections/$host_bridge.nmconnection";
 
     if (is_sle('16+') && !is_s390x && script_run("[[ -f $config_path ]]") != 0) {
-        # Install required packages python313-psutil and python313-dbus-python
-        zypper_call '-t in python313-psutil python313-dbus-python', exitcode => [0, 4, 102, 103, 106];
+        # Check or install required packages python313-psutil and python313-dbus-python
+        if (is_transactional) {
+            croak('Packages python313-psutil and python313-dbus-python need to be installed beforehand on immutable system') if (!query_installed_packages(packages => 'python313-psutil,python313-dbus-python'));
+        }
+        else {
+            zypper_call '-t in python313-psutil python313-dbus-python', exitcode => [0, 4, 102, 103, 106];
+        }
         my $wait_script = "180";
         my $script_name = "create_host_bridge.py";
         my $script_url = data_url("virt_autotest/$script_name");

--- a/tests/virt_autotest/prepare_transactional_server.pm
+++ b/tests/virt_autotest/prepare_transactional_server.pm
@@ -20,6 +20,7 @@ use Utils::Systemd;
 use Utils::Backends qw(get_serial_console);
 use ipmi_backend_utils;
 use virt_autotest::utils;
+use virt_autotest::virtual_network_utils;
 
 sub run {
     my $self = shift;
@@ -45,6 +46,7 @@ sub prepare_on_active_system {
     double_check_xen_role if (is_xen_host and is_sle('>=16.1') and is_disk_image);
     check_kvm_modules if (is_kvm_host and is_sle('>=16.1') and is_disk_image);
     $self->prepare_services;
+    $self->prepare_networks;
 }
 
 sub prepare_extensions {
@@ -88,6 +90,13 @@ sub prepare_services {
     #Disable rebootmgr service to prevent scheduled maitenance reboot.
     disable_and_stop_service('rebootmgr.service');
     systemctl('status rebootmgr.service', ignore_failure => 1);
+}
+
+sub prepare_networks {
+    my $self = shift;
+
+    # Skip br0 bridge creation if SKIP_HOST_BRIDGE_SETUP is set
+    get_var('SKIP_HOST_BRIDGE_SETUP') ? record_info("Host bridge br0 creating skipped") : virt_autotest::virtual_network_utils::create_host_bridge_nm;
 }
 
 sub test_flags {


### PR DESCRIPTION
* **New** subroutine ```query_installed_packages``` in test module ```lib/utils.pm``` to check whether interested packages already installed.

* **In** subroutine ```create_host_bridge_nm``` in test module ```lib/virt_autotest/virtual_network_utils.pm``` call ```query_installed_packages``` to check prerequisite packages ```python313-psutil``` and ```python313-dbus-python``` are installed on immutable system, otherwise test run must die.

* **New** subroutine ```prepare_networks``` in test module ```tests/virt_autotest/prepare_transactional_server.pm```
calls ```create_host_bridge_nm``` do host bridge br0 creating in preparation phase on immutable system to avoid unnecessary failures in subsequent modules.

* **Please** also review [this merge request](https://gitlab.suse.de/qa-testsuites/openqa-job-group-yaml/-/merge_requests/412).

* **Verification Runs:**
  * [sle-16.1-Base-SelfInstall-pxe-x86_64-Build11.12-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23275581)
  * [sle-16.1-Online-x86_64-Build55.1-uefi-gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23275702)
  * [sle-16.1-Online-x86_64-Build55.1-uefi-gi-guest_developing-on-host_sles15sp7-kvm](https://openqa.suse.de/tests/23275703)
  * [Five consecutive test runs sle-16.1-Online-x86_64-Build55.1-immutable-gi-online-guest_developing-on-host_developing-kvm passed 1](https://openqa.suse.de/tests/23275666) [2](https://openqa.suse.de/tests/23275669) [3](https://openqa.suse.de/tests/23275670) [4](https://openqa.suse.de/tests/23275671) [5](https://openqa.suse.de/tests/23275672)
  * [1 package not installed](https://openqa.suse.de/tests/23330154#step/prepare_transactional_server/86)
  * [2 packages not installed](https://openqa.suse.de/tests/23330247#step/prepare_transactional_server/88)
  * [skip host bridge setup](https://openqa.suse.de/tests/23330183#step/prepare_transactional_server/80)
