### PR TITLE
Remove obsolete doc about CLUSTER_TYPES

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -310,7 +310,6 @@ The following variables are relevant for publiccloud related jobs. Keep in mind 
 
 Variable        | Type      | Default value | Details
 ---             | ---       | ---           | ---
-CLUSTER_TYPES | string | false | Set the type of cluster that have to be analyzed (example: "drbd hana").
 OPENTOFU_VERSION | string | "1.11.6" | Version of opentofu to include into PC Tools image
 PUBLIC_AZURE_CLI_TEST | string | "vmss" | Azure CLI test names. This variable should list the test name which should be tested.
 PUBLIC_CLOUD | boolean | false | All Public Cloud tests have this variable set to true. Contact: qa-c@suse.de


### PR DESCRIPTION
CLUSTER_TYPES was a variable used in tests/publiccloud/sles4sap.pm The variable, in the PublicCloud domain, was only used there. That file has been removed in 663eab1560c5b64891a5fc2d0a0eb54268768e95 PR#20516.
