### PR TITLE
Automate the different ways in which Agama can finish the installation

### DIFF
--- a/schedule/yam/agama_unattended_inst_finish_poweroff.yaml
+++ b/schedule/yam/agama_unattended_inst_finish_poweroff.yaml
@@ -1,0 +1,7 @@
+---
+name: agama_unattended_inst_finish_poweroff
+description: >
+  Default unattended installation with inst.finish=poweroff.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto

--- a/schedule/yam/agama_unattended_inst_finish_reboot.yaml
+++ b/schedule/yam/agama_unattended_inst_finish_reboot.yaml
@@ -1,0 +1,8 @@
+---
+name: agama_unattended_inst_finish_reboot
+description: >
+  Default unattended installation with inst.finish=reboot.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - installation/first_boot

--- a/tests/yam/agama/agama_auto.pm
+++ b/tests/yam/agama/agama_auto.pm
@@ -10,13 +10,23 @@ use Mojo::Base 'Yam::Agama::agama_base';
 use testapi;
 use Utils::Architectures qw(is_s390x is_ppc64le);
 use Utils::Backends qw(is_pvm is_svirt is_hyperv);
-use power_action_utils 'power_action';
+use power_action_utils qw(power_action);
 use version_utils qw(is_vmware is_leap);
 
 sub run {
     my $self = shift;
     select_console 'installation';
     my $reboot_page = $testapi::distri->get_reboot();
+
+    if (check_var('INST_FINISH', 'reboot') || check_var('INST_FINISH_DISABLED', '1')) {
+        $self->wait_boot(textmode => 1, ready_time => 600, bootloader_time => 300);
+        return;
+    }
+    elsif (check_var('INST_FINISH', 'poweroff')) {
+        assert_shutdown(300);
+        power_action('reboot', keepconsole => 1, textmode => 1);
+        return;
+    }
     $reboot_page->expect_is_shown();
 
     $self->upload_agama_logs() unless is_hyperv();

--- a/tests/yam/agama/boot_agama.pm
+++ b/tests/yam/agama/boot_agama.pm
@@ -47,7 +47,8 @@ sub prepare_boot_params {
               expand_agama_profile($inst_auto);
         }
         set_var('INST_AUTO', $profile_url);
-        push @params, "inst.auto=\"$profile_url\"", 'inst.finish=stop';
+        push @params, "inst.auto=\"$profile_url\"";
+        push @params, map { "inst.finish=$_" } grep { $_ && !get_var('INST_FINISH_DISABLED') } (get_var('INST_FINISH') || 'stop');
     }
 
     # add register url

--- a/variables.md
+++ b/variables.md
@@ -114,6 +114,8 @@ INSTALL_SOURCE | string | | Specify network protocol to be used as installation 
 INSTALLATION_VALIDATION | string | | Comma separated list of modules to be used for installed system validation, should be used in combination with INSTALLONLY, to schedule only relevant test modules.
 INSTALLONLY | boolean | false | Indicates that test suite conducts only installation. Is recommended to be used for all jobs which create and publish images
 INSTLANG | string | en_US | Installation locale settings.
+INST_FINISH | see Agama documentation for boot options parameter inst.finish.
+INST_FINISH_DISABLED | If set to 1 then the default behaviour is used, which is 'stop' for interactive installation, 'reboot' for unattende installation.
 IPERF_REPO | string | | Link to repository with iperf tool for network performance testing. Currently used in Public Cloud Azure test
 IPXE | boolean | false | Indicates ipxe boot.
 IPXE_BOOT_FIXED | boolean | false | Indicates to ipxe boot fixed distribution independent on DISTRI and VERSION variables.


### PR DESCRIPTION


- Related ticket: https://progress.opensuse.org/issues/203154
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/866/
- Needles: N/A
- Verification run: 
[production and development group](https://openqa.suse.de/tests/overview?build=lemon-suse%2Fos-autoinst-distri-opensuse%23automate-ways-inst-finish&version=16.1&distri=sle) \
[QU group](https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=lemon-suse%2Fos-autoinst-distri-opensuse%23automate-ways-inst-finish) \
*.null means no INST_FINISH set, regression test.
