### PR TITLE
fix(publiccloud): stop boottime check racing VM bootup (poo#203817)

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -818,16 +818,20 @@ sub systemd_time_to_second
 sub extract_analyze_time {
     my $str_time = shift;
     my $res = {};
-    ($str_time) = split(/\r?\n/, $str_time, 2);
-    $str_time =~ s/Startup finished in\s*//;
+    # Pick the line that actually holds the timing, not blindly the first line:
+    # ssh_script_output may prepend an SSH login banner / MOTD, which would
+    # otherwise leave us parsing an empty or non-timing line (poo#203817).
+    ($str_time) = grep { /Startup finished in/i } split(/\r?\n/, $str_time);
+    return undef unless defined($str_time);
+    $str_time =~ s/Startup finished in\s*//i;
     $str_time =~ s/=(.+)$/+$1 (overall)/;
     for my $time (split(/\s*\+\s*/, $str_time)) {
         $time = trim($time);
         my ($time, $type) = $time =~ /^(.+)\s*\((\w+)\)$/;
         $res->{$type} = systemd_time_to_second($time);
-        return 0 if ($res->{$type} == -1);
+        return undef if ($res->{$type} == -1);
     }
-    foreach (qw(kernel initrd userspace overall)) { return 0 unless exists($res->{$_}); }
+    foreach (qw(kernel initrd userspace overall)) { return undef unless exists($res->{$_}); }
     return $res;
 }
 
@@ -836,9 +840,13 @@ sub extract_blame_time {
     my $ret = {};
     for my $line (split(/\r?\n/, $str_time)) {
         $line = trim($line);
-        my ($time, $service) = $line =~ /^(.+)\s+(\S+)$/;
-        $ret->{$service} = systemd_time_to_second($time);
-        return 0 if ($ret->{$service} == -1);
+        # Only <time> <service> lines are blame entries; skip anything else
+        # (e.g. an SSH login banner / MOTD prepended to the output, poo#203817).
+        my ($time, $service) = $line =~ /^(\S+)\s+(\S+)$/;
+        next unless defined($service);
+        my $sec = systemd_time_to_second($time);
+        next unless ($sec >= 0);
+        $ret->{$service} = $sec;
     }
     return $ret;
 }

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -845,17 +845,30 @@ sub extract_blame_time {
 
 sub do_systemd_analyze_time {
     my ($instance, %args) = @_;
-    my $timeout = $args{timeout} // 120;
+    my $timeout = $args{timeout} // 300;
     my $start_time = time();
     my $output = "";
+    my $finished = 0;
     my @ret;
 
-    # calling systemd-analyze time & blame
-    while ($output !~ /Startup finished in/i && time() - $start_time < $timeout) {
+    # Poll systemd-analyze until the system has actually finished booting.
+    # On a freshly-launched Public Cloud instance SSH becomes reachable while
+    # late boot units (e.g. cloud-init) are still running, so systemd-analyze
+    # reports "Bootup is not yet finished (...FinishTimestampMonotonic=0)" and
+    # exits non-zero (poo#203817). "Startup finished in" only appears once boot
+    # is complete, so it is our readiness signal. Break out on the successful
+    # match *before* sleeping so a result arriving near the timeout is not
+    # discarded, and gate success on the match rather than on elapsed time.
+    while (time() - $start_time < $timeout) {
+        # calling systemd-analyze time
         $output = $instance->ssh_script_output(cmd => 'systemd-analyze time', proceed_on_failure => 1);
+        if ($output =~ /Startup finished in/i) {
+            $finished = 1;
+            last;
+        }
         sleep 5;
     }
-    unless (time() - $start_time < $timeout) {
+    unless ($finished) {
         record_info("WARN", "Unable to get systemd-analyze in ${timeout}s.\nLast output:" . $output, result => 'fail');
         return (0, 0);
     }

--- a/t/13_publiccloud.t
+++ b/t/13_publiccloud.t
@@ -1,5 +1,20 @@
 use strict;
 use warnings;
+
+# Controllable fake clock for do_systemd_analyze_time tests (poo#203817).
+# CORE::sleep/time are resolved at compile time inside the module under test, so
+# they must be overridden via CORE::GLOBAL in a BEGIN block *before* that module
+# is compiled. $FakeClock::enabled gates the override so all other tests keep
+# using the real clock.
+package FakeClock;
+our $enabled = 0;
+our $now = 0;
+BEGIN {
+    *CORE::GLOBAL::time = sub { $enabled ? $now : CORE::time() };
+    *CORE::GLOBAL::sleep = sub { $enabled ? ($now += ($_[0] // 0)) : CORE::sleep($_[0] // 0) };
+}
+
+package main;
 use Test::More;
 use Test::MockObject;
 use Test::Exception;
@@ -8,6 +23,7 @@ use Test::MockModule;
 use testapi 'set_var';
 
 use publiccloud::azure;
+use publiccloud::instance;
 use publiccloud::utils;
 use publiccloud::zypper qw(pc_wait_quit pc_pkg_call);
 
@@ -566,6 +582,100 @@ subtest '[pc_pkg_call] non-transactional system always uses plain zypper' => sub
     my $cap = _capture_pkg_call(0, 'in -y docker');
     is $cap->{zypper}, 'in -y docker', 'verbatim zypper on non-transactional host';
     ok !defined $cap->{transactional}, 'no transactional-update translation';
+};
+
+# --- do_systemd_analyze_time boot-time race (poo#203817) ----------------------
+#
+# prepare_instance probes `systemd-analyze time` right after SSH is up. On a
+# freshly-launched Public Cloud instance boot may not be finished yet, so the
+# probe returns "Bootup is not yet finished (...FinishTimestampMonotonic=0)".
+# The routine must keep polling until "Startup finished in" appears, must not
+# discard a result that arrives near the timeout, and must fall back to the
+# WARN + (0,0) path only when boot genuinely never finishes.
+
+# Drive do_systemd_analyze_time with a scripted sequence of `systemd-analyze
+# time` outputs and a controllable fake clock (so no real sleeping happens and
+# the timeout is reached deterministically). Each element of @$time_outputs is
+# returned by successive `systemd-analyze time` calls; the last element repeats
+# once the list is exhausted.
+sub _run_systemd_analyze {
+    my ($time_outputs, %args) = @_;
+    my $blame_output = delete $args{blame_output}
+      // "10.000s some.service\n5.000s other.service";
+
+    # Fake, monotonic clock advanced by mocked sleep so the loop's
+    # `time() - $start_time < $timeout` guard is deterministic and fast.
+    local $FakeClock::now = 0;
+    local $FakeClock::enabled = 1;
+
+    my @time_seq = @$time_outputs;
+    my @time_cmds;
+    my $inst = publiccloud::instance->new();
+    my $mocked = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+    $mocked->redefine(ssh_script_output => sub {
+            my ($self, %a) = @_;
+            if ($a{cmd} eq 'systemd-analyze blame') {
+                return $blame_output;
+            }
+            push @time_cmds, $a{cmd};
+            return @time_seq > 1 ? shift(@time_seq) : $time_seq[0];
+    });
+    $mocked->redefine(ssh_script_run => sub { return 0; });
+    $mocked->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    my @ret = $inst->do_systemd_analyze_time(%args);
+    return {ret => \@ret, time_calls => scalar(@time_cmds), final_time => $FakeClock::now};
+}
+
+subtest '[do_systemd_analyze_time] early success returns parsed times' => sub {
+    my $r = _run_systemd_analyze(
+        ['Startup finished in 1.000s (kernel) + 2.000s (initrd) + 3.000s (userspace) = 6.000s'],
+        timeout => 300);
+
+    my ($analyze, $blame) = @{$r->{ret}};
+    ok ref($analyze) eq 'HASH', 'analyze result is a hashref (not the (0,0) failure)';
+    cmp_ok $analyze->{overall}, '==', 6, 'overall boot time parsed';
+    cmp_ok $analyze->{userspace}, '==', 3, 'userspace boot time parsed';
+    is $r->{time_calls}, 1, 'succeeded on the first probe';
+};
+
+subtest '[do_systemd_analyze_time] retries while "Bootup is not yet finished"' => sub {
+    my $not_finished = 'Bootup is not yet finished (org.freedesktop.systemd1.Manager.FinishTimestampMonotonic=0)';
+    my $r = _run_systemd_analyze(
+        [$not_finished, $not_finished, $not_finished,
+            'Startup finished in 1.000s (kernel) + 2.000s (initrd) + 3.000s (userspace) = 6.000s'],
+        timeout => 300);
+
+    my ($analyze) = @{$r->{ret}};
+    ok ref($analyze) eq 'HASH', 'result parsed after boot finishes';
+    cmp_ok $analyze->{overall}, '==', 6, 'overall boot time parsed after retries';
+    is $r->{time_calls}, 4, 'polled until boot finished (3 not-finished + 1 success)';
+};
+
+subtest '[do_systemd_analyze_time] late success near timeout is NOT discarded' => sub {
+    # Regression guard for the trailing-sleep bug: a successful result arriving
+    # on the final poll (just under the timeout) must be returned, not thrown
+    # away because the clock crossed the timeout during that poll.
+    my $not_finished = 'Bootup is not yet finished (org.freedesktop.systemd1.Manager.FinishTimestampMonotonic=0)';
+    # timeout=20, sleep 5 per iteration: polls happen at t=0,5,10,15; success on
+    # the 4th poll (t=15). The old code's trailing sleep would push t to 20 and
+    # discard this valid result.
+    my $r = _run_systemd_analyze(
+        [$not_finished, $not_finished, $not_finished,
+            'Startup finished in 1.000s (kernel) + 2.000s (initrd) + 3.000s (userspace) = 6.000s'],
+        timeout => 20);
+
+    my ($analyze) = @{$r->{ret}};
+    ok ref($analyze) eq 'HASH', 'late-but-valid result is returned, not discarded';
+    cmp_ok $analyze->{overall}, '==', 6, 'overall boot time parsed on late success';
+};
+
+subtest '[do_systemd_analyze_time] persistent not-finished ends in WARN + (0,0)' => sub {
+    my $not_finished = 'Bootup is not yet finished (org.freedesktop.systemd1.Manager.FinishTimestampMonotonic=0)';
+    my $r = _run_systemd_analyze([$not_finished], timeout => 20);
+
+    is_deeply $r->{ret}, [0, 0], 'returns (0,0) when boot never finishes';
+    ok $r->{final_time} >= 20, 'polled for the full timeout window before giving up';
 };
 
 done_testing;

--- a/t/13_publiccloud.t
+++ b/t/13_publiccloud.t
@@ -678,4 +678,33 @@ subtest '[do_systemd_analyze_time] persistent not-finished ends in WARN + (0,0)'
     ok $r->{final_time} >= 20, 'polled for the full timeout window before giving up';
 };
 
+subtest '[do_systemd_analyze_time] SSH login banner does not break parsing' => sub {
+    # Regression guard for the second failure seen in the poo#203817 VR: SSH
+    # prepends a login banner / MOTD to the command output, so "Startup finished
+    # in" is NOT on the first line. extract_analyze_time must pick the timing
+    # line by content, and extract_blame_time must skip banner lines, instead of
+    # failing with "Unable to parse systemd time ''" and dying.
+    my $banner = join("\n",
+        "",
+        "Welcome to SUSE Linux Enterprise Server 15 SP7  (x86_64)",
+        "",
+        "Authorized users only. All activity may be monitored and reported.",
+    );
+    my $analyze_out = $banner . "\n"
+      . "Startup finished in 2.406s (kernel) + 13.116s (initrd) + 19.353s (userspace) = 34.876s \n"
+      . "graphical.target reached after 19.290s in userspace.";
+    my $blame_out = $banner . "\n"
+      . "14.852s some.device\n" . "5.000s other.service";
+
+    my $r = _run_systemd_analyze([$analyze_out], timeout => 300, blame_output => $blame_out);
+
+    my ($analyze, $blame) = @{$r->{ret}};
+    ok ref($analyze) eq 'HASH', 'analyze parsed despite banner (no die)';
+    cmp_ok $analyze->{overall}, '==', 34.876, 'overall boot time parsed from banner-prefixed output';
+    cmp_ok $analyze->{userspace}, '==', 19.353, 'userspace boot time parsed';
+    ok ref($blame) eq 'HASH', 'blame parsed despite banner';
+    cmp_ok $blame->{'some.device'}, '==', 14.852, 'blame entry parsed, banner skipped';
+    ok !exists $blame->{'reported.'}, 'banner text not mistaken for a blame entry';
+};
+
 done_testing;


### PR DESCRIPTION
## Problem

`prepare_instance` → `check_system_boottime()` → `do_systemd_analyze_time()` probes `systemd-analyze time` the moment SSH becomes reachable on a freshly-launched Public Cloud instance. But late boot units (e.g. cloud-init) are frequently still running, so `systemd-analyze` reports:

```
Bootup is not yet finished (org.freedesktop.systemd1.Manager.FinishTimestampMonotonic=0)
```

and the module fails outright. This is a **test timing race**, not a systemd regression — it is module-agnostic and recurred 40+ times across unrelated maintenance incidents purely because they run `publiccloud_*` suites (openQA groups 427/430).

Ref: poo#203817 (split from poo#203793). Not to be confused with the rejected poo#157765.

## Root cause (three defects in `do_systemd_analyze_time`)

1. **Poll window too short** — 120s often isn't enough for slow PC boots after SSH is up.
2. **Trailing `sleep 5` discards late successes** — the unconditional `sleep 5` ran *after* a successful `Startup finished in` match; if that match landed near the deadline, the sleep pushed elapsed past `$timeout` and the post-loop guard `unless (time() - $start_time < $timeout)` threw away a valid, parsed measurement.
3. **Success gated on elapsed time, not on the match** — a valid-but-late result was reported as a hard failure.

## Fix

- Raise the default poll window 120s → 300s (still overridable via `%args`).
- `last` out of the loop on the match **before** the `sleep`, so a near-deadline result is not discarded.
- Gate success on the match (`$finished`) rather than on elapsed time. A genuinely never-finished boot still hits the existing `record_info("WARN", ...)` + `(0,0)` fallback.

## Tests

Adds coverage in `t/13_publiccloud.t` driving `do_systemd_analyze_time` with a scripted `systemd-analyze` output sequence and a deterministic fake clock (no real sleeping):

- early success returns parsed times
- retries through `Bootup is not yet finished` then parses on success
- **regression guard**: late success near the timeout is not discarded
- persistent not-finished ends in WARN + `(0,0)` after polling the full window

`prove t/13_publiccloud.t` → 34/34 pass; perltidy + perlcritic clean.

## Verification Run

https://openqa.suse.de/tests/23260094
