### PR TITLE
Remove unused conv_openqa_tf_name

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -72,20 +72,6 @@ sub generate_basename {
     return "$distri-$version-$flavor-$arch";
 }
 
-=head2 conv_openqa_tf_name
-
-Does the conversion between C<PUBLIC_CLOUD_PROVIDER> and Terraform providers name.
-
-=cut
-
-sub conv_openqa_tf_name {
-    # Check https://github.com/SUSE/ha-sap-terraform-deployments/issues/177 for more information
-    my $cloud_provider = lc get_var('PUBLIC_CLOUD_PROVIDER');
-    return 'aws' if $cloud_provider eq 'ec2';
-    return 'gcp' if $cloud_provider eq 'gce';
-    return $cloud_provider;
-}
-
 =head2 find_img
 
 Retrieves the image-id by given image C<name>.
@@ -465,7 +451,6 @@ sub terraform_apply {
 
     $args{count} //= '1';
     my $instance_type = get_var('PUBLIC_CLOUD_INSTANCE_TYPE');
-    my $cloud_name = $self->conv_openqa_tf_name;
 
     record_info('WARNING', 'Terraform apply has been run previously.') if ($self->terraform_applied);
 

--- a/t/45_publiccloud_provider.t
+++ b/t/45_publiccloud_provider.t
@@ -22,19 +22,6 @@ use publiccloud::provider;
 
 sub _unset { for my $k (@_) { set_var($k, undef) } }
 
-subtest '[conv_openqa_tf_name] provider name mapping' => sub {
-    set_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
-    is(publiccloud::provider::conv_openqa_tf_name(), 'aws', 'EC2 maps to aws');
-
-    set_var('PUBLIC_CLOUD_PROVIDER', 'GCE');
-    is(publiccloud::provider::conv_openqa_tf_name(), 'gcp', 'GCE maps to gcp');
-
-    set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
-    is(publiccloud::provider::conv_openqa_tf_name(), 'azure', 'AZURE stays azure (lowercased)');
-
-    _unset('PUBLIC_CLOUD_PROVIDER');
-};
-
 subtest '[escape_single_quote] shell-safe single quotes' => sub {
     is(publiccloud::provider::escape_single_quote('plain'), 'plain', 'no quotes unchanged');
     is(publiccloud::provider::escape_single_quote(q{it's}), q{it'"'"'s}, 'single quote escaped');
@@ -113,7 +100,6 @@ subtest '[terraform_apply] minimal happy path' => sub {
     $mock->redefine($_ => sub { }) for qw(record_info assert_script_run script_retry terraform_prepare_env);
     $mock->redefine(get_image_uri => sub { '' });
     $mock->redefine(get_image_id => sub { '' });
-    $mock->redefine(conv_openqa_tf_name => sub { 'tf' });
     $mock->redefine(terraform_param_tags => sub { '{}' });
     $mock->redefine(script_run => sub { 0 });
     $mock->redefine(script_output => sub {


### PR DESCRIPTION
Remove unused function, it was only used to set a local variable in `terraform_apply` that is later unused.

- Related ticket: https://progress.opensuse.org/issues/202446

# Verification run:
 - sle-16.1-Azure-BYOS-x86_64-Build0918-publiccloud_smoketests az_Standard_L8s_v3 -> http://openqa.suse.de/tests/23305079