### PR TITLE
Add unit tests for public cloud provider terraform_apply

### DIFF
--- a/t/45_publiccloud_provider.t
+++ b/t/45_publiccloud_provider.t
@@ -19,6 +19,7 @@ use testapi 'set_var';
 use List::Util qw(any);
 
 use publiccloud::azure_client;
+use publiccloud::gcp_client;
 use publiccloud::provider;
 
 sub _unset { for my $k (@_) { set_var($k, undef) } }
@@ -93,7 +94,8 @@ subtest '[terraform_apply] minimal happy path' => sub {
     set_var('FLAVOR', 'Talaxian');
     set_var('OPENQA_URL', 'Xindi');
     my $mock = Test::MockModule->new('publiccloud::provider', no_auto => 1);
-    $mock->redefine($_ => sub { '' }) for qw(get_image_uri get_image_id data_url);
+    $mock->redefine(get_image_id => sub { '' });
+    $mock->noop("$_") for qw(get_image_uri data_url);
     $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $mock->redefine(get_current_job_id => sub { return 42; });
     my @calls;
@@ -105,6 +107,7 @@ subtest '[terraform_apply] minimal happy path' => sub {
     Test::MockModule->new('publiccloud::instances', no_auto => 1)->redefine(set_instances => sub { });
 
     my $provider = publiccloud::provider->new(provider_client => publiccloud::azure_client->new());
+
     my @instances = $provider->terraform_apply();
 
     is scalar(@instances), 0, 'terraform_apply returns the list of created instances';
@@ -123,13 +126,17 @@ subtest '[terraform_apply] vars' => sub {
     set_var('FLAVOR', 'Talaxian');
     set_var('OPENQA_URL', 'Xindi');
     my $mock = Test::MockModule->new('publiccloud::provider', no_auto => 1);
-    $mock->redefine($_ => sub { '' }) for qw(get_image_uri get_image_id data_url);
+    $mock->redefine(get_image_id => sub { '' });
+    $mock->noop("$_") for qw(get_image_uri data_url);
     $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $mock->redefine(get_current_job_id => sub { return 42; });
     my @calls;
     $mock->redefine($_ => sub { push @calls, $_[0]; return 0; }) for qw(assert_script_run script_run script_retry);
     $mock->redefine(script_output => sub {
+            push @calls, $_[0];
             return '{"vm_name":{"value":[]},"public_ip":{"value":[]}}' if ($_[0] =~ /output -json/);
+            return 'Vulcan' if ($_[0] =~ /az network/);
+            return 'Aenar' if ($_[0] =~ /cat tf_apply_output/);
             return '';
     });
     Test::MockModule->new('publiccloud::instances', no_auto => 1)->redefine(set_instances => sub { });
@@ -139,8 +146,10 @@ subtest '[terraform_apply] vars' => sub {
     $test_vars{Borg00} = 'ResistanceIsFutile';
     $test_vars{Borg01} = q{Resistance'IsFutile};
     $test_vars{Borg10} = q{Resistance'Is'Futile};
-    my @instances = $provider->terraform_apply(vars => \%test_vars);
 
+    $provider->terraform_apply(vars => \%test_vars);
+
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
     # Extract the single recorded call that runs 'tofu ... plan ...'
     my ($plan_cmd) = grep { /tofu.*plan/ } @calls;
     ok($plan_cmd, "tofu plan is executed");
@@ -164,7 +173,147 @@ subtest '[terraform_apply] vars' => sub {
     is($borg{Borg01}, q{Resistance'"'"'IsFutile}, 'single quote escaped');
     is($borg{Borg10}, q{Resistance'"'"'Is'"'"'Futile}, 'multiple single quotes escaped');
 
-    note("\n  C-->  " . join("\n  C-->  ", @calls));
+    _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_REGION PUBLIC_CLOUD_INSTANCE_TYPE FLAVOR OPENQA_URL/);
+};
+
+subtest '[terraform_apply] query csp about network' => sub {
+    set_var('PUBLIC_CLOUD', 1);
+    set_var('PUBLIC_CLOUD_REGION', 'Ferengi');
+    set_var('PUBLIC_CLOUD_INSTANCE_TYPE', 'Romulan');
+    set_var('FLAVOR', 'Talaxian');
+    set_var('OPENQA_URL', 'Xindi');
+    my $mock = Test::MockModule->new('publiccloud::provider', no_auto => 1);
+    $mock->noop("$_") for qw(get_image_uri data_url);
+    $mock->redefine(get_image_id => sub { '' });
+    $mock->redefine(get_current_job_id => sub { return 42; });
+    $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    my @calls;
+    $mock->redefine($_ => sub { push @calls, $_[0]; return 0; }) for qw(assert_script_run script_run script_retry);
+    my @csp_cli;
+    $mock->redefine(script_output => sub {
+            push @calls, $_[0];
+            return '{"vm_name":{"value":[]},"public_ip":{"value":[]}}' if ($_[0] =~ /output -json/);
+            # Collect any provider CLI call (az, aws, gcloud) issued to query the network.
+            if ($_[0] =~ /^(?:az|aws|gcloud)\s/) {
+                push @csp_cli, $_[0];
+                return 'Vulcan';
+            }
+            return '';
+    });
+    Test::MockModule->new('publiccloud::instances', no_auto => 1)->redefine(set_instances => sub { });
+
+    my $provider = publiccloud::provider->new(provider_client => publiccloud::azure_client->new());
+
+    my %csp_cli_cmd = (
+        AZURE => 'az network vnet',
+        EC2 => 'aws ec2 describe-instance-type-offerings',
+        GCE => undef,
+    );
+
+    for my $csp (sort keys %csp_cli_cmd) {
+        set_var('PUBLIC_CLOUD_PROVIDER', $csp);
+        @csp_cli = ();
+        $provider->terraform_apply(vars => {});
+        note("\n  CSP_CLI ($csp) -->  " . join("\n  CSP_CLI ($csp) -->  ", @csp_cli));
+
+        my $expected = $csp_cli_cmd{$csp};
+        if (defined $expected) {
+            ok(scalar(@csp_cli), "$csp queries the CSP about the network");
+            # Match only the first 3 words of the command, e.g. 'az network vnet'.
+            my $first3 = join(' ', (split ' ', ($csp_cli[0] // ''))[0 .. 2]);
+            is($first3, $expected, "$csp uses the '$expected' command");
+        } else {
+            is(scalar(@csp_cli), 0, "$csp does not query the CSP about the network");
+        }
+    }
+    _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_REGION PUBLIC_CLOUD_INSTANCE_TYPE FLAVOR OPENQA_URL/);
+};
+
+subtest '[terraform_apply] returns instance objects' => sub {
+    set_var('PUBLIC_CLOUD', 1);
+    set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    set_var('PUBLIC_CLOUD_REGION', 'Ferengi');
+    set_var('PUBLIC_CLOUD_INSTANCE_TYPE', 'Romulan');
+    set_var('FLAVOR', 'Talaxian');
+    set_var('OPENQA_URL', 'Xindi');
+    my $mock = Test::MockModule->new('publiccloud::provider', no_auto => 1);
+    $mock->redefine(get_image_id => sub { '' });
+    $mock->noop("$_") for qw(get_image_uri data_url);
+    $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $mock->redefine(get_current_job_id => sub { return 42; });
+    $mock->redefine($_ => sub { return 0; }) for qw(assert_script_run script_run script_retry);
+    # 'tofu output -json' reports two VMs with their public IPs, so terraform_apply
+    # must build one publiccloud::instance object per VM.
+    $mock->redefine(script_output => sub {
+            return '{"vm_name":{"value":["vm-0","vm-1"]},"public_ip":{"value":["10.0.0.1","10.0.0.2"]}}' if ($_[0] =~ /output -json/);
+            return '';
+    });
+    Test::MockModule->new('publiccloud::instances', no_auto => 1)->redefine(set_instances => sub { });
+
+    my $provider = publiccloud::provider->new(provider_client => publiccloud::azure_client->new());
+
+    my @instances = $provider->terraform_apply();
+
+    is(scalar(@instances), 2, 'terraform_apply returns one instance per VM');
+    isa_ok($instances[0], 'publiccloud::instance', 'returned element');
+    is($instances[0]->instance_id, 'vm-0', 'first instance_id taken from vm_name output');
+    is($instances[0]->public_ip, '10.0.0.1', 'first public_ip taken from public_ip output');
+    is($instances[1]->instance_id, 'vm-1', 'second instance_id taken from vm_name output');
+    is($instances[1]->public_ip, '10.0.0.2', 'second public_ip taken from public_ip output');
+
+    _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_REGION PUBLIC_CLOUD_INSTANCE_TYPE FLAVOR OPENQA_URL/);
+};
+
+subtest '[terraform_apply] gcloud alternative_zones' => sub {
+    set_var('PUBLIC_CLOUD', 1);
+    set_var('PUBLIC_CLOUD_PROVIDER', 'GCE');
+    set_var('PUBLIC_CLOUD_REGION', 'Ferengi');
+    set_var('PUBLIC_CLOUD_INSTANCE_TYPE', 'Romulan');
+    set_var('FLAVOR', 'Talaxian');
+    set_var('OPENQA_URL', 'Xindi');
+    my $mock = Test::MockModule->new('publiccloud::provider', no_auto => 1);
+    $mock->redefine(get_image_id => sub { '' });
+    $mock->noop("$_") for qw(get_image_uri data_url);
+    $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $mock->redefine(get_current_job_id => sub { return 42; });
+    my @calls;
+    $mock->redefine($_ => sub { push @calls, $_[0]; return 0; }) for qw(assert_script_run script_retry);
+
+    # 'tofu apply' returns a different exit value on each call,
+    # simulating a deployment that fails in the initial zone and in the first alternative zone,
+    # then succeeds in the second one.
+    my @apply_exit = (42, 42, 0);
+    my $apply_idx = 0;
+    $mock->redefine(script_run => sub {
+            my ($cmd) = @_;
+            push @calls, $cmd;
+            return $apply_exit[$apply_idx++] // 0 if ($cmd =~ /apply.*myplan/);
+            return 0;
+    });
+
+    $mock->redefine(script_output => sub {
+            push @calls, $_[0];
+            return '{"vm_name":{"value":[]},"public_ip":{"value":[]}}' if ($_[0] =~ /output -json/);
+            # GCE zone-exhaustion message that triggers the alternative-zones retry.
+            return "The zone 'projects/p/zones/a' does not have enough resources available to fulfill the request" if ($_[0] =~ /cat tf_apply_output/);
+            # The available zones in the region (last part of the zone name).
+            return 'a,b,c,' if ($_[0] =~ /gcloud compute zones list/);
+            return '';
+    });
+    Test::MockModule->new('publiccloud::instances', no_auto => 1)->redefine(set_instances => sub { });
+
+    my $provider = publiccloud::provider->new(provider_client => publiccloud::gcp_client->new());
+
+    # Seed availability_zone so the initial (failing) zone 'a' is excluded from
+    # the alternative zones the retry loop iterates over.
+    $provider->terraform_apply(vars => {availability_zone => 'a'});
+
+    is($apply_idx, 3, 'apply attempted in initial zone plus two alternative zones');
+    ok((any { /gcloud compute zones list/ } @calls), 'queried gcloud for alternative zones');
+    is($provider->provider_client->availability_zone, 'c', 'availability_zone set to the zone where apply succeeded');
+    ok((any { /-var 'availability_zone=b'/ } @calls), 'retried plan in alternative zone b');
+    ok((any { /-var 'availability_zone=c'/ } @calls), 'retried plan in alternative zone c');
+
     _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_REGION PUBLIC_CLOUD_INSTANCE_TYPE FLAVOR OPENQA_URL/);
 };
 


### PR DESCRIPTION
Add unit tests to verify the behavior of the terraform_apply method under different Cloud Service Providers (CSPs).
Cover the cli commands used to get the network names. Add test to check the GCE alternative zone mechanism. Add test to check the instances return value.

Related ticket: https://progress.opensuse.org/issues/202446