### PR TITLE
fix(publiccloud): guard LTP results.json upload when kirk aborts

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -130,7 +130,16 @@ sub upload_ltp_logs
     my $log_file = Mojo::File::path('ulogs/results.json');
 
     record_info('LTP Logs', 'upload');
-    upload_logs("/tmp/kirk.\$USER/latest/results.json", log_name => $log_file->basename, failok => 1);
+    # kirk only writes results.json when the session collected results. On an
+    # aborted run (e.g. an SSH drop mid-suite raising a KirkException, kirk exits
+    # 1) the file is never created, so a blind upload emits a confusing
+    # "curl: (26) Failed to open/read local data" line. Guard the upload and
+    # note the absence instead. See poo#203316.
+    if (script_run('test -e /tmp/kirk.$USER/latest/results.json') == 0) {
+        upload_logs("/tmp/kirk.\$USER/latest/results.json", log_name => $log_file->basename, failok => 1);
+    } else {
+        record_info('No results.json', 'kirk did not produce results.json (run likely aborted); skipping upload', result => 'softfail');
+    }
     upload_logs("/tmp/kirk.\$USER/latest/debug.log", log_name => 'debug.txt', failok => 1);
 
     return unless -e $log_file->to_string;


### PR DESCRIPTION
## Problem

publiccloud_ltp jobs occasionally show a confusing `curl: (26) Failed to open/read local data` error while uploading `results.json`, e.g. https://openqa.suse.de/tests/23071818#step/run_ltp/105 (poo#203316).

## Root cause

kirk writes `/tmp/kirk.$USER/latest/results.json` only when the session collected results (`if self._results:` in libkirk/session.py). When the run aborts — in the linked job an SSH drop mid-`cgroup_fj_stress` raised a KirkException and kirk exited 1 — the file is never created. `debug.log` is always created (at session start), which is why the debug.txt upload succeeds (exit 0) but the results.json upload fails (exit 26) from the same directory.

kirk's exit codes are only RC_OK=0 / RC_ERROR=1 / RC_INTERRUPT=130; test pass/fail is not encoded in the exit code, so `die('kirk failed') if ($kirk_exit_code)` correctly fails the module on an aborted run. The only defect is the misleading curl error from the unconditional upload.

## Fix

Guard the `results.json` upload behind a `test -e` check and record a softfail note when it is absent, instead of blindly curling a non-existent file. No pass/fail semantics change.

## Testing

perltidy clean against .perltidyrc. Change is limited to `upload_ltp_logs` in tests/publiccloud/run_ltp.pm.