### PR TITLE
blktests: add BLKTESTS_INSTALL=from_git to run from a git repo

### DIFF
--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -45,6 +45,7 @@ sub run {
     my $md_kver = get_var('BLKTESTS_MD_KVER');
     my $issues = get_var('BLKTESTS_KNOWN_ISSUES');
     my $test_case_dev_array = get_var('BLKTESTS_TEST_CASE_DEV_ARRAY');
+    my $install = get_var('BLKTESTS_INSTALL', 'from_repo');
 
     record_info('KERNEL', script_output('rpm -qi kernel-default'));
     save_and_upload_log('(rpm -qi kernel-default; uname -a)', 'kernel_bug_report.txt');
@@ -52,7 +53,22 @@ sub run {
     #QA repo is added with lower prio in order to avoid possible problems
     #with some packages provided in both, tested product and qa repo; example: fio
     add_qa_head_repo(priority => 100);
-    install_package('blktests fio', trup_apply => 1);
+
+    my $test_dir;
+    if ($install eq 'from_git') {
+        my $repository = get_var('BLKTESTS_REPO', 'https://github.com/linux-blktests/blktests.git');
+        my $version = get_var('BLKTESTS_VERSION', '');
+        install_package('git-core fio nvme-cli', trup_apply => 1);
+        my $clone_cmd = "git clone --depth=1 $repository";
+        $clone_cmd .= " --branch $version" if $version;
+        assert_script_run($clone_cmd);
+        $test_dir = 'blktests';
+        record_info('test version', script_output('git -C blktests log -1 --oneline'));
+    }
+    else {
+        install_package('blktests fio', trup_apply => 1);
+        $test_dir = '/usr/lib/blktests';
+    }
 
     #Prepare configuration, log/results directories
     assert_script_run("mkdir -p /etc/blktests");
@@ -69,7 +85,7 @@ sub run {
     is_block_device(split(/\s+/, $devices)) if $devices ne 'none';
 
     my @tests = split(',', $tests);
-    assert_script_run('cd /usr/lib/blktests');
+    assert_script_run("cd $test_dir");
 
     # BLKTESTS_EXCLUDE provides the initial list; known-issue entries are appended below
     my @exclude = split(/,/, $exclude // '');
@@ -127,7 +143,8 @@ sub post_fail_hook {
 
 =head1 Description
 
-Run the upstream blktests suite from the C<blktests> package.
+Run the upstream blktests suite either from the C<blktests> package (default)
+or from a git checkout.
 
 The test groups to execute are selected with C<BLKTESTS>. Individual tests can
 be skipped either directly with C<BLKTESTS_EXCLUDE> (mostly for debugging purposes)
@@ -137,6 +154,22 @@ matches the upstream C<blktests> variable name, for example C<BLKTESTS_TRTYPES>
 for C<TRTYPES>.
 
 =head1 Configuration
+
+=head2 BLKTESTS_INSTALL
+
+Installation method. Defaults to C<from_repo> which installs the C<blktests>
+package from QA:Head. Set to C<from_git> to clone the upstream C<blktests>
+sources instead, for example to test a fix that is not yet packaged.
+
+=head2 BLKTESTS_REPO
+
+The blktests git repository URL. Used only with C<BLKTESTS_INSTALL=from_git>.
+Defaults to C<https://github.com/linux-blktests/blktests.git>.
+
+=head2 BLKTESTS_VERSION
+
+Branch or tag to check out. Used only with C<BLKTESTS_INSTALL=from_git>.
+Defaults to the default branch of the repository.
 
 =head2 BLKTESTS
 


### PR DESCRIPTION
Allows testing blktests fixes that aren't packaged yet by cloning a given repo/branch (BLKTESTS_REPO/BLKTESTS_VERSION) instead of installing the blktests RPM. This way upstream blktests changes can be tested or some investigations can be conducted easily

- Related ticket: https://progress.opensuse.org/issues/201948#note-2
- Verification run:
  - `BLKTESTS_INSTALL 	from_git`: https://openqa.suse.de/tests/23334116, both `BLKTESTS_REPO` and `BLKTESTS_VERSION` set
  - default `BLKTESTS_INSTALL`: https://openqa.suse.de/tests/23334170
