### PR TITLE
YAML scheduler: Avoid false positives if expected test data is empty

### DIFF
--- a/lib/scheduler.pm
+++ b/lib/scheduler.pm
@@ -115,6 +115,7 @@ Returns test data parsed from the yaml file.
 =cut
 
 sub get_test_suite_data {
+    die("No test data available, check that either YAML_TEST_DATA is defined or that the schedule contains test_data") unless keys %{$test_suite_data};
     return $test_suite_data;
 }
 

--- a/tests/console/validate_md_raid.pm
+++ b/tests/console/validate_md_raid.pm
@@ -36,6 +36,8 @@ sub run {
     select_console 'root-console';
 
     my $test_data = get_test_suite_data();
+    die("No test data available, check 'YAML_TEST_DATA' is defined either in the test schedule or by test settings") if (!defined($test_data->{mds}));
+
     my ($mdadm_output, $mdadm_cfg);
 
     foreach my $md (@{$test_data->{mds}}) {

--- a/tests/console/validate_md_raid.pm
+++ b/tests/console/validate_md_raid.pm
@@ -36,8 +36,6 @@ sub run {
     select_console 'root-console';
 
     my $test_data = get_test_suite_data();
-    die("No test data available, check 'YAML_TEST_DATA' is defined either in the test schedule or by test settings") if (!defined($test_data->{mds}));
-
     my ($mdadm_output, $mdadm_cfg);
 
     foreach my $md (@{$test_data->{mds}}) {

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -30,7 +30,7 @@ use Utils::Logging 'save_and_upload_log';
 
 # load expected test data from yaml
 # common for both iscsi MM modules
-my $test_data = get_test_suite_data();
+my $test_data = undef;
 
 sub initiator_service_tab {
     apply_workaround_poo124652('iscsi-client-service') if (is_sle('>=15-SP4'));
@@ -119,6 +119,7 @@ sub initiator_connected_targets_tab {
 
 
 sub run {
+    $test_data = get_test_suite_data();
     prepare_xterm_and_setup_static_network(ip => $test_data->{initiator_conf}->{ip}, message => 'Configure MM network - client');
     zypper_call("in open-iscsi yast2-iscsi-client");
     mutex_wait('iscsi_target_ready', undef, 'Target configuration in progress!');

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -31,7 +31,7 @@ use YaST::workarounds;
 
 # load expected test data from yaml
 # common for both iscsi MM modules
-my $test_data = get_test_suite_data();
+my $test_data = undef;
 
 sub create_fileio {
     if (defined($test_data->{target_conf}->{backstore})) {
@@ -205,6 +205,7 @@ sub display_targets {
 
 sub run {
     my $self = shift;
+    $test_data = get_test_suite_data();
     # open xterm, configure server network and create drive for iscsi
     prepare_xterm_and_setup_static_network(ip => $test_data->{target_conf}->{ip}, message => 'Configure MM network - server');
     prepare_iscsi_deps;


### PR DESCRIPTION
In case YAML_TEST_DATA is not defined the test will pass leading to a [false positive](https://openqa.opensuse.org/tests/6094796#step/validate_md_raid/7).

openqa: clone https://openqa.opensuse.org/tests/6101827 RAIDLEVEL=0 YAML_TEST_DATA="" YAML_SCHEDULE=""
openqa: clone https://openqa.opensuse.org/tests/6101827 RAIDLEVEL=0
#### Results from cloned jobs:
- [![https://openqa.opensuse.org/tests/6104152](https://openqa.opensuse.org/tests/6104152/badge)](https://openqa.opensuse.org/tests/6104152)
- [![https://openqa.opensuse.org/tests/6104247](https://openqa.opensuse.org/tests/6104247/badge)](https://openqa.opensuse.org/tests/6104247)

<sub>The above list is generated with a script with information from the "clone_mentioned_job" workflow.</sub>
