### PR TITLE
openSUSE: Add RAID agama configuration profiles

### DIFF
--- a/data/agama_auto/opensuse/raid0.jsonnet
+++ b/data/agama_auto/opensuse/raid0.jsonnet
@@ -1,0 +1,99 @@
+{
+  "bootloader": {
+    "stopOnBootMenu": true
+  },
+  "product": {
+    "id": "{{AGAMA_PRODUCT_ID}}"
+  },
+  "storage": {
+    "drives": [
+      {
+        "partitions": [
+          {
+            "delete": true,
+            "search": "*"
+          },
+          {
+            "filesystem": {
+              "path": "/boot",
+              "type": "vfat"
+            },
+            "id": "esp",
+            "size": "1024 MiB"
+          },
+          {
+            "alias": "mdroot",
+            "id": "raid",
+            "size": "7.81 GiB"
+          },
+          {
+            "alias": "mdswap",
+            "id": "raid",
+            "size": "512 MiB"
+          }
+        ]
+      },
+      {
+        "partitions": [
+          {
+            "delete": true,
+            "search": "*"
+          },
+          {
+            "filesystem": {
+              "type": "vfat"
+            },
+            "id": "esp",
+            "size": "1024 MiB"
+          },
+          {
+            "alias": "mdroot",
+            "id": "raid",
+            "size": "7.81 GiB"
+          },
+          {
+            "alias": "mdswap",
+            "id": "raid",
+            "size": "512 MiB"
+          }
+        ],
+        "search": "*"
+      }
+    ],
+    "mdRaids": [
+      {
+        "devices": [
+          "mdroot"
+        ],
+        "filesystem": {
+          "path": "/",
+          "type": {
+            "btrfs": {
+              "snapshots": false
+            }
+          }
+        },
+        "level": "raid0"
+      },
+      {
+        "devices": [
+          "mdswap"
+        ],
+        "filesystem": {
+          "path": "swap"
+        },
+        "level": "raid0"
+      }
+    ]
+  },
+  "user": {
+    "fullName": "Bernhard M. Wiedemann",
+    "password": "$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/",
+    "hashedPassword": true,
+    "userName": "bernhard"
+  },
+  "root": {
+    "password": "$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/",
+    "hashedPassword": true
+  }
+}

--- a/data/agama_auto/opensuse/raid1.jsonnet
+++ b/data/agama_auto/opensuse/raid1.jsonnet
@@ -1,0 +1,99 @@
+{
+  "bootloader": {
+    "stopOnBootMenu": true
+  },
+  "product": {
+    "id": "{{AGAMA_PRODUCT_ID}}"
+  },
+  "storage": {
+    "drives": [
+      {
+        "partitions": [
+          {
+            "delete": true,
+            "search": "*"
+          },
+          {
+            "filesystem": {
+              "path": "/boot",
+              "type": "vfat"
+            },
+            "id": "esp",
+            "size": "1024 MiB"
+          },
+          {
+            "alias": "mdroot",
+            "id": "raid",
+            "size": "7.81 GiB"
+          },
+          {
+            "alias": "mdswap",
+            "id": "raid",
+            "size": "512 MiB"
+          }
+        ]
+      },
+      {
+        "partitions": [
+          {
+            "delete": true,
+            "search": "*"
+          },
+          {
+            "filesystem": {
+              "type": "vfat"
+            },
+            "id": "esp",
+            "size": "1024 MiB"
+          },
+          {
+            "alias": "mdroot",
+            "id": "raid",
+            "size": "7.81 GiB"
+          },
+          {
+            "alias": "mdswap",
+            "id": "raid",
+            "size": "512 MiB"
+          }
+        ],
+        "search": "*"
+      }
+    ],
+    "mdRaids": [
+      {
+        "devices": [
+          "mdroot"
+        ],
+        "filesystem": {
+          "path": "/",
+          "type": {
+            "btrfs": {
+              "snapshots": false
+            }
+          }
+        },
+        "level": "raid1"
+      },
+      {
+        "devices": [
+          "mdswap"
+        ],
+        "filesystem": {
+          "path": "swap"
+        },
+        "level": "raid0"
+      }
+    ]
+  },
+  "user": {
+    "fullName": "Bernhard M. Wiedemann",
+    "password": "$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/",
+    "hashedPassword": true,
+    "userName": "bernhard"
+  },
+  "root": {
+    "password": "$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/",
+    "hashedPassword": true
+  }
+}

--- a/data/agama_auto/opensuse/raid10.jsonnet
+++ b/data/agama_auto/opensuse/raid10.jsonnet
@@ -1,0 +1,99 @@
+{
+  "bootloader": {
+    "stopOnBootMenu": true
+  },
+  "product": {
+    "id": "{{AGAMA_PRODUCT_ID}}"
+  },
+  "storage": {
+    "drives": [
+      {
+        "partitions": [
+          {
+            "delete": true,
+            "search": "*"
+          },
+          {
+            "filesystem": {
+              "path": "/boot",
+              "type": "vfat"
+            },
+            "id": "esp",
+            "size": "1024 MiB"
+          },
+          {
+            "alias": "mdroot",
+            "id": "raid",
+            "size": "7.81 GiB"
+          },
+          {
+            "alias": "mdswap",
+            "id": "raid",
+            "size": "512 MiB"
+          }
+        ]
+      },
+      {
+        "partitions": [
+          {
+            "delete": true,
+            "search": "*"
+          },
+          {
+            "filesystem": {
+              "type": "vfat"
+            },
+            "id": "esp",
+            "size": "1024 MiB"
+          },
+          {
+            "alias": "mdroot",
+            "id": "raid",
+            "size": "7.81 GiB"
+          },
+          {
+            "alias": "mdswap",
+            "id": "raid",
+            "size": "512 MiB"
+          }
+        ],
+        "search": "*"
+      }
+    ],
+    "mdRaids": [
+      {
+        "devices": [
+          "mdroot"
+        ],
+        "filesystem": {
+          "path": "/",
+          "type": {
+            "btrfs": {
+              "snapshots": false
+            }
+          }
+        },
+        "level": "raid10"
+      },
+      {
+        "devices": [
+          "mdswap"
+        ],
+        "filesystem": {
+          "path": "swap"
+        },
+        "level": "raid0"
+      }
+    ]
+  },
+  "user": {
+    "fullName": "Bernhard M. Wiedemann",
+    "password": "$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/",
+    "hashedPassword": true,
+    "userName": "bernhard"
+  },
+  "root": {
+    "password": "$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/",
+    "hashedPassword": true
+  }
+}

--- a/data/agama_auto/opensuse/raid5.jsonnet
+++ b/data/agama_auto/opensuse/raid5.jsonnet
@@ -1,0 +1,99 @@
+{
+  "bootloader": {
+    "stopOnBootMenu": true
+  },
+  "product": {
+    "id": "{{AGAMA_PRODUCT_ID}}"
+  },
+  "storage": {
+    "drives": [
+      {
+        "partitions": [
+          {
+            "delete": true,
+            "search": "*"
+          },
+          {
+            "filesystem": {
+              "path": "/boot",
+              "type": "vfat"
+            },
+            "id": "esp",
+            "size": "1024 MiB"
+          },
+          {
+            "alias": "mdroot",
+            "id": "raid",
+            "size": "7.81 GiB"
+          },
+          {
+            "alias": "mdswap",
+            "id": "raid",
+            "size": "512 MiB"
+          }
+        ]
+      },
+      {
+        "partitions": [
+          {
+            "delete": true,
+            "search": "*"
+          },
+          {
+            "filesystem": {
+              "type": "vfat"
+            },
+            "id": "esp",
+            "size": "1024 MiB"
+          },
+          {
+            "alias": "mdroot",
+            "id": "raid",
+            "size": "7.81 GiB"
+          },
+          {
+            "alias": "mdswap",
+            "id": "raid",
+            "size": "512 MiB"
+          }
+        ],
+        "search": "*"
+      }
+    ],
+    "mdRaids": [
+      {
+        "devices": [
+          "mdroot"
+        ],
+        "filesystem": {
+          "path": "/",
+          "type": {
+            "btrfs": {
+              "snapshots": false
+            }
+          }
+        },
+        "level": "raid5"
+      },
+      {
+        "devices": [
+          "mdswap"
+        ],
+        "filesystem": {
+          "path": "swap"
+        },
+        "level": "raid0"
+      }
+    ]
+  },
+  "user": {
+    "fullName": "Bernhard M. Wiedemann",
+    "password": "$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/",
+    "hashedPassword": true,
+    "userName": "bernhard"
+  },
+  "root": {
+    "password": "$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/",
+    "hashedPassword": true
+  }
+}

--- a/data/agama_auto/opensuse/raid6.jsonnet
+++ b/data/agama_auto/opensuse/raid6.jsonnet
@@ -1,0 +1,99 @@
+{
+  "bootloader": {
+    "stopOnBootMenu": true
+  },
+  "product": {
+    "id": "{{AGAMA_PRODUCT_ID}}"
+  },
+  "storage": {
+    "drives": [
+      {
+        "partitions": [
+          {
+            "delete": true,
+            "search": "*"
+          },
+          {
+            "filesystem": {
+              "path": "/boot",
+              "type": "vfat"
+            },
+            "id": "esp",
+            "size": "1024 MiB"
+          },
+          {
+            "alias": "mdroot",
+            "id": "raid",
+            "size": "7.81 GiB"
+          },
+          {
+            "alias": "mdswap",
+            "id": "raid",
+            "size": "512 MiB"
+          }
+        ]
+      },
+      {
+        "partitions": [
+          {
+            "delete": true,
+            "search": "*"
+          },
+          {
+            "filesystem": {
+              "type": "vfat"
+            },
+            "id": "esp",
+            "size": "1024 MiB"
+          },
+          {
+            "alias": "mdroot",
+            "id": "raid",
+            "size": "7.81 GiB"
+          },
+          {
+            "alias": "mdswap",
+            "id": "raid",
+            "size": "512 MiB"
+          }
+        ],
+        "search": "*"
+      }
+    ],
+    "mdRaids": [
+      {
+        "devices": [
+          "mdroot"
+        ],
+        "filesystem": {
+          "path": "/",
+          "type": {
+            "btrfs": {
+              "snapshots": false
+            }
+          }
+        },
+        "level": "raid6"
+      },
+      {
+        "devices": [
+          "mdswap"
+        ],
+        "filesystem": {
+          "path": "swap"
+        },
+        "level": "raid0"
+      }
+    ]
+  },
+  "user": {
+    "fullName": "Bernhard M. Wiedemann",
+    "password": "$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/",
+    "hashedPassword": true,
+    "userName": "bernhard"
+  },
+  "root": {
+    "password": "$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/",
+    "hashedPassword": true
+  }
+}

--- a/test_data/yast/raid/raid6_gpt_uefi_test_data.yaml
+++ b/test_data/yast/raid/raid6_gpt_uefi_test_data.yaml
@@ -1,0 +1,80 @@
+disks:
+  - name: vda
+    partitions:
+      - size: 300mb
+        role: raw-volume
+        formatting_options:
+          should_format: 1
+          filesystem: fat
+        mounting_options:
+          should_mount: 1
+          mount_point: '/boot/efi'
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 512mb
+        role: raw-volume
+        id: linux-raid
+  - name: vdb
+    partitions:
+      - size: 300mb
+        role: raw-volume
+        id: efi
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 512mb
+        role: raw-volume
+        id: linux-raid
+  - name: vdc
+    partitions:
+      - size: 300mb
+        role: raw-volume
+        id: efi
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 512mb
+        role: raw-volume
+        id: linux-raid
+  - name: vdd
+    partitions:
+      - size: 300mb
+        role: raw-volume
+        id: efi
+      - size: 8000mb
+        role: raw-volume
+        id: linux-raid
+      - size: 512mb
+        role: raw-volume
+        id: linux-raid
+mds:
+  - raid_level: 6
+    name: md0
+    chunk_size: '64 KiB'
+    devices:
+      - vda2
+      - vdb2
+      - vdc2
+      - vdd2
+    partition:
+      role: operating-system
+      formatting_options:
+        should_format: 1
+      mounting_options:
+        should_mount: 1
+  - raid_level: 0
+    name: md1
+    chunk_size: '64 KiB'
+    devices:
+      - vda3
+      - vdb3
+      - vdc3
+      - vdd3
+    partition:
+      role: swap
+      formatting_options:
+        should_format: 1
+        filesystem: swap
+      mounting_options:
+        should_mount: 1


### PR DESCRIPTION
This adds RAID profiles for unattended installations with agama

VR: https://openqa.opensuse.org/tests/overview?version=Tumbleweed&distri=opensuse&build=raid
