### PR TITLE
Revert skip of maintenance tests for dtb/kernel-ec2 builds

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -22,11 +22,6 @@ our @EXPORT = qw(load_publiccloud_tests load_publiccloud_download_repos);
 sub load_maintenance_publiccloud_tests {
     my $args = OpenQA::Test::RunArgs->new();
 
-    # Avoid running jobs for ARM-only packages on x86_64. poo#201303
-    return if (is_x86_64 && get_var("BUILD") =~ /:\d+:dtb-(?:aarch64|armv7l)/);
-    # Avoid testing kernel-ec2 on Azure & GCE
-    return if (!is_ec2() && get_var("BUILD") =~ /:\d+:kernel-ec2/);
-
     loadtest "publiccloud/download_repos" unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
     loadtest "publiccloud/prepare_instance", run_args => $args;
     if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {


### PR DESCRIPTION
Reverts the early-return guards added in poo#201303 inside `load_maintenance_publiccloud_tests()` that skipped the full publiccloud maintenance test schedule whenever `BUILD` matched `dtb-(aarch64|armv7l)` on x86_64 or `kernel-ec2` on non-EC2 backends. Restores the full schedule (download_repos, prepare_instance, registration, transfer_repos, patch_and_reboot, ssh_interactive_start, instance_overview, smoketest, systemd_detect_virt, destroy) for these builds.

* Related ticket: [poo#204201](https://progress.opensuse.org/issues/204201)
* Related failure: [openqa.suse.de/t23416163](https://openqa.suse.de/tests/23416163)
* Verification runs:
