### PR TITLE
NFS: Determine protocol versions by product, not kernel configs

### DIFF
--- a/lib/Kernel/nfs.pm
+++ b/lib/Kernel/nfs.pm
@@ -3,14 +3,17 @@
 
 package Kernel::nfs;
 
-use Exporter;
+use Exporter 'import';
 
 use strict;
 use warnings;
 use testapi;
+use version_utils qw(is_sle);
 
 our @EXPORT = qw(
   create_export
+  get_nfs_versions
+  nfs_mount_config
 );
 
 =head1 SYNOPSIS
@@ -38,7 +41,72 @@ sub create_export {
     assert_script_run "echo $path $cl\\($options\\) >> /etc/exports";
 }
 
+=head2 get_nfs_versions
 
+  get_nfs_versions();
 
+Returns the list of NFS versions (e.g. C<3>, C<4.0>, C<4.1>, C<4.2>) that
+should be tested on the current SUT.
+
+Can be overridden with the C<NFS_VERSIONS> openQA variable (comma-separated
+list, takes precedence over everything else), or narrowed down with
+C<NFS_VERSIONS_SKIP> (comma-separated list of versions to leave out).
+
+=cut
+
+sub get_nfs_versions {
+    return split(/,/, get_var('NFS_VERSIONS')) if get_var('NFS_VERSIONS');
+
+    # NFS versions supported by every currently tested product
+    my @versions = ('3', '4.0', '4.1');
+
+    # nfsd on SLE12-SP5 has no support for NFS 4.2
+    push @versions, '4.2' unless is_sle('<=12-SP5');
+
+    my @skip_versions = split(/,/, get_var('NFS_VERSIONS_SKIP', ''));
+
+    my @result;
+    for my $version (@versions) {
+        next if grep { $_ eq $version } @skip_versions;
+        push @result, $version;
+    }
+
+    return @result;
+}
+
+=head2 nfs_mount_config
+
+  nfs_mount_config();
+
+Returns a hashref with the paths used to export/mount a given NFS version:
+C<remote>, C<remote_async>, C<local>, C<local_async>. Every path can be
+overridden with the corresponding C<NFS_MOUNT_NFS*> / C<NFS_LOCAL_NFS*>
+openQA variable, e.g. C<NFS_MOUNT_NFS4_2> or C<NFS_LOCAL_NFS4_2_ASYNC>.
+
+Also returns C<vers_opt>, the C<mount> option string selecting this NFS
+version, e.g. C<nfsvers=3> or C<nfsvers=4,minorversion=2>. The
+C<minorversion> option is used instead of the C<nfsvers=4.N> shorthand
+since the latter is parsed inconsistently across C<nfs-utils> versions.
+
+=cut
+
+sub nfs_mount_config {
+    my ($version) = @_;
+
+    my $slug = $version;
+    $slug =~ s/\./_/g;
+
+    my ($major, $minor) = split(/\./, $version);
+    my $vers_opt = "nfsvers=$major";
+    $vers_opt .= ",minorversion=$minor" if defined $minor;
+
+    return {
+        vers_opt => $vers_opt,
+        remote => get_var("NFS_MOUNT_NFS$slug", "/var/lib/nfs-tests/shared_nfs$slug"),
+        remote_async => get_var("NFS_MOUNT_NFS${slug}_ASYNC", "/var/lib/nfs-tests/shared_nfs${slug}_async"),
+        local => get_var("NFS_LOCAL_NFS$slug", "/var/lib/nfs-tests/localNFS$slug"),
+        local_async => get_var("NFS_LOCAL_NFS${slug}_ASYNC", "/var/lib/nfs-tests/localNFS${slug}async"),
+    };
+}
 
 1;

--- a/lib/Kernel/nfs.pm
+++ b/lib/Kernel/nfs.pm
@@ -8,7 +8,7 @@ use Exporter 'import';
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_sle);
+use version_utils qw(is_sle is_tumbleweed);
 
 our @EXPORT = qw(
   create_export
@@ -46,7 +46,8 @@ sub create_export {
   get_nfs_versions();
 
 Returns the list of NFS versions (e.g. C<3>, C<4.0>, C<4.1>, C<4.2>) that
-should be tested on the current SUT.
+should be tested on the current SUT. NFS 4.0 is left out on Tumbleweed,
+whose kernel dropped C<CONFIG_NFS_V4_0> support.
 
 Can be overridden with the C<NFS_VERSIONS> openQA variable (comma-separated
 list, takes precedence over everything else), or narrowed down with
@@ -65,10 +66,16 @@ sub get_nfs_versions {
 
     my @skip_versions = split(/,/, get_var('NFS_VERSIONS_SKIP', ''));
 
+    # Tumbleweed's kernel dropped CONFIG_NFS_V4_0, keeping only 4.1/4.2
+    push @skip_versions, '4.0' if is_tumbleweed;
+
     my @result;
     for my $version (@versions) {
-        next if grep { $_ eq $version } @skip_versions;
-        push @result, $version;
+        my $skip = 0;
+        for my $skip_version (@skip_versions) {
+            $skip = 1 if $skip_version eq $version;
+        }
+        push @result, $version unless $skip;
     }
 
     return @result;

--- a/tests/kernel/nfs_client.pm
+++ b/tests/kernel/nfs_client.pm
@@ -54,9 +54,9 @@ sub run {
         for my $mount ($cfg->{local}, $cfg->{local_async}) {
             assert_script_run("cp testfile md5sum.txt $mount");
 
-            copy_file('direct', $mount, 'testfile_oflag_direct');
-            copy_file('dsync', $mount, 'testfile_oflag_dsync');
-            copy_file('sync', $mount, 'testfile_oflag_sync');
+            for my $flag (qw(direct dsync sync)) {
+                copy_file($flag, $mount, "testfile_oflag_$flag");
+            }
         }
     }
 

--- a/tests/kernel/nfs_client.pm
+++ b/tests/kernel/nfs_client.pm
@@ -3,7 +3,7 @@
 # Copyright 2023-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: Provision NFS client, mount NFSv3/NFSv4 shares and write test data.
+# Summary: Provision NFS client, mount NFS shares and write test data.
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
 use Mojo::Base 'opensusebasetest';
@@ -12,6 +12,7 @@ use serial_terminal "select_serial_terminal";
 use lockapi;
 use utils;
 use package_utils 'install_package';
+use Kernel::nfs;
 
 sub copy_file {
     my ($flag, $nfs_mount, $file) = @_;
@@ -25,50 +26,19 @@ sub run {
 
     install_package('nfs-client', trup_apply => 1);
 
-    my $nfs_mount_nfs3 = get_var('NFS_MOUNT_NFS3', '/var/lib/nfs-tests/shared_nfs3');
-    my $nfs_mount_nfs3_async = get_var('NFS_MOUNT_NFS3_ASYNC', '/var/lib/nfs-tests/shared_nfs3_async');
-    my $nfs_mount_nfs4 = get_var('NFS_MOUNT_NFS4', '/var/lib/nfs-tests/shared_nfs4');
-    my $nfs_mount_nfs4_async = get_var('NFS_MOUNT_NFS4_ASYNC', '/var/lib/nfs-tests/shared_nfs4_async');
-    my $local_nfs3 = get_var('NFS_LOCAL_NFS3', '/var/lib/nfs-tests/localNFS3');
-    my $local_nfs3_async = get_var('NFS_LOCAL_NFS3_ASYNC', '/var/lib/nfs-tests/localNFS3async');
-    my $local_nfs4 = get_var('NFS_LOCAL_NFS4', '/var/lib/nfs-tests/localNFS4');
-    my $local_nfs4_async = get_var('NFS_LOCAL_NFS4_ASYNC', '/var/lib/nfs-tests/localNFS4async');
+    my @nfs_versions = get_nfs_versions();
     my $multipath = get_var('NFS_MULTIPATH', '0');
-
-    # check kernel config options and set the variables
-    my $kernel_nfs3 = 0;
-    my $kernel_nfs4 = 0;
-    my $kernel_nfs4_1 = 0;
-    my $kernel_nfs4_2 = 0;
-    my $kernel_nfsd_v3 = 0;
-    my $kernel_nfsd_v4 = 0;
-
-    $kernel_nfs3 = 1 unless script_run('zgrep "CONFIG_NFS_V3=[my]" /proc/config.gz');
-    $kernel_nfs4 = 1 unless script_run('zgrep "CONFIG_NFS_V4=[my]" /proc/config.gz');
-    $kernel_nfs4_1 = 1 unless script_run('zgrep "CONFIG_NFS_V4_1=[my]" /proc/config.gz');
-    $kernel_nfs4_2 = 1 unless script_run('zgrep "CONFIG_NFS_V4_2=[my]" /proc/config.gz');
-    $kernel_nfsd_v3 = 1 unless script_run('zgrep "CONFIG_NFSD=[my]" /proc/config.gz');
-    $kernel_nfsd_v4 = 1 unless script_run('zgrep "CONFIG_NFSD_V4=[my]" /proc/config.gz');
 
     barrier_wait("NFS_SERVER_ENABLED");
     record_info("showmount", script_output("showmount -e $server_node"));
 
-    if ($kernel_nfs3 == 1) {
-        record_info('INFO', 'Kernel has support for NFSv3');
-        assert_script_run("mkdir -p $local_nfs3 $local_nfs3_async");
-        assert_script_run("mount -t nfs -o nfsvers=3,sync $server_node:$nfs_mount_nfs3 $local_nfs3");
-        assert_script_run("mount -t nfs -o nfsvers=3 $server_node:$nfs_mount_nfs3_async $local_nfs3_async");
-    } else {
-        record_info('INFO', 'Kernel has no support for NFSv3, skipping NFSv3 tests');
-    }
+    for my $version (@nfs_versions) {
+        my $cfg = nfs_mount_config($version);
 
-    if ($kernel_nfs4 == 1) {
-        record_info('INFO', 'Kernel has support for NFSv4');
-        assert_script_run("mkdir -p $local_nfs4 $local_nfs4_async");
-        assert_script_run("mount -t nfs -o nfsvers=4,sync $server_node:$nfs_mount_nfs4 $local_nfs4");
-        assert_script_run("mount -t nfs -o nfsvers=4 $server_node:$nfs_mount_nfs4_async $local_nfs4_async");
-    } else {
-        record_info('INFO', 'Kernel has no support for NFSv4, skipping NFSv4tests');
+        record_info('INFO', "Mounting NFSv$version exports");
+        assert_script_run("mkdir -p $cfg->{local} $cfg->{local_async}");
+        assert_script_run("mount -t nfs -o $cfg->{vers_opt},sync $server_node:$cfg->{remote} $cfg->{local}");
+        assert_script_run("mount -t nfs -o $cfg->{vers_opt} $server_node:$cfg->{remote_async} $cfg->{local_async}");
     }
 
     barrier_wait("NFS_CLIENT_ENABLED");
@@ -78,29 +48,16 @@ sub run {
     assert_script_run("dd if=/dev/zero of=testfile bs=1024 count=10240");
     assert_script_run("md5sum testfile > md5sum.txt");
 
-    if ($kernel_nfs3 == 1) {
-        assert_script_run("cp testfile md5sum.txt $local_nfs3");
-        assert_script_run("cp testfile md5sum.txt $local_nfs3_async");
+    for my $version (@nfs_versions) {
+        my $cfg = nfs_mount_config($version);
 
-        copy_file('direct', $local_nfs3, 'testfile_oflag_direct');
-        copy_file('dsync', $local_nfs3, 'testfile_oflag_dsync');
-        copy_file('sync', $local_nfs3, 'testfile_oflag_sync');
+        for my $mount ($cfg->{local}, $cfg->{local_async}) {
+            assert_script_run("cp testfile md5sum.txt $mount");
 
-        copy_file('direct', $local_nfs3_async, 'testfile_oflag_direct');
-        copy_file('dsync', $local_nfs3_async, 'testfile_oflag_dsync');
-        copy_file('sync', $local_nfs3_async, 'testfile_oflag_sync');
-    }
-    if ($kernel_nfs4 == 1) {
-        assert_script_run("cp testfile md5sum.txt $local_nfs4");
-        assert_script_run("cp testfile md5sum.txt $local_nfs4_async");
-
-        copy_file('direct', $local_nfs4, 'testfile_oflag_direct');
-        copy_file('dsync', $local_nfs4, 'testfile_oflag_dsync');
-        copy_file('sync', $local_nfs4, 'testfile_oflag_sync');
-
-        copy_file('direct', $local_nfs4_async, 'testfile_oflag_direct');
-        copy_file('dsync', $local_nfs4_async, 'testfile_oflag_dsync');
-        copy_file('sync', $local_nfs4_async, 'testfile_oflag_sync');
+            copy_file('direct', $mount, 'testfile_oflag_direct');
+            copy_file('dsync', $mount, 'testfile_oflag_dsync');
+            copy_file('sync', $mount, 'testfile_oflag_sync');
+        }
     }
 
     barrier_wait("NFS_SERVER_CHECK");
@@ -124,10 +81,11 @@ Provisions the NFS client node of the coordinated multi-machine NFS test.
 This module is designed to execute in lockstep with L<tests/kernel/nfs_server.pm>,
 synchronised at runtime via shared barriers.
 
-Installs C<nfs-client>, mounts the exports provided by the server (NFSv3 and
-NFSv4, sync and async variants, subject to kernel support), creates a 10 MiB
-test file with C<dd>, computes its md5 checksum, then copies it to every mount
-using C<cp> and C<dd> with C<direct>, C<dsync>, and C<sync> flags.
+Installs C<nfs-client>, mounts the exports provided by the server (sync and
+async variants for every NFS version returned by
+L<Kernel::nfs/get_nfs_versions>), creates a 10 MiB test file with C<dd>,
+computes its md5 checksum, then copies it to every mount using C<cp> and
+C<dd> with C<direct>, C<dsync>, and C<sync> flags.
 
 =head1 Configuration
 
@@ -136,45 +94,36 @@ using C<cp> and C<dd> with C<direct>, C<dsync>, and C<sync> flags.
 Hostname or IP of the NFS server.
 Defaults to C<server-node00>.
 
-=head2 NFS_MOUNT_NFS3
+=head2 NFS_VERSIONS
 
-Server-side export path for the NFSv3 synchronous mount.
-Defaults to C</var/lib/nfs-tests/shared_nfs3>.
+Comma-separated list of NFS versions to test, e.g. C<3,4.2>. Overrides the
+default version support matrix. See L<Kernel::nfs/get_nfs_versions>.
 
-=head2 NFS_MOUNT_NFS3_ASYNC
+=head2 NFS_VERSIONS_SKIP
 
-Server-side export path for the NFSv3 asynchronous mount.
-Defaults to C</var/lib/nfs-tests/shared_nfs3_async>.
+Comma-separated list of NFS versions to leave out of the default support
+matrix, e.g. C<4.2>. Ignored if C<NFS_VERSIONS> is set.
 
-=head2 NFS_MOUNT_NFS4
+=head2 NFS_MOUNT_NFS<VERSION>
 
-Server-side export path for the NFSv4 synchronous mount.
-Defaults to C</var/lib/nfs-tests/shared_nfs4>.
+Server-side export path for a given NFS version, e.g. C<NFS_MOUNT_NFS3> or
+C<NFS_MOUNT_NFS4_2>.
+Defaults to C</var/lib/nfs-tests/shared_nfs<version>>.
 
-=head2 NFS_MOUNT_NFS4_ASYNC
+=head2 NFS_MOUNT_NFS<VERSION>_ASYNC
 
-Server-side export path for the NFSv4 asynchronous mount.
-Defaults to C</var/lib/nfs-tests/shared_nfs4_async>.
+Server-side export path for the asynchronous mount of a given NFS version.
+Defaults to C</var/lib/nfs-tests/shared_nfs<version>_async>.
 
-=head2 NFS_LOCAL_NFS3
+=head2 NFS_LOCAL_NFS<VERSION>
 
-Local mountpoint for the NFSv3 synchronous export.
-Defaults to C</var/lib/nfs-tests/localNFS3>.
+Local mountpoint for a given NFS version.
+Defaults to C</var/lib/nfs-tests/localNFS<version>>.
 
-=head2 NFS_LOCAL_NFS3_ASYNC
+=head2 NFS_LOCAL_NFS<VERSION>_ASYNC
 
-Local mountpoint for the NFSv3 asynchronous export.
-Defaults to C</var/lib/nfs-tests/localNFS3async>.
-
-=head2 NFS_LOCAL_NFS4
-
-Local mountpoint for the NFSv4 synchronous export.
-Defaults to C</var/lib/nfs-tests/localNFS4>.
-
-=head2 NFS_LOCAL_NFS4_ASYNC
-
-Local mountpoint for the NFSv4 asynchronous export.
-Defaults to C</var/lib/nfs-tests/localNFS4async>.
+Local mountpoint for the asynchronous mount of a given NFS version.
+Defaults to C</var/lib/nfs-tests/localNFS<version>async>.
 
 =head2 NFS_MULTIPATH
 

--- a/tests/kernel/nfs_server.pm
+++ b/tests/kernel/nfs_server.pm
@@ -41,11 +41,6 @@ sub run {
     my $nfs_options = get_var('NFS_OPTIONS', 'rw,sync,no_root_squash');
     my $nfs_options_async = get_var('NFS_OPTIONS_ASYNC', 'rw,async,no_root_squash');
 
-    # following files are copied on the client side using dd with specific flags: direct, dsync, sync
-    my $file_flag_direct = 'testfile_oflag_direct';
-    my $file_flag_dsync = 'testfile_oflag_dsync';
-    my $file_flag_sync = 'testfile_oflag_sync';
-
     # provision NFS server(s) of various types
     install_package('nfs-kernel-server', trup_apply => 1);
 
@@ -69,7 +64,6 @@ sub run {
     record_info("RPC", script_output("rpcinfo"));
     record_info("NFS config", script_output("cat /etc/sysconfig/nfs"));
 
-    #my $nfsstat = script_output("nfsstat -s");
     record_info("NFS stat for server", script_output("nfsstat -s"));
 
     barrier_wait("NFS_SERVER_ENABLED");
@@ -89,10 +83,10 @@ sub run {
             record_info("NFSv$version checksum", script_output("md5sum -c md5sum.txt"));
             record_info("NFSv$version checksum", script_output("cat md5sum.txt"));
 
-            #check files copied with various flags: direct, dsync, sync
-            compare_checksums($file_flag_direct);
-            compare_checksums($file_flag_dsync);
-            compare_checksums($file_flag_sync);
+            # check files copied with various flags: direct, dsync, sync
+            for my $flag (qw(direct dsync sync)) {
+                compare_checksums("testfile_oflag_$flag");
+            }
         }
     }
 

--- a/tests/kernel/nfs_server.pm
+++ b/tests/kernel/nfs_server.pm
@@ -3,7 +3,7 @@
 # Copyright 2023-2025 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: Provision NFS server, export NFSv3/NFSv4 shares and verify data integrity.
+# Summary: Provision NFS server, export NFS shares and verify data integrity.
 # Maintainer: Kernel QE <kernel-qa@suse.de>
 
 use Mojo::Base 'opensusebasetest';
@@ -31,32 +31,15 @@ sub compare_checksums {
 
 sub run {
     my $self = @_;
-    my $kernel_nfs3 = 0;
-    my $kernel_nfs4 = 0;
-    my $kernel_nfs4_1 = 0;
-    my $kernel_nfs4_2 = 0;
-    my $kernel_nfsd_v3 = 0;
-    my $kernel_nfsd_v4 = 0;
     my $client = get_var('CLIENT_NODE', 'client-node00');
 
     select_serial_terminal();
     record_info("hostname", script_output("hostname"));
 
-    my $nfs_mount_nfs3 = get_var('NFS_MOUNT_NFS3', '/var/lib/nfs-tests/shared_nfs3');
-    my $nfs_mount_nfs3_async = get_var('NFS_MOUNT_NFS3_ASYNC', '/var/lib/nfs-tests/shared_nfs3_async');
-    my $nfs_mount_nfs4 = get_var('NFS_MOUNT_NFS4', '/var/lib/nfs-tests/shared_nfs4');
-    my $nfs_mount_nfs4_async = get_var('NFS_MOUNT_NFS4_ASYNC', '/var/lib/nfs-tests/shared_nfs4_async');
+    my @nfs_versions = get_nfs_versions();
 
     my $nfs_options = get_var('NFS_OPTIONS', 'rw,sync,no_root_squash');
     my $nfs_options_async = get_var('NFS_OPTIONS_ASYNC', 'rw,async,no_root_squash');
-
-    # check kernel config options and set the variables
-    $kernel_nfs3 = 1 unless script_run('zgrep "CONFIG_NFS_V3=[my]" /proc/config.gz');
-    $kernel_nfs4 = 1 unless script_run('zgrep "CONFIG_NFS_V4=[my]" /proc/config.gz');
-    $kernel_nfs4_1 = 1 unless script_run('zgrep "CONFIG_NFS_V4_1=[my]" /proc/config.gz');
-    $kernel_nfs4_2 = 1 unless script_run('zgrep "CONFIG_NFS_V4_2=[my]" /proc/config.gz');
-    $kernel_nfsd_v3 = 1 unless script_run('zgrep "CONFIG_NFSD=[my]" /proc/config.gz');
-    $kernel_nfsd_v4 = 1 unless script_run('zgrep "CONFIG_NFSD_V4=[my]" /proc/config.gz');
 
     # following files are copied on the client side using dd with specific flags: direct, dsync, sync
     my $file_flag_direct = 'testfile_oflag_direct';
@@ -67,19 +50,12 @@ sub run {
     install_package('nfs-kernel-server', trup_apply => 1);
 
     # configure our exports
-    if ($kernel_nfs3 == 1) {
-        record_info('INFO', 'Kernel has support for NFSv3');
-        create_export($nfs_mount_nfs3, $client, $nfs_options);
-        create_export($nfs_mount_nfs3_async, $client, $nfs_options_async);
-    } else {
-        record_info('INFO', 'Kernel has no support for NFSv3, skipping NFSv3 tests');
-    }
-    if ($kernel_nfs4 == 1) {
-        record_info('INFO', 'Kernel has support for NFSv4');
-        create_export($nfs_mount_nfs4, $client, $nfs_options);
-        create_export($nfs_mount_nfs4_async, $client, $nfs_options_async);
-    } else {
-        record_info('INFO', 'Kernel has no support for NFSv4, skipping NFSv4 tests');
+    for my $version (@nfs_versions) {
+        my $cfg = nfs_mount_config($version);
+
+        record_info('INFO', "Exporting NFSv$version shares");
+        create_export($cfg->{remote}, $client, $nfs_options);
+        create_export($cfg->{remote_async}, $client, $nfs_options_async);
     }
 
     record_info("EXPORTS", script_output("cat /etc/exports"));
@@ -100,59 +76,24 @@ sub run {
     barrier_wait("NFS_CLIENT_ENABLED");
     barrier_wait("NFS_SERVER_CHECK");
 
-    if ($kernel_nfs3 == 1) {
-        #checking files in /nfs/shared_nfs3
-        record_info("TESTS: NFS3");
-        record_info("NFS3 list all files", script_output("ls $nfs_mount_nfs3"));
+    for my $version (@nfs_versions) {
+        my $cfg = nfs_mount_config($version);
 
-        assert_script_run("cd $nfs_mount_nfs3");
+        record_info("TESTS: NFSv$version", "Verifying checksums for NFSv$version exports");
 
-        assert_script_run("md5sum -c md5sum.txt");
-        record_info("NFS3 checksum", script_output("md5sum -c md5sum.txt"));
-        record_info("NFS3 checksum", script_output("cat md5sum.txt"));
+        for my $export ($cfg->{remote}, $cfg->{remote_async}) {
+            record_info("NFSv$version list all files", script_output("ls $export"));
 
-        #check files copied with various flags: direct, dsync, sync
-        compare_checksums($file_flag_direct);
-        compare_checksums($file_flag_dsync);
-        compare_checksums($file_flag_sync);
+            assert_script_run("cd $export");
+            assert_script_run("md5sum -c md5sum.txt");
+            record_info("NFSv$version checksum", script_output("md5sum -c md5sum.txt"));
+            record_info("NFSv$version checksum", script_output("cat md5sum.txt"));
 
-        #checking files in /nfs/shared_nfs3_async
-        record_info("TESTS: NFS3 async");
-
-        assert_script_run("cd $nfs_mount_nfs3_async");
-        assert_script_run("md5sum -c md5sum.txt");
-        record_info("NFS3 async checksum", script_output("md5sum -c md5sum.txt"));
-
-        #check files copied with various flags: direct, dsync, sync
-        compare_checksums($file_flag_direct);
-        compare_checksums($file_flag_dsync);
-        compare_checksums($file_flag_sync);
-    }
-
-    if ($kernel_nfs4 == 1) {
-        #checking files in /nfs/shared_nfs4
-        record_info("TESTS: NFS4");
-
-        assert_script_run("cd $nfs_mount_nfs4");
-        assert_script_run("md5sum -c md5sum.txt");
-        record_info("NFS4 checksum", script_output("md5sum -c md5sum.txt"));
-
-        #check files copied with various flags: direct, dsync, sync
-        compare_checksums($file_flag_direct);
-        compare_checksums($file_flag_dsync);
-        compare_checksums($file_flag_sync);
-
-        #checking files in /nfs/shared_nfs4_async
-        record_info("TESTS: NFS4 async");
-
-        assert_script_run("cd $nfs_mount_nfs4_async");
-        assert_script_run("md5sum -c md5sum.txt");
-        record_info("NFS4 async checksum", script_output("md5sum -c md5sum.txt"));
-
-        #check files copied with various flags: direct, dsync, sync
-        compare_checksums($file_flag_direct);
-        compare_checksums($file_flag_dsync);
-        compare_checksums($file_flag_sync);
+            #check files copied with various flags: direct, dsync, sync
+            compare_checksums($file_flag_direct);
+            compare_checksums($file_flag_dsync);
+            compare_checksums($file_flag_sync);
+        }
     }
 
     record_info("NFS stat for server", script_output("nfsstat -s"));
@@ -179,9 +120,9 @@ synchronised at runtime via shared barriers.
 
 Verifies data integrity on all exports after the client has finished writing.
 
-Installs C<nfs-kernel-server> and creates up to four exports under
-C</var/lib/nfs-tests/>, conditional on kernel NFS support detected via
-C</proc/config.gz>: NFSv3 sync, NFSv3 async, NFSv4 sync, and NFSv4 async.
+Installs C<nfs-kernel-server> and creates a sync and an async export under
+C</var/lib/nfs-tests/> for every NFS version returned by
+L<Kernel::nfs/get_nfs_versions>.
 
 After the client has written a test file and dd-copies using C<direct>,
 C<dsync>, and C<sync> flags, the server verifies data integrity for every
@@ -194,25 +135,26 @@ file using md5 checksums.
 Hostname or IP of the NFS client used in the export access list.
 Defaults to C<client-node00>.
 
-=head2 NFS_MOUNT_NFS3
+=head2 NFS_VERSIONS
 
-Server-side path for the NFSv3 synchronous export.
-Defaults to C</var/lib/nfs-tests/shared_nfs3>.
+Comma-separated list of NFS versions to test, e.g. C<3,4.2>. Overrides the
+default version support matrix. See L<Kernel::nfs/get_nfs_versions>.
 
-=head2 NFS_MOUNT_NFS3_ASYNC
+=head2 NFS_VERSIONS_SKIP
 
-Server-side path for the NFSv3 asynchronous export.
-Defaults to C</var/lib/nfs-tests/shared_nfs3_async>.
+Comma-separated list of NFS versions to leave out of the default support
+matrix, e.g. C<4.2>. Ignored if C<NFS_VERSIONS> is set.
 
-=head2 NFS_MOUNT_NFS4
+=head2 NFS_MOUNT_NFS<VERSION>
 
-Server-side path for the NFSv4 synchronous export.
-Defaults to C</var/lib/nfs-tests/shared_nfs4>.
+Server-side path for the synchronous export of a given NFS version, e.g.
+C<NFS_MOUNT_NFS3> or C<NFS_MOUNT_NFS4_2>.
+Defaults to C</var/lib/nfs-tests/shared_nfs<version>>.
 
-=head2 NFS_MOUNT_NFS4_ASYNC
+=head2 NFS_MOUNT_NFS<VERSION>_ASYNC
 
-Server-side path for the NFSv4 asynchronous export.
-Defaults to C</var/lib/nfs-tests/shared_nfs4_async>.
+Server-side path for the asynchronous export of a given NFS version.
+Defaults to C</var/lib/nfs-tests/shared_nfs<version>_async>.
 
 =head2 NFS_OPTIONS
 

--- a/tests/kernel/nfs_stress_ng.pm
+++ b/tests/kernel/nfs_stress_ng.pm
@@ -15,6 +15,7 @@ use registration;
 use version_utils qw(is_sle is_transactional);
 use repo_tools 'add_qa_head_repo';
 use package_utils 'install_package';
+use Kernel::nfs;
 
 sub check_nfs_mounts {
     my @paths = @_;
@@ -69,13 +70,12 @@ sub server {
 
 sub client {
     my ($self) = @_;
-    my $local_nfs4 = get_var('NFS_LOCAL_NFS4', '/var/lib/nfs-tests/localNFS4');
-    my $local_nfs4_async = get_var('NFS_LOCAL_NFS4_ASYNC', '/var/lib/nfs-tests/localNFS4async');
+    my $cfg = nfs_mount_config('4.0');
     my $stressor_timeout = get_var('NFS_STRESS_NG_TIMEOUT') // 3;
     my $exclude = get_var('NFS_STRESS_NG_EXCLUDE');
     # allow to override the default exports
     my $exports = get_var('NFS_STRESS_EXPORTS');
-    my @paths = $exports ? split(/,/, $exports) : ($local_nfs4, $local_nfs4_async);
+    my @paths = $exports ? split(/,/, $exports) : ($cfg->{local}, $cfg->{local_async});
 
     if (!check_nfs_mounts(@paths)) {
         $self->result('fail');
@@ -193,20 +193,21 @@ workload completes.
 Required. Set to C<nfs_client> or C<nfs_server> to select the node's role
 in the multi-machine scenario.
 
-=head2 NFS_LOCAL_NFS4
+=head2 NFS_LOCAL_NFS4_0
 
-Client-side mountpoint for the NFSv4 synchronous export used as the default
-stress-ng target. Defaults to C</var/lib/nfs-tests/localNFS4>.
+Client-side mountpoint for the NFSv4.0 synchronous export used as the default
+stress-ng target. Defaults to C</var/lib/nfs-tests/localNFS4_0>. See
+L<Kernel::nfs/nfs_mount_config>.
 
-=head2 NFS_LOCAL_NFS4_ASYNC
+=head2 NFS_LOCAL_NFS4_0_ASYNC
 
-Client-side mountpoint for the NFSv4 asynchronous export used as the default
-stress-ng target. Defaults to C</var/lib/nfs-tests/localNFS4async>.
+Client-side mountpoint for the NFSv4.0 asynchronous export used as the default
+stress-ng target. Defaults to C</var/lib/nfs-tests/localNFS4_0async>.
 
 =head2 NFS_STRESS_EXPORTS
 
 Comma-separated list of client-side mount points where C<stress-ng> will be
-executed, overriding the C<NFS_LOCAL_NFS4> and C<NFS_LOCAL_NFS4_ASYNC> defaults.
+executed, overriding the C<NFS_LOCAL_NFS4_0> and C<NFS_LOCAL_NFS4_0_ASYNC> defaults.
 
 =head2 NFS_STRESS_NG_TIMEOUT
 

--- a/tests/kernel/nfs_stress_ng.pm
+++ b/tests/kernel/nfs_stress_ng.pm
@@ -70,7 +70,8 @@ sub server {
 
 sub client {
     my ($self) = @_;
-    my $cfg = nfs_mount_config('4.0');
+    my @nfs_versions = get_nfs_versions();
+    my $cfg = nfs_mount_config($nfs_versions[-1]);
     my $stressor_timeout = get_var('NFS_STRESS_NG_TIMEOUT') // 3;
     my $exclude = get_var('NFS_STRESS_NG_EXCLUDE');
     # allow to override the default exports
@@ -193,21 +194,13 @@ workload completes.
 Required. Set to C<nfs_client> or C<nfs_server> to select the node's role
 in the multi-machine scenario.
 
-=head2 NFS_LOCAL_NFS4_0
-
-Client-side mountpoint for the NFSv4.0 synchronous export used as the default
-stress-ng target. Defaults to C</var/lib/nfs-tests/localNFS4_0>. See
-L<Kernel::nfs/nfs_mount_config>.
-
-=head2 NFS_LOCAL_NFS4_0_ASYNC
-
-Client-side mountpoint for the NFSv4.0 asynchronous export used as the default
-stress-ng target. Defaults to C</var/lib/nfs-tests/localNFS4_0async>.
-
 =head2 NFS_STRESS_EXPORTS
 
 Comma-separated list of client-side mount points where C<stress-ng> will be
-executed, overriding the C<NFS_LOCAL_NFS4_0> and C<NFS_LOCAL_NFS4_0_ASYNC> defaults.
+executed, overriding the default of the synchronous and asynchronous mounts
+for the highest NFS version returned by L<Kernel::nfs/get_nfs_versions>
+(see also L<Kernel::nfs/nfs_mount_config> for the C<NFS_LOCAL_NFS*>
+variables that control those default paths).
 
 =head2 NFS_STRESS_NG_TIMEOUT
 


### PR DESCRIPTION
Determining what NFS versions are supported is wrong, this should be determined by what is expected to be supported in the product.
This cleans that logic and runs the tests also for NFS versions 4.1 and 4.2 explicitly and does some minor cleanups.

Also this needs a fix for Tumbleweed, because that dropped support for version 4.0. The nfs_stress_ng now always uses the latest available protocol version.

- Related ticket: https://progress.opensuse.org/issues/160658
- Verification runs: 
  SLE16.1: 
  Server: https://openqa.suse.de/tests/23347019 Client: https://openqa.suse.de/tests/23347021
  SLE16.1 Immutable: 
  Server: https://openqa.suse.de/tests/23347017 Client: https://openqa.suse.de/tests/23347016
  Tumbleweed:
  Server: https://openqa.opensuse.org/tests/6098818 Client: https://openqa.opensuse.org/tests/6098817