### PR TITLE
kernel: Add new Online-Kernel-Nvidia to validation flavor

### DIFF
--- a/lib/kernel.pm
+++ b/lib/kernel.pm
@@ -119,7 +119,7 @@ sub check_kernel_package {
 
 # Check if flavor is validation
 sub is_kernel_validation_flavor {
-    return get_var('FLAVOR', '') =~ /(Online-Immutable|Full-QR|Online-QR|Online|Online-Kernel-(RT|Base|Azure|Baremetal|(RT|64kb)-Baremetal))$/;
+    return get_var('FLAVOR', '') =~ /(Online-Immutable|Full-QR|Online-QR|Online|Online-Kernel-(Nvidia|RT|Base|Azure|Baremetal|(RT|64kb)-Baremetal))$/;
 }
 
 1;


### PR DESCRIPTION
Enhancement poo#204183: We need to test the new kernel-nvidia package in SLE 16.1 product development. A new Online-Kernel-Nvidia flavor has been created and must be added to validation.

Otherwise it will fail with missing `INCIDENT_REPO` https://openqa.suse.de/tests/23417696#step/update_kernel/36.

- Related ticket: https://progress.opensuse.org/issues/204183
- Needles: none
- Verification run:  https://openqa.suse.de/tests/23419976 (fails as expected on missing not available yet kernel-nvidia package)
