### PR TITLE
qa_test_klp: Enable kernel debugfs for SLE 16.1+

### DIFF
--- a/tests/kernel/qa_test_klp.pm
+++ b/tests/kernel/qa_test_klp.pm
@@ -34,6 +34,9 @@ sub run {
     add_suseconnect_product("sle-sdk") if (is_sle('<12-SP5'));
     install_package('autoconf automake gcc git make');
 
+    # kernel debugfs is disabled by default PED-8812
+    systemctl('enable --now sys-kernel-debug.mount') if is_sle('16.1+');
+
     if (script_run('[ -d /lib/modules/$(uname -r)/build ]') != 0) {
         my $devel_pack = get_kernel_devel_flavor;
 


### PR DESCRIPTION
Enhancement poo#204171: SLE 16.1 has debugfs disabled by default as a new feature and we need to enable it for `qa_test_klp`.


- Related ticket: https://progress.opensuse.org/issues/204171
- Needles: none
- Verification run: 
SLE 16.1: https://openqa.suse.de/tests/23406011
SLE 16.1 immutable: https://openqa.suse.de/tests/23406098
SLE 16.0: https://openqa.suse.de/tests/23406009
Micro 6.2: https://openqa.suse.de/tests/23406010
