### PR TITLE
Improve publiccloud scp documentation and unit test coverage

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -201,12 +201,41 @@ sub ssh_script_retry {
 
 =head2 scp
 
-    scp($from, $to[, timeout => 90, proceed_on_failure => 0]);
+    scp($from, $to [, timeout => 90] [, proceed_on_failure => 0]);
 
-Use scp to copy a file from or to this instance. A url starting with
-C<remote:> is replaced with the IP from this instance. E.g. a call to copy
-the file I</var/log/cloudregister> to I</tmp> looks like:
-C<<<$instance->scp('remote:/var/log/cloudregister', '/tmp');>>>
+Copy a file to or from this instance using C<scp>.
+
+Arguments:
+
+C<$from> - source path. When it starts with C<remote:>, the prefix is
+    replaced with C<< <username>@<public_ip>: >> so the file is read from
+    this instance (download). Otherwise it is treated as a local path.
+    Using C<remote:> is only a convenience: you are free to pass an explicit
+    C<< user@host:/path >> instead, which is left untouched by this function.
+
+C<$to> - destination path. Uses the same C<remote:> rewriting as C<$from>,
+    so a C<remote:> destination uploads a local file to this instance. As
+    with C<$from>, an explicit C<< user@host:/path >> can be passed and is
+    left untouched.
+
+C<timeout> - maximum time in seconds allowed for the scp command. Defaults
+    to C<SSH_TIMEOUT> (90 seconds).
+
+C<proceed_on_failure> - when set to a true value a failing scp does not abort
+    the test: the command is run via C<script_run> and only an informational
+    message is recorded. When false (the default) the copy is run via
+    C<assert_script_run> so a failure dies. Defaults to C<0>.
+
+Any C<-E <file>> logging options present in C<< $instance->ssh_opts >> are
+stripped, because C<scp> does not accept them.
+
+E.g. to download the file I</var/log/cloudregister> into I</tmp>:
+
+    $instance->scp('remote:/var/log/cloudregister', '/tmp');
+
+and to upload a local I</tmp/foo> to the instance home directory:
+
+    $instance->scp('/tmp/foo', 'remote:/home/user/foo');
 =cut
 
 sub scp {

--- a/t/44_publiccloud_instance.t
+++ b/t/44_publiccloud_instance.t
@@ -156,17 +156,99 @@ subtest '[ssh_script_output] strips trailing connection-closed line' => sub {
     unlike($out, qr/Connection to .* closed/, 'strips connection-closed trailer');
 };
 
-subtest '[scp] composes scp command and rewrites remote:' => sub {
-    my $instance = Test::MockModule->new('publiccloud::instance', no_auto => 1);
-    my $seen_cmd;
-    $instance->redefine(assert_script_run => sub { $seen_cmd = $_[0]; return 0 });
+subtest '[scp] composes scp command and rewrites only remote: paths' => sub {
+    # remote: is rewritten to the instance identity (user@public_ip:), while
+    # local paths and an explicit user@host are passed through verbatim. -E is
+    # stripped from ssh_opts because scp does not accept it.
+    my @cases = (
+        {
+            name => 'rewrites remote: in source (download)',
+            username => 'DONALDUCK',
+            ssh_opts => '-o X=y -E /tmp/log',
+            src => 'remote:/var/log/messages',
+            dst => '/tmp/messages',
+            like => [qr/^scp /, qr/DONALDUCK\@198\.51\.100\.2:\/var\/log\/messages/, qr/"\/tmp\/messages"/],
+            unlike => [qr/DONALDUCK\@198\.51\.100\.2:\/tmp\/messages/, qr/-E /],
+        },
+        {
+            name => 'rewrites remote: in destination (upload)',
+            username => 'GOOFY',
+            src => '/tmp/foo',
+            dst => 'remote:/home/admin/foo',
+            like => [qr/GOOFY\@198\.51\.100\.2:\/home\/admin\/foo/, qr/"\/tmp\/foo"/],
+            unlike => [qr/GOOFY\@198\.51\.100\.2:\/tmp\/foo/],
+        },
+        {
+            name => 'neither path has remote:',
+            username => 'admin',
+            src => '/tmp/src',
+            dst => '/tmp/dst',
+            like => [qr/"\/tmp\/src"/, qr/"\/tmp\/dst"/],
+            unlike => [qr/admin\@198\.51\.100\.2/],
+        },
+        {
+            name => 'explicit user@host:/path in source',
+            username => 'admin',
+            src => 'other@example.com:/etc/hosts',
+            dst => '/tmp/hosts',
+            like => [qr/"other\@example\.com:\/etc\/hosts"/],
+            unlike => [qr/admin\@198\.51\.100\.2/],
+        },
+    );
 
-    my $inst = publiccloud::instance->new(public_ip => '198.51.100.2', username => 'admin', ssh_opts => '-o X=y -E /tmp/log');
-    $inst->scp('remote:/var/log/messages', '/tmp/messages');
-    like($seen_cmd, qr/^scp /, 'starts with scp');
-    like($seen_cmd, qr/admin\@198\.51\.100\.2:\/var\/log\/messages/, 'remote: rewritten to user@ip:');
-    like($seen_cmd, qr/\/tmp\/messages/, 'destination present');
-    unlike($seen_cmd, qr/-E /, '-E option stripped (scp does not accept it)');
+    foreach my $case (@cases) {
+        my $instance = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+        my @calls;
+        $instance->redefine(assert_script_run => sub { push @calls, $_[0]; return 0 });
+        $instance->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+        my $inst = publiccloud::instance->new(public_ip => '198.51.100.2', username => $case->{username}, ssh_opts => $case->{ssh_opts} // '');
+
+        $inst->scp($case->{src}, $case->{dst});
+
+        note("\n  -->  " . join("\n  -->  ", @calls));
+        like($calls[0], $_, "$case->{name}: matches $_") for @{$case->{like}};
+        unlike($calls[0], $_, "$case->{name}: does not match $_") for @{$case->{unlike} // []};
+    }
+};
+
+subtest '[scp] timeout defaults to SSH_TIMEOUT and is overridable' => sub {
+    my $instance = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+    my %seen;
+    $instance->redefine(assert_script_run => sub { my ($c, %a) = @_; %seen = %a; return 0 });
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
+
+    $inst->scp('/tmp/a', '/tmp/b');
+    is($seen{timeout}, 90, 'defaults to SSH_TIMEOUT (90s) when not given');
+
+    $inst->scp('/tmp/a', '/tmp/b', timeout => 300);
+    is($seen{timeout}, 300, 'custom timeout forwarded to assert_script_run');
+};
+
+subtest '[scp] proceed_on_failure controls failure handling' => sub {
+    my $instance = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+    my $assert_called;
+    $instance->redefine(assert_script_run => sub { $assert_called++; return 0 });
+    my $script_run_ret;
+    $instance->redefine(script_run => sub { return $script_run_ret });
+    $instance->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
+
+    # proceed_on_failure=1 and scp fails: no die, no assert_script_run, an info is recorded
+    $script_run_ret = 1;
+    $assert_called = 0;
+    lives_ok { $inst->scp('/tmp/a', '/tmp/b', proceed_on_failure => 1) }
+    'does not die on scp failure when proceed_on_failure is set';
+    is($assert_called, 0, 'assert_script_run not used when proceed_on_failure is set');
+
+    # proceed_on_failure=1 and scp succeeds
+    $script_run_ret = 0;
+    $inst->scp('/tmp/a', '/tmp/b', proceed_on_failure => 1);
+    is($assert_called, 0, 'assert_script_run not used when proceed_on_failure is set');
+
+    # default (proceed_on_failure not set): the copy is asserted
+    $assert_called = 0;
+    $inst->scp('/tmp/a', '/tmp/b');
+    is($assert_called, 1, 'assert_script_run used by default');
 };
 
 subtest '[retry_ssh_command] retries then succeeds' => sub {


### PR DESCRIPTION
Update Pod documentation for the publiccloud instance 'scp' subroutine to clarify the behavior of rewriting 'remote:' prefixes. Additionally, refactor and expand unit tests for 'scp' in t/44_publiccloud_instance.t