### PR TITLE
Add HA 16.1 Priority Fencing Test 4 Immutable Mode

### DIFF
--- a/tests/ha/priority_fencing_delay.pm
+++ b/tests/ha/priority_fencing_delay.pm
@@ -11,9 +11,10 @@ use Mojo::Base 'haclusterbasetest';
 use testapi;
 use lockapi;
 use hacluster;
-use utils qw(zypper_call reconnect_mgmt_console);
+use utils qw(reconnect_mgmt_console);
 use Utils::Backends qw(is_pvm);
 use version_utils qw(is_sle);
+use package_utils qw(install_package);
 
 sub stonith_iptables {
     my ($self, $count, $cluster) = @_;
@@ -52,7 +53,7 @@ sub run {
     prepare_console_for_fencing;
 
     # iptables is not installed in SLE 16 by default
-    zypper_call 'in iptables' if is_sle('>=16');
+    install_package('iptables', trup_apply => 1) if is_sle('>=16');
 
     # Configure a master resource on node1 for getting a heavier weight for the priority fencing feature
     if (is_node(1)) {


### PR DESCRIPTION
Add HA Priority Fencing Test for SLES in Immutable Mode: 16.1   

- Related ticket: [TEAM-11272](https://jira.suse.com/browse/TEAM-11272) - [16.1][ppc64le] Add HA Priority Fencing Test for SLES in Immutable Mode
- Verification run:  
16.1 Immutable mode: 
https://openqa.suse.de/tests/23343150#step/priority_fencing_delay/8 (passed)
https://openqa.suse.de/tests/23343316#step/priority_fencing_delay/8 (passed)
16.1 common mode: https://openqa.suse.de/tests/23343151#dependencies (passed)
16.0: common mode: https://openqa.suse.de/tests/23343154#dependencies (passed) 