### PR TITLE
io_uring: Improve record_info() message of excluded tests

### DIFF
--- a/tests/kernel/io_uring.pm
+++ b/tests/kernel/io_uring.pm
@@ -81,10 +81,11 @@ sub run {
     my @skipped = $whitelist->list_skipped_tests($environment, 'liburing');
     if (@skipped) {
         push @skipped, $exclude if $exclude;
-        $test_exclude = join(' ', @skipped);
+        $test_exclude = join("\n", sort @skipped);
+        my $count = $#skipped + 1;
         record_info(
-            "Exclude",
-            "Excluding tests: $test_exclude",
+            "Exclude ($count)",
+            "Excluding tests ($count):\n$test_exclude",
             result => 'softfail'
         );
     }


### PR DESCRIPTION
* Add a count of excluded test
* Print tests with new line (more readable than having them in single long line
* Sort excluded tests

This helps readability when comparing 2 results.

- Verification run: https://openqa.suse.de/tests/23389809#step/io_uring/47

@schlad FYI (absolutely no rush with the review)
