### PR TITLE
Include VERSION=16.1-PRXXX in the simplified version regex

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -139,7 +139,7 @@ sub init_main {
     # note: This is useful because then jobs for individual submissions are not wrongly considered
     #       to be for consecutive builds and e.g. wrong bugref carry over is avoided.
     if (my $version = get_var('VERSION')) {
-        my $simplified_version = $version =~ s/:(?:(git|smelt)[-:])\d+$//rgi;
+        my $simplified_version = $version =~ s/:(?:(git|smelt|PR)[-:])\d+$//rgi;
         if ($version ne $simplified_version) {
             set_var('VERSION_ORIGINAL', $version);
             set_var('VERSION', $simplified_version);


### PR DESCRIPTION
Staging jobs for products under development are triggered with a different VERSION format. For example VERSION=16.1:PR-5466 This breaks a lot of tests that rely on a "real" version string.
VRs: https://openqa.suse.de/tests/overview?build=jlausuch%2Fos-autoinst-distri-opensuse%23gitea_PR&version=16.1%3APR-6185&distri=sle 