### PR TITLE
Replace get_workload_resource_group

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -2370,7 +2370,7 @@ sub az_network_dns_link_create {
         "--zone-name $args{zone_name}",
         "--virtual-network $args{vnet}",
         "--name $args{name}",
-        '--registration-enabled true',
+        '--registration-enabled false',
         $SDAF_Azure_podman_flake_filter    # This updates all VMs A records immediately
     );
 

--- a/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
@@ -187,7 +187,7 @@ Returns B<HASHREF> with all data collected in following format:
 sub sdaf_ibsm_data_collect {
     my $ibsm_rg = get_required_var('IBSM_RG');
     my $ibsm_vnet_name = ${az_network_vnet_get(resource_group => $ibsm_rg)}[0];
-    my $workload_resource_group = get_workload_resource_group(deployment_id => find_deployment_id());
+    my $workload_resource_group = get_sdaf_resource_group(deployment_id => find_deployment_id(), resource_group_type => 'workload_zone');
     my $workload_vnet_name = ${az_network_vnet_get(resource_group => $workload_resource_group)}[0];
     my $ibsm_peering_name = get_ibsm_peering_name(source_vnet => $ibsm_vnet_name, target_vnet => $workload_vnet_name);
     my $workload_peering_name = get_ibsm_peering_name(source_vnet => $workload_vnet_name, target_vnet => $ibsm_vnet_name);

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -1554,7 +1554,7 @@ subtest '[az_network_dns_link_create] Compose command' => sub {
     ok(grep(/--zone-name opensuse.org/, @calls), 'Check for argument "--zone-name"');
     ok(grep(/--virtual-network vnet_rg/, @calls), 'Check for argument "--virtual-network"');
     ok(grep(/--name link_to_rg_vnet/, @calls), 'Check for argument "--name"');
-    ok(grep(/--registration-enabled true/, @calls), 'Check for argument "--auto-registration"');
+    ok(grep(/--registration-enabled false/, @calls), 'Check for argument "--auto-registration"');
 };
 
 subtest '[az_network_dns_zone_list] Compose command' => sub {


### PR DESCRIPTION
Replace `get_workload_resource_group` with `get_sdaf_resource_group` as it was deleted
Replace '--registration-enabled true' with '--registration-enabled false' as `Conflict` happened.
For example: http://openqaworker15.qe.prg2.suse.org/tests/377605#step/ibsm_configure/132
```
az network private-dns link vnet create        --resource-group SDAF-OpenQA-workload_zone-377605 --zone-name suse.de --virtual-network OpenQA-377605 --name OpenQA-377605 --registration-enabled true 2> >(grep -Ev 'FutureWarning|Launching flake|self.' >&2); echo 1yuVV-$?-\
  
 ERROR: (Conflict) A virtual network can only be linked to 1 Private DNS zone(s) with auto-registration enabled; 
 conflicting Private DNS zone is '
 /subscriptions/xxx/resourcegroups/openqa-sdaf-lab-library-swedencentral/providers/microsoft.network/privatednszones/openqa.net'.
Code: Conflict
```


- Related ticket: [TEAM-11233](https://jira.suse.com/browse/TEAM-11233) - [SDAF] Prepare shadow testing run for SDAF maintenance update testing
  
- Verification run:
https://openqaworker15.qe.prg2.suse.org/tests/377900#step/patch_and_reboot/382 (patch_and_reboot test module passed, the failure is another issue I will investigate later)