### PR TITLE
Move provider-specific terraform variables to subclasses

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -504,8 +504,11 @@ sub terraform_apply {
     $args{vars} //= {};
     my $offer = get_var("PUBLIC_CLOUD_AZURE_OFFER");
     my $sku = get_var("PUBLIC_CLOUD_AZURE_SKU");
+    # Note: Only the default Azure terraform profiles contains the 'storage-account' variable
+    my $storage_account = get_var('PUBLIC_CLOUD_STORAGE_ACCOUNT');
     $args{vars}->{offer} = $offer if ($offer);
     $args{vars}->{sku} = $sku if ($sku);
+    $args{vars}->{'storage-account'} = $storage_account if ($storage_account);
 
     return $self->SUPER::terraform_apply(%args);
 }

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -165,7 +165,10 @@ sub upload_img {
 
 sub terraform_apply {
     my ($self, %args) = @_;
-    $args{confidential_compute} = get_var("PUBLIC_CLOUD_CONFIDENTIAL_VM", 0);
+    my $confidential_compute = get_var('PUBLIC_CLOUD_CONFIDENTIAL_VM');
+    $args{vars}->{enable_confidential_vm} = 'enabled' if $confidential_compute;
+    $args{vars}->{ipv6_address_count} = get_var('PUBLIC_CLOUD_EC2_IPV6_ADDRESS_COUNT', 0);
+    $args{vars}->{nitro_enclave} = "true" if check_var("PUBLIC_CLOUD_EC2_NITRO_ENCLAVE", "1");
     return $self->SUPER::terraform_apply(%args);
 }
 

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -203,7 +203,14 @@ sub img_proof {
 sub terraform_apply {
     my ($self, %args) = @_;
     $args{project} //= $self->provider_client->project_id;
-    $args{confidential_compute} = get_var("PUBLIC_CLOUD_CONFIDENTIAL_VM", 0);
+    my $confidential_compute = get_var('PUBLIC_CLOUD_CONFIDENTIAL_VM');
+    $args{vars}->{enable_confidential_vm} = 'true' if $confidential_compute;
+    my $stack_type = get_var('PUBLIC_CLOUD_GCE_STACK_TYPE', 'IPV4_ONLY');
+    $args{vars}->{stack_type} = $stack_type;
+    my $nic_type = get_var('PUBLIC_CLOUD_GCE_NIC_TYPE', '');
+    $args{vars}->{nic_type} = $nic_type if $nic_type;
+    $args{vars}->{availability_zone} = $self->provider_client->availability_zone;
+
     my @instances = $self->SUPER::terraform_apply(%args);
 
     my $instance_id = $self->get_terraform_output(".vm_name.value[0]");

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -485,20 +485,9 @@ sub terraform_apply {
             die('Instance type not supported by the selected Availability Zone') if ($vars{availability_zone} =~ /None/);
             $vars{vpc_security_group_ids} = script_output("aws ec2 describe-security-groups --region '" . $self->provider_client->region . "' --filters 'Name=group-name,Values=tf-sg' --query 'SecurityGroups[0].GroupId' --output text");
             $vars{subnet_id} = script_output("aws ec2 describe-subnets --region '" . $self->provider_client->region . "' --filters 'Name=tag:Name,Values=tf-subnet' 'Name=availabilityZone,Values=" . $vars{availability_zone} . "' --query 'Subnets[0].SubnetId' --output text");
-            $vars{ipv6_address_count} = get_var('PUBLIC_CLOUD_EC2_IPV6_ADDRESS_COUNT', 0);
-            $vars{nitro_enclave} = "true" if check_var("PUBLIC_CLOUD_EC2_NITRO_ENCLAVE", "1");
         } elsif (is_azure) {
             my $subnet_id = script_output("az network vnet subnet list -g 'tf-" . $self->provider_client->region . "-rg' --vnet-name 'tf-network' --query '[0].id' --output 'tsv'");
             $vars{subnet_id} = $subnet_id if ($subnet_id);
-            # Note: Only the default Azure terraform profiles contains the 'storage-account' variable
-            my $storage_account = get_var('PUBLIC_CLOUD_STORAGE_ACCOUNT');
-            $vars{'storage-account'} = $storage_account if ($storage_account);
-        } elsif (is_gce) {
-            my $stack_type = get_var('PUBLIC_CLOUD_GCE_STACK_TYPE', 'IPV4_ONLY');
-            $vars{stack_type} = $stack_type;
-            my $nic_type = get_var('PUBLIC_CLOUD_GCE_NIC_TYPE', '');
-            $vars{nic_type} = $nic_type if $nic_type;
-            $vars{availability_zone} = $self->provider_client->availability_zone;
         }
         $vars{instance_count} = $args{count};
         $vars{type} = $instance_type;
@@ -507,8 +496,6 @@ sub terraform_apply {
         $vars{project} = $args{project} if ($args{project});
         $vars{cloud_init} = TERRAFORM_DIR . "/cloud-init.yaml" if (get_var('PUBLIC_CLOUD_CLOUD_INIT'));
         $vars{vm_create_timeout} = $terraform_vm_create_timeout;
-        $vars{enable_confidential_vm} = 'true' if ($args{confidential_compute} && is_gce());
-        $vars{enable_confidential_vm} = 'enabled' if ($args{confidential_compute} && is_ec2());
         my $root_size = get_var('PUBLIC_CLOUD_ROOT_DISK_SIZE');
         $vars{'root-disk-size'} = $root_size if ($root_size);
         $vars{tags} = escape_single_quote($self->terraform_param_tags);

--- a/t/45_publiccloud_provider.t
+++ b/t/45_publiccloud_provider.t
@@ -16,17 +16,13 @@ use Test::MockModule;
 use Test::Exception;
 use Test::Warnings;
 use testapi 'set_var';
+use List::Util qw(any);
 
 use publiccloud::azure_client;
 use publiccloud::provider;
 
 sub _unset { for my $k (@_) { set_var($k, undef) } }
 
-subtest '[escape_single_quote] shell-safe single quotes' => sub {
-    is(publiccloud::provider::escape_single_quote('plain'), 'plain', 'no quotes unchanged');
-    is(publiccloud::provider::escape_single_quote(q{it's}), q{it'"'"'s}, 'single quote escaped');
-    is(publiccloud::provider::escape_single_quote(q{a'b'c}), q{a'"'"'b'"'"'c}, 'multiple quotes escaped');
-};
 
 subtest '[terraform_param_tags] json tag structure' => sub {
     my $provider = publiccloud::provider->new();
@@ -92,16 +88,16 @@ subtest '[create_ssh_key] derives algorithm and generates when absent' => sub {
 subtest '[terraform_apply] minimal happy path' => sub {
     set_var('PUBLIC_CLOUD', 1);
     set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
-    set_var('PUBLIC_CLOUD_REGION', 'westeurope');
-    set_var('PUBLIC_CLOUD_INSTANCE_TYPE', 'Standard_B1s');
-    set_var('FLAVOR', 'DVD');
-
+    set_var('PUBLIC_CLOUD_REGION', 'Ferengi');
+    set_var('PUBLIC_CLOUD_INSTANCE_TYPE', 'Romulan');
+    set_var('FLAVOR', 'Talaxian');
+    set_var('OPENQA_URL', 'Xindi');
     my $mock = Test::MockModule->new('publiccloud::provider', no_auto => 1);
-    $mock->redefine($_ => sub { }) for qw(record_info assert_script_run script_retry terraform_prepare_env);
-    $mock->redefine(get_image_uri => sub { '' });
-    $mock->redefine(get_image_id => sub { '' });
-    $mock->redefine(terraform_param_tags => sub { '{}' });
-    $mock->redefine(script_run => sub { 0 });
+    $mock->redefine($_ => sub { '' }) for qw(get_image_uri get_image_id data_url);
+    $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $mock->redefine(get_current_job_id => sub { return 42; });
+    my @calls;
+    $mock->redefine($_ => sub { push @calls, $_[0]; return 0; }) for qw(assert_script_run script_run script_retry);
     $mock->redefine(script_output => sub {
             return '{"vm_name":{"value":[]},"public_ip":{"value":[]}}' if ($_[0] =~ /output -json/);
             return '';
@@ -113,8 +109,64 @@ subtest '[terraform_apply] minimal happy path' => sub {
 
     is scalar(@instances), 0, 'terraform_apply returns the list of created instances';
     ok $provider->terraform_applied, 'terraform_apply flags the deployment as applied';
+    ok((any { qr/tofu.*$_/ } @calls), "tofu $_ is executed") foreach (qw(init plan apply));
 
-    _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_REGION PUBLIC_CLOUD_INSTANCE_TYPE FLAVOR/);
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_REGION PUBLIC_CLOUD_INSTANCE_TYPE FLAVOR OPENQA_URL/);
 };
+
+subtest '[terraform_apply] vars' => sub {
+    set_var('PUBLIC_CLOUD', 1);
+    set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    set_var('PUBLIC_CLOUD_REGION', 'Ferengi');
+    set_var('PUBLIC_CLOUD_INSTANCE_TYPE', 'Romulan');
+    set_var('FLAVOR', 'Talaxian');
+    set_var('OPENQA_URL', 'Xindi');
+    my $mock = Test::MockModule->new('publiccloud::provider', no_auto => 1);
+    $mock->redefine($_ => sub { '' }) for qw(get_image_uri get_image_id data_url);
+    $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $mock->redefine(get_current_job_id => sub { return 42; });
+    my @calls;
+    $mock->redefine($_ => sub { push @calls, $_[0]; return 0; }) for qw(assert_script_run script_run script_retry);
+    $mock->redefine(script_output => sub {
+            return '{"vm_name":{"value":[]},"public_ip":{"value":[]}}' if ($_[0] =~ /output -json/);
+            return '';
+    });
+    Test::MockModule->new('publiccloud::instances', no_auto => 1)->redefine(set_instances => sub { });
+
+    my $provider = publiccloud::provider->new(provider_client => publiccloud::azure_client->new());
+    my %test_vars;
+    $test_vars{Borg00} = 'ResistanceIsFutile';
+    $test_vars{Borg01} = q{Resistance'IsFutile};
+    $test_vars{Borg10} = q{Resistance'Is'Futile};
+    my @instances = $provider->terraform_apply(vars => \%test_vars);
+
+    # Extract the single recorded call that runs 'tofu ... plan ...'
+    my ($plan_cmd) = grep { /tofu.*plan/ } @calls;
+    ok($plan_cmd, "tofu plan is executed");
+
+    # Split the command into its individual -var arguments. Values may contain
+    # the shell single-quote escape sequence '"'"', so we split on the ' -var '
+    # delimiter rather than trying to match balanced quotes.
+    my @var_args = split(/\s+-var\s+/, $plan_cmd);
+    shift @var_args;    # drop the 'tofu plan -no-color -out myplan' prefix
+
+    # Keep only the Borg* vars we injected, mapping key => escaped value.
+    # Each argument looks like:  'KEY=VALUE'
+    my %borg;
+    for my $arg (@var_args) {
+        my ($key, $val) = $arg =~ /^'([^=]+)=(.*)'\s*$/s;
+        next unless defined $key && $key =~ /^Borg/;
+        $borg{$key} = $val;
+    }
+
+    is($borg{Borg00}, q{ResistanceIsFutile}, 'plain value left unescaped');
+    is($borg{Borg01}, q{Resistance'"'"'IsFutile}, 'single quote escaped');
+    is($borg{Borg10}, q{Resistance'"'"'Is'"'"'Futile}, 'multiple single quotes escaped');
+
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_REGION PUBLIC_CLOUD_INSTANCE_TYPE FLAVOR OPENQA_URL/);
+};
+
 
 done_testing;


### PR DESCRIPTION
Refactor terraform_apply to delegate CSP specific variables to their respective children subclasses.
Previously they was managed half and half in two layers. This change shifts that responsibility to the `terraform_apply` implementations of the `azure`, `ec2`, and `gce` subclass modules.

- Related ticket: https://progress.opensuse.org/issues/203946

# Verification run:

## Azure
sle-16.1-Azure-BYOS-x86_64-Build0918-publiccloud_smoketests az_Standard_L8s_v3
- http://openqa.suse.de/tests/23311433 :green_circle: 

## AWS
sle-15-SP7-EC2-BYOS-Hardened-Incidents-x86_64-Build:smelt:43604:systemd-publiccloud_smoketests ec2_t3a.small
- http://openqa.suse.de/tests/23329173 :green_circle: 

## Gcp
sle-15-SP4-GCE-BYOS-Hardened-Incidents-x86_64-Build:smelt:45056:glibc-publiccloud_smoketests gce_g2-standard-4
- http://openqa.suse.de/tests/23329174
- http://openqa.suse.de/tests/23331222 :green_circle: 