### PR TITLE
refactor(publiccloud): rename ignore_timeout_failure option

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -82,8 +82,8 @@ sub _prepare_ssh_cmd {
 }
 
 
-=head2 _apply_cmd_timeout
-    _apply_cmd_timeout($args, $ssh_cmd) - wraps $ssh_cmd within timeout call which will make sure graceful and unconditional interruption
+=head2  _wrap_timeout
+     _wrap_timeout($args, $ssh_cmd) - wraps $ssh_cmd within timeout call which will make sure graceful and unconditional interruption
       after defined period of time
 
     C<args> - reference to args hash. it is important to pass reference so function can modify timeout passed to script_run by the caller
@@ -93,14 +93,14 @@ sub _prepare_ssh_cmd {
 
 =cut
 
-sub _apply_cmd_timeout {
+sub _wrap_timeout {
 
     my ($self, $args, $ssh_cmd) = @_;
 
-    $args->{ignore_timeout_failure} //= 0;
+    $args->{apply_graceful_timeout} //= 0;
     $args->{timeout} //= SSH_TIMEOUT;
 
-    if ($args->{ignore_timeout_failure}) {
+    if ($args->{apply_graceful_timeout} && ($args->{timeout}) > 0) {
         my $external_timeout = $args->{timeout};
         # $args{timeout} will be passed into script_run so it needs to be bigger than value used by timeout command
         # otherwise script_run will die faster than timeout needs to kill running command. Giving 20 second buffer looks safe enough
@@ -110,28 +110,28 @@ sub _apply_cmd_timeout {
         # kernel has 10 seconds to proceed with killing the process
         $$ssh_cmd = "timeout --foreground -k 10s $external_timeout " . $$ssh_cmd;
     }
-    delete($args->{ignore_timeout_failure});
+    delete($args->{apply_graceful_timeout});
 }
 
 =head2 ssh_script_run
 
-    ssh_script_run($cmd [, timeout => $timeout] [,quiet => $quiet] [,ssh_opts => $ssh_opts] [,username => $username][, ignore_timeout_failure => $ignore_timeout_failure])
+    ssh_script_run($cmd [, timeout => $timeout] [,quiet => $quiet] [,ssh_opts => $ssh_opts] [,username => $username][, apply_graceful_timeout => $apply_graceful_timeout])
 
     C<timeout> - TTL for command execution measured in seconds . After that period of time execution will be aborded
     C<quiet> - avoid recording serial_results ( value pass to script_run call)
     C<ssh_opts> - additional ssh options passed to ssh
     C<username> - username used for ssh tunnel
-    C<ignore_timeout_failure> - in case waiting longer than timeout normally script_run will die. Setting this parameter to true
+    C<apply_graceful_timeout> - in case waiting longer than timeout normally script_run will die. Setting this parameter to true
         will avoid such failure
 
-Runs a command C<cmd> via ssh on the publiccloud instance and returns the return code.
+Runs a command C<cmd> via ssh on the publiccloud instance and returns the return code, using testapi::script_run.
 =cut
 
 sub ssh_script_run {
     my $self = shift;
     my %args = testapi::compat_args({cmd => undef}, ['cmd'], @_);
     my $ssh_cmd = $self->_prepare_ssh_cmd(%args);
-    $self->_apply_cmd_timeout(\%args, \$ssh_cmd);
+    $self->_wrap_timeout(\%args, \$ssh_cmd);
     delete($args{cmd});
     delete($args{ssh_opts});
     delete($args{username});
@@ -141,16 +141,19 @@ sub ssh_script_run {
 
 =head2 ssh_assert_script_run
 
-    ssh_assert_script_run($cmd [, timeout => $timeout] [, fail_message => $fail_message] [,quiet => $quiet] [,ssh_opts => $ssh_opts] [,username => $username])
+    ssh_assert_script_run($cmd [, timeout => $timeout] [, fail_message => $fail_message] [,quiet => $quiet] [,ssh_opts => $ssh_opts] [,username => $username][, apply_graceful_timeout => $apply_graceful_timeout])
 
-Runs a command C<cmd> via ssh on the publiccloud instance and die, unless it returns zero.
+Runs a command C<cmd> via ssh on the publiccloud instance and die on error.
+
+Use the parameters of ssh_script_run.
+
 =cut
 
 sub ssh_assert_script_run {
     my $self = shift;
     my %args = testapi::compat_args({cmd => undef}, ['cmd'], @_);
     my $ssh_cmd = $self->_prepare_ssh_cmd(%args);
-    $self->_apply_cmd_timeout(\%args, \$ssh_cmd);
+    $self->_wrap_timeout(\%args, \$ssh_cmd);
     delete($args{cmd});
     delete($args{ssh_opts});
     delete($args{username});
@@ -198,7 +201,7 @@ sub ssh_script_retry {
 
 =head2 scp
 
-    scp($from, $to [, timeout => 90] [, proceed_on_failure => 0]);
+    scp($from, $to [, timeout => 90] [, proceed_on_failure => 0][, apply_graceful_timeout => $apply_graceful_timeout]);
 
 Copy a file to or from this instance using C<scp>.
 
@@ -222,6 +225,8 @@ C<proceed_on_failure> - when set to a true value a failing scp does not abort
     the test: the command is run via C<script_run> and only an informational
     message is recorded. When false (the default) the copy is run via
     C<assert_script_run> so a failure dies. Defaults to C<0>.
+
+C<apply_graceful_timeout> - same parameter as ssh_script_run.
 
 Any C<-E <file>> logging options present in C<< $instance->ssh_opts >> are
 stripped, because C<scp> does not accept them.
@@ -250,7 +255,7 @@ sub scp {
 
     my $ssh_cmd = sprintf('scp %s "%s" "%s"', $ssh_opts, $from, $to);
 
-    $self->_apply_cmd_timeout(\%args, \$ssh_cmd);
+    $self->_wrap_timeout(\%args, \$ssh_cmd);
 
     if ($args{proceed_on_failure}) {
         record_info(
@@ -275,7 +280,7 @@ sub upload_log {
     my $tmpdir = script_output_retry('mktemp -d');
     my $dest = $tmpdir . '/' . basename($remote_file);
     $args{failok} //= 0;
-    $args{ignore_timeout_failure} = 1 if ($args{failok});
+    $args{apply_graceful_timeout} = 1 if ($args{failok});
     my $ret = $self->scp('remote:' . $remote_file, $dest, proceed_on_failure => 1, %args);
     upload_logs($dest, %args) if (defined($ret) && $ret == 0);
     script_run("test -d '$tmpdir' && rm -rf '$tmpdir'");
@@ -302,7 +307,7 @@ sub upload_check_logs_tar {
     return 1 unless (scalar(@logs) > 0);
     # Upload existing logs to openqa  UI
     $cmd = "sudo tar -czvf $remote_tar " . join(" ", @logs);
-    $res = $self->ssh_script_run(cmd => $cmd, ignore_timeout_failure => 1);
+    $res = $self->ssh_script_run(cmd => $cmd, apply_graceful_timeout => 1);
     $self->upload_log("$remote_tar", log_name => basename($remote_tar), failok => 1) if ($res == 0);
     return 1;
 }
@@ -328,7 +333,7 @@ sub wait_for_guestregister {
     my $name = $autotest::current_test->{name} . '-cloudregister.log.txt';
 
     # Check what version of registercloudguest binary we use
-    $self->ssh_script_run(cmd => "rpm -qa cloud-regionsrv-client", ignore_timeout_failure => 1);
+    $self->ssh_script_run(cmd => "rpm -qa cloud-regionsrv-client", apply_graceful_timeout => 1);
     record_info('CHECK guestregister', 'guestregister check');
     while (time() - $start_time < $args{timeout}) {
         my $out = $self->ssh_script_output(cmd => 'sudo systemctl is-active guestregister', proceed_on_failure => 1, quiet => 1);
@@ -437,7 +442,7 @@ sub _wait_for_ssh_login {
             ssh_opts => $ssh_opts,
             username => $args{username},
             timeout => $args{timeout} - $duration,
-            ignore_timeout_failure => 1
+            apply_graceful_timeout => 1
         );
 
         last if isok($exit_code);
@@ -638,15 +643,15 @@ sub network_speed_test() {
     my $rmt_host = "smt-" . lc(get_required_var('PUBLIC_CLOUD_PROVIDER')) . ".susecloud.net";
 
     $cmd = "grep \"$rmt_host\" /etc/hosts";
-    $ret = $self->ssh_script_run(cmd => $cmd, ignore_timeout_failure => 1);
+    $ret = $self->ssh_script_run(cmd => $cmd, apply_graceful_timeout => 1);
     record_info("RMT_HOST", printf('$ %s\n%s', $cmd, $ret));
 
     $cmd = "ping -c3 1.1.1.1";
-    $ret = $self->ssh_script_run(cmd => $cmd, ignore_timeout_failure => 1);
+    $ret = $self->ssh_script_run(cmd => $cmd, apply_graceful_timeout => 1);
     record_info("PING", printf('$ %s\n%s', $cmd, $ret));
 
     $cmd = "curl -w '$write_out' -o /dev/null -v https://$rmt_host/";
-    $ret = $self->ssh_script_run(cmd => $cmd, ignore_timeout_failure => 1);
+    $ret = $self->ssh_script_run(cmd => $cmd, apply_graceful_timeout => 1);
     record_info("CURL", printf('$ %s\n%s', $cmd, $ret));
 }
 
@@ -866,8 +871,8 @@ sub upload_supportconfig_log {
     $exclude = undef if ($exclude eq '-');
     $exclude = "-x " . $exclude if ($exclude);
     my $cmd = "echo | sudo supportconfig -R " . dirname($logs) . " -B supportconfig $exclude > $logs.txt 2>&1";
-    my $res = $self->ssh_script_run($cmd, timeout => $timeout, ignore_timeout_failure => 1);
-    $self->ssh_script_run(cmd => "sudo chmod 0644 $logs.txz", ignore_timeout_failure => 1);
+    my $res = $self->ssh_script_run($cmd, timeout => $timeout, apply_graceful_timeout => 1);
+    $self->ssh_script_run(cmd => "sudo chmod 0644 $logs.txz", apply_graceful_timeout => 1);
     $self->upload_log("$logs.txz", failok => 1, timeout => 180);
     if (isok($res)) {
         record_info('supportconfig done', "OK: duration " . (time() - $start) . "s. Log $logs.txz" . (($exclude) ? " - Excluded: $exclude" : ''));

--- a/lib/sles4sap/publiccloud.pm
+++ b/lib/sles4sap/publiccloud.pm
@@ -173,7 +173,7 @@ sub run_cmd_retry {
     my $ret = 0;
 
     for (1 .. $retry) {
-        $ret = eval { $self->run_cmd(timeout => $timeout, ignore_timeout_failure => 1, %args); };
+        $ret = eval { $self->run_cmd(timeout => $timeout, apply_graceful_timeout => 1, %args); };
         # If we want return code, then retry until the command succeeds,
         # if we want output, then retry until we can get the output.
         if ($args{rc_only}) {
@@ -439,7 +439,7 @@ sub wait_hana_node_up {
             my $failed_service = $instance->ssh_script_output(cmd => 'sudo systemctl --failed', timeout => 600, proceed_on_failure => 1);
             if ($out =~ /degraded/ && $failed_service =~ /guestregister/) {
                 record_soft_failure('bsc#1238152 - Restart guestregister service');
-                $instance->ssh_script_run(cmd => 'sudo systemctl restart guestregister.service', timeout => 600, ignore_timeout_failure => 1);
+                $instance->ssh_script_run(cmd => 'sudo systemctl restart guestregister.service', timeout => 600, apply_graceful_timeout => 1);
             }
         }
         record_info('WAIT_FOR_SYSTEM', "System state: $out");
@@ -1554,7 +1554,7 @@ sub wait_for_zypper {
     while ($retry < $args{max_retries}) {
         my $ret = $args{instance}->ssh_script_run(cmd => 'sudo zypper ref',
             username => $args{runas},
-            ignore_timeout_failure => 1,
+            apply_graceful_timeout => 1,
             quiet => 1,
             timeout => $args{timeout});
         if ($ret == 7) {
@@ -1591,7 +1591,7 @@ sub check_zypper_ref {
 
     my $ret = $self->{my_instance}->ssh_script_run(cmd => 'sudo zypper ref',
         username => $args{runas},
-        ignore_timeout_failure => 1,
+        apply_graceful_timeout => 1,
         quiet => 1,
         timeout => $args{timeout});
     if ($ret == 4) {

--- a/t/44_publiccloud_instance.t
+++ b/t/44_publiccloud_instance.t
@@ -112,20 +112,20 @@ subtest '[_prepare_ssh_cmd] dies without cmd' => sub {
     throws_ok { $inst->_prepare_ssh_cmd() } qr/No command defined/, 'missing cmd dies';
 };
 
-subtest '[_apply_cmd_timeout] wraps with timeout when ignore_timeout_failure' => sub {
+subtest '[_wrap_timeout] wraps with timeout when apply_graceful_timeout' => sub {
     my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
 
-    my %args = (timeout => 100, ignore_timeout_failure => 1);
+    my %args = (timeout => 100, apply_graceful_timeout => 1);
     my $ssh_cmd = 'ssh foo';
-    $inst->_apply_cmd_timeout(\%args, \$ssh_cmd);
+    $inst->_wrap_timeout(\%args, \$ssh_cmd);
     like($ssh_cmd, qr/^timeout --foreground -k 10s 100 ssh foo$/, 'wrapped in timeout call');
     is($args{timeout}, 120, 'script_run timeout bumped by 20s buffer');
-    ok(!exists $args{ignore_timeout_failure}, 'ignore_timeout_failure consumed');
+    ok(!exists $args{apply_graceful_timeout}, 'apply_graceful_timeout consumed');
 
     # Without the flag: no wrapping
     my %args2 = (timeout => 50);
     my $ssh_cmd2 = 'ssh bar';
-    $inst->_apply_cmd_timeout(\%args2, \$ssh_cmd2);
+    $inst->_wrap_timeout(\%args2, \$ssh_cmd2);
     is($ssh_cmd2, 'ssh bar', 'command untouched when flag not set');
     is($args2{timeout}, 50, 'timeout unchanged when flag not set');
 };

--- a/tests/publiccloud/destroy.pm
+++ b/tests/publiccloud/destroy.pm
@@ -43,7 +43,7 @@ sub upload_final_logs {
 
     my @instance_logs = ('/var/log/cloudregister', '/etc/hosts', '/var/log/zypper.log', '/etc/zypp/credentials.d/SCCcredentials');
     for my $instance_log (@instance_logs) {
-        $instance->ssh_script_run("sudo chmod a+r " . $instance_log, quiet => 1, ignore_timeout_failure => 1);
+        $instance->ssh_script_run("sudo chmod a+r " . $instance_log, quiet => 1, apply_graceful_timeout => 1);
         $instance->upload_log($instance_log, failok => 1, log_name => $instance_log . ".txt");
     }
     $instance->upload_supportconfig_log();

--- a/tests/sles4sap/crash/test_crash.pm
+++ b/tests/sles4sap/crash/test_crash.pm
@@ -79,7 +79,7 @@ sub run {
     $instance->ssh_script_run(
         cmd => 'sudo su -c "echo b > /proc/sysrq-trigger &"',
         timeout => 10,
-        ignore_timeout_failure => 1,
+        apply_graceful_timeout => 1,
         ssh_opts => '-E /var/tmp/ssh_sut.log -fn -o ServerAliveInterval=2',
         username => $username);
 


### PR DESCRIPTION
- rename  `ignore_timeout_failure` in `_apply_cmd_timeout()` to better represent the action performed when it is enabled;

- rename also `_apply_cmd_timeout` to a more meaningful name;

- ticket ref: https://progress.opensuse.org/issues/200744;

- Verification run: see next posts.
