### PR TITLE
Fix SHA checksum timeout on a large iso image

### DIFF
--- a/lib/data_integrity_utils.pm
+++ b/lib/data_integrity_utils.pm
@@ -35,7 +35,7 @@ Digest retrieval is platform-specific depends.
 =cut
 
 sub get_image_digest {
-    my ($image_path, $algorithm) = @_;
+    my ($image_path, $algorithm, $timeout) = @_;
     $algorithm ||= 'SHA-256';    # default
 
     my $digest;
@@ -48,7 +48,7 @@ sub get_image_digest {
             $digest =~ s/^\s+|\s+$//g;    # trim whitespace
         } else {
             my $cmd = $algorithm eq 'SHA-512' ? 'sha512sum' : 'sha256sum';
-            $digest = console('svirt')->get_cmd_output("$cmd $image_path", {domain => is_vmware() ? 'sshVMwareServer' : undef});
+            $digest = console('svirt')->get_cmd_output("$cmd $image_path", {domain => is_vmware() ? 'sshVMwareServer' : undef, timeout => $timeout});
             my $len = $algorithm eq 'SHA-512' ? 128 : 64;
             $digest = substr $digest, 0, $len;    # extract hash from the output
         }
@@ -74,6 +74,7 @@ Returns error message in case of failure, empty string in case of success.
 
 sub verify_checksum {
     my ($dir_path) = shift;
+    my $timeout = shift // 600;
     my $error = '';
     diag "Comparing data integrity calculated with SHA256/SHA512 digest against checksum from IBS/OBS via rsync.pl";
     foreach my $image (grep { /^CHECKSUM_/ } keys %bmwqemu::vars) {
@@ -83,14 +84,14 @@ sub verify_checksum {
         $image_path = $dir_path . basename($image_path) if $dir_path;
 
         # Try SHA-256 first (most common, preserves existing behavior)
-        my $digest256 = get_image_digest($image_path, 'SHA-256');
+        my $digest256 = get_image_digest($image_path, 'SHA-256', timeout => $timeout);
         if ($digest256 && $checksum eq $digest256) {
             diag("$image OK (SHA-256)\n$image_path: OK");
             next;
         }
 
         # Fall back to SHA-512 only when SHA-256 didn't match
-        my $digest512 = get_image_digest($image_path, 'SHA-512');
+        my $digest512 = get_image_digest($image_path, 'SHA-512', timeout => $timeout);
         if ($digest512 && ($checksum eq $digest512 || (length($checksum) == 64 && $checksum eq substr($digest512, 0, 64)))) {
             my $variant = length($checksum) == 128 ? 'SHA-512' : 'SHA-512 truncated';
             diag("$image OK ($variant)\n$image_path: OK");


### PR DESCRIPTION
Timeout failure occurs while running checksum on a large ISO image (14GB). Set the timeout parameter on the checksum command to fix the failure. 
https://openqa.suse.de/tests/23442569#step/bootloader_svirt/24
```
# Test died: {
  "wantarray" => bless( do{\(my $o = 0)}, 'JSON::PP::Boolean' ),
  "cmd" => "backend_proxy_console_call",
  "json_cmd_token" => "URnPhjCw",
  "args" => [
              "sha256sum /vmfs/volumes/openqa/iso/SLES-16.0-Full-x86_64-Build259.5.install.iso",
              {
                "domain" => "sshVMwareServer"
              }
            ],
  "console" => "svirt",
  "function" => "get_cmd_output"
}
Time out waiting for data (-9 LIBSSH2_ERROR_TIMEOUT) at /usr/lib/perl5/vendor_perl/5.42.0/x86_64-linux-thread-multi/Net/SSH2.pm line 51, <$fh> line 25.
```

- Related ticket: https://progress.opensuse.org/issues/204249
- Verification run: https://openqa.suse.de/tests/23446736, https://openqa.suse.de/tests/23474170
