### PR TITLE
Drop packagehub for migration testings

### DIFF
--- a/data/yam/autoyast/textmode_all_modules_and_extensions_aarch64.xml.ep
+++ b/data/yam/autoyast/textmode_all_modules_and_extensions_aarch64.xml.ep
@@ -80,11 +80,6 @@
         <arch>{{ARCH}}</arch>
       </addon>
       <addon>
-        <name>PackageHub</name>
-        <version>{{VERSION}}</version>
-        <arch>{{ARCH}}</arch>
-      </addon>
-      <addon>
         <name>sle-module-NVIDIA-compute</name>
         <version>15</version>
         <arch>{{ARCH}}</arch>

--- a/data/yam/autoyast/textmode_all_modules_and_extensions_ppc64le.xml.ep
+++ b/data/yam/autoyast/textmode_all_modules_and_extensions_ppc64le.xml.ep
@@ -79,11 +79,6 @@
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
       </addon>
-      <addon>
-        <name>PackageHub</name>
-        <version>{{VERSION}}</version>
-        <arch>{{ARCH}}</arch>
-      </addon>
     </addons>
   </suse_register>
   <general>

--- a/data/yam/autoyast/textmode_all_modules_and_extensions_s390x.xml.ep
+++ b/data/yam/autoyast/textmode_all_modules_and_extensions_s390x.xml.ep
@@ -79,11 +79,6 @@
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
       </addon>
-      <addon>
-        <name>PackageHub</name>
-        <version>{{VERSION}}</version>
-        <arch>{{ARCH}}</arch>
-      </addon>
     </addons>
   </suse_register>
   <general>

--- a/data/yam/autoyast/textmode_all_modules_and_extensions_x86_64.xml.ep
+++ b/data/yam/autoyast/textmode_all_modules_and_extensions_x86_64.xml.ep
@@ -86,11 +86,6 @@
         <arch>{{ARCH}}</arch>
       </addon>
       <addon>
-        <name>PackageHub</name>
-        <version>{{VERSION}}</version>
-        <arch>{{ARCH}}</arch>
-      </addon>
-      <addon>
         <name>sle-module-NVIDIA-compute</name>
         <version>15</version>
         <arch>{{ARCH}}</arch>


### PR DESCRIPTION
PackageHub is not supportted for migration, so drop it for all migration cases.

- Related ticket: https://progress.opensuse.org/issues/203745
- Verification run: https://openqa.suse.de/tests/overview?version=16.1&build=chcao_poo203745&distri=sle
- Related mr: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/862
