### PR TITLE
Kselftests: BPF: Match test_maps CHECK() macro failures

### DIFF
--- a/lib/Kselftests/parsers/bpf/test_maps.pm
+++ b/lib/Kselftests/parsers/bpf/test_maps.pm
@@ -28,6 +28,11 @@ sub parse_line {
         $test_idx++;
         return $normalized;
     }
+    if ($test_ln =~ /^#\s(\S+)\(\d+\):FAIL:/) {
+        my $normalized = "# not ok $test_idx $1";
+        $test_idx++;
+        return $normalized;
+    }
     return undef;
 }
 


### PR DESCRIPTION
test_maps.c's CHECK() macro (test_maps.h) reports failures as "<func>(<line>):FAIL:<tag> <msg>" instead of the plain "<name>:FAIL" format, so parse_line() never matched them and no subtest-level "not ok" was emitted, only the top-level test_maps failure from the summary. Match this format too, using the function name as the subtest description.

- Verification run: https://openqa.opensuse.org/tests/6092445 (sporadic issue `test_sk_storage_map` that was missing from [original cloned job](https://openqa.opensuse.org/tests/6090890#step/test_maps/16) did not happen, though)
