### PR TITLE
Change libslirp package name to libslirp0  poo203169

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2484,10 +2484,12 @@ sub set_mu_virt_vars {
     # If $_pkg contains none, it is for ease of functional testing when no incidents are coming.
     if ($_pkg =~ /none/) {
         $_update_package = '';
-    } elsif ($_pkg =~ /qemu|xen|virt-manager|libguestfs|libslirp|open-vm-tools|dnsmasq|sevctl/) {
+    } elsif ($_pkg =~ /qemu|xen|virt-manager|libguestfs|open-vm-tools|dnsmasq|sevctl/) {
         $_update_package = $_pkg;
     } elsif ($_pkg =~ /libvirt/) {
         $_update_package = 'libvirt-client';
+    } elsif ($_pkg =~ /libslirp/) {
+        $_update_package = 'libslirp0';
     } else {
         $_update_package = 'kernel-default';
     }
@@ -2604,7 +2606,7 @@ sub set_sles16_mu_virt_vars {
         if ($_pkg =~ /none/) {
             # 'none' is for ease of functional testing when no package update is needed
             $_update_package = '';
-        } elsif ($_pkg =~ /qemu|virt-manager|libguestfs|libslirp|open-vm-tools|snphost|dnsmasq/) {
+        } elsif ($_pkg =~ /qemu|virt-manager|libguestfs|open-vm-tools|snphost|dnsmasq/) {
             # Direct package name usage (SLES16 currently supports KVM/QEMU only)
             $_update_package = $_pkg;
         } elsif ($_pkg =~ /snpguest/) {
@@ -2614,6 +2616,9 @@ sub set_sles16_mu_virt_vars {
         } elsif ($_pkg =~ /libvirt/) {
             # Special case: libvirt maps to libvirt-client
             $_update_package = 'libvirt-client';
+        } elsif ($_pkg =~ /libslirp/) {
+            # Special case: libslirp maps to libslirp0
+            $_update_package = 'libslirp0';
         } elsif ($_pkg =~ /xen/) {
             # Xen support will return in SLES16.2
             die "Xen testing is not supported in SLES16 (will return in SLES16.2)";


### PR DESCRIPTION
Change libslirp package name to libslirp0 on UPDATE_PACKAGE setting,   


- Related ticket: https://progress.opensuse.org/issues/poo203169

- Verification run: 
SLES 15 SP7 - https://openqa.suse.de/tests/23286417#step/kernel/1
SLES 15- SP4 - https://openqa.suse.de/tests/23302074#step/kernel/1
                          https://openqa.suse.de/tests/23302075#step/kernel/1
SLES 16 - https://openqa.suse.de/tests/23143696#step/install_update_package/19