### PR TITLE
fix: Add softfailure for bsc#1271468

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -223,6 +223,10 @@ sub check_jeos_on_serial_terminal {
         record_soft_failure("bsc#1260359 - No serial terminal on ppc64le");
         return;
     }
+    elsif (is_sle("=16.0") && is_ppc64le) {
+        record_soft_failure("bsc#1271468 - No serial terminal on ppc64le");
+        return;
+    }
     die "JeOS firstboot not detected on serial terminal";
 }
 


### PR DESCRIPTION
SLES 16.0 is also affected by [bsc#1260359](https://bugzilla.suse.com/show_bug.cgi?id=1260359) and needs to be added to the sotfail. The issue is reported in [bsc#1271468](https://bugzilla.suse.com/show_bug.cgi?id=1271468).

- Related failure: https://openqa.suse.de/tests/23388945#step/firstrun/3
- Verification run: https://openqa.suse.de/tests/23389133#step/firstrun/3
