### PR TITLE
fix(rebootmgr): Skip redundant select_console after soft reboot

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -161,7 +161,11 @@ sub process_reboot {
     }
 
     # Switch to the previous console
-    select_console $prev_console;
+    # Skip if already on root-console: after a soft reboot select_console 'root-console' was
+    # already called above (line 158) and calling it again triggers a race condition on aarch64
+    # where the tty is not yet fully initialised, causing a "no candidate needle" failure.
+    # See https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25771 and poo#202980.
+    select_console $prev_console unless ($prev_console eq 'root-console');
 }
 
 # Reboot if there's a diff between the current FS and the new snapshot


### PR DESCRIPTION
After `process_reboot` logs in via `select_console 'root-console'` (to clear the login needle post-reboot), the trailing `select_console $prev_console` was called unconditionally — even when `$prev_console` was already `'root-console'`. On aarch64 this second call hit a race where the tty was not yet fully reinitialised after a soft reboot, consistently causing:

```
no candidate needle with tag(s) 'root-console' matched
```

Fix: guard the call so it is skipped when `$prev_console eq 'root-console'`. Safe for all other callers — when `$prev_console` is a different console the switch still happens normally.

- Related ticket: poo#202980 https://progress.opensuse.org/issues/202980
- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25771 (added `assert_screen 'linux-login'` + `wait_still_screen` in the soft-reboot path; this PR addresses the remaining race in the same code path)
- Verification run: