### PR TITLE
Set registration server for SLES16.0 guest explicitly

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_sev_es_x86_64_agama_full_repo.xml
+++ b/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_sev_es_x86_64_agama_full_repo.xml
@@ -95,7 +95,7 @@
     <guest_noreboot/>
     <guest_default_target>graphical</guest_default_target>
     <guest_do_registration>true</guest_do_registration>
-    <guest_registration_server/>
+    <guest_registration_server>https://scc.suse.com/</guest_registration_server>
     <guest_registration_username/>
     <guest_registration_password/>
     <guest_registration_extensions/>

--- a/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_sev_snp_x86_64_agama_full_repo.xml
+++ b/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_sev_snp_x86_64_agama_full_repo.xml
@@ -94,7 +94,7 @@
     <guest_noreboot/>
     <guest_default_target>graphical</guest_default_target>
     <guest_do_registration>true</guest_do_registration>
-    <guest_registration_server/>
+    <guest_registration_server>https://scc.suse.com/</guest_registration_server>
     <guest_registration_username/>
     <guest_registration_password/>
     <guest_registration_extensions/>

--- a/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_full_repo.xml
+++ b/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_full_repo.xml
@@ -94,7 +94,7 @@
     <guest_noreboot/>
     <guest_default_target>graphical</guest_default_target>
     <guest_do_registration>true</guest_do_registration>
-    <guest_registration_server/>
+    <guest_registration_server>https://scc.suse.com/</guest_registration_server>
     <guest_registration_username/>
     <guest_registration_password/>
     <guest_registration_extensions/>

--- a/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_full_repo_qcow2_nvram.xml
+++ b/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_full_repo_qcow2_nvram.xml
@@ -94,7 +94,7 @@
     <guest_noreboot/>
     <guest_default_target>graphical</guest_default_target>
     <guest_do_registration>true</guest_do_registration>
-    <guest_registration_server/>
+    <guest_registration_server>https://scc.suse.com/</guest_registration_server>
     <guest_registration_username/>
     <guest_registration_password/>
     <guest_registration_extensions/>

--- a/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_kvm_hvm_aarch64_agama_full_repo.xml
+++ b/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_kvm_hvm_aarch64_agama_full_repo.xml
@@ -94,7 +94,7 @@
     <guest_noreboot/>
     <guest_default_target>graphical</guest_default_target>
     <guest_do_registration>true</guest_do_registration>
-    <guest_registration_server/>
+    <guest_registration_server>https://scc.suse.com/</guest_registration_server>
     <guest_registration_username/>
     <guest_registration_password/>
     <guest_registration_extensions/>


### PR DESCRIPTION
* **Set** registration server for SLES16.0 guest explicitly:
  * ```SLE_16_0_QU_sles_16_64_kvm_hvm_sev_es_x86_64_agama_full_repo.xml```
  * ```SLE_16_0_QU_sles_16_64_kvm_hvm_sev_snp_x86_64_agama_full_repo.xml```
  * ```SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_full_repo.xml```
  * ```SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_full_repo_qcow2_nvram.xml```
  * ```SLE_16_0_QU_sles_16_kvm_hvm_aarch64_agama_full_repo.xml```

* **This** change can avoid querying ```BUILD_SLE``` setting in subroutine ```render_scc_url``` which causes failure [like this](https://openqa.suse.de/tests/23358605#step/unified_guest_installation/264), because automatic OSD test run trigger  for SLES16.0 full media has no ```BUILD_SLE```.

* **Verification Runs:**
  * [sle-16.0-Full-x86_64-Build259.5-sev-es-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23405152)
  * [sle-16.0-Full-x86_64-Build259.5-sev-snp-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23405153)
  * [sle-16.0-Full-x86_64-Build259.5-snapshot-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23405155)
  * [sle-16.0-Full-x86_64-Build259.5-uefi-gi-full-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23405157)