### PR TITLE
Refactor(publiccloud): remove SSH_TIMEOUT wherever possible

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -70,7 +70,6 @@ sub _prepare_ssh_cmd {
     die('No command defined') unless ($args{cmd});
     $args{ssh_opts} //= $self->ssh_opts();
     $args{username} //= $self->username();
-    $args{timeout} //= SSH_TIMEOUT;
 
     my $cmd = $args{cmd};
     $cmd =~ s/'/\\'/g;
@@ -242,7 +241,6 @@ and to upload a local I</tmp/foo> to the instance home directory:
 
 sub scp {
     my ($self, $from, $to, %args) = @_;
-    $args{timeout} //= SSH_TIMEOUT;
     $args{proceed_on_failure} //= 0;
 
     my $url = sprintf('%s@%s:', $self->username, $self->public_ip);


### PR DESCRIPTION
- remove the internal timeout preset from instance::_prepare_ssh_cmd being it neither used into that routine nor passed by-reference in any call
- remove timeout preset from instance::scp() routine being a preset already done in the internal call to _wrap_timeout()
- keep  the timeout preset in instance::_wrap_timeout() to provide a common default to all the upper routines calling it

- Ref.tkt.: **AC2** in https://progress.opensuse.org/issues/200744#note-13

- Verification run:
  - sle-15-SP7-EC2-Updates-x86_64-Build2026 0713-1-publiccloud_aws_nitro @ec2_m5a.xlarge
    https://openqa.suse.de/tests/23347772  
  - sle-15-SP7-EC2-BYOS-Updates-x86_64-Build20260713-1-publiccloud_cloud_functional @ec2_t3a.large 
    https://openqa.suse.de/tests/23347773  
  - sle-12-SP5-GCE-Updates-x86_64-Build20260713-1-publiccloud_registrationtests  @gce_n1_standard_2
    https://openqa.suse.de/tests/23348031 
  - sle-15-SP7-Azure-BYOS-Updates-x86_64-Build20260713-1-publiccloud_ahb @az_Standard_B2s 
    https://openqa.suse.de/tests/23347775 