### PR TITLE
data/microos: avoid hardcoding path to root partition

### DIFF
--- a/data/microos/butane/script
+++ b/data/microos/butane/script
@@ -142,7 +142,6 @@ if [ "${1-}" = "--prepare" ]; then
     if [ -c "/dev/tpm0" ] && command -v disk-encryption-tool &> /dev/null; then
         mkdir -p /run/credstore
         echo "force" > /run/credstore/disk-encryption-tool-dracut.encrypt
-        echo "cr_root /dev/vda3" >> /run/credstore/disk-encryption-tool-dracut.partitions
     fi
 
     exit 0


### PR DESCRIPTION
It is not /dev/vda3 everywhere. disk-encryption-tool encrypts / by default, so just drop the explicit mention.

- Related ticket: https://progress.opensuse.org/issues/184444
- Verification run: https://openqa.opensuse.org/tests/6084095
