### PR TITLE
NFS: fixup Create new lib/Kernel/nfs.pm

### DIFF
--- a/lib/Kernel/nfs.pm
+++ b/lib/Kernel/nfs.pm
@@ -3,7 +3,7 @@
 
 package Kernel::nfs;
 
-use Exporter;
+use Exporter 'import';
 
 use strict;
 use warnings;


### PR DESCRIPTION
The introduction of the new NFS kernel library had a wrong use Exporter; 
This fixes the line

- Verification run: https://openqa.suse.de/tests/23372995 https://openqa.suse.de/tests/23372996 
