### PR TITLE
sles4sap: Fix options passed to "run_cmd" in "run_cmd_retry"

### DIFF
--- a/lib/sles4sap/publiccloud.pm
+++ b/lib/sles4sap/publiccloud.pm
@@ -169,11 +169,19 @@ sub run_cmd_retry {
     my $timeout = delete $args{timeout} // 60;
     my $retry = delete $args{retry} // 3;
     my $delay = delete $args{delay} // 10;
-    delete($args{proceed_on_failure});
+    my $proceed_on_failure = delete $args{proceed_on_failure} // 0;
+    my $ret = 0;
 
     for (1 .. $retry) {
-        my $ret = eval { $self->run_cmd(timeout => $timeout, ignore_timeout_failure => 1, proceed_on_failure => 0, %args); };
-        return $ret if (defined $ret);
+        $ret = eval { $self->run_cmd(timeout => $timeout, ignore_timeout_failure => 1, %args); };
+        # If we want return code, then retry until the command succeeds,
+        # if we want output, then retry until we can get the output.
+        if ($args{rc_only}) {
+            return $ret if (defined($ret) && $ret == 0);
+        }
+        else {
+            return $ret if (defined $ret);
+        }
 
         # Unblock console in case the previous command hung and timed out
         type_string('', terminate_with => 'ETX') if $args{ssh_keepalive};
@@ -181,6 +189,7 @@ sub run_cmd_retry {
         sleep $delay;
         record_soft_failure('jsc#TEAM-10485 SSH timeout or failure, retrying');
     }
+    return $ret if $proceed_on_failure;
     die('Maximum number of SSH retry attempts exceeded');
 }
 
@@ -1612,7 +1621,7 @@ sub wait_for_idle {
     my ($self, %args) = @_;
     my $timeout = $args{timeout} // 60;
 
-    my $rc = $self->run_cmd_retry(cmd => 'cs_wait_for_idle --sleep 5', timeout => $timeout, rc_only => 1);
+    my $rc = $self->run_cmd_retry(cmd => 'cs_wait_for_idle --sleep 5', timeout => $timeout, rc_only => 1, proceed_on_failure => 1);
     if ($rc == 124) {
         record_info('WARN cs_wait_for_idle', "cs_wait_for_idle timed out after $timeout. Gathering info and retrying");
         $self->run_cmd(cmd => 'cs_clusterstate', proceed_on_failure => 1);

--- a/t/12_sles4sap_publiccloud.t
+++ b/t/12_sles4sap_publiccloud.t
@@ -1210,6 +1210,9 @@ subtest '[wait_for_idle] command fails with rc 124, passes at second try' => sub
     $sles4sap_publiccloud->redefine(record_info => sub {
             note(join(' ', 'RECORD_INFO -->', @_));
     });
+    $sles4sap_publiccloud->redefine(record_soft_failure => sub {
+            note(join(' ', 'SOFT_FAILURE -->', @_));
+    });
 
     lives_ok { $self->wait_for_idle() } 'Cluster was not idle the first time but succeeded the second';
     ok((any { qr/cs_clusterstate/ } @calls), 'function calls cs_clusterstate');


### PR DESCRIPTION
This PR enhances `run_cmd_retry` by treating different options differently.

`run_cmd_retry` uses `run_cmd`, which uses `ssh_script_run` or `ssh_script_output`, depending on the parameter `rc_only`.  We need to treat the return value separately.

Also `proceed_on_failure` has a special meaning in the context: if it is used, do not fail the test, but return the error code instead.

- Related ticket: https://jira.suse.com/browse/TEAM-11280
- Needles: none
- Verification run: https://openqa.suse.de/tests/23273726
