### PR TITLE
containers: Adapt volume test for podman v6.0.0

### DIFF
--- a/tests/containers/volumes.pm
+++ b/tests/containers/volumes.pm
@@ -109,7 +109,9 @@ sub test {
         assert_script_run("! $runtime volume inspect $test_volume");
     }
 
-    my $all = ($runtime eq "docker") ? "-a" : "";
+    # podman behaviour changed in podman v6.0.0 to match Docker's behaviour
+    my $podman_version = ($runtime eq "podman") ? script_output("podman version -f '{{.Version}}' | cut -d. -f1") : undef;
+    my $all = ($runtime eq "docker" || $podman_version >= 6) ? "-a" : "";
 
     # Create a dangling (not used by any container) volume and test its removal
     assert_script_run("$runtime volume create $test_volume");


### PR DESCRIPTION

From the changelog at https://github.com/podman-container-tools/podman/releases#release-v6.0.0-rc1
> The podman volume prune command now matches Docker's behavior by only pruning unused anonymous volumes. Please use the newly-added --all option for the previous behavior (pruning all volumes).

Failed job: https://openqa.opensuse.org/tests/6105521#step/volumes_podman/178
Verification run: https://openqa.opensuse.org/tests/6106077