### PR TITLE
Adapt Agama tests in Stagings for product development

### DIFF
--- a/lib/Yam/Agama/LiveIso.pm
+++ b/lib/Yam/Agama/LiveIso.pm
@@ -15,15 +15,18 @@ use testapi;
 
 our @EXPORT = qw(read_live_iso);
 
+# In product development, the staging jobs don't have ISO variable set, they use ISO_1 instead
+my $iso_path = get_var('ISO', get_var('ISO_1'));
+
 sub read_iso_info {
-    my $iso_info = `isoinfo -j UTF-8 -R -x /LiveOS/.info -i @{[ get_var('ISO') ]}`;
+    my $iso_info = `isoinfo -j UTF-8 -R -x /LiveOS/.info -i $iso_path`;
     die "Error getting info from ISO image" if ($? != 0);
     return $iso_info;
 }
 
 sub get_package_version {
     my ($package_name) = @_;
-    my $command = "isoinfo -j UTF-8 -R -x /LiveOS/.packages.json.gz -i @{[ get_var('ISO') ]}" .
+    my $command = "isoinfo -j UTF-8 -R -x /LiveOS/.packages.json.gz -i $iso_path" .
       " | gunzip" .
       " | jq -r '.[] | select(.name==\"$package_name\") | .version'";
 
@@ -58,7 +61,7 @@ sub record_agama_info {
 }
 
 sub read_live_iso {
-    return unless get_var('ISO');
+    return unless $iso_path;
     my $info = read_iso_info();
     my $pkgs = parse_agama_packages();
     $info =~ /^Image.version:\s+(?<major_version>\d+\.\w+)\./m;

--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -68,7 +68,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils qw(is_leap is_sle is_sle_micro is_tumbleweed);
+use version_utils qw(is_leap is_sle is_sle_micro is_tumbleweed get_base_version);
 use y2_module_consoletest;
 use Test::Assert ':all';
 use xml_utils;
@@ -537,13 +537,15 @@ sub validate_repo_properties {
     my $actual_repo_data = parse_repo_data($search_criteria);
 
     if ($args->{Alias}) {
-        assert_true($actual_repo_data->{Alias} =~ /$args->{Alias}/,
-            "Repository $args->{Name} has wrong alias, expected: '$args->{Alias}', got: '$actual_repo_data->{Alias}'");
+        my $expected_alias = get_base_version($args->{Alias});
+        assert_true($actual_repo_data->{Alias} =~ /$expected_alias/,
+            "Repository $args->{Name} has wrong alias, expected: '$expected_alias', got: '$actual_repo_data->{Alias}'");
     }
 
     if ($args->{Name}) {
-        assert_true($actual_repo_data->{Name} =~ /$args->{Name}/,
-            "Repository '$args->{Name}' has wrong name: '$actual_repo_data->{Name}'");
+        my $expected_name = get_base_version($args->{Name});
+        assert_true($actual_repo_data->{Name} =~ /$expected_name/,
+            "Repository '$args->{Name}' has wrong name: '$expected_name'");
     }
 
     if ($args->{URI}) {
@@ -580,7 +582,7 @@ Returns Hash reference with all the parsed properties and their values, for exam
 
 sub parse_repo_data {
     my ($repo_identifier) = @_;
-    my @lines = split(/\n/, script_output("zypper -q lr $repo_identifier"));
+    my @lines = split(/\n/, script_output("zypper -q lr " . get_base_version($repo_identifier)));
     my %repo_data = map { split(/\s*:\s*/, $_, 2) } @lines;
     return \%repo_data;
 }

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -69,6 +69,7 @@ use constant {
           has_selinux
           is_wsl
           is_ltss
+          get_base_version
         )
     ],
     BACKEND => [
@@ -1104,6 +1105,22 @@ sub is_ltss {
 
     # Check if current date is past the lifecycle date
     return $general_ends{$version} <= $current_date;
+}
+
+=head2 get_base_version
+
+ get_base_version($string);
+
+In SLFO development, the staging jobs have VERSION with format containing :PR-XXXX
+This function removes the :PR-XXXX pattern from the string.
+If no argument is provided, it uses get_var('VERSION') by default.
+
+=cut
+
+sub get_base_version {
+    my $str = shift // get_var('VERSION');
+    $str =~ s/:PR-\d+//g;
+    return $str;
 }
 
 

--- a/tests/console/validate_repos.pm
+++ b/tests/console/validate_repos.pm
@@ -11,6 +11,7 @@ use Mojo::Base 'consoletest';
 use testapi;
 use repo_tools 'validate_repo_properties';
 use scheduler 'get_test_suite_data';
+use version_utils 'get_base_version';
 
 sub run {
     my $test_data = get_test_suite_data();
@@ -41,7 +42,8 @@ sub run {
     }
     foreach my $alias (@actual_aliases) {
         next if grep { $alias =~ $_ } @skip_aliases;
-        if (!$expected_repos{$alias}) {
+        my $expected_alias = get_base_version($expected_repos{$alias});
+        if (!$expected_alias) {
             $unexpected_aliases .= $alias . '\n';
         }
     }

--- a/tests/yam/agama/agama.pm
+++ b/tests/yam/agama/agama.pm
@@ -23,7 +23,7 @@ use testapi qw(
 );
 use Utils::Architectures qw(is_s390x is_ppc64le);
 use Utils::Backends qw(is_pvm is_svirt);
-use version_utils qw(is_vmware);
+use version_utils qw(is_vmware get_base_version);
 use power_action_utils 'power_action';
 
 sub is_headless_installation {
@@ -44,7 +44,7 @@ sub run {
       " --test-reporter-destination=/tmp/$spec" .
       " --test-reporter-destination=/tmp/$tap" .
       " /usr/share/agama/system-tests/${test}.js" .
-      " --product-version " . get_required_var('VERSION') .
+      " --product-version " . get_base_version() .
       " --agama-web-ui-package-version " . get_var('AGAMA_WEBUI_PACKAGE_VERSION') .
       " $test_options";
 

--- a/tests/yam/validate/validate_product.pm
+++ b/tests/yam/validate/validate_product.pm
@@ -11,6 +11,7 @@ use testapi;
 use Config::Tiny;
 use Test::Assert ':all';
 use scheduler 'get_test_suite_data';
+use version_utils 'get_base_version';
 
 sub run {
     select_console 'root-console';
@@ -22,6 +23,7 @@ sub run {
         my $expected = $test_data->{$key};
         my $actual = $os_release->{$key};
         $actual =~ s/^"|"$//g;
+        $expected = get_base_version($expected);
         assert_equals($expected, $actual, "Mismatch for $key, expect $expected but got $actual");
     }
 }

--- a/tests/yam/validate/validate_registered_products.pm
+++ b/tests/yam/validate/validate_registered_products.pm
@@ -11,12 +11,13 @@ use utils 'zypper_call';
 use testapi;
 use JSON;
 use scheduler 'get_test_suite_data';
+use version_utils 'get_base_version';
 
 sub is_registered_and_active {
     my ($product) = @_;
 
     return $product->{status} eq 'Registered' &&
-      $product->{version} eq get_var("VERSION") &&
+      $product->{version} eq get_base_version() &&
       $product->{subscription_status} eq 'ACTIVE';
 }
 


### PR DESCRIPTION
Staging jobs for products under development are triggered with
a different VERSION format. For example VERSION=16.1:PR-5466
This breaks a lot of tests that rely on a "real" version string.
This commit adapts some of the test modules to strip all the
characters after the colon.

Example of failure: https://openqa.suse.de/tests/23263909
VRs: 
- [16.1 stagings](https://openqa.suse.de/tests/overview?distri=sle&version=16.1%3APR-5466&build=PR-5466-7.1%3ASLES-16.1&groupid=714&flavor=Online-Staging-dev)
- [16.1 milestone](https://openqa.suse.de/tests/overview?version=16.1&build=jlausuch%2Fos-autoinst-distri-opensuse%23161_staging&distri=sle)