### PR TITLE
Add SLES-SAP-16.1 to guest_os_features hash

### DIFF
--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -138,6 +138,17 @@ sub get_gcp_guest_os_features {
             'UEFI_COMPATIBLE',
             'VIRTIO_SCSI_MULTIQUEUE',
         ],
+        'SLES-SAP-16.1' => [
+            'GVNIC',
+            'IDPF',
+            'SEV_CAPABLE',
+            'SEV_LIVE_MIGRATABLE',
+            'SEV_LIVE_MIGRATABLE_V2',
+            'SEV_SNP_CAPABLE',
+            'TDX_CAPABLE',
+            'UEFI_COMPATIBLE',
+            'VIRTIO_SCSI_MULTIQUEUE',
+        ],
     );
 
     my $os_version;


### PR DESCRIPTION
there is an issue like this https://openqa.suse.de/tests/23228165#step/upload_image/65, this PR adds **SLES-SAP-16.1** into **guest_os_features** Hash

- Related ticket: https://jira.suse.com/browse/TEAM-11318
- Verification run: https://openqa.suse.de/tests/23260083
