### PR TITLE
ci: automate Dependabot updates and auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    groups:
+      all-actions:
+        patterns:
+          - "*"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -28,3 +28,12 @@ pull_request_rules:
     actions:
       review:
         type: APPROVE
+  - name: automatic merge for dependabot updates
+    conditions:
+      - and: *base_checks
+      - and:
+          - base=master
+          - author=dependabot[bot]
+    actions:
+      merge:
+        method: squash


### PR DESCRIPTION
Motivation:
Automate GHA workflow updates via Dependabot and automatically squash-merge
them when CI passes to eliminate manual maintenance.

Design Choices:
Configured Dependabot for github-actions and added a squash auto-merge
Mergify rule for `dependabot[bot]`. Removed obsolete delayed-merge rules.

Benefits:
Saves maintainer time by fully automating dependency updates with high security
while preserving clean linear git history.