### PR TITLE
Install tomcat10/11 for tomcat setup

### DIFF
--- a/lib/Tomcat/Utils.pm
+++ b/lib/Tomcat/Utils.pm
@@ -35,16 +35,18 @@ sub browse_with_keyboard {
 
 # Install tomcat and set initial configuration
 sub tomcat_setup() {
-    # log in to root console
-    select_console('root-console');
+    my ($self, $version) = @_;
+    $version //= '';    # default version is tomcat9
+    select_console('root-console');    # log in to root console
 
     record_info('Initial Setup');
     # we need to disable packagekit because it can block zypper sometimes later
     quit_packagekit if is_sle;
 
-    zypper_call('in tomcat tomcat-webapps tomcat-admin-webapps', timeout => 300);
+    my $tomcat = 'tomcat' . $version;
+    zypper_call("in $tomcat ${tomcat}-webapps ${tomcat}-admin-webapps", timeout => 300);
     zypper_call('in libtcnative-2-0') if is_sle('>=15-sp4');
-    assert_script_run('rpm -q tomcat');
+    assert_script_run("rpm -q $tomcat");
 
     # start the tomcat daemon and check that it is running
     systemctl('start tomcat');

--- a/tests/x11/tomcat.pm
+++ b/tests/x11/tomcat.pm
@@ -28,7 +28,7 @@ sub run() {
     my ($self) = shift;
     # install and configure tomcat in console
     turn_off_screensaver;
-    Tomcat::Utils->tomcat_setup();
+    Tomcat::Utils->tomcat_setup(get_var('TOMCAT_VER', ''));
 
     # verify that the tomcat manager works
     Tomcat::Utils->tomcat_manager_test();


### PR DESCRIPTION
Install tomcat10/11 for tomcat setup, Using 'TOMCAT_VER' settings to test different tomcat version with different jobs eg: qam-regression-tomcat10 and qam-regression-tomcat11. It can avoid mutual interference between different tomcat versions.

- Related ticket: https://progress.opensuse.org/issues/203808
- Verification run: sle15sp7: tomcat10: https://openqa.suse.de/tests/23329212
tomcat11: https://openqa.suse.de/tests/23329227
sle15sp6: tomcat10: https://openqa.suse.de/tests/23329316
tomcat11: https://openqa.suse.de/tests/23329321
sle15sp5: tomcat10: https://openqa.suse.de/tests/23329351
- Related MR: https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/1017