### PR TITLE
change_password: Modify wait time

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -57,14 +57,14 @@ sub change_pwd {
     assert_and_click "users-password";
     assert_and_click "current-password";
     type_password;
-    wait_still_screen;
+    wait_still_screen(1, 2);
     assert_and_click "new-password";
-    wait_still_screen;
-    type_string $newpwd;
-    wait_still_screen;
+    wait_still_screen(1, 2);
+    type_password $newpwd;
+    wait_still_screen(1, 2);
     assert_and_click "confirm-new-password";
-    wait_still_screen;
-    type_string $newpwd;
+    wait_still_screen(1, 2);
+    type_password $newpwd;
     assert_and_click "actived-change-password";
     assert_screen "users-settings", 60;
 }

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -769,6 +769,7 @@ sub unlock_user_settings {
     type_string "users";
     assert_screen "settings-users-selected";
     send_key "ret";
+    wait_still_screen(1, 2);
     assert_screen "users-settings";
     assert_and_click "Unlock-user-settings";
     assert_screen "authentication-required-user-settings";


### PR DESCRIPTION
The test was failing because authentication failed and 'add user and change settings' was not unlocked
Other changes will make test a bit faster due to blinking cursor

- Related ticket: https://progress.opensuse.org/issues/204285
- Verification run:
https://openqa.suse.de/tests/overview?distri=sle&version=15-SP7&build=jpupava_pw