### PR TITLE
Make podman flake filter private

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -24,7 +24,6 @@ Library to compose and run Azure cli commands
 =cut
 
 our @EXPORT = qw(
-  $SDAF_Azure_podman_flake_filter
   az_version
   az_group_create
   az_group_name_get
@@ -196,9 +195,7 @@ sub az_group_delete(%args) {
 
     az_group_exists(name => 'resource group name' [, quiet=>'pssst!']);
 
-Check if specified resource group exists.
-Returns whatever 'az group exist' is returning
-that usually is string B<true> or B<false>.
+Returns non-empty value if resource group exists, otherwise B<undef>
 
 =over
 
@@ -211,7 +208,11 @@ that usually is string B<true> or B<false>.
 
 sub az_group_exists(%args) {
     croak "Missing mandatory argument: 'name'" unless $args{name};
-    return script_output("az group exists --resource-group $args{name} $SDAF_Azure_podman_flake_filter", quiet => $args{quiet});
+    my $cmd = "az group exists --resource-group $args{name} $SDAF_Azure_podman_flake_filter";
+    my $out = script_output($cmd, quiet => $args{quiet});
+    die "Command '$cmd' failed.\nCommand returned: $out" unless $out =~ /(true|false)/i;
+    return undef if $out =~ /false/i;
+    return $out;
 }
 
 =head2 az_network_vnet_create

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -770,28 +770,6 @@ sub prepare_sdaf_project {
     assert_script_run("mkdir -p $_") foreach @create_workspace_dirs;
 }
 
-=head2 resource_group_exists
-
-    resource_group_exists($resource_group);
-
-Checks if resource group exists. Function accepts only full resource name.
-Croaks if command does not return true/false value.
-
-=over
-
-=item * B<$resource_group>: Resource group name to check
-
-=back
-=cut
-
-sub resource_group_exists {
-    my ($resource_group) = @_;
-    croak 'Mandatory positional argument "$resource_group" not defined.' unless $resource_group;
-
-    my $cmd_out = script_output("az group exists -n $resource_group $SDAF_Azure_podman_flake_filter");
-    die "Command 'az group exists -n $resource_group' failed.\nCommand returned: $cmd_out" unless grep /false|true/, $cmd_out;
-    return ($cmd_out eq 'true');
-}
 
 =head2 sdaf_execute_remover
 
@@ -876,8 +854,9 @@ sub sdaf_cleanup {
     my %result;
     # Sap system needs to be destroyed before workload zone so order matters here.
     for my $deployment_type ('sap_system', 'workload_zone') {
-        my $resource_group = resource_group_exists(generate_resource_group_name(deployment_type => $deployment_type));
-        unless ($resource_group) {
+        my $group_exists = az_group_exists(
+            name => generate_resource_group_name(deployment_type => $deployment_type));
+        unless ($group_exists) {
             record_info('Cleanup skip', "Resource group for deployment type '$deployment_type' does not exist. Skipping cleanup");
             next;
         }

--- a/t/20_sdaf_deployment_library.t
+++ b/t/20_sdaf_deployment_library.t
@@ -210,10 +210,11 @@ subtest '[sdaf_cleanup] Test correct usage' => sub {
     $ms_sdaf->noop(qw(record_info
           script_output
           deployment_dir
-          resource_group_exists));
+    ));
     $ms_sdaf->redefine(generate_resource_group_name => sub { return 'ResourceGroup'; });
     $ms_sdaf->redefine(sdaf_execute_remover => sub { return 0; });
     $ms_sdaf->redefine(script_run => sub { return 0; });
+    $ms_sdaf->redefine(az_group_exists => sub { return 'true'; });
 
     my %cleanup_results = %{sdaf_cleanup()};
     ok(!$cleanup_results{remover_failed}, 'Remover passes with correct usage');
@@ -224,7 +225,7 @@ subtest '[sdaf_cleanup] Test remover script failures' => sub {
     my $ms_sdaf = Test::MockModule->new('sles4sap::sap_deployment_automation_framework::deployment', no_auto => 1);
     my $force_group_delete;
     $ms_sdaf->noop(qw(script_output deployment_dir generate_resource_group_name ));
-    $ms_sdaf->redefine(resource_group_exists => sub { return 'yes'; });
+    $ms_sdaf->redefine(az_group_exists => sub { return 'true'; });
     $ms_sdaf->redefine(sdaf_destroy_resources => sub { $force_group_delete = 1; });
     $ms_sdaf->redefine(sdaf_execute_remover => sub { return 1; });
     $ms_sdaf->redefine(script_run => sub { return 0; });
@@ -246,12 +247,12 @@ subtest '[sdaf_execute_remover] Check command line arguments' => sub {
           record_info
           upload_logs
           assert_script_run
-          resource_group_exists
           log_dir
           deployment_dir
           sdaf_scripts_dir
           generate_resource_group_name)
     );
+    $ms_sdaf->redefine(az_group_exists => sub { return 'true'; });
     $ms_sdaf->redefine(script_run => sub { push @script_run_calls, $_[0] if grep /remover/, $_[0]; return 0; });
     $ms_sdaf->redefine(get_os_variable => sub {
             return '/some/path/LAB-SECE-SAP04-INFRASTRUCTURE-6453.tfvars' if $_[0] eq 'workload_zone_parameter_file';
@@ -268,7 +269,6 @@ subtest '[sdaf_execute_remover] Check command line arguments' => sub {
         ok(grep(/| tee .*\.log/, split(' ', $cmd)), 'Log command output');
         ok(grep(/\$\{PIPESTATUS\[0]}/, split(' ', $cmd)), 'Return command RC instead of tee');
     }
-
     # Test remover retry
     $ms_sdaf->redefine(script_run => sub { return 1; });
     dies_ok { sdaf_cleanup() } 'Test failing remover script: retried 3 times and failed';

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -1430,15 +1430,24 @@ subtest '[az_keyvault_secret_show] Calling with "name" and "vault_name" argument
 subtest '[az_group_exists] Compose command' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { @calls = $_[0]; return 'Arlecchino'; });
-
-    my $ret = az_group_exists(name => 'Pantalone');
-
+    $azcli->redefine(script_output => sub { @calls = $_[0]; return 'true'; });
+    az_group_exists(name => 'Pantalone');
     note("\n --> " . join("\n --> ", @calls));
     ok((any { /az group exists/ } @calls), 'Correct composition of the main command');
     ok((grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"'), 'Correct argument about resource group name');
-    ok(($ret eq 'Arlecchino'), "Correct return code: expect 'Arlecchino' get '$ret'");
 };
+
+
+subtest '[az_group_exists] Test return values' => sub {
+    my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
+    $azcli->redefine(script_output => sub { return 'true'; });
+    ok((az_group_exists(name => 'Pantalone') eq 'true'), 'Return "true" if group exists');
+    $azcli->redefine(script_output => sub { return 'false'; });
+    ok(!az_group_exists(name => 'Pantalone'), 'Return "undef" if group does not exist');
+    $azcli->redefine(script_output => sub { return 'Arlecchino'; });
+    dies_ok { az_group_exists(name => 'Pantalone') } 'Fail with incorrect command output.';
+};
+
 
 subtest '[az_nic_list] Compose command' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);


### PR DESCRIPTION
This PR is first step in removing `$SDAF_Azure_podman_flake_filter` from
 az cli library. Change makes filter private and removes redundant
 function.  
 
Ticket: https://jira.suse.com/browse/TEAM-11278
VR: https://openqaworker15.qe.prg2.suse.org/tests/377609#details