### PR TITLE
docker: No need to set default DOCKER_MIN_API_VERSION with v29.4

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -174,8 +174,10 @@ sub configure_docker {
     run_command "mv -f /etc/sysconfig/docker{,.bak} || true";
     run_command "mv -f /etc/docker/daemon.json{,.bak} || true";
     if (script_output(q(docker --version | awk -F'[. ]' '{ print $3 }')) > 28) {
-        my $docker_min_api_version = get_var("DOCKER_MIN_API_VERSION", "1.24");
-        run_command qq(echo '{"min-api-version": "$docker_min_api_version"}' > /etc/docker/daemon.json);
+        # Docker v29 increased minimum API version from 1.24 to 1.44 which broke some tests and stuff like
+        # docker-compose & container_diff and also some tests.  Docker v29.3 lowered it from 1.44 to 1.40.
+        my $docker_min_api_version = get_var("DOCKER_MIN_API_VERSION");
+        run_command qq(echo '{"min-api-version": "$docker_min_api_version"}' > /etc/docker/daemon.json) if $docker_min_api_version;
     }
     run_command qq(echo 'DOCKER_OPTS="$docker_opts"' > /etc/sysconfig/docker);
     record_info "DOCKER_OPTS", $docker_opts;
@@ -210,9 +212,8 @@ sub configure_rootless_docker {
     if (script_output(q(docker --version | awk -F'[. ]' '{ print $3 }')) > 28) {
         # Docker v29 increased minimum API version from 1.24 to 1.44 which broke some tests and stuff like
         # docker-compose & container_diff and also some tests.  Docker v29.3 lowered it from 1.44 to 1.40.
-        # Remove this when we no longer have Docker v29.2 in SLES 16.1.
-        my $docker_min_api_version = get_var("DOCKER_MIN_API_VERSION", "1.24");
-        run_command qq(echo '{"min-api-version": "$docker_min_api_version"}' > \$HOME/.config/docker/daemon.json);
+        my $docker_min_api_version = get_var("DOCKER_MIN_API_VERSION");
+        run_command qq(echo '{"min-api-version": "$docker_min_api_version"}' > \$HOME/.config/docker/daemon.json) if $docker_min_api_version;
     }
     run_command qq(DAEMON_JSON=\$(jq '.+{"registry-mirrors": ["http://$registry"]}' \$HOME/.config/docker/daemon.json));
     run_command q(tee $HOME/.config/docker/daemon.json <<< "$DAEMON_JSON");


### PR DESCRIPTION
We now have Docker v29.4 on all products where we're running the upstream tests.  It fixed some breakage introduced in v29.2 like raising minimum API version, fixed in Docker v29.3.

We want to detect minimum API breakage again, so let's not assign a default.

Verification run: https://openqa.suse.de/tests/23407049