### PR TITLE
Introduce `az` function

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -24,7 +24,6 @@ Library to compose and run Azure cli commands
 =cut
 
 our @EXPORT = qw(
-  $SDAF_Azure_podman_flake_filter
   az_version
   az_group_create
   az_group_name_get
@@ -96,6 +95,75 @@ our $SDAF_Azure_podman_flake_filter = (get_var('SDAF_GIT_AUTOMATION_BRANCH', '')
   ? "2> >(grep -Ev 'FutureWarning|Launching flake|self.' >&2)"
   : '';
 
+=head2 az
+
+    az(az_args => 'group list' [, query => '[].name']);
+
+Executes az cli command specified. Commands are executed with `-o json`
+Returns perl data structure containing return code, command output, errors.
+
+Example:
+{
+    rc => '0',
+    output => ['group_name_a', 'group_name_b'],
+    error => ''
+}
+
+=over
+
+=item B<az_args> - Specify arguments passed to `az cli`
+
+=item B<query> - specify `--query`
+
+=item B<quiet> - pass B<quiet> to azure cli commands
+
+=item B<timeout> - override default bmwqemu timeout for `az cli` command
+
+=back
+=cut
+
+sub az(%args) {
+    $args{timeout} //= $bmwqemu::default_timeout;
+    croak 'Command `az` is not needed in $args{az_args}'
+      if $args{az_args} =~ /az/;
+    croak 'Missing mandatory argument: <az_args>' unless $args{az_args};
+    croak 'Jmespath query "--query" must be specified using $args{query}'
+      if $args{az_args} =~ /--query/;
+    croak 'Argument "--only-show-errors" is used by default and not needed.'
+      if $args{az_args} =~ /--only-show-errors/;
+    croak 'Argument "--output" is not supported.'
+      if $args{az_args} =~ /--output/;
+
+    my %result;
+    # Create unique temporary files (inside /tmp by default)
+    my $err_file = script_output('mktemp --suffix _az.err', quiet => '1');
+    my $out_file = script_output('mktemp --suffix _az.json', quiet => '1');
+
+    my @az_cmd = ('az', $args{az_args});
+    push @az_cmd, '--only-show-errors';
+    push @az_cmd, "--query \"$args{query}\"" if $args{query};
+    push @az_cmd, '--output json';
+    # Remove lines which should not be considered as error.
+    my $grep_filter = 'FutureWarning|self.|Launching flake';
+    # This should be at the end of whole command !
+    push @az_cmd, "> $out_file 2> >(grep -Ev \"$grep_filter\" |tee $err_file >&2)";
+
+    $result{rc} = script_run(join(' ', @az_cmd),
+        quiet => $args{quiet}, timeout => $args{timeout});
+    $result{output} = decode_json(script_output("cat $out_file",
+            quiet => $args{quiet}));
+    $result{error} = script_output("cat $err_file",
+        quiet => $args{quiet});
+
+    die "Error messages present during az cli execution:\n$result{error}\n"
+      if $result{error};
+    die "AZ CLI returned non zero value:$result{rc}\n" if $result{error};
+
+    # Delete unique temporary files
+    assert_script_run("rm $err_file $out_file", quiet => '1');
+    return \%result;
+}
+
 =head2 az_version
 
     az_version();
@@ -106,7 +174,6 @@ Print the version of the az cli available on system
 sub az_version {
     assert_script_run('az --version');
 }
-
 
 =head2 az_group_create
 
@@ -196,9 +263,7 @@ sub az_group_delete(%args) {
 
     az_group_exists(name => 'resource group name' [, quiet=>'pssst!']);
 
-Check if specified resource group exists.
-Returns whatever 'az group exist' is returning
-that usually is string B<true> or B<false>.
+Returns non-empty value if resource group exists, otherwise B<undef>
 
 =over
 
@@ -211,7 +276,11 @@ that usually is string B<true> or B<false>.
 
 sub az_group_exists(%args) {
     croak "Missing mandatory argument: 'name'" unless $args{name};
-    return script_output("az group exists --resource-group $args{name} $SDAF_Azure_podman_flake_filter", quiet => $args{quiet});
+    my $out = az(az_args => "group exists --resource-group $args{name}",
+        quiet => $args{quiet});
+    die "Command failed.\nCommand didn't return a boolean value: $out->{output}"
+      unless JSON::PP::is_bool($out->{output});
+    return $out->{output};
 }
 
 =head2 az_network_vnet_create
@@ -911,14 +980,9 @@ sub az_vm_list(%args) {
     croak("Argument < resource_group > missing") unless $args{resource_group};
     $args{query} //= '[].name';
 
-    my $az_cmd = join(' ',
-        'az vm list',
-        "-g $args{resource_group}",
-        "--query \"$args{query}\"",
-        '-o json',
-        $SDAF_Azure_podman_flake_filter
-    );
-    return decode_json(script_output($az_cmd));
+    my $az_args = "vm list -g $args{resource_group}";
+    my $result = az(az_args => $az_args, query => $args{query});
+    return $result->{output};
 }
 
 
@@ -1786,7 +1850,7 @@ sub az_resource_delete(%args) {
 
 Lists existing az resources based on arguments provided. Calling function without any argument returns full information
 from all existing resource groups.
-Returns decoded json structure if json format is requested, otherwise whole output is a string.
+Returns data structure returned from az cli json output.
 
 =over
 
@@ -1798,13 +1862,11 @@ Returns decoded json structure if json format is requested, otherwise whole outp
 =cut
 
 sub az_resource_list(%args) {
-    my @az_command = ('az resource list');
+    $args{query} //= undef;
+    my @az_command = ('resource list');
     push(@az_command, "--resource-group $args{resource_group}") if $args{resource_group};
-    push(@az_command, "--query \"$args{query}\"") if $args{query};
-    push(@az_command, '--output json');
-    push(@az_command, $SDAF_Azure_podman_flake_filter);
-
-    return (decode_json(script_output(join(' ', @az_command))));
+    my $az_out = az(az_args => join(' ', @az_command), query => $args{query});
+    return $az_out->{output};
 }
 
 =head2 az_resource_tag
@@ -2019,18 +2081,16 @@ sub az_storage_blob_list(%args) {
         croak "Missing mandatory argument: '$_'" unless $args{$_};
     }
     $args{query} //= '[].name';
+    $args{timeout} //= $bmwqemu::default_timeout;
 
     my $az_cmd = join(' ',
-        'az storage blob list',
-        '--only-show-errors',
+        'storage blob list',
         "--container-name $args{container_name}",
-        "--account-name $args{storage_account_name}",
-        "--query \"$args{query}\"",
-        '--output json',
-        $SDAF_Azure_podman_flake_filter
+        "--account-name $args{storage_account_name}"
     );
-
-    return decode_json(script_output($az_cmd, $args{timeout}));
+    my $out =
+      az(az_args => $az_cmd, timeout => $args{timeout}, query => $args{query});
+    return $out->{output};
 }
 
 =head2 az_storage_blob_update

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -770,28 +770,6 @@ sub prepare_sdaf_project {
     assert_script_run("mkdir -p $_") foreach @create_workspace_dirs;
 }
 
-=head2 resource_group_exists
-
-    resource_group_exists($resource_group);
-
-Checks if resource group exists. Function accepts only full resource name.
-Croaks if command does not return true/false value.
-
-=over
-
-=item * B<$resource_group>: Resource group name to check
-
-=back
-=cut
-
-sub resource_group_exists {
-    my ($resource_group) = @_;
-    croak 'Mandatory positional argument "$resource_group" not defined.' unless $resource_group;
-
-    my $cmd_out = script_output("az group exists -n $resource_group $SDAF_Azure_podman_flake_filter");
-    die "Command 'az group exists -n $resource_group' failed.\nCommand returned: $cmd_out" unless grep /false|true/, $cmd_out;
-    return ($cmd_out eq 'true');
-}
 
 =head2 sdaf_execute_remover
 
@@ -876,8 +854,8 @@ sub sdaf_cleanup {
     my %result;
     # Sap system needs to be destroyed before workload zone so order matters here.
     for my $deployment_type ('sap_system', 'workload_zone') {
-        my $resource_group = resource_group_exists(generate_resource_group_name(deployment_type => $deployment_type));
-        unless ($resource_group) {
+        my $group_exists = az_group_exists(name => generate_resource_group_name(deployment_type => $deployment_type));
+        unless ($group_exists) {
             record_info('Cleanup skip', "Resource group for deployment type '$deployment_type' does not exist. Skipping cleanup");
             next;
         }

--- a/t/15_qesap_azure.t
+++ b/t/15_qesap_azure.t
@@ -342,12 +342,12 @@ subtest '[qesap_az_diagnostic_log] no VMs integration test' => sub {
     $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
     # Configure vm list to return no VMs
-    $azcli->redefine(script_output => sub { push @calls, $_[0]; return '[]'; });
+    $azcli->redefine(az_vm_list => sub { push @calls, $_[1]; return (); });
 
     my @log_files = qesap_az_diagnostic_log();
 
     note("\n  C-->  " . join("\n  C-->  ", @calls));
-    ok((any { /az vm list.*DENTIST.*/ } @calls), 'List all VMs in the resource group');
+    ok((any { /.*DENTIST.*/ } @calls), 'List all VMs in the resource group');
     ok((scalar @log_files == 0), 'No returned logs');
 };
 
@@ -371,9 +371,8 @@ subtest '[qesap_az_diagnostic_log] one VMs integration test' => sub {
 
     $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
     # Configure vm list to return one VM
-    $azcli->redefine(script_output => sub {
-            push @calls, $_[0];
-            return '[{"name":"NEMO", "id":"MARLIN"}]';
+    $azcli->redefine(az_vm_list => sub {
+            return [{name => 'NEMO', id => 'MARLIN'}];
     });
     $azcli->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
@@ -394,7 +393,6 @@ subtest '[qesap_az_diagnostic_log] three VMs' => sub {
 
     # Configure vm list to return three VMs
     $qesap->redefine(az_vm_list => sub {
-            push @calls, {@_};
             return [
                 {name => "DORY", id => "BLUE_TANG"},
                 {name => "BRUCE", id => "GREAT_WHITE"},
@@ -415,9 +413,12 @@ subtest '[qesap_az_diagnostic_log] three VMs integration test' => sub {
 
     $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
     # Configure vm list to return 3 VMs
-    $azcli->redefine(script_output => sub {
-            push @calls, $_[0];
-            return '[{"name":"DORY", "id":"BLUE_TANG"},{"name":"BRUCE", "id":"GREAT_WHITE"},{"name":"CRUSH", "id":"SEA_TURTLE"}]';
+    $azcli->redefine(az_vm_list => sub {
+            return [
+                {name => 'DORY', id => 'BLUE_TANG'},
+                {name => 'BRUCE', id => 'GREAT_WHITE'},
+                {name => 'CRUSH', 'id' => 'SEA_TURTLE'}
+            ];
     });
     $azcli->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 

--- a/t/20_sdaf_deployment_library.t
+++ b/t/20_sdaf_deployment_library.t
@@ -9,6 +9,7 @@ use List::MoreUtils qw(uniq);
 use List::Util qw(any none);
 use Data::Dumper;
 use testapi;
+use JSON::PP;
 use sles4sap::sap_deployment_automation_framework::deployment;
 
 sub undef_variables {
@@ -210,10 +211,11 @@ subtest '[sdaf_cleanup] Test correct usage' => sub {
     $ms_sdaf->noop(qw(record_info
           script_output
           deployment_dir
-          resource_group_exists));
+    ));
     $ms_sdaf->redefine(generate_resource_group_name => sub { return 'ResourceGroup'; });
     $ms_sdaf->redefine(sdaf_execute_remover => sub { return 0; });
     $ms_sdaf->redefine(script_run => sub { return 0; });
+    $ms_sdaf->redefine(az_group_exists => sub { return $JSON::PP::true; });
 
     my %cleanup_results = %{sdaf_cleanup()};
     ok(!$cleanup_results{remover_failed}, 'Remover passes with correct usage');
@@ -224,7 +226,7 @@ subtest '[sdaf_cleanup] Test remover script failures' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
     my $force_group_delete;
     $ms_sdaf->noop(qw(script_output deployment_dir generate_resource_group_name ));
-    $ms_sdaf->redefine(resource_group_exists => sub { return 'yes'; });
+    $ms_sdaf->redefine(az_group_exists => sub { return $JSON::PP::true; });
     $ms_sdaf->redefine(sdaf_destroy_resources => sub { $force_group_delete = 1; });
     $ms_sdaf->redefine(sdaf_execute_remover => sub { return 1; });
     $ms_sdaf->redefine(script_run => sub { return 0; });
@@ -238,21 +240,23 @@ subtest '[sdaf_cleanup] Test remover script failures' => sub {
 
 subtest '[sdaf_execute_remover] Check command line arguments' => sub {
     # Tested indirectly via sdaf_cleanup()
-
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
     my @script_run_calls;
 
     $ms_sdaf->noop(qw(
-          record_info
           upload_logs
           assert_script_run
-          resource_group_exists
           log_dir
           deployment_dir
-          sdaf_scripts_dir
-          generate_resource_group_name)
+          sdaf_scripts_dir )
     );
-    $ms_sdaf->redefine(script_run => sub { push @script_run_calls, $_[0] if grep /remover/, $_[0]; return 0; });
+    $ms_sdaf->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', join(' : ', @_))); });
+    $ms_sdaf->redefine(generate_resource_group_name => sub { return 'sap_system'; });
+    $ms_sdaf->redefine(az_group_exists => sub { return $JSON::PP::true if grep /sap_system/, @_; });
+    $ms_sdaf->redefine(script_run => sub {
+            push @script_run_calls, $_[0] if grep /remover/, $_[0];
+            return 0;
+    });
     $ms_sdaf->redefine(get_os_variable => sub {
             return '/some/path/LAB-SECE-SAP04-INFRASTRUCTURE-6453.tfvars' if $_[0] eq 'workload_zone_parameter_file';
             return '/some/path/LAB-SECE-SAP04-QES-6453.tfvars' if $_[0] eq 'sap_system_parameter_file';
@@ -273,7 +277,6 @@ subtest '[sdaf_execute_remover] Check command line arguments' => sub {
     $ms_sdaf->redefine(script_run => sub { return 1; });
     dies_ok { sdaf_cleanup() } 'Test failing remover script: retried 3 times and failed';
 };
-
 
 subtest '[sdaf_execute_deployment] Test expected failures' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -6,7 +6,7 @@ use Test::Warnings;
 use Test::MockModule;
 use Test::Mock::Time;
 use List::Util qw(any none);
-
+use JSON::PP;
 use sles4sap::azure_cli;
 
 subtest '[az_img_from_vhd_create]' => sub {
@@ -446,31 +446,20 @@ subtest '[az_vm_create] SDAF mix' => sub {
 subtest '[az_vm_list]' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
     $azcli->redefine(script_output => sub {
-            push @calls, $_[0];
-            return '["Mirandolina","Truffaldino"]'; });
+            return 'error.log' if grep /az.err/, $_[0];
+            return 'out.json' if grep /az.json/, $_[0];
+            return '["Mirandolina","Truffaldino"]' if grep /out.json/, $_[0]; });
 
     my $res = az_vm_list(resource_group => 'Arlecchino', query => 'ZAMZAM');
 
     note("\n  -->  " . join("\n  -->  ", @calls));
-    ok((any { /az vm list/ } @calls), 'Correct composition of the main command');
+    ok((any { /vm list/ } @calls), 'Correct composition of the main command');
     ok((any { /-g Arlecchino/ } @calls), 'Correct composition of the -g argument');
     ok((any { /Mirandolina/ } @$res), 'Correct result decoding');
 };
-
-subtest '[az_vm_list] query' => sub {
-    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
-    my @calls;
-    $azcli->redefine(script_output => sub {
-            push @calls, $_[0];
-            return '["Mirandolina","Truffaldino"]'; });
-
-    my $res = az_vm_list(resource_group => 'Arlecchino', query => 'ZAMZAM');
-
-    note("\n  -->  " . join("\n  -->  ", @calls));
-    ok((any { /--query.*ZAMZAM/ } @calls), 'Correct composition of the --query argument');
-};
-
 
 subtest '[az_vm_wait_running] running at first try' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
@@ -895,10 +884,10 @@ subtest '[az_vm_diagnostic_log_enable]' => sub {
 subtest '[az_vm_diagnostic_log_get]' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub {
-            push @calls, $_[0];
+    $azcli->redefine(az_vm_list => sub {
             # simulate 2 VM
-            return '[{"id": "0001", "name": "Truffaldino"}, {"id": "0002", "name": "Mirandolina"}]'; });
+            return [{id => '0001', name => 'Truffaldino'}, {id => '0002', name => 'Mirandolina'}];
+    });
     $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
     $azcli->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
@@ -906,7 +895,6 @@ subtest '[az_vm_diagnostic_log_get]' => sub {
 
     note("\n  C-->  " . join("\n  C-->  ", @calls));
     note("\n  R-->  " . join("\n  R-->  ", @ret));
-    ok((any { /az vm list/ } @calls), 'Correct composition of the list command');
     ok((any { /az vm boot-diagnostics get-boot-log/ } @calls), 'Correct composition of the main command');
     ok((any { /--ids 0001.*Truffaldino\.txt/ } @calls), 'Correct composition of the --id for the first VM');
     ok((any { /--ids 0002.*Mirandolina\.txt/ } @calls), 'Correct composition of the --id for the second VM');
@@ -919,10 +907,10 @@ subtest '[az_vm_diagnostic_log_get]' => sub {
 subtest '[az_vm_diagnostic_log_get] verbose' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub {
-            push @calls, $_[0];
+    $azcli->redefine(az_vm_list => sub {
             # simulate 2 VM
-            return '[{"id": "0001", "name": "Truffaldino"}, {"id": "0002", "name": "Mirandolina"}]'; });
+            return [{id => '0001', name => 'Truffaldino'}, {id => '0002', name => 'Mirandolina'}];
+    });
     $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
     $azcli->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
@@ -936,10 +924,7 @@ subtest '[az_vm_diagnostic_log_get] verbose' => sub {
 subtest '[az_vm_diagnostic_log_get] no VMs' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub {
-            push @calls, $_[0];
-            # simulate 2 VM
-            return '[]'; });
+    $azcli->redefine(az_vm_list => sub { return []; });
     $azcli->redefine(script_run => sub { push @calls, $_[0]; });
     $azcli->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
@@ -947,7 +932,6 @@ subtest '[az_vm_diagnostic_log_get] no VMs' => sub {
 
     note("\n  C-->  " . join("\n  C-->  ", @calls));
     note("\n  R-->  " . join("\n  R-->  ", @ret));
-    ok((any { /az vm list/ } @calls), 'Correct composition of the list command');
     ok((none { /az vm boot-diagnostics get-boot-log/ } @calls), 'Correct composition of the main command');
     ok scalar @ret == 0, "No logs";
 };
@@ -955,10 +939,10 @@ subtest '[az_vm_diagnostic_log_get] no VMs' => sub {
 subtest '[az_vm_diagnostic_log_get] one fail' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub {
-            push @calls, $_[0];
+    $azcli->redefine(az_vm_list => sub {
             # simulate 2 VM
-            return '[{"id": "0001", "name": "Truffaldino"}, {"id": "0002", "name": "Mirandolina"}]'; });
+            return [{id => '0001', name => 'Truffaldino'}, {id => '0002', name => 'Mirandolina'}];
+    });
     $azcli->redefine(script_run => sub {
             my ($cmd) = @_;
             push @calls, $cmd;
@@ -969,7 +953,6 @@ subtest '[az_vm_diagnostic_log_get] one fail' => sub {
 
     note("\n  C-->  " . join("\n  C-->  ", @calls));
     note("\n  R-->  " . join("\n  R-->  ", @ret));
-    ok((any { /az vm list/ } @calls), 'Correct composition of the list command');
     ok((any { /az vm boot-diagnostics get-boot-log/ } @calls), 'Correct composition of the main command');
     ok((any { /--ids 0001.*Truffaldino\.txt/ } @calls), 'Correct composition of the --id for the first VM');
     ok((any { /--ids 0002.*Mirandolina\.txt/ } @calls), 'Correct composition of the --id for the second VM');
@@ -1174,27 +1157,12 @@ END_MSG
     }
 };
 
-subtest '[az_resource_list] Check command composition' => sub {
-    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
-    my @calls;
-    $azcli->redefine(script_output => sub { @calls = $_[0]; return '[]'; });
-
-    az_resource_list();
-
-    note("\n --> " . join("\n --> ", @calls));
-    ok((any { /az resource list/ } @calls), 'Correct composition of the main command');
-
-    az_resource_list(resource_group => 'Carlo', query => '[].Goldoni');
-
-    note("\n --> " . join("\n --> ", @calls));
-    ok((any { /--resource-group Carlo/ } @calls), 'Check for --resource-group option.');
-    ok((any { /--query \"\[].Goldoni\"/ } @calls), 'Check for --query option.');
-};
-
 subtest '[az_resource_list] Check return values' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
-    $azcli->redefine(script_output => sub { return '["Carlo", "Goldoni"]'; });
-
+    $azcli->noop('assert_script_run', 'script_run');
+    $azcli->redefine(script_output => sub {
+            return 'out.json' if grep /az.json/, $_[0];
+            return '["Carlo","Goldoni"]' if grep /out.json/, $_[0]; });
     my $output = az_resource_list();
 
     note("\n --> " . join("\n --> ", join(' ', @$output)));
@@ -1285,7 +1253,11 @@ subtest '[az_storage_blob_lease_acquire] valid UUID with error ErrorCode' => sub
 subtest '[az_storage_blob_list]' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { @calls = $_[0]; return '["Arlecchino", "Pantalone"]'; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            return 'out.json' if grep /az.json/, $_[0];
+            return '["Arlecchino","Pantalone"]' if grep /out.json/, $_[0]; });
 
     my $return_value = az_storage_blob_list(
         container_name => 'Arlecchino',
@@ -1293,12 +1265,10 @@ subtest '[az_storage_blob_list]' => sub {
     );
 
     note("\n --> " . join("\n --> ", @calls));
-    ok((any { /az storage blob list/ } @calls), 'Correct composition of the main command');
-    ok(grep(/--only-show-errors/, @calls), 'Check for argument "--only-show-errors"');
+    ok((any { /storage blob list/ } @calls), 'Correct composition of the main command');
     ok(grep(/--container-name Arlecchino/, @calls), 'Check for argument "--container-name"');
     ok(grep(/--account-name Pantalone/, @calls), 'Check for argument "--account-name"');
-    ok(grep(/--output json/, @calls), 'Return output in "json" format');
-    is(join(' ', @$return_value), 'Arlecchino Pantalone', 'Return correct value');
+    is(join(' ', @{$return_value}), 'Arlecchino Pantalone', 'Return correct value');
 };
 
 subtest '[az_storage_blob_update]' => sub {
@@ -1430,14 +1400,33 @@ subtest '[az_keyvault_secret_show] Calling with "name" and "vault_name" argument
 subtest '[az_group_exists] Compose command' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { @calls = $_[0]; return 'Arlecchino'; });
-
-    my $ret = az_group_exists(name => 'Pantalone');
-
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            return 'out.json' if grep /az.json/, $_[0];
+            return 'true' if grep /out.json/, $_[0]; });
+    az_group_exists(name => 'Pantalone');
     note("\n --> " . join("\n --> ", @calls));
-    ok((any { /az group exists/ } @calls), 'Correct composition of the main command');
+    ok((any { /group exists/ } @calls), 'Correct composition of the main command');
     ok((grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"'), 'Correct argument about resource group name');
-    ok(($ret eq 'Arlecchino'), "Correct return code: expect 'Arlecchino' get '$ret'");
+};
+
+subtest '[az_group_exists] Test return values' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { return 0; });
+    my @passing_values = ('true', 'false');
+
+    for my $value (@passing_values) {
+        $azcli->redefine(script_output => sub {
+                return 'out.json' if grep /az.json/, $_[0];
+                return $value if grep /out.json/, $_[0]; });
+        ok(JSON::PP::is_bool(az_group_exists(name => 'Pantalone')), "Pass with boolean value '$value' returned.");
+    }
+    $azcli->redefine(script_output => sub {
+            return 'out.json' if grep /az.json/, $_[0];
+            return 'Valore non valido' if grep /out.json/, $_[0]; });
+    dies_ok { az_group_exists(name => 'Pantalone') } 'Fail with non boolean value returned';
 };
 
 subtest '[az_nic_list] Compose command' => sub {
@@ -1463,7 +1452,6 @@ subtest '[az_nic_list] Optional args' => sub {
     note("\n --> " . join("\n --> ", @calls));
     ok(grep(/--query "\[].calzini"/, @calls), 'Check for optional argument "--query"');
 };
-
 
 subtest '[az_network_vnet_show] Compose command' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -297,26 +297,25 @@ subtest '[ipaddr2_cluster_check_version]' => sub {
 
 subtest '[ipaddr2_deployment_sanity] Pass' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
+    my @vm_waits;
+    my @vm_list = qw(ip2t-vm-01 ip2t-vm-02 ip2t-vm-bastion);
+
+    $ipaddr2->redefine(az_vm_list => sub { return \@vm_list; });
     $ipaddr2->redefine(script_run => sub { push @calls, ['ipaddr2', $_[0]]; return; });
     $ipaddr2->redefine(get_current_job_id => sub { return 'Volta'; });
     $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
-
-    my @vm_list = qw(ip2t-vm-01 ip2t-vm-02 ip2t-vm-bastion);
-    my @vm_waits;
+    # Simulate az cli to return exactly one name for the bastion VM name
     $ipaddr2->redefine(az_vm_wait_running => sub {
             my (%args) = @_;
             push @vm_waits, $args{name};
     });
-
-    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     $azcli->redefine(script_output => sub {
             push @calls, ['azure_cli', $_[0]];
             # Simulate az cli to return 2 resource groups
             # one for the current jobId Volta and another one
             if ($_[0] =~ /az group list*/) { return '["ip2tVolta","ip2tFermi"]'; }
-            # Simulate az cli to return exactly one name for the bastion VM name
-            if ($_[0] =~ /az vm list*/) { return '["ip2t-vm-bastion", "ip2t-vm-02", "ip2t-vm-01"]'; }
     });
 
     ipaddr2_deployment_sanity();
@@ -335,6 +334,7 @@ subtest '[ipaddr2_deployment_sanity] Fails rg num' => sub {
     my @calls;
     $ipaddr2->redefine(script_run => sub { push @calls, ['ipaddr2', $_[0]]; return; });
     $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $ipaddr2->redefine(az_vm_list => sub { return ['ip2t-vm-bastion']; });
 
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
 
@@ -344,7 +344,6 @@ subtest '[ipaddr2_deployment_sanity] Fails rg num' => sub {
     $azcli->redefine(script_output => sub {
             push @calls, ['azure_cli', $_[0]];
             if ($_[0] =~ /az group list*/) { return '["ip2tVolta","ip2tFermi"]'; }
-            if ($_[0] =~ /az vm list*/) { return '["ip2t-vm-bastion"]'; }
     });
 
     dies_ok { ipaddr2_deployment_sanity() } "Sanity check if there's any rg with the expected name";

--- a/t/26_deployment_connector.t
+++ b/t/26_deployment_connector.t
@@ -292,7 +292,8 @@ subtest '[destroy_orphaned_peerings]' => sub {
     $mock_function->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $mock_function->redefine(az_network_peering_delete => sub { return; });
     $mock_function->redefine(az_network_vnet_get => sub { return ['Zabi-VNET']; });
-    $mock_function->redefine(az_group_exists => sub { return 'true' if grep /^existing$/, @_; return 'false' });
+    $mock_function->redefine(az_group_exists => sub { return $JSON::PP::true if grep /^existing$/, @_;
+            return $JSON::PP::false });
     $mock_function->redefine(az_network_peering_list => sub { return [
                 {"workload_resource_group" => "existing", "peering_name" => "Iron_blooded_orphans"},
                 {"workload_resource_group" => "existing", "peering_name" => "EarthFederation"}];

--- a/tests/sles4sap/sap_deployment_automation_framework/deploy_workload_zone.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/deploy_workload_zone.pm
@@ -69,7 +69,6 @@ sub run {
     for my $variable_name (keys(%network_data)) {
         set_var(uc($variable_name), $network_data{$variable_name});
     }
-
     create_workload_tfvars(network_data => \%network_data, workload_vnet_code => $workload_vnet_code, os_image => $os);
 
     az_login();


### PR DESCRIPTION
This PR introduces `az` function which should serve as a general purpose
 `az cli` executor. Output is split into RC, result and error messages
 as a perl data structure.

**Ticket:** https://jira.suse.com/browse/TEAM-11278

**VRs:**
**SDAF:** https://openqaworker15.qe.prg2.suse.org/tests/381328#
**ipaddr2:** https://openqaworker15.qe.prg2.suse.org/tests/381330#
**qesap-deployment:** 
https://openqaworker15.qe.prg2.suse.org/tests/381561#  Failure unrelated
https://openqaworker15.qe.prg2.suse.org/tests/381565#live