### PR TITLE
refactor(publiccloud): combine kernel-devel package lookup into one rpm query

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -46,15 +46,7 @@ sub install_build_deps {
     # Remove kernel-default-devel from the list of dependencies since matching kernel version kernel-<flavor>-devel-<ver> package will be added.
     @deps = grep { $_ ne 'kernel-default-devel' } @deps;
 
-    # Query rpm's NAME/VERSION/RELEASE tags directly for the package owning
-    # the running kernel's config file, instead of parsing free-form `rpm -qf`
-    # output. The previous sed/cut/awk chain assumed the package name always
-    # splits cleanly into kernel-<flavor>-<version>, which is not guaranteed
-    # and produced an invalid 'kernel--devel-<version>' package on some SUTs.
-    my $kernel_pkg_name = $instance->ssh_script_output(cmd => q{rpm -qf --qf '%{NAME}' /boot/config-$(uname -r)});
-    my $kernel_pkg_ver = $instance->ssh_script_output(cmd => q{rpm -qf --qf '%{VERSION}-%{RELEASE}' /boot/config-$(uname -r)});
-    # Sample value: kernel-default-devel-6.12.0-160000.27.1
-    my $kernel_devel_pkg = "${kernel_pkg_name}-devel-${kernel_pkg_ver}";
+    my $kernel_devel_pkg = $instance->ssh_script_output(cmd => q{rpm -qf --qf '%{NAME}-devel-%{VERSION}-%{RELEASE}' /boot/config-$(uname -r)});
 
     push @deps, $kernel_devel_pkg;
 


### PR DESCRIPTION
## Why

Resolving the kernel-devel package name required two separate `ssh_script_output` calls to the SUT (one for NAME, one for VERSION-RELEASE), doubling SSH round-trips for a single lookup.

## What changed

- Merged the two `rpm -qf` queries into a single call using `%{NAME}-devel-%{VERSION}-%{RELEASE}`, producing the same package name string with one SSH call instead of two.