### PR TITLE
podman_e2e: Set STORAGE_DRIVER only on podman 6.0.0+

### DIFF
--- a/tests/containers/podman_e2e.pm
+++ b/tests/containers/podman_e2e.pm
@@ -81,11 +81,11 @@ sub run {
         PODMAN_BINARY => "/usr/bin/podman",
         PODMAN_REMOTE_BINARY => "/usr/bin/podman-remote",
         QUADLET_BINARY => "/usr/libexec/podman/quadlet",
-        STORAGE_DRIVER => "overlay",
         TESTFLAGS => "--junit-report=report.xml",
         TMPDIR => "/var/tmp",
     );
     my $env = join " ", map { "$_=$env{$_}" } sort keys %env;
+    $env{STORAGE_DRIVER} = "overlay" if (version->parse(numeric_version($version)) > version->parse("6.0.0"));
 
     my @xfails = (
         'Libpod Suite::[It] Podman pod create podman pod create --restart=on-failure',


### PR DESCRIPTION
This work-around is needed only on podman v6.0.0+ where we're no longer setting the driver in storage.conf.  Otherwise it fails on podman v5.8.x

Failed job: https://openqa.opensuse.org/tests/6106879

```
Expected
    <string>: 
to contain substring
    <string>: The storage 'driver' option should be set in 
[FAILED] Expected
    <string>: 
to contain substring
    <string>: The storage 'driver' option should be set in 
In [It] at: /var/tmp/podman/test/e2e/pull_test.go:135 @ 07/17/26 06:34:57.488
```

No VR needed.