### PR TITLE
Capture OpenTofu init/plan output on timeout and shorten their timeouts

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -25,6 +25,11 @@ use version_utils qw(is_sle_micro);
 
 use constant TERRAFORM_DIR => get_var('PUBLIC_CLOUD_TERRAFORM_DIR', '/root/terraform');
 use constant TERRAFORM_TIMEOUT => 30 * 60;
+use constant TERRAFORM_INIT_TIMEOUT => 3 * 60;
+use constant TERRAFORM_PLAN_TIMEOUT => 5 * 60;
+# Valid values according to documentation: TRACE, DEBUG, INFO, WARN, ERROR & OFF
+# https://developer.hashicorp.com/terraform/internals/debugging
+use constant TERRAFORM_LOG => get_var('TERRAFORM_LOG', '');
 
 our $instance_counter;    # Package variable tracking create_instance calls
 
@@ -434,6 +439,17 @@ sub terraform_cmd {
     return $cmd;
 }
 
+# Run a tofu/terraform step with output captured to a file.
+sub _tofu_run_step {
+    my ($self, %args) = @_;
+    my $output_file = "tf_$args{step}_output";
+    my $cmd = "set -o pipefail; TF_LOG=" . TERRAFORM_LOG . " $args{cmd} 2>&1 | tee $output_file";
+    my $ret = script_retry($cmd, timeout => $args{timeout}, delay => $args{delay}, retry => $args{retry}, die => 0);
+    my $output = script_output("cat $output_file", proceed_on_failure => 1);
+    record_info("TFM $args{step} output", "exit code: $ret", result => ($ret) ? 'fail' : 'ok');
+    return ($ret, $output);
+}
+
 =head2 region_out_of_resources
 
     my $bool = $self->region_out_of_resources($terraform_output);
@@ -486,7 +502,8 @@ sub terraform_apply {
 
     # 1) Terraform init
     assert_script_run('cd ' . TERRAFORM_DIR);
-    script_retry($runner . ' init -no-color', timeout => $terraform_timeout, delay => 3, retry => 6);
+    my ($init_ret) = $self->_tofu_run_step(step => 'init', cmd => $runner . ' init -no-color', timeout => TERRAFORM_INIT_TIMEOUT, delay => 10, retry => 6);
+    die("Terraform init failed with exit code $init_ret") if $init_ret;
 
     # 2) Terraform plan & apply
     #
@@ -496,10 +513,6 @@ sub terraform_apply {
     # Any other kind of failure fails immediately.
     my @regions = ($self->provider_client->region);
     push @regions, split(/\s*,\s*/, get_var('PUBLIC_CLOUD_ALTERNATE_REGIONS', ''));
-
-    # Valid values according to documentation: TRACE, DEBUG, INFO, WARN, ERROR & OFF
-    # https://developer.hashicorp.com/terraform/internals/debugging
-    my $tf_log = get_var("TERRAFORM_LOG", "");
 
     my %vars = ();
     # Some auxiliary variables, requires for fine control and public cloud provider specifics
@@ -559,14 +572,11 @@ sub terraform_apply {
         $vars{region} = $self->provider_client->region;
 
         my $cmd = terraform_cmd($runner . ' plan -no-color -out myplan', %vars);
-        script_retry($cmd, timeout => $terraform_timeout, delay => 3, retry => 6);
+        my ($plan_ret) = $self->_tofu_run_step(step => 'plan', cmd => $cmd, timeout => TERRAFORM_PLAN_TIMEOUT, delay => 10, retry => 6);
+        die("Terraform plan failed with exit code $plan_ret") if $plan_ret;
 
-        $ret = script_run("set -o pipefail; TF_LOG=$tf_log $runner apply -no-color -input=false myplan 2>&1 | tee tf_apply_output", timeout => $terraform_timeout);
-        $tf_apply_output = script_output('cat tf_apply_output', proceed_on_failure => 1);
+        ($ret, $tf_apply_output) = $self->_tofu_run_step(step => 'apply', cmd => "$runner apply -no-color -input=false myplan", timeout => $terraform_timeout, delay => 0, retry => 1);
         $self->terraform_applied(1);    # Must happen here to prevent resource leakage
-
-        record_info("TFM apply output", $tf_apply_output, result => ($ret) ? 'fail' : 'ok');
-        record_info("TFM apply exit code", $ret);
 
         # when all instances of certain type are booked in one AZ there is a chance that other AZ in same region still have them
         # to improve test stability let's loop over all available AZ in case initial one throwing error that all instances are booked
@@ -579,11 +589,10 @@ sub terraform_apply {
                 $vars{availability_zone} = $az;
 
                 $cmd = terraform_cmd($runner . ' plan -no-color -out myplan', %vars);
-                script_retry($cmd, timeout => $terraform_timeout, delay => 3, retry => 6);
-                $ret = script_run("set -o pipefail; TF_LOG=$tf_log $runner apply -no-color -input=false myplan 2>&1 | tee tf_apply_output", timeout => $terraform_timeout);
-                $tf_apply_output = script_output('cat tf_apply_output', proceed_on_failure => 1);
-                record_info("TFM apply output", $tf_apply_output);
-                record_info("TFM apply exit code", $ret, result => ($ret) ? 'fail' : 'ok');
+                ($plan_ret) = $self->_tofu_run_step(step => 'plan', cmd => $cmd, timeout => TERRAFORM_PLAN_TIMEOUT, delay => 10, retry => 6);
+                die("Terraform plan failed with exit code $plan_ret") if $plan_ret;
+
+                ($ret, $tf_apply_output) = $self->_tofu_run_step(step => 'apply', cmd => "$runner apply -no-color -input=false myplan", timeout => $terraform_timeout, delay => 0, retry => 1);
                 if ($ret == 0) {
                     $self->provider_client->availability_zone($az);
                     last;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -461,8 +461,7 @@ to a failure.
 sub _tofu_run_step {
     my ($self, %args) = @_;
     my $output_file = "tf_$args{step}_output";
-    my $cmd = "set -o pipefail; TF_LOG=" . TERRAFORM_LOG . " $args{cmd} 2>&1 | tee $output_file";
-    my $ret = script_retry($cmd, timeout => $args{timeout}, delay => $args{delay}, retry => $args{retry}, die => 0);
+    my $ret = script_retry("set -o pipefail; TF_LOG=" . TERRAFORM_LOG . " $args{cmd} 2>&1 | tee $output_file", timeout => $args{timeout}, delay => $args{delay}, retry => $args{retry}, die => 0);
     my $output = script_output("cat $output_file", proceed_on_failure => 1);
     record_info("TFM $args{step} output", "exit code: $ret", result => ($ret) ? 'fail' : 'ok');
     return ($ret, $output);

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -439,7 +439,25 @@ sub terraform_cmd {
     return $cmd;
 }
 
-# Run a tofu/terraform step with output captured to a file.
+=head2 _tofu_run_step
+
+    my ($ret, $output) = $self->_tofu_run_step(
+        step    => 'init',            # short label, also used to name the output file (tf_<step>_output)
+        cmd     => 'tofu init -no-color',
+        timeout => 180,               # overall script_retry() timeout, in seconds
+        delay   => 10,                # seconds to wait between retries
+        retry   => 6,                 # number of script_retry() attempts
+    );
+
+Run a single tofu/terraform step (C<init>, C<plan> or C<apply>) via
+C<script_retry()>, capturing its combined stdout/stderr to C<tf_<step>_output>
+so the output survives even on a timeout (unlike letting C<script_retry> die
+internally with no diagnostics). Always returns the exit code and the
+captured output rather than dying itself, so the caller decides how to react
+to a failure.
+
+=cut
+
 sub _tofu_run_step {
     my ($self, %args) = @_;
     my $output_file = "tf_$args{step}_output";

--- a/t/45_publiccloud_provider.t
+++ b/t/45_publiccloud_provider.t
@@ -13,7 +13,6 @@ use warnings;
 use Test::More;
 use Test::MockObject;
 use Test::MockModule;
-use Test::Exception;
 use Test::Warnings;
 use testapi 'set_var';
 use List::Util qw(any);
@@ -162,10 +161,13 @@ subtest '[terraform_apply] vars' => sub {
     shift @var_args;    # drop the 'tofu plan -no-color -out myplan' prefix
 
     # Keep only the Borg* vars we injected, mapping key => escaped value.
-    # Each argument looks like:  'KEY=VALUE'
+    # Each argument looks like:  'KEY=VALUE', with the last one also carrying
+    # the ' 2>&1 | tee tf_plan_output' redirection _tofu_run_step appends. As
+    # that suffix never contains a quote, dropping the trailing anchor still
+    # lets the greedy (.*) match up to the real closing quote.
     my %borg;
     for my $arg (@var_args) {
-        my ($key, $val) = $arg =~ /^'([^=]+)=(.*)'\s*$/s;
+        my ($key, $val) = $arg =~ /^'([^=]+)=(.*)'/s;
         next unless defined $key && $key =~ /^Borg/;
         $borg{$key} = $val;
     }
@@ -268,15 +270,20 @@ subtest '[terraform_apply] returns instance objects' => sub {
 #              * to an ordered list of { exit => ..., output => ... } responses.
 #
 #              On every matching command the next response in that list is consumed:
-#              'exit' is returned to script_run, 'output' to script_output. There
-#              is no implicit coupling between commands: the apply exit code and
-#              the terraform output read back by 'cat tf_apply_output' are two
-#              distinct commands, so they are scripted with two distinct regexps.
+#              'exit' is returned to script_run/script_retry, 'output' to
+#              script_output. There is no implicit coupling between commands: the
+#              apply exit code and the terraform output read back by
+#              'cat tf_apply_output' are two distinct commands, so they are
+#              scripted with two distinct regexps. init/plan also each run their
+#              own 'cat tf_{init,plan}_output' (via _tofu_run_step), but these
+#              subtests don't script those -- they fall through to the default
+#              '' output, since init/plan success/failure isn't what's under test
+#              here (see the dedicated init/plan subtest instead).
 #              Each list must hold exactly one entry per expected match; if a
 #              matching command is run after its list is exhausted the helper dies,
 #              so the test fails loudly on an unexpected extra command. E.g.:
-#                { 'apply.*myplan' => [{exit=>42}, {exit=>0}],
-#                  'cat'           => [{output=>$MSG}, {output=>''}],
+#                { 'apply.*myplan'      => [{exit=>42}, {exit=>0}],
+#                  'cat tf_apply_output' => [{output=>$MSG}, {output=>''}],
 #                  'az network vnet subnet' => [{output=>'subnet-0'}, {output=>'subnet-1'}] }
 #   calls   => [out] arrayref the caller passes in empty; the helper appends
 #              every executed command to it for the caller to inspect afterwards.
@@ -290,8 +297,7 @@ sub _mock_terraform_apply {
     $mock->noop("$_") for qw(get_image_uri data_url);
     $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $mock->redefine(get_current_job_id => sub { 42 });
-    $mock->redefine($_ => sub { push @{$args{calls}}, $_[0]; return 0; }) for qw(assert_script_run script_retry);
-
+    $mock->redefine(assert_script_run => sub { push @{$args{calls}}, $_[0]; return 0; });
 
     # It consumes each regexp's list in order and dies if list of response is exhausted. Returns undef when no regexp matches at all.
     my %cursor;
@@ -308,12 +314,17 @@ sub _mock_terraform_apply {
         }
         return undef;
     };
-    $mock->redefine(script_run => sub {
+    # init/plan/apply all run via _tofu_run_step -> script_retry now (no more
+    # direct script_run for apply), so script_retry needs the same scripted
+    # responses script_run gets. init/plan aren't under test here and match
+    # none of the 'apply.*myplan'-style patterns below, so they transparently
+    # succeed (exit 0) unless a subtest explicitly scripts them.
+    $mock->redefine($_ => sub {
             my ($cmd) = @_;
             push @{$args{calls}}, $cmd;
             my $r = $next_response->($cmd);
             return (defined $r ? ($r->{exit} // 0) : 0);
-    });
+    }) for qw(script_run script_retry);
     $mock->redefine(script_output => sub {
             my ($cmd) = @_;
             push @{$args{calls}}, $cmd;
@@ -357,7 +368,7 @@ subtest '[terraform_apply] Azure retries in the first alternate region and succe
                 {exit => 0, output => ''},
             ],
             # this simulate the script_output(cat) of the "tofu apply" log, and it containing a specific error message
-            'cat ' => [
+            'cat tf_apply_output' => [
                 {exit => 0, output => $OUT_OF_RESOURCES{AZURE}},
                 {exit => 0, output => ''},
             ],
@@ -410,7 +421,7 @@ subtest '[terraform_apply] Azure retries in the first alternate region and fails
                 {exit => 42, output => 'None care'},
                 {exit => 0, output => ''},
             ],
-            'cat ' => [
+            'cat tf_apply_output' => [
                 {exit => 0, output => $OUT_OF_RESOURCES{AZURE}},
                 {exit => 0, output => $OUT_OF_RESOURCES{AZURE}},
                 {exit => 0, output => ''},
@@ -454,7 +465,7 @@ subtest '[terraform_apply] Azure retries never succeed' => sub {
                 {exit => 42, output => 'None care'},
                 {exit => 42, output => 'None care'},
             ],
-            'cat ' => [
+            'cat tf_apply_output' => [
                 {exit => 0, output => $OUT_OF_RESOURCES{AZURE}},
                 {exit => 0, output => $OUT_OF_RESOURCES{AZURE}},
                 {exit => 0, output => $OUT_OF_RESOURCES{AZURE}},
@@ -466,8 +477,11 @@ subtest '[terraform_apply] Azure retries never succeed' => sub {
     my $provider = publiccloud::provider->new(provider_client => publiccloud::azure_client->new());
 
     # Every region fails with a resource shortage, so after trying them all
-    # terraform_apply gives up and dies.
-    dies_ok { $provider->terraform_apply(vars => {}) } 'terraform_apply dies after every region is exhausted';
+    # terraform_apply gives up and dies. Plain eval rather than dies_ok: the
+    # extra _tofu_run_step call frame trips up Test::Exception's Sub::Uplevel
+    # stack rewriting here, letting the exception escape the subtest instead
+    # of being reported as a normal test failure.
+    ok(!eval { $provider->terraform_apply(vars => {}); 1 }, 'terraform_apply dies after every region is exhausted');
 
     note("\n  C-->  " . join("\n  C-->  ", @calls));
     # code under test try "tofu plan" in all the regions
@@ -497,7 +511,7 @@ subtest '[terraform_apply] EC2 retries in an alternate region' => sub {
                 {exit => 42, output => 'None care'},
                 {exit => 0, output => ''},
             ],
-            'cat ' => [
+            'cat tf_apply_output' => [
                 {exit => 0, output => $OUT_OF_RESOURCES{EC2}},
                 {exit => 0, output => ''},
             ],
@@ -540,7 +554,7 @@ subtest '[terraform_apply] GCE succeed in the first zone of the first region' =>
             'apply.*myplan' => [
                 {exit => 0, output => 'None care'},    # primary region, initial zone 'a'
             ],
-            'cat ' => [
+            'cat tf_apply_output' => [
                 {exit => 0, output => ''},    # primary region, initial zone 'a'
             ],
             # 'gcloud compute zones list' returns the zones of the region (last name part).
@@ -594,7 +608,7 @@ subtest '[terraform_apply] GCE loops over zones, then over regions' => sub {
                 {exit => 42, output => 'None care'},    # primary region, zone 'c'
                 {exit => 0, output => ''},    # alternate region 'Bajor'
             ],
-            'cat ' => [
+            'cat tf_apply_output' => [
                 {exit => 0, output => $OUT_OF_RESOURCES{GCE}},    # primary region, initial zone 'a'
                 {exit => 0, output => $OUT_OF_RESOURCES{GCE}},    # primary region, zone 'b'
                 {exit => 0, output => $OUT_OF_RESOURCES{GCE}},    # primary region, zone 'c'
@@ -625,6 +639,58 @@ subtest '[terraform_apply] GCE loops over zones, then over regions' => sub {
     is(scalar(@gcloud), 2, 'gcloud zone list queried at each region loop');
     like($gcloud[0], qr/^gcloud compute zones list --filter='region=Ferengi'/, 'zone list scoped to the failing region');
     is($provider->provider_client->region, 'Bajoran', 'active region left on the successful alternate');
+
+    _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_REGION PUBLIC_CLOUD_ALTERNATE_REGIONS PUBLIC_CLOUD_INSTANCE_TYPE FLAVOR OPENQA_URL/);
+};
+
+subtest '[terraform_apply] init/plan failures die with captured output, no region retry (poo#204060)' => sub {
+    set_var('PUBLIC_CLOUD', 1);
+    set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    set_var('PUBLIC_CLOUD_REGION', 'Ferengi');
+    set_var('PUBLIC_CLOUD_ALTERNATE_REGIONS', 'Cardassia');
+    set_var('PUBLIC_CLOUD_INSTANCE_TYPE', 'Romulan');
+    set_var('FLAVOR', 'Talaxian');
+    set_var('OPENQA_URL', 'Xindi');
+    my $mock = Test::MockModule->new('publiccloud::provider', no_auto => 1);
+    $mock->redefine(get_image_id => sub { '' });
+    $mock->noop("$_") for qw(get_image_uri data_url);
+    $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $mock->redefine(get_current_job_id => sub { return 42; });
+    $mock->redefine(assert_script_run => sub { return 0; });
+    Test::MockModule->new('publiccloud::instances', no_auto => 1)->redefine(set_instances => sub { });
+
+    for my $case (
+        {step => 'init', fail_cmd => qr/tofu init/, timeout => 180, garbage => 'connection refused'},
+        {step => 'plan', fail_cmd => qr/tofu plan/, timeout => 300, garbage => ''},
+      )
+    {
+        my @retry_calls;
+        $mock->redefine(script_retry => sub {
+                my ($cmd, %retry_args) = @_;
+                push @retry_calls, [$cmd, \%retry_args];
+                return 1 if ($cmd =~ $case->{fail_cmd});
+                return 0;
+        });
+        $mock->redefine(script_output => sub {
+                return $case->{garbage} if ($_[0] =~ /cat /);
+                return '';
+        });
+
+        my $provider = publiccloud::provider->new(provider_client => publiccloud::azure_client->new());
+        eval { $provider->terraform_apply() };
+        my $died = $@;
+        like($died, qr/Terraform $case->{step} failed/i, "$case->{step} failure dies with a clear message");
+        # Regression check for the scalar-context bug where `my $ret = ...`
+        # (instead of `my ($ret) = ...`) silently captured the captured
+        # output text instead of the numeric exit code from script_retry.
+        like($died, qr/exit code 1\b/, "$case->{step} die message reports the numeric exit code, not the captured output");
+
+        my ($retry_call) = grep { $_->[0] =~ $case->{fail_cmd} } @retry_calls;
+        ok($retry_call, "$case->{step} is retried via script_retry");
+        is($retry_call->[1]{timeout}, $case->{timeout}, "$case->{step} uses its own fixed timeout, not TERRAFORM_TIMEOUT");
+        ok($retry_call->[1]{retry} > 1, "$case->{step} is configured to actually retry multiple times");
+        is($retry_call->[1]{die}, 0, "$case->{step} does not let script_retry die internally (so output can be captured)");
+    }
 
     _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_REGION PUBLIC_CLOUD_ALTERNATE_REGIONS PUBLIC_CLOUD_INSTANCE_TYPE FLAVOR OPENQA_URL/);
 };

--- a/t/45_publiccloud_provider.t
+++ b/t/45_publiccloud_provider.t
@@ -13,6 +13,7 @@ use warnings;
 use Test::More;
 use Test::MockObject;
 use Test::MockModule;
+use Test::Exception;
 use Test::Warnings;
 use testapi 'set_var';
 use List::Util qw(any);
@@ -479,11 +480,8 @@ subtest '[terraform_apply] Azure retries never succeed' => sub {
     my $provider = publiccloud::provider->new(provider_client => publiccloud::azure_client->new());
 
     # Every region fails with a resource shortage, so after trying them all
-    # terraform_apply gives up and dies. Plain eval rather than dies_ok: the
-    # extra _tofu_run_step call frame trips up Test::Exception's Sub::Uplevel
-    # stack rewriting here, letting the exception escape the subtest instead
-    # of being reported as a normal test failure.
-    ok(!eval { $provider->terraform_apply(vars => {}); 1 }, 'terraform_apply dies after every region is exhausted');
+    # terraform_apply gives up and dies.
+    dies_ok { $provider->terraform_apply(vars => {}) } 'terraform_apply dies after every region is exhausted';
 
     note("\n  C-->  " . join("\n  C-->  ", @calls));
     # code under test try "tofu plan" in all the regions
@@ -641,7 +639,7 @@ subtest '[terraform_apply] GCE loops over zones, then over regions' => sub {
     _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_REGION PUBLIC_CLOUD_ALTERNATE_REGIONS PUBLIC_CLOUD_INSTANCE_TYPE FLAVOR OPENQA_URL/);
 };
 
-subtest '[terraform_apply] init/plan failures die with captured output, no region retry (poo#204060)' => sub {
+subtest '[terraform_apply] init/plan failures die with captured output, no region retry' => sub {
     set_var('PUBLIC_CLOUD', 1);
     set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
     set_var('PUBLIC_CLOUD_REGION', 'Ferengi');
@@ -654,7 +652,6 @@ subtest '[terraform_apply] init/plan failures die with captured output, no regio
     $mock->noop("$_") for qw(get_image_uri data_url);
     $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $mock->redefine(get_current_job_id => sub { return 42; });
-    $mock->redefine(assert_script_run => sub { return 0; });
     Test::MockModule->new('publiccloud::instances', no_auto => 1)->redefine(set_instances => sub { });
 
     for my $case (
@@ -662,14 +659,17 @@ subtest '[terraform_apply] init/plan failures die with captured output, no regio
         {step => 'plan', fail_cmd => qr/tofu plan/, timeout => 300, garbage => ''},
       )
     {
-        my @retry_calls;
+        my (@calls, @retry_calls);
+        $mock->redefine(assert_script_run => sub { push @calls, $_[0]; return 0; });
         $mock->redefine(script_retry => sub {
                 my ($cmd, %retry_args) = @_;
+                push @calls, $cmd;
                 push @retry_calls, [$cmd, \%retry_args];
                 return 1 if ($cmd =~ $case->{fail_cmd});
                 return 0;
         });
         $mock->redefine(script_output => sub {
+                push @calls, $_[0];
                 return $case->{garbage} if ($_[0] =~ /cat /);
                 return '';
         });
@@ -688,6 +688,8 @@ subtest '[terraform_apply] init/plan failures die with captured output, no regio
         is($retry_call->[1]{timeout}, $case->{timeout}, "$case->{step} uses its own fixed timeout, not TERRAFORM_TIMEOUT");
         ok($retry_call->[1]{retry} > 1, "$case->{step} is configured to actually retry multiple times");
         is($retry_call->[1]{die}, 0, "$case->{step} does not let script_retry die internally (so output can be captured)");
+
+        note("\n  C-->  " . join("\n  C-->  ", @calls));
     }
 
     _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_REGION PUBLIC_CLOUD_ALTERNATE_REGIONS PUBLIC_CLOUD_INSTANCE_TYPE FLAVOR OPENQA_URL/);

--- a/t/45_publiccloud_provider.t
+++ b/t/45_publiccloud_provider.t
@@ -272,18 +272,21 @@ subtest '[terraform_apply] returns instance objects' => sub {
 #              On every matching command the next response in that list is consumed:
 #              'exit' is returned to script_run/script_retry, 'output' to
 #              script_output. There is no implicit coupling between commands: the
-#              apply exit code and the terraform output read back by
-#              'cat tf_apply_output' are two distinct commands, so they are
-#              scripted with two distinct regexps. init/plan also each run their
-#              own 'cat tf_{init,plan}_output' (via _tofu_run_step), but these
-#              subtests don't script those -- they fall through to the default
-#              '' output, since init/plan success/failure isn't what's under test
-#              here (see the dedicated init/plan subtest instead).
+#              apply exit code and the terraform output read back by '^cat '
+#              are two distinct commands, so they are scripted with two
+#              distinct regexps. '^cat ' matches init/plan/apply's output-file
+#              read-back alike (_tofu_run_step doesn't care about the
+#              filename, and neither does this test) -- use the
+#              _cat_responses() helper below to build that list, since only
+#              apply's output matters to these subtests but every step's own
+#              cat still consumes a slot in the shared queue. (Anchored to
+#              avoid false hits like EC2's "describe-instance-type-offerings
+#              --lo-CAT-ion-type ..." matching a bare /cat/.)
 #              Each list must hold exactly one entry per expected match; if a
 #              matching command is run after its list is exhausted the helper dies,
 #              so the test fails loudly on an unexpected extra command. E.g.:
-#                { 'apply.*myplan'      => [{exit=>42}, {exit=>0}],
-#                  'cat tf_apply_output' => [{output=>$MSG}, {output=>''}],
+#                { 'apply.*myplan' => [{exit=>42}, {exit=>0}],
+#                  '^cat '         => [_cat_responses({output=>$MSG}, {output=>''})],
 #                  'az network vnet subnet' => [{output=>'subnet-0'}, {output=>'subnet-1'}] }
 #   calls   => [out] arrayref the caller passes in empty; the helper appends
 #              every executed command to it for the caller to inspect afterwards.
@@ -336,6 +339,16 @@ sub _mock_terraform_apply {
     return $mock;
 }
 
+# Build a 'cat' response list for _mock_terraform_apply's script_responses.
+# _tofu_run_step() reads back every step's own output file (init, plan, and
+# apply each get their own 'cat', regardless of filename), but only apply's
+# output feeds region_out_of_resources() -- init's and plan's are irrelevant
+# to these region-retry subtests. Rather than coupling the test to the
+# tf_<step>_output filenames, this pads the shared 'cat' queue with one
+# placeholder for init and one for each apply's preceding plan, so callers
+# only need to state the apply outputs they actually care about.
+sub _cat_responses { return ({output => ''}, map { ({output => ''}, $_) } @_); }
+
 # Provider-specific terraform 'apply' outputs that flag a resource shortage:
 my %OUT_OF_RESOURCES = (
     AZURE => q{Error: creating Linux Virtual Machine ... Code="SkuNotAvailable" Message="The requested VM size ... is not available"},
@@ -368,10 +381,7 @@ subtest '[terraform_apply] Azure retries in the first alternate region and succe
                 {exit => 0, output => ''},
             ],
             # this simulate the script_output(cat) of the "tofu apply" log, and it containing a specific error message
-            'cat tf_apply_output' => [
-                {exit => 0, output => $OUT_OF_RESOURCES{AZURE}},
-                {exit => 0, output => ''},
-            ],
+            '^cat ' => [_cat_responses({exit => 0, output => $OUT_OF_RESOURCES{AZURE}}, {exit => 0, output => ''})],
             # az network query runs once per region attempt (primary + 1st alternate)
             'az network vnet subnet list' => [{output => 'subnet-Ferenginar'}, {output => 'subnet-Bajor'}],
         });
@@ -421,11 +431,7 @@ subtest '[terraform_apply] Azure retries in the first alternate region and fails
                 {exit => 42, output => 'None care'},
                 {exit => 0, output => ''},
             ],
-            'cat tf_apply_output' => [
-                {exit => 0, output => $OUT_OF_RESOURCES{AZURE}},
-                {exit => 0, output => $OUT_OF_RESOURCES{AZURE}},
-                {exit => 0, output => ''},
-            ],
+'^cat ' => [_cat_responses({exit => 0, output => $OUT_OF_RESOURCES{AZURE}}, {exit => 0, output => $OUT_OF_RESOURCES{AZURE}}, {exit => 0, output => ''})],
             # az network query runs once per region attempt (primary + 2 alternates)
             'az network vnet subnet list' => [{output => 'subnet-Ferenginar'}, {output => 'subnet-Bajor'}, {output => 'subnet-Cardassia'}],
         });
@@ -465,11 +471,7 @@ subtest '[terraform_apply] Azure retries never succeed' => sub {
                 {exit => 42, output => 'None care'},
                 {exit => 42, output => 'None care'},
             ],
-            'cat tf_apply_output' => [
-                {exit => 0, output => $OUT_OF_RESOURCES{AZURE}},
-                {exit => 0, output => $OUT_OF_RESOURCES{AZURE}},
-                {exit => 0, output => $OUT_OF_RESOURCES{AZURE}},
-            ],
+'^cat ' => [_cat_responses({exit => 0, output => $OUT_OF_RESOURCES{AZURE}}, {exit => 0, output => $OUT_OF_RESOURCES{AZURE}}, {exit => 0, output => $OUT_OF_RESOURCES{AZURE}})],
             # az network query runs once per region attempt (primary + 2 alternates)
             'az network vnet subnet list' => [{output => 'subnet-Ferengi'}, {output => 'subnet-Bajor'}, {output => 'subnet-Cardassia'}],
         });
@@ -511,10 +513,7 @@ subtest '[terraform_apply] EC2 retries in an alternate region' => sub {
                 {exit => 42, output => 'None care'},
                 {exit => 0, output => ''},
             ],
-            'cat tf_apply_output' => [
-                {exit => 0, output => $OUT_OF_RESOURCES{EC2}},
-                {exit => 0, output => ''},
-            ],
+            '^cat ' => [_cat_responses({exit => 0, output => $OUT_OF_RESOURCES{EC2}}, {exit => 0, output => ''})],
             # each aws query runs once per region attempt (primary + 1 alternate)
             'describe-instance-type-offerings' => [{output => 'us-east-1a'}, {output => 'us-east-1b'}],
             'describe-security-groups' => [{output => 'sg-0'}, {output => 'sg-1'}],
@@ -554,12 +553,10 @@ subtest '[terraform_apply] GCE succeed in the first zone of the first region' =>
             'apply.*myplan' => [
                 {exit => 0, output => 'None care'},    # primary region, initial zone 'a'
             ],
-            'cat tf_apply_output' => [
-                {exit => 0, output => ''},    # primary region, initial zone 'a'
-            ],
-            # 'gcloud compute zones list' returns the zones of the region (last name part).
-            # This line also simulate that what has been configured in the PUBLIC_CLOUD_AVAILABILITY_ZONE
-            # is in agreement with what the cloud has.
+            '^cat ' => [_cat_responses({exit => 0, output => ''})],    # primary region, initial zone 'a'
+                                                                       # 'gcloud compute zones list' returns the zones of the region (last name part).
+                # This line also simulate that what has been configured in the PUBLIC_CLOUD_AVAILABILITY_ZONE
+                # is in agreement with what the cloud has.
             'gcloud compute zones list.*filter.*region.*Ferengi' => [{exit => 0, output => 'Weeville,b,c,'}],
         });
     Test::MockModule->new('publiccloud::instances', no_auto => 1)->redefine(set_instances => sub { });
@@ -608,12 +605,13 @@ subtest '[terraform_apply] GCE loops over zones, then over regions' => sub {
                 {exit => 42, output => 'None care'},    # primary region, zone 'c'
                 {exit => 0, output => ''},    # alternate region 'Bajor'
             ],
-            'cat tf_apply_output' => [
-                {exit => 0, output => $OUT_OF_RESOURCES{GCE}},    # primary region, initial zone 'a'
-                {exit => 0, output => $OUT_OF_RESOURCES{GCE}},    # primary region, zone 'b'
-                {exit => 0, output => $OUT_OF_RESOURCES{GCE}},    # primary region, zone 'c'
-                {exit => 0, output => ''},    # alternate region 'Bajor'
-            ],
+            '^cat ' => [
+                _cat_responses(
+                    {exit => 0, output => $OUT_OF_RESOURCES{GCE}},    # primary region, initial zone 'a'
+                    {exit => 0, output => $OUT_OF_RESOURCES{GCE}},    # primary region, zone 'b'
+                    {exit => 0, output => $OUT_OF_RESOURCES{GCE}},    # primary region, zone 'c'
+                    {exit => 0, output => ''},    # alternate region 'Bajor'
+                )],
             'gcloud compute zones list.*filter.*region.*Ferengi' => [{exit => 0, output => 'a,b,c,'}],
             'gcloud compute zones list.*filter.*region.*Bajoran' => [{exit => 0, output => 'd,e,f,'}],    # this test does not use it, but it should
         });

--- a/t/45_publiccloud_provider.t
+++ b/t/45_publiccloud_provider.t
@@ -654,27 +654,33 @@ subtest '[terraform_apply] init/plan failures die with captured output, no regio
     $mock->redefine(get_current_job_id => sub { return 42; });
     Test::MockModule->new('publiccloud::instances', no_auto => 1)->redefine(set_instances => sub { });
 
-    for my $case (
+    # Mocks are defined once, closing over $case (set fresh each loop
+    # iteration below) rather than being redefined per iteration.
+    my $case;
+    my (@calls, @retry_calls);
+    $mock->redefine(assert_script_run => sub { push @calls, $_[0]; return 0; });
+    $mock->redefine(script_retry => sub {
+            my ($cmd, %retry_args) = @_;
+            push @calls, $cmd;
+            push @retry_calls, [$cmd, \%retry_args];
+            return 1 if ($cmd =~ $case->{fail_cmd});
+            return 0;
+    });
+    $mock->redefine(script_output => sub {
+            push @calls, $_[0];
+            return $case->{garbage} if ($_[0] =~ /cat /);
+            return '';
+    });
+    my $provider = publiccloud::provider->new(provider_client => publiccloud::azure_client->new());
+
+    for my $c (
         {step => 'init', fail_cmd => qr/tofu init/, timeout => 180, garbage => 'connection refused'},
         {step => 'plan', fail_cmd => qr/tofu plan/, timeout => 300, garbage => ''},
       )
     {
-        my (@calls, @retry_calls);
-        $mock->redefine(assert_script_run => sub { push @calls, $_[0]; return 0; });
-        $mock->redefine(script_retry => sub {
-                my ($cmd, %retry_args) = @_;
-                push @calls, $cmd;
-                push @retry_calls, [$cmd, \%retry_args];
-                return 1 if ($cmd =~ $case->{fail_cmd});
-                return 0;
-        });
-        $mock->redefine(script_output => sub {
-                push @calls, $_[0];
-                return $case->{garbage} if ($_[0] =~ /cat /);
-                return '';
-        });
+        $case = $c;
+        (@calls, @retry_calls) = ();
 
-        my $provider = publiccloud::provider->new(provider_client => publiccloud::azure_client->new());
         eval { $provider->terraform_apply() };
         my $died = $@;
         like($died, qr/Terraform $case->{step} failed/i, "$case->{step} failure dies with a clear message");


### PR DESCRIPTION
Added a `_tofu_run_step` helper in `publiccloud::provider` that captures OpenTofu's stdout/stderr for `init`, `plan`, and `apply` and records it via `record_info` on failure, instead of `init`/`plan` letting `script_retry` die silently with no diagnostics. Gave `init` and `plan` their own short, fixed timeouts (180s/300s) with real multi-attempt retries instead of inheriting `apply`'s 1800s timeout. Extended unit test coverage for the new failure/diagnostics paths.

* Related ticket: [poo#204060](https://progress.opensuse.org/issues/204060)
* Verification runs: In comment below
