### PR TITLE
Remove ntp validation for SLE 160 QU test

### DIFF
--- a/schedule/yam/agama_autoyast_supported_qemu_160.yaml
+++ b/schedule/yam/agama_autoyast_supported_qemu_160.yaml
@@ -1,0 +1,13 @@
+---
+name: agama_autoyast_supported for 160
+description: >
+  Agama installation with backwards compatibility with AutoYaST using only supported AutoYaST elements.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_base_product
+  - yam/validate/validate_first_user
+  - yam/validate/validate_deployed_files
+  - console/verify_separate_home

--- a/schedule/yam/agama_extended_unattended_160.yaml
+++ b/schedule/yam/agama_extended_unattended_160.yaml
@@ -1,0 +1,17 @@
+---
+name: agama_extended_unattended for 160
+description: >
+  Perform unattended installation with agama setting a custom hostname via kernel parameters and individual packages installed.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_hostname
+  - yam/validate/validate_packages
+  - yam/validate/validate_post_partitioning
+  - yam/validate/validate_deployed_files
+  - yam/validate/validate_systemd_timers
+  - yam/validate/validate_bootloader_timeout
+  - console/validate_repos
+  - yam/validate/validate_extra_kernel_params

--- a/schedule/yam/agama_extended_unattended_ppc64le_160.yaml
+++ b/schedule/yam/agama_extended_unattended_ppc64le_160.yaml
@@ -1,0 +1,17 @@
+---
+name: agama_extened_packages_unattended for 160 ppc64le
+description: >
+  Prepare unattended installation with individual packages installed
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_packages
+  - yam/validate/validate_post_partitioning
+  - yam/validate/validate_deployed_files
+  - yam/validate/validate_systemd_timers
+  - yam/validate/validate_bootloader_timeout
+  - console/validate_repos
+  - yam/validate/validate_extra_kernel_params

--- a/schedule/yam/agama_extended_unattended_s390x_160.yaml
+++ b/schedule/yam/agama_extended_unattended_s390x_160.yaml
@@ -1,0 +1,17 @@
+---
+name: agama_extened_packages_unattended for 160 s390x
+description: >
+  Prepare unattended installation with individual packages installed
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - yam/validate/validate_packages
+  - yam/validate/validate_post_partitioning
+  - yam/validate/validate_deployed_files
+  - yam/validate/validate_systemd_timers
+  - yam/validate/validate_bootloader_timeout
+  - console/validate_repos
+  - yam/validate/validate_extra_kernel_params


### PR DESCRIPTION
## 
## Summary
NTP configuration in Agama is a new feature in 16.1, We need to remove it from SLE 160 QU test.


- Related ticket: Quick PR
- Needles: N/A
- Verification run: N/A

##