### PR TITLE
Do not need workaround for s390x in ds389_advanced_functional

### DIFF
--- a/lib/services/389ds_server.pm
+++ b/lib/services/389ds_server.pm
@@ -48,11 +48,11 @@ sub workaround_CC_s390x {
 
 # The function below covers all required steps for 389ds server's configuration
 sub config_service {
-    my ($no_check) = @_;
-    $no_check //= 0;    # Need to check by default
-                        # Permit ssh/scp from client as root
-    permit_root_ssh();
-    workaround_CC_s390x if is_s390x;
+    my %args = @_;
+    my $no_check = $args{no_check} // 0;    # Need to check by default
+    my $workaround = $args{workaround} // 1;    # Need workaround for s390x
+    permit_root_ssh();    # Permit ssh/scp from client as root
+    workaround_CC_s390x if (is_s390x && $workaround);
     # Start a local instance with basic configuration file
     assert_script_run("wget --quiet " . data_url("389ds/instance.inf") . " -O /tmp/instance.inf");
     assert_script_run("sed -i 's/\{\{PASSWORD\}\}/$testapi::password/g' /tmp/instance.inf");

--- a/tests/console/ds389_advanced_functional.pm
+++ b/tests/console/ds389_advanced_functional.pm
@@ -23,7 +23,7 @@ sub run {
     record_info("Setup", "Installing and configuring 389ds using library methods");
     assert_script_run("echo '127.0.0.1 localhost.localdomain localhost' > /etc/hosts");
     services::389ds_server::install_service();
-    services::389ds_server::config_service(no_check => 1);
+    services::389ds_server::config_service(no_check => 1, workaround => 0);
     services::389ds_server::enable_service();
     services::389ds_server::check_service();
 


### PR DESCRIPTION
Do not need workaround for s390x in ds389_advanced_functional test module

- Related ticket: https://progress.opensuse.org/issues/204180
- Verification run: https://openqa.suse.de/tests/23438490