### PR TITLE
Revert "YAML scheduler: Avoid false positives if expected test data is empty"

### DIFF
--- a/lib/scheduler.pm
+++ b/lib/scheduler.pm
@@ -115,7 +115,6 @@ Returns test data parsed from the yaml file.
 =cut
 
 sub get_test_suite_data {
-    die("No test data available, check that either YAML_TEST_DATA is defined or that the schedule contains test_data") unless keys %{$test_suite_data};
     return $test_suite_data;
 }
 

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -30,7 +30,7 @@ use Utils::Logging 'save_and_upload_log';
 
 # load expected test data from yaml
 # common for both iscsi MM modules
-my $test_data = undef;
+my $test_data = get_test_suite_data();
 
 sub initiator_service_tab {
     apply_workaround_poo124652('iscsi-client-service') if (is_sle('>=15-SP4'));
@@ -119,7 +119,6 @@ sub initiator_connected_targets_tab {
 
 
 sub run {
-    $test_data = get_test_suite_data();
     prepare_xterm_and_setup_static_network(ip => $test_data->{initiator_conf}->{ip}, message => 'Configure MM network - client');
     zypper_call("in open-iscsi yast2-iscsi-client");
     mutex_wait('iscsi_target_ready', undef, 'Target configuration in progress!');

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -31,7 +31,7 @@ use YaST::workarounds;
 
 # load expected test data from yaml
 # common for both iscsi MM modules
-my $test_data = undef;
+my $test_data = get_test_suite_data();
 
 sub create_fileio {
     if (defined($test_data->{target_conf}->{backstore})) {
@@ -205,7 +205,6 @@ sub display_targets {
 
 sub run {
     my $self = shift;
-    $test_data = get_test_suite_data();
     # open xterm, configure server network and create drive for iscsi
     prepare_xterm_and_setup_static_network(ip => $test_data->{target_conf}->{ip}, message => 'Configure MM network - server');
     prepare_iscsi_deps;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#26090

The original PR would break most installations using autoyast... https://openqa.suse.de/tests/23417535#