### PR TITLE
registercloudguest: retry docker/podman install when zypp lock causes commit failure

### DIFF
--- a/lib/publiccloud/zypper.pm
+++ b/lib/publiccloud/zypper.pm
@@ -74,6 +74,7 @@ use constant {
     EXIT_SOLVER => 4,    # generic solver problem
     EXIT_NO_REPOS => 6,    # ZYPPER_EXIT_NO_REPOS
     EXIT_LOCKED => 7,    # ZYPPER_EXIT_ZYPP_LOCKED
+    EXIT_ERR_COMMIT => 8,    # ZYPPER_EXIT_ERR_COMMIT (commit error; can be caused by a lock held at transaction time)
     EXIT_REBOOT_NEEDED => 102,
     EXIT_REBOOT_SCHED => 103,
     EXIT_CAP_NOT_FOUND => 104,    # ZYPPER_EXIT_INF_CAP_NOT_FOUND
@@ -100,6 +101,7 @@ our @EXPORT_OK = qw(
   EXIT_SOLVER
   EXIT_NO_REPOS
   EXIT_LOCKED
+  EXIT_ERR_COMMIT
   EXIT_REBOOT_NEEDED
   EXIT_REBOOT_SCHED
   EXIT_CAP_NOT_FOUND
@@ -497,6 +499,18 @@ sub _handle_transient_failure {
     if ($ret == EXIT_LOCKED) {
         record_info("Retry $attempt/$max as system management is locked");
         return 'retry';
+    }
+    # EXIT_ERR_COMMIT (8) can be caused by the zypp lock being held at
+    # transaction time (the lock is taken later than the PID check done by
+    # pc_wait_quit, so pgrep passes while the lock file is still present).
+    # Only retry when the log confirms the root cause is a lock; otherwise
+    # treat it as a genuine commit failure.
+    if ($ret == EXIT_ERR_COMMIT) {
+        if (_log_grep($instance, 'System management is locked') == 0) {
+            record_info("Retry $attempt/$max as commit failed due to zypp lock");
+            return 'retry';
+        }
+        return 'fail';
     }
     return 'fail';
 }

--- a/tests/publiccloud/registercloudguest.pm
+++ b/tests/publiccloud/registercloudguest.pm
@@ -187,7 +187,7 @@ sub test_container_runtimes {
 
     record_info('Test docker');
     $instance->ssh_assert_script_run("sudo rm -f /root/.docker/config.json");    # workaround for https://bugzilla.suse.com/show_bug.cgi?id=1231185
-    pc_pkg_call($instance, "in -y docker", timeout => 600);
+    pc_pkg_call($instance, "in -y docker", timeout => 600, retry => 3, delay => 30);
     $instance->ssh_assert_script_run("sudo systemctl start docker.service");
     record_info("systemctl status docker.service", $instance->ssh_script_output("systemctl status docker.service"));
     $instance->ssh_script_retry("sudo docker pull $image", retry => 3, delay => 60, timeout => 600);
@@ -213,7 +213,7 @@ sub test_container_runtimes {
         }
         $instance->ssh_script_run('sudo chmod 644 /etc/containers/registries.conf');
     }
-    pc_pkg_call($instance, "in -y podman", timeout => 240);
+    pc_pkg_call($instance, "in -y podman", timeout => 240, retry => 3, delay => 30);
     $instance->ssh_script_retry("podman --debug pull $image", retry => 3, delay => 60, timeout => 600);
     return 0;
 }


### PR DESCRIPTION
Added `EXIT_ERR_COMMIT => 8` constant to `lib/publiccloud/zypper.pm` and extended `_handle_transient_failure` to retry on it when the zypper log confirms a lock. Added `retry => 3, delay => 30` to the docker and podman `pc_pkg_call` invocations in `registercloudguest.pm`.

* Related ticket: [poo#203676](https://progress.opensuse.org/issues/203676)
* Related failure: [openqa.suse.de/t23209208](https://openqa.suse.de/tests/23209208)
* Verification runs: