### PR TITLE
kernel/pressure_stall_information: Adapt for Tumbleweed

### DIFF
--- a/tests/kernel/pressure_stall_information.pm
+++ b/tests/kernel/pressure_stall_information.pm
@@ -14,7 +14,7 @@ use serial_terminal 'select_serial_terminal';
 use power_action_utils 'power_action';
 use bootloader_setup 'add_grub_cmdline_settings';
 use Utils::Architectures;
-use version_utils qw(is_sle);
+use version_utils qw(is_sle is_tumbleweed);
 
 sub boot {
     my $self = shift;
@@ -33,8 +33,9 @@ sub run {
 
     $self->boot;
 
-    if (is_sle('>=16.1')) {
-        # Starting with SLE-16.1, CONFIG_PSI_DEFAULT_DISABLED is no longer enabled,
+    if (is_sle('>=16.1') || is_tumbleweed()) {
+        # Starting with SLE-16.1 along with Tumbleweed (jsc#PED-15418),
+        # CONFIG_PSI_DEFAULT_DISABLED is no longer enabled,
         # so PSI files are present by default.
         assert_script_run('cd /proc/pressure');
         assert_script_run('cat cpu memory io');


### PR DESCRIPTION
Now tumbleweed kernel also have PSI measurement enabled by default (PED-15418). Adding the TW check before scheduling it in o3 kernel jobgroup.

- Related ticket: https://progress.opensuse.org/issues/199745
- Verification run: https://openqa.opensuse.org/tests/6083423
