### PR TITLE
fix(publiccloud): Adopt guestregister BYOS detection run on boot

### DIFF
--- a/tests/publiccloud/registercloudguest.pm
+++ b/tests/publiccloud/registercloudguest.pm
@@ -92,7 +92,12 @@ sub run {
             }
 
             if ($instance->ssh_script_run(cmd => 'sudo test -s /var/log/cloudregister') == 0) {
-                die('/var/log/cloudregister is not empty');
+                my $log_content = $instance->ssh_script_output(cmd => 'sudo cat /var/log/cloudregister');
+                if ($log_content =~ /check_payg_byos.*Successful server query: BYOS/s) {
+                    record_info('guestregister BYOS check', 'guestregister ran a BYOS/PAYG detection on boot and confirmed BYOS. No registration occurred.');
+                } else {
+                    die('/var/log/cloudregister is not empty');
+                }
             }
             rotate_cloudregister_log($instance);
             $instance->ssh_assert_script_run(cmd => '! sudo SUSEConnect -d', fail_message => 'SUSEConnect succeeds but it is not supported should fail on BYOS');


### PR DESCRIPTION
Since image build 1.10, `guestregister.service` runs a BYOS/PAYG detection check on boot and writes to `/var/log/cloudregister` even when no registration occurs. The log ends with `check_payg_byos: Successful server query: BYOS` — the service confirmed BYOS and exited cleanly.

The test was unconditionally dying on any non-empty log. Fix: read the log content and only die if it doesn't match the known BYOS detection fingerprint. The existing `check_instance_unregistered` call earlier in the block already guards against actual registration.

- Related ticket: https://progress.opensuse.org/issues/202152
- Verification run: 