### PR TITLE
data: Include ignition and combustion files for .qcow2 images

### DIFF
--- a/data/ignition-combustion-configs/Makefile
+++ b/data/ignition-combustion-configs/Makefile
@@ -1,0 +1,21 @@
+QCOWS = ignition_no_network_probe_minimal.qcow2 ignition_no_network_probe_test.qcow2 \
+        ignition_only_no_network_minimal.qcow2 ignitiononly.qcow2 ignition.qcow2 \
+        combustion_ltp.qcow2 combustiononly_no_network.qcow2 combustiononly.qcow2 \
+        extended_combustion.qcow2
+# Target directory for the .qcow2 files
+HDD_FIXED_DIR ?= /var/lib/openqa/factory/hdd/
+all: $(QCOWS:%=$(HDD_FIXED_DIR)/%)
+.PHONY: all
+.ONESHELL:
+.SHELLFLAGS = -ec
+.SECONDEXPANSION:
+# All files in the directory named after the qcow2 are dependencies
+$(HDD_FIXED_DIR)/%.qcow2: $$(shell find $(PWD)/%)
+	if echo $* | grep -q combustion; then
+		/sbin/mkfs.ext4 -q -L combustion -d $* $@.raw 16M
+	else
+		/sbin/mkfs.ext4 -q -L ignition -d $* $@.raw 16M
+	fi
+	qemu-img convert -c -O qcow2 $@.raw $@.new
+	rm $@.raw
+	mv $@.new $@

--- a/data/ignition-combustion-configs/combustion_ltp/combustion/script
+++ b/data/ignition-combustion-configs/combustion_ltp/combustion/script
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Simple openQA combustion script used for sle-micro or Minimal-VM starting from 15-SP6 and their opensuse counterparts
+# for LTP testing
+ 
+# initialize network before running the script
+# combustion: network
+set -euxo pipefail
+
+reboot_me() {
+
+cat << EOF > /etc/systemd/system/rebootme.service
+[Unit]
+Description=Reboot SUT
+
+After=multi-user.target systemd-user-sessions.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+User=root
+ExecStartPre=systemctl disable rebootme.service
+ExecStart=/sbin/reboot
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+}
+
+# Redirect output to the console
+exec > >(exec tee -a /dev/console) 2>&1
+
+# locale
+rm -f /etc/localtime
+systemd-firstboot --force --timezone=UTC --locale=en_US.UTF-8 --keymap=us
+echo 'FONT=eurlatgr.psfu' >> /etc/vconsole.conf
+
+# hostname
+echo "" > /etc/hostname
+
+# set root password
+echo 'root:$6$eEm2HpuzI7dfE4i7$dbYiTRLhrqVvwryR7zmMEcnrp13IqZ3mzLbsx9EeHAX7849PibGVgX5vdPuaeYYIO7hVfcboI9/JDpGiDZhHf/' | chpasswd -e
+
+# leave a marker that combustion configure the system
+echo Combustion was here > /usr/share/combustion-welcome
+curl conncheck.opensuse.org
+
+. /etc/sysconfig/bootloader
+if [ -z "${LOADER_TYPE##*grub2*}" ]; then
+    sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT=/s/quiet/ignore_loglevel/' /etc/default/grub
+    grub2-mkconfig -o /boot/grub2/grub.cfg
+    reboot_me
+    systemctl daemon-reload
+    systemctl enable rebootme.service
+fi
+
+
+
+# close outputs and wait for tee to finish
+exec 1>&- 2>&-; wait;

--- a/data/ignition-combustion-configs/combustiononly/combustion/script
+++ b/data/ignition-combustion-configs/combustiononly/combustion/script
@@ -1,0 +1,148 @@
+#!/bin/bash
+# combustion: network prepare
+# 
+# Simple openQA combustion script used for sle-micro or Minimal-VM start from 15-SP6 and their opensuse counterparts
+# due to known bug boo#1157133, the script is intended to be used only on x86_64
+# 
+# Test Objects:
+#   1) set localization and timezone
+#   2) create new fs in the test drive
+#   3) set root password
+#   4) create test users
+#   5) set systemd mount for test partition
+#   6) create test oneshot systemd service that creates a file
+#   7) enable sshd
+#   8) set test hostname 
+#   9) test networking
+#
+set -euxo pipefail
+
+# look for a drive that has no partition table or other information that blkid would return
+detect_free_drive() {
+    declare -a drives
+    drives=( $(ls /sys/block/) )
+    empty=
+
+    for d in ${drives[@]}; do
+        blkid /dev/"$d" &> /dev/null || echo "/dev/$d"
+    done
+}
+
+create_fs() {
+    DRIVE=$(detect_free_drive)
+    test -n "$DRIVE" || exit 2
+
+    PART="${DRIVE}1"
+
+    # create partition and filesystem on additional drive
+    echo "label: gpt" | sfdisk "$DRIVE"
+    echo "name=testing_part" | sfdisk "$DRIVE" -N1
+
+    # label new partition for testing and create labeled ext4
+    mkfs.ext4 -L home "$PART"
+
+    # mount new partition
+    mount -t ext4 "$PART" /home
+
+    # DEBUG
+    blkid
+    lsblk
+}
+
+systemd_mount() {
+
+cat << EOF > /etc/systemd/system/home.mount
+[Unit]
+Before=local-fs.target
+Requires=systemd-fsck@dev-disk-by\x2dpartlabel-testing_part.service
+After=systemd-fsck@dev-disk-by\x2dpartlabel-testing_part.service
+
+[Mount]
+Where=/home
+What=/dev/disk/by-partlabel/testing_part
+Type=ext4
+
+[Install]
+RequiredBy=local-fs.target
+EOF
+
+}
+
+test_prepare() {
+    echo "combustion: test_prepare function ran OK" > /dev/kmsg
+}
+
+if [ "${1-}" = "--prepare" ]; then
+    test_prepare
+    exit 0
+fi
+
+# Redirect output to the console
+exec > >(exec tee -a /dev/console) 2>&1
+
+### set locale, keyboard and timezone
+# exception: sle-micro comes with symlink /etc/localtime, thus systemd-firstboot fails
+# bsc#1215618 - systemd-firstboot --force fails to replace an existing /etc/localtime symlink
+rm -f /etc/localtime
+systemd-firstboot --force --timezone=UTC --locale=en_US.UTF-8 --keymap=us
+echo 'FONT=eurlatgr.psfu' >> /etc/vconsole.conf
+
+if ! grep -q tumbleweed /etc/os-release; then
+    create_fs
+    systemd_mount
+fi
+
+#
+### users and groups
+# groups
+groupadd --gid 2002 geekos
+
+# users
+echo 'root:$6$eEm2HpuzI7dfE4i7$dbYiTRLhrqVvwryR7zmMEcnrp13IqZ3mzLbsx9EeHAX7849PibGVgX5vdPuaeYYIO7hVfcboI9/JDpGiDZhHf/' | chpasswd -e
+useradd --no-create-home --uid 2002 --gid geekos --groups users HomelessTester
+useradd --create-home --uid 1001 --comment "Bernhard M. Wiedemann" --no-user-group --gid users bernhard
+echo 'bernhard:$6$eEm2HpuzI7dfE4i7$dbYiTRLhrqVvwryR7zmMEcnrp13IqZ3mzLbsx9EeHAX7849PibGVgX5vdPuaeYYIO7hVfcboI9/JDpGiDZhHf/' | chpasswd -e
+
+#
+### files and directories
+#
+echo "cucaracha" > /etc/hostname
+mkdir --mode=0755 /home/bernhard/testdir
+chown bernhard:users /home/bernhard/testdir
+echo "Hello there!" > /home/bernhard/testdir/hello
+chown bernhard:users /home/bernhard/testdir/hello
+chmod 0600 /home/bernhard/testdir/hello
+
+#
+### systemd units
+#
+cat << EOF > /etc/systemd/system/create_test_file.service
+[Unit]
+Description=Just a Test!
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart=/usr/bin/touch /var/log/flagfile
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl enable sshd.service
+systemctl enable create_test_file.service
+
+#
+### Networking
+#
+# configure interface for minimal-vm based on sle
+IF=$(find /sys/class/net -type l -not -lname '*virtual*' -printf '%f\n' | head -n1)
+IF_CFG="/etc/sysconfig/network/ifcfg-$IF"
+if command -v wicked &> /dev/null && ! grep -q 'dhcp' "$IF_CFG" &> /dev/null; then
+    echo -e "BOOTPROTO=dhcp\nSTARTMODE=auto" > "$IF_CFG"
+fi
+
+# leave a marker that combustion configure the system
+echo Combustion was here > /usr/share/combustion-welcome
+curl conncheck.opensuse.org
+
+# close outputs and wait for tee to finish
+exec 1>&- 2>&-; wait;

--- a/data/ignition-combustion-configs/combustiononly_no_network/combustion/script
+++ b/data/ignition-combustion-configs/combustiononly_no_network/combustion/script
@@ -1,0 +1,136 @@
+#!/bin/bash
+# 
+# Simple openQA combustion script used for sle-micro or Minimal-VM start from 15-SP6 and their opensuse counterparts
+# due to known bug boo#1157133, the script is intended to be used only on x86_64
+# 
+# Test Objects:
+#   1) set localization and timezone
+#   2) create new fs in the test drive
+#   3) set root password
+#   4) create test users
+#   5) set systemd mount for test partition
+#   6) create test oneshot systemd service that creates a file
+#   7) enable sshd
+#   8) set test hostname 
+#   9) test networking
+#
+set -euxo pipefail
+
+# look for a drive that has no partition table or other information that blkid would return
+detect_free_drive() {
+    declare -a drives
+    drives=( $(ls /sys/block/) )
+    empty=
+
+    for d in ${drives[@]}; do
+        blkid /dev/"$d" &> /dev/null || echo "/dev/$d"
+    done
+}
+
+create_fs() {
+    DRIVE=$(detect_free_drive)
+    test -n "$DRIVE" || exit 2
+
+    PART="${DRIVE}1"
+
+    # create partition and filesystem on additional drive
+    echo "label: gpt" | sfdisk "$DRIVE"
+    echo "name=testing_part" | sfdisk "$DRIVE" -N1
+
+    # label new partition for testing and create labeled ext4
+    mkfs.ext4 -L home "$PART"
+
+    # mount new partition
+    mount -t ext4 "$PART" /home
+
+    # DEBUG
+    blkid
+    lsblk
+}
+
+systemd_mount() {
+
+cat << EOF > /etc/systemd/system/home.mount
+[Unit]
+Before=local-fs.target
+Requires=systemd-fsck@dev-disk-by\x2dpartlabel-testing_part.service
+After=systemd-fsck@dev-disk-by\x2dpartlabel-testing_part.service
+
+[Mount]
+Where=/home
+What=/dev/disk/by-partlabel/testing_part
+Type=ext4
+
+[Install]
+RequiredBy=local-fs.target
+EOF
+
+}
+
+test_prepare() {
+    echo "combustion: test_prepare function ran OK" > /dev/kmsg
+}
+
+if [ "${1-}" = "--prepare" ]; then
+    test_prepare
+    exit 0
+fi
+
+# Redirect output to the console
+exec > >(exec tee -a /dev/console) 2>&1
+
+### set locale, keyboard and timezone
+# exception: sle-micro comes with symlink /etc/localtime, thus systemd-firstboot fails
+# bsc#1215618 - systemd-firstboot --force fails to replace an existing /etc/localtime symlink
+rm -f /etc/localtime
+systemd-firstboot --force --timezone=UTC --locale=en_US.UTF-8 --keymap=us
+echo 'FONT=eurlatgr.psfu' >> /etc/vconsole.conf
+
+if ! grep -q tumbleweed /etc/os-release; then
+    create_fs
+    systemd_mount
+fi
+
+#
+### users and groups
+# groups
+groupadd --gid 2002 geekos
+
+# users
+echo 'root:$6$eEm2HpuzI7dfE4i7$dbYiTRLhrqVvwryR7zmMEcnrp13IqZ3mzLbsx9EeHAX7849PibGVgX5vdPuaeYYIO7hVfcboI9/JDpGiDZhHf/' | chpasswd -e
+useradd --no-create-home --uid 2002 --gid geekos --groups users HomelessTester
+useradd --create-home --uid 1001 --comment "Bernhard M. Wiedemann" --no-user-group --gid users bernhard
+echo 'bernhard:$6$eEm2HpuzI7dfE4i7$dbYiTRLhrqVvwryR7zmMEcnrp13IqZ3mzLbsx9EeHAX7849PibGVgX5vdPuaeYYIO7hVfcboI9/JDpGiDZhHf/' | chpasswd -e
+
+#
+### files and directories
+#
+echo "cucaracha" > /etc/hostname
+mkdir --mode=0755 /home/bernhard/testdir
+chown bernhard:users /home/bernhard/testdir
+echo "Hello there!" > /home/bernhard/testdir/hello
+chown bernhard:users /home/bernhard/testdir/hello
+chmod 0600 /home/bernhard/testdir/hello
+
+#
+### systemd units
+#
+cat << EOF > /etc/systemd/system/create_test_file.service
+[Unit]
+Description=Just a Test!
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart=/usr/bin/touch /var/log/flagfile
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl enable sshd.service
+systemctl enable create_test_file.service
+
+# leave a marker that combustion configure the system
+echo Combustion was here > /usr/share/combustion-welcome
+
+# close outputs and wait for tee to finish
+exec 1>&- 2>&-; wait;

--- a/data/ignition-combustion-configs/extended_combustion/combustion/script
+++ b/data/ignition-combustion-configs/extended_combustion/combustion/script
@@ -1,0 +1,194 @@
+#!/bin/bash
+# combustion: network prepare
+# 
+# Simple openQA combustion script used for sle-micro or Minimal-VM start from 15-SP6 and their opensuse counterparts
+# due to known bug boo#1157133, the script is intended to be used only on x86_64
+# 
+# Test Objects:
+#   1) set localization and timezone
+#   2) create new fs in the test drive
+#   3) set root password
+#   4) create test users
+#   5) set systemd mount for test partition
+#   6) create test oneshot systemd service that creates a file
+#   7) enable sshd
+#   8) set test hostname 
+#   9) test networking
+#
+set -euxo pipefail
+
+# look for a drive that has no partition table or other information that blkid would return
+detect_free_drive() {
+    declare -a drives
+    drives=( $(ls /sys/block/) )
+
+    for d in ${drives[@]}; do
+        # 64bit worker boots the image with cd-rom (sr0) device
+        # vmware adds floppy drive
+        # skip any of this device in case it is detected
+        [[ "$d" =~ ^(sr|fd)[0-9]$ ]] && continue
+        blkid /dev/"$d" &> /dev/null
+        if [[ "$?" -eq 2 ]]; then
+            printf "%s" "/dev/$d"
+            return 0
+        fi
+    done
+}
+
+create_fs() {
+    DRIVE=$(detect_free_drive)
+    test -n "$DRIVE" || exit 2
+
+    PART="${DRIVE}1"
+
+    # create partition and filesystem on additional drive
+    echo "label: gpt" | sfdisk "$DRIVE"
+    echo "name=testing_part" | sfdisk "$DRIVE" -N1
+
+    # label new partition for testing and create labeled ext4
+    mkfs.ext4 -L home "$PART"
+
+    # mount new partition
+    mount -t ext4 "$PART" /home
+
+    # Tell the kernel about the new layout
+    partx -u "$DRIVE"
+
+    # DEBUG
+    blkid
+    lsblk
+}
+
+systemd_mount() {
+
+cat << EOF > /etc/systemd/system/home.mount
+[Unit]
+Before=local-fs.target
+Requires=systemd-fsck@dev-disk-by\x2dpartlabel-testing_part.service
+After=systemd-fsck@dev-disk-by\x2dpartlabel-testing_part.service
+
+[Mount]
+Where=/home
+What=/dev/disk/by-partlabel/testing_part
+Type=ext4
+
+[Install]
+RequiredBy=local-fs.target
+EOF
+
+}
+
+test_prepare() {
+    echo "combustion: test_prepare function ran OK" > /dev/kmsg
+}
+
+can_encrypt() {
+	[ -c "/dev/tpm0" ] && command -v disk-encryption-tool >/dev/null
+}
+
+if [ "${1-}" = "--prepare" ]; then
+    test_prepare
+
+	if can_encrypt; then
+        mkdir -p /run/credstore
+        echo "force" > /run/credstore/disk-encryption-tool-dracut.encrypt
+    fi
+
+    exit 0
+fi
+
+# Redirect output to the console
+exec > >(exec tee -a /dev/console) 2>&1
+
+. /etc/os-release
+
+if [ "${ID}" = "opensuse-microos" ]; then
+    mount /home
+fi
+
+if [ "${ID_LIKE}" = "suse" ]; then
+    create_fs
+    systemd_mount
+fi
+
+
+if can_encrypt; then
+	systemd-machine-id-setup
+	[ -z "${TRANSACTIONAL_UPDATE+x}" ] || mount /var
+	mkdir -p /etc/credstore.encrypted
+	credential="$(mktemp disk-encryption-tool.XXXXXXXXXX)"
+	# Enroll recovery key
+	echo "1" > "$credential"
+	systemd-creds encrypt --name=sdbootutil-enroll.rk "$credential" /etc/credstore.encrypted/sdbootutil-enroll.rk
+ 	# Enroll TPM2
+	echo "1" > "$credential"
+	systemd-creds encrypt --name=sdbootutil-enroll.tpm2 "$credential" /etc/credstore.encrypted/sdbootutil-enroll.tpm2
+	shred -u "$credential"
+	# hack as heck, skip jeos-firstboot
+	# https://github.com/openSUSE/jeos-firstboot/issues/128
+	rm -f /sysroot/var/lib/YaST2/reconfig_system
+	# Umount back /var to not confuse tukit later
+	[ -z "${TRANSACTIONAL_UPDATE+x}" ] || umount /var
+fi
+
+### set locale, keyboard and timezone
+# exception: sle-micro comes with symlink /etc/localtime, thus systemd-firstboot fails
+# bsc#1215618 - systemd-firstboot --force fails to replace an existing /etc/localtime symlink
+rm -f /etc/localtime
+systemd-firstboot --force --timezone=UTC --locale=en_US.UTF-8 --keymap=us
+echo 'FONT=eurlatgr.psfu' >> /etc/vconsole.conf
+
+#
+### users and groups
+# groups
+groupadd --gid 2002 geekos
+
+# users
+echo 'root:$6$eEm2HpuzI7dfE4i7$dbYiTRLhrqVvwryR7zmMEcnrp13IqZ3mzLbsx9EeHAX7849PibGVgX5vdPuaeYYIO7hVfcboI9/JDpGiDZhHf/' | chpasswd -e
+useradd --no-create-home --uid 2002 --gid geekos --groups users HomelessTester
+useradd --create-home --uid 1001 --comment "Bernhard M. Wiedemann" --no-user-group --gid users bernhard
+echo 'bernhard:$6$eEm2HpuzI7dfE4i7$dbYiTRLhrqVvwryR7zmMEcnrp13IqZ3mzLbsx9EeHAX7849PibGVgX5vdPuaeYYIO7hVfcboI9/JDpGiDZhHf/' | chpasswd -e
+
+#
+### files and directories
+#
+echo "cucaracha" > /etc/hostname
+mkdir --mode=0755 /home/bernhard/testdir
+chown bernhard:users /home/bernhard/testdir
+echo "Hello there!" > /home/bernhard/testdir/hello
+chown bernhard:users /home/bernhard/testdir/hello
+chmod 0600 /home/bernhard/testdir/hello
+
+#
+### systemd units
+#
+cat << EOF > /etc/systemd/system/create_test_file.service
+[Unit]
+Description=Just a Test!
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart=/usr/bin/touch /var/log/flagfile
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl enable sshd.service
+systemctl enable create_test_file.service
+
+#
+### Networking
+#
+# configure interface for minimal-vm based on sle
+IF=$(find /sys/class/net -type l -not -lname '*virtual*' -printf '%f\n' | head -n1)
+IF_CFG="/etc/sysconfig/network/ifcfg-$IF"
+if command -v wicked &> /dev/null && ! grep -q 'dhcp' "$IF_CFG" &> /dev/null; then
+    echo -e "BOOTPROTO=dhcp\nSTARTMODE=auto" > "$IF_CFG"
+fi
+
+# leave a marker that combustion configure the system
+echo Combustion was here > /usr/share/combustion-welcome
+curl conncheck.opensuse.org
+
+# close outputs and wait for tee to finish
+exec 1>&- 2>&-; wait;

--- a/data/ignition-combustion-configs/ignition/combustion/script
+++ b/data/ignition-combustion-configs/ignition/combustion/script
@@ -1,0 +1,6 @@
+#!/bin/sh
+# combustion: network
+set -eux
+systemctl enable sshd.service
+echo Combustion was here > /usr/share/combustion-welcome
+curl conncheck.opensuse.org

--- a/data/ignition-combustion-configs/ignition/ignition/config.ign
+++ b/data/ignition-combustion-configs/ignition/ignition/config.ign
@@ -1,0 +1,11 @@
+{
+	"ignition": { "version": "3.0.0" },
+	"passwd": {
+		"users": [
+			{
+				"name": "root",
+				"passwordHash": "$6$eEm2HpuzI7dfE4i7$dbYiTRLhrqVvwryR7zmMEcnrp13IqZ3mzLbsx9EeHAX7849PibGVgX5vdPuaeYYIO7hVfcboI9/JDpGiDZhHf/"
+			}
+		]
+	}
+}

--- a/data/ignition-combustion-configs/ignition_no_network_probe_minimal/combustion/script
+++ b/data/ignition-combustion-configs/ignition_no_network_probe_minimal/combustion/script
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Redirect output to the console
+exec > >(exec tee -a /dev/console) 2>&1
+set -eux
+echo Combustion was here > /usr/share/combustion-welcome

--- a/data/ignition-combustion-configs/ignition_no_network_probe_minimal/ignition/config.ign
+++ b/data/ignition-combustion-configs/ignition_no_network_probe_minimal/ignition/config.ign
@@ -1,0 +1,25 @@
+{
+	"ignition": { "version": "3.0.0" },
+	"systemd": {
+		"units": [
+			{
+				"name": "nm-wait-online-initrd.service",
+				"enabled": false,
+				"mask": true
+			},
+			{
+				"name": "health-checker.service",
+				"enabled": false,
+				"mask": true
+			}
+		]
+	},
+	"passwd": {
+		"users": [
+			{
+				"name": "root",
+				"passwordHash": "$6$eEm2HpuzI7dfE4i7$dbYiTRLhrqVvwryR7zmMEcnrp13IqZ3mzLbsx9EeHAX7849PibGVgX5vdPuaeYYIO7hVfcboI9/JDpGiDZhHf/"
+			}
+		]
+	}
+}

--- a/data/ignition-combustion-configs/ignition_no_network_probe_test/combustion/script
+++ b/data/ignition-combustion-configs/ignition_no_network_probe_test/combustion/script
@@ -1,0 +1,10 @@
+#!/bin/bash
+# combustion: network
+# Redirect output to the console
+exec > >(exec tee -a /dev/console) 2>&1
+set -eux
+echo Combustion was here > /usr/share/combustion-welcome
+systemctl enable sshd.service
+#disabled on MM because networking is not configured at boot stage
+#curl conncheck.opensuse.org
+systemctl restart getty@tty2.service

--- a/data/ignition-combustion-configs/ignition_no_network_probe_test/ignition/config.ign
+++ b/data/ignition-combustion-configs/ignition_no_network_probe_test/ignition/config.ign
@@ -1,0 +1,11 @@
+{
+	"ignition": { "version": "3.0.0" },
+	"passwd": {
+		"users": [
+			{
+				"name": "root",
+				"passwordHash": "$6$eEm2HpuzI7dfE4i7$dbYiTRLhrqVvwryR7zmMEcnrp13IqZ3mzLbsx9EeHAX7849PibGVgX5vdPuaeYYIO7hVfcboI9/JDpGiDZhHf/"
+			}
+		]
+	}
+}

--- a/data/ignition-combustion-configs/ignition_only_no_network_minimal/ignition/config.ign
+++ b/data/ignition-combustion-configs/ignition_only_no_network_minimal/ignition/config.ign
@@ -1,0 +1,25 @@
+{
+	"ignition": { "version": "3.0.0" },
+	"systemd": {
+		"units": [
+			{
+				"name": "nm-wait-online-initrd.service",
+				"enabled": false,
+				"mask": true
+			},
+			{
+				"name": "health-checker.service",
+				"enabled": false,
+				"mask": true
+			}
+		]
+	},
+	"passwd": {
+		"users": [
+			{
+				"name": "root",
+				"passwordHash": "$6$eEm2HpuzI7dfE4i7$dbYiTRLhrqVvwryR7zmMEcnrp13IqZ3mzLbsx9EeHAX7849PibGVgX5vdPuaeYYIO7hVfcboI9/JDpGiDZhHf/"
+			}
+		]
+	}
+}

--- a/data/ignition-combustion-configs/ignitiononly/ignition/config.ign
+++ b/data/ignition-combustion-configs/ignitiononly/ignition/config.ign
@@ -1,0 +1,11 @@
+{
+	"ignition": { "version": "3.0.0" },
+	"passwd": {
+		"users": [
+			{
+				"name": "root",
+				"passwordHash": "$6$eEm2HpuzI7dfE4i7$dbYiTRLhrqVvwryR7zmMEcnrp13IqZ3mzLbsx9EeHAX7849PibGVgX5vdPuaeYYIO7hVfcboI9/JDpGiDZhHf/"
+			}
+		]
+	}
+}


### PR DESCRIPTION
The included Makefile generates the needed .qcow2 files from scratch if necessary.

Resurrection of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20243 with newer contents.
Directories based on content of images on o3 as of 2026-07-10 10:41:15+00:00. Resulting qcow2s look good, but are untested.