### PR TITLE
Improve NTP validation

### DIFF
--- a/tests/yam/validate/validate_ntp.pm
+++ b/tests/yam/validate/validate_ntp.pm
@@ -20,16 +20,6 @@ sub run {
     my $chrony_config = '/etc/chrony.d/99-installer.conf';
     assert_script_run("cat $chrony_config");
     assert_script_run("grep '$_' $chrony_config") foreach @{$test_data->{ntp_servers}};
-
-    my $tracking_output = script_output('chronyc tracking');
-
-    if ($tracking_output =~ /Leap\s+status\s*:\s*(?<status>.+?)\s*$/m) {
-        my $status = $+{status};
-        $status =~ s/\s+$//;
-        die "Chrony tracking failed. Expected Leap status 'Normal', but got '$status'." if $status ne 'Normal';
-    } else {
-        die "Could not parse Leap status from chronyc tracking output.";
-    }
 }
 
 1;


### PR DESCRIPTION
##
### Improve NTP validation
After discussion with developer, We should not validate NTP with Leap status while should do a more reliable ntp validate with chronyc.
- Related ticket: https://progress.opensuse.org/issues/203742

- Verification run: 
  - [__validate_ntp__](https://openqa.suse.de/tests/overview?flavor=Online&version=16.1&build=hjluo_sles_extended_ntp_sync_999&distri=sle)

##
