### PR TITLE
Replace zypper_call with install_package in test for immutable images

### DIFF
--- a/tests/console/btrfs_autocompletion.pm
+++ b/tests/console/btrfs_autocompletion.pm
@@ -17,6 +17,7 @@ use Mojo::Base 'btrfs_test';
 use testapi;
 use utils 'zypper_call';
 use version_utils qw(is_jeos is_sle is_leap);
+use package_utils 'install_package';
 
 # Btrfs understands short commands like "btrfs d st"
 # Compare autocompleted commands as strings
@@ -46,7 +47,7 @@ sub run {
 
     if (is_sle('>=16') || is_leap('>=16.0')) {
         # Split bash completion to sub package
-        zypper_call('in btrfsprogs-bash-completion');
+        install_package('btrfsprogs-bash-completion', trup_reboot => 1);
         # Execute bash to make sure changes work in running shell session
         enter_cmd('bash');
     }

--- a/tests/console/btrfsmaintenance.pm
+++ b/tests/console/btrfsmaintenance.pm
@@ -17,6 +17,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use version_utils qw(is_leap is_sle);
+use package_utils qw(install_package uninstall_package);
 
 my $reinstall_btrfsmaintenance = 0;
 
@@ -113,7 +114,7 @@ sub run {
     }
 
     # Check for crontab remnants of btrfsmaintenance after uninstall (see https://bugzilla.suse.com/show_bug.cgi?id=1159891)
-    zypper_call 'remove btrfsmaintenance';
+    uninstall_package('btrfsmaintenance', trup_continue => 1, trup_reboot => 1);
     $reinstall_btrfsmaintenance = 1;
     if (script_run("crontab -l") == 0 && script_run('crontab -l | grep btrfs') == 0) {
         record_soft_failure("bsc#1159891 btrfs remnants present in crontab");
@@ -126,12 +127,12 @@ sub run {
 
 sub post_run_hook {
     # Restore btrfsmaintenance
-    zypper_call 'in btrfsmaintenance' if ($reinstall_btrfsmaintenance);
+    install_package('btrfsmaintenance', trup_reboot => 1) if ($reinstall_btrfsmaintenance);
 }
 
 sub post_fail_hook {
     # Restore btrfsmaintenance
-    zypper_call 'in btrfsmaintenance' if ($reinstall_btrfsmaintenance);
+    install_package('btrfsmaintenance', trup_reboot => 1) if ($reinstall_btrfsmaintenance);
 }
 
 1;

--- a/tests/console/lsof.pm
+++ b/tests/console/lsof.pm
@@ -27,11 +27,11 @@
 use Mojo::Base 'consoletest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use utils 'zypper_call';
+use package_utils 'install_package';
 
 sub run {
     select_serial_terminal;
-    zypper_call('in netcat lsof psmisc');
+    install_package('netcat lsof psmisc', trup_reboot => 1);
     assert_script_run("lsof");
     assert_script_run("lsof -u root");
     assert_script_run("lsof -i");

--- a/tests/console/udisks2.pm
+++ b/tests/console/udisks2.pm
@@ -13,6 +13,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use version_utils qw(is_sle);
+use package_utils 'install_package';
 
 sub run {
     select_serial_terminal;
@@ -23,7 +24,7 @@ sub run {
         zypper_call('in cdrkit-cdrtools-compat udisks2 util-linux');
     }
     else {
-        zypper_call('in mkisofs udisks2 util-linux');
+        install_package('mkisofs udisks2 util-linux', trup_reboot => 1);
     }
 
     # Compares block devices from lsblk and udisksctl outputs.

--- a/tests/network/samba/server.pm
+++ b/tests/network/samba/server.pm
@@ -13,11 +13,12 @@ use serial_terminal 'select_serial_terminal';
 use utils;
 use version_utils;
 use registration;
+use package_utils 'install_package';
 
 sub run {
     select_serial_terminal;
 
-    zypper_call "in samba samba-winbind";
+    install_package("samba samba-winbind", trup_reboot => 1);
 
     record_info 'start services';
     systemctl 'start smb nmb winbind';

--- a/tests/network/wireguard.pm
+++ b/tests/network/wireguard.pm
@@ -17,6 +17,7 @@ use version_utils 'is_sle';
 use registration;
 use lockapi;
 use mmapi 'wait_for_children';
+use package_utils 'install_package';
 
 sub start_wgquick {
     foreach my $dev (@_) {
@@ -72,7 +73,7 @@ sub run {
     assert_script_run("grep -i CONFIG_WIREGUARD $boot_config") unless (script_run("stat $boot_config") != 0);
     assert_script_run 'modinfo wireguard';
 
-    zypper_call 'in wireguard-tools iperf';
+    install_package('wireguard-tools iperf', trup_reboot => 1);
 
     assert_script_run 'which wg';
     assert_script_run 'umask 077';

--- a/tests/network/wireguard_nm.pm
+++ b/tests/network/wireguard_nm.pm
@@ -15,6 +15,7 @@ use utils;
 use registration;
 use lockapi;
 use mmapi 'wait_for_children';
+use package_utils 'install_package';
 
 sub run {
     if (get_var('IS_MM_SERVER')) {
@@ -39,7 +40,7 @@ sub run {
         $vpn_local = '192.168.2.2';
         $vpn_remote = '192.168.2.1';
     }
-    zypper_call 'in wireguard-tools';
+    install_package('wireguard-tools', trup_reboot => 1);
     ## Test wireguard with NetworkManager
     assert_script_run('cd /etc/wireguard');
     if (get_var('IS_MM_SERVER')) {


### PR DESCRIPTION


- Related ticket:https://progress.opensuse.org/issues/203301
- Needles: NO
- Verification run: 
   wireguard: [sle-16.1-Online-Immutable](https://openqa.suse.de/tests/23275699#)  | [sle-16.1-Online](https://openqa.suse.de/tests/23275709)
   wireguard_nm : [sle-16.1-Online-Immutable](https://openqa.suse.de/tests/23276590) | [sle-16.1-Online](https://openqa.suse.de/tests/23276619)
 extra_tests_dracut:  [sle-16.1-Online-Immutable](https://openqa.suse.de/tests/23330137#step/dracut/18) | [sle-16.1-Online](https://openqa.suse.de/tests/23330142#step/dracut/18)
extra_tests_filesystem:   [sle-16.1-Online-Immutable](https://openqa.suse.de/tests/23330162) | [sle-16.1-Online](https://openqa.suse.de/tests/23330155)
https://openqa.suse.de/tests/overview?result=passed&distri=sle&version=16.1&build=55.1&groupid=683

MR:https://gitlab.suse.de/qe-core/qa-sle-functional-userspace/-/merge_requests/342