### PR TITLE
Kselftests: BPF: Ignore test_progs duplicate error log summary

### DIFF
--- a/lib/Kselftests/parsers/bpf/test_progs.pm
+++ b/lib/Kselftests/parsers/bpf/test_progs.pm
@@ -14,9 +14,12 @@ use strict;
 use warnings;
 
 our $test_idx = 1;
+our $seen_error_logs = 0;
 
 sub parse_line {
     my ($self, $test_ln) = @_;
+    $seen_error_logs ||= ($test_ln =~ /^#\s+All error logs:/);
+    return undef if $seen_error_logs;
     if ($test_ln =~ /(?:^#\s)?#\S+\s+(\S+):(OK|FAIL|SKIP)$/) {
         my ($description, $st) = ($1, $2);
         my $normalized;


### PR DESCRIPTION
test_progs reprints the log and result of every failed subtest a second time under a "All error logs:" banner once all tests finish. parse_line() had no way to distinguish these reprinted lines from the original ones, so it double counted failures causing duplicated rows in the rendered KTAP results. Track whether the banner was seen and ignore it and everything after.

- Verification run: https://openqa.opensuse.org/tests/6092425 (64 vs 128 errors)
