### PR TITLE
Replace csync2 with crm cluster copy in haproxy test module

### DIFF
--- a/data/ha/haproxy.cfg.template
+++ b/data/ha/haproxy.cfg.template
@@ -14,12 +14,12 @@ defaults
   timeout client    50s
   timeout server    50000
 
-frontend LB
+frontend LBF
   bind %VIP_IP%:8080
   http-request add-header X-Forwarded-Proto http
-  default_backend LB
+  default_backend LBB
 
-backend LB
+backend LBB
   mode http
   stats enable
   stats hide-version

--- a/tests/ha/haproxy.pm
+++ b/tests/ha/haproxy.pm
@@ -51,10 +51,7 @@ sub run {
         assert_script_run "sed -i 's/%NODE_02_IP%/$node_02_ip/g' $haproxy_cfg";
         assert_script_run "sed -i 's/%VIP_IP%/$vip_ip/g' $haproxy_cfg";
 
-        add_file_in_csync(value => "$haproxy_cfg");
-
-        # Execute csync2 to synchronise the configuration files
-        exec_csync;
+        sync_file($haproxy_cfg);
 
         # Modify the apache template file according to our needs
         assert_script_run "sed -i 's/%NODE%/$node_01/g' $apache_file";
@@ -65,6 +62,8 @@ sub run {
         assert_script_run "sed -i 's/%NODE%/$node_02/g' $apache_file";
         assert_script_run "sed -i 's/%IP%/$node_02_ip/g' $apache_file";
     }
+
+    upload_logs($_, failok => 1) for ($apache_file, $haproxy_cfg);
 
     # Apache have to be started on the both nodes for load balancing
     # TODO: Add apache2 in the HA configuration
@@ -90,17 +89,25 @@ sub run {
         # Sometimes we need to cleanup the resource
         rsc_cleanup $haproxy_rsc;
         wait_for_idle_cluster;
+
+        # Do a check of the cluster with a screenshot
+        save_state;
+
+        # Check service is started
+        systemctl 'status haproxy';
     }
 
-    # Do a check of the cluster with a screenshot
-    save_state;
-
     if (is_node(2)) {
+        # Do a check of the cluster with a screenshot
+        save_state;
         # Test if the HTML content is the one expected on both nodes
         assert_script_run "curl -s $node_02_ip | grep $node_02";
     }
     elsif (is_node(1)) {
         assert_script_run "curl -s $node_01_ip | grep $node_01";
+        # Confirm $vip_ip is responding in HTTP (apache2) and 8080 (haproxy)
+        assert_script_run "curl $vip_ip";
+        assert_script_run "curl $vip_ip:8080";
         # Check if haproxy round-robin mode is working
         # The output of both curl commands must be different
         assert_script_run "[[ \$(curl -s $vip_ip:8080) != \$(curl -s $vip_ip:8080) ]]";


### PR DESCRIPTION
And update `haproxy` configuration for version 3.3.

Also record more details about HTTP and proxy service served by apache2 and haproxy respectively.

- Related Ticket: https://jira.suse.com/browse/TEAM-11012
- Needles: N/A
- Verification run: [16.1](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=team11012&distri=sle&version=16.1) :green_circle: , [16.0](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=team11012&distri=sle&version=16.0) :green_circle: , [15-SP7](https://openqaworker15.qe.prg2.suse.org/tests/overview?build=team11012&distri=sle&version=15-SP7) :green_circle: 