### PR TITLE
Remove PUBLIC_CLOUD_SLES4SAP from terraform_apply

### DIFF
--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -215,12 +215,7 @@ sub terraform_apply {
 
     my $instance_id = $self->get_terraform_output(".vm_name.value[0]");
     # gce provides full serial log, so extended timeout
-    if (!check_var('PUBLIC_CLOUD_SLES4SAP', 1) && defined($instance_id)) {
-        if ($instance_id !~ /$self->{resource_name}/) {
-            record_info("Warn", "instance_id " . ($instance_id) ? $instance_id : "empty", result => 'fail');
-        }
-    }
-
+    record_info("Warn", "instance_id " . ($instance_id) ? $instance_id : "empty", result => 'fail') if (defined($instance_id) && $instance_id !~ /$self->{resource_name}/);
     return @instances;
 }
 

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -215,7 +215,7 @@ sub terraform_apply {
 
     my $instance_id = $self->get_terraform_output(".vm_name.value[0]");
     # gce provides full serial log, so extended timeout
-    record_info("Warn", "instance_id " . ($instance_id) ? $instance_id : "empty", result => 'fail') if (defined($instance_id) && $instance_id !~ /$self->{resource_name}/);
+    record_info("Warn", "instance_id:" . ($instance_id ? $instance_id : "empty"), result => 'fail') if (defined($instance_id) && $instance_id !~ /$self->{resource_name}/);
     return @instances;
 }
 

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -542,18 +542,16 @@ sub terraform_apply {
         $self->provider_client->region($region);
         record_info('REGION', "Attempting the deployment in region '$region'");
 
-        if (!get_var('PUBLIC_CLOUD_SLES4SAP')) {
-            if (is_ec2) {
-                $vars{availability_zone} = script_output("aws ec2 describe-instance-type-offerings --location-type availability-zone --filters Name=instance-type,Values=" . $instance_type . " --region '" . $self->provider_client->region . "' --query 'InstanceTypeOfferings[0].Location' --output 'text'");
-                die('Instance type not supported by the selected Availability Zone') if ($vars{availability_zone} =~ /None/);
-                $vars{vpc_security_group_ids} = script_output("aws ec2 describe-security-groups --region '" . $self->provider_client->region . "' --filters 'Name=group-name,Values=tf-sg' --query 'SecurityGroups[0].GroupId' --output text");
-                $vars{subnet_id} = script_output("aws ec2 describe-subnets --region '" . $self->provider_client->region . "' --filters 'Name=tag:Name,Values=tf-subnet' 'Name=availabilityZone,Values=" . $vars{availability_zone} . "' --query 'Subnets[0].SubnetId' --output text");
-            } elsif (is_azure) {
-                my $subnet_id = script_output("az network vnet subnet list -g 'tf-" . $self->provider_client->region . "-rg' --vnet-name 'tf-network' --query '[0].id' --output 'tsv'");
-                $vars{subnet_id} = $subnet_id if ($subnet_id);
-            }
-            $vars{region} = $self->provider_client->region;
+        if (is_ec2) {
+            $vars{availability_zone} = script_output("aws ec2 describe-instance-type-offerings --location-type availability-zone --filters Name=instance-type,Values=" . $instance_type . " --region '" . $self->provider_client->region . "' --query 'InstanceTypeOfferings[0].Location' --output 'text'");
+            die('Instance type not supported by the selected Availability Zone') if ($vars{availability_zone} =~ /None/);
+            $vars{vpc_security_group_ids} = script_output("aws ec2 describe-security-groups --region '" . $self->provider_client->region . "' --filters 'Name=group-name,Values=tf-sg' --query 'SecurityGroups[0].GroupId' --output text");
+            $vars{subnet_id} = script_output("aws ec2 describe-subnets --region '" . $self->provider_client->region . "' --filters 'Name=tag:Name,Values=tf-subnet' 'Name=availabilityZone,Values=" . $vars{availability_zone} . "' --query 'Subnets[0].SubnetId' --output text");
+        } elsif (is_azure) {
+            my $subnet_id = script_output("az network vnet subnet list -g 'tf-" . $self->provider_client->region . "-rg' --vnet-name 'tf-network' --query '[0].id' --output 'tsv'");
+            $vars{subnet_id} = $subnet_id if ($subnet_id);
         }
+        $vars{region} = $self->provider_client->region;
 
         my $cmd = terraform_cmd($runner . ' plan -no-color -out myplan', %vars);
         script_retry($cmd, timeout => $terraform_timeout, delay => 3, retry => 6);
@@ -619,17 +617,10 @@ sub terraform_apply {
 
     my $output = decode_json(script_output($runner . ' output -json'));
     my ($vms, $ips, $resource_id);
-    if (get_var('PUBLIC_CLOUD_SLES4SAP')) {
-        foreach my $vm_type ('hana', 'drbd', 'netweaver') {
-            push @{$vms}, @{$output->{$vm_type . '_name'}->{value}};
-            push @{$ips}, @{$output->{$vm_type . '_public_ip'}->{value}};
-        }
-    } else {
-        $vms = $output->{vm_name}->{value};
-        $ips = $output->{public_ip}->{value};
-        # ResourceID is only provided in the PUBLIC_CLOUD_AZURE_NFS_TEST
-        $resource_id = $output->{resource_id}->{value} if (get_var('PUBLIC_CLOUD_AZURE_NFS_TEST'));
-    }
+    $vms = $output->{vm_name}->{value};
+    $ips = $output->{public_ip}->{value};
+    # ResourceID is only provided in the PUBLIC_CLOUD_AZURE_NFS_TEST
+    $resource_id = $output->{resource_id}->{value} if (get_var('PUBLIC_CLOUD_AZURE_NFS_TEST'));
 
     my @instances;
     foreach my $i (0 .. $#{$vms}) {


### PR DESCRIPTION
terraform_apply is only used via create_instance, that is only sued in test module tests/publiccloud/prepare_instance.
This test module is ot used anymore in any sles4sap test schedule or test.
Remove the special handling of some of the terraform_apply code to keep the code cleaner and simpler.


Related ticket: https://progress.opensuse.org/issues/203703 and https://jira.suse.com/browse/TEAM-11007


# Verification run:

## QE-C

 - sle-15-SP7-Azure-Incidents-x86_64-Build:smelt:43604:systemd-publiccloud_smoketests_gen1 az_Standard_B2s -> http://openqa.suse.de/tests/23425747 :green_circle: 

 - sle-15-SP7-GCE-BYOS-Hardened-Incidents-x86_64-Build:smelt:43604:systemd-publiccloud_smoketests gce_c3-highcpu-22 -> http://openqa.suse.de/tests/23427322 :green_circle: 

## QE-SAP

### HanaSR
sle-15-SP6-Azure-SAP-BYOS-Incidents-x86_64-Build:smelt:43830:python-toml-SAPHanaSR-ScaleUp-PerfOpt az_Standard_E4s_v3
 - http://openqa.suse.de/tests/23425231 :green_circle: 

### mr-test
sle-15-SP5-GCE-SAP-BYOS-Incidents-saptune-x86_64-Build:smelt:43830:python-toml-sles4sap_gnome_saptune_delete_rename gce_n1_highmem_8 
- http://openqa.suse.de/tests/23425217 :red_circle: 
- https://openqa.suse.de/tests/23427357

sle-15-SP5-Azure-SAP-BYOS-Incidents-saptune-x86_64-Build:smelt:45151:dtb-armv7l-sles4sap_gnome_saptune_delete_rename  az_Standard_E4s_v3 
 - http://openqa.suse.de/tests/23428183 :green_circle: 