### PR TITLE
io_uring: keep test_exclude single-line to avoid breaking shell command

### DIFF
--- a/tests/kernel/io_uring.pm
+++ b/tests/kernel/io_uring.pm
@@ -81,11 +81,12 @@ sub run {
     my @skipped = $whitelist->list_skipped_tests($environment, 'liburing');
     if (@skipped) {
         push @skipped, $exclude if $exclude;
-        $test_exclude = join("\n", sort @skipped);
-        my $count = $#skipped + 1;
+        my @sorted = sort @skipped;
+        $test_exclude = join(' ', @sorted);
+        my $count = scalar @sorted;
         record_info(
             "Exclude ($count)",
-            "Excluding tests ($count):\n$test_exclude",
+            "Excluding tests ($count):\n" . join("\n", @sorted),
             result => 'softfail'
         );
     }


### PR DESCRIPTION
Keep $test_exclude space-separated for the shell;
build sorted, one-per-line text only for record_info.

Fixes: 1b3c3c60a188 ("io_uring: Improve record_info() message of excluded tests")

- Verification runs: 
 [Tumbleweed](https://openqa.opensuse.org/tests/6114679#) (with `LIBURING_INSTALL 	from_git`)
 [SLE](https://openqa.suse.de/tests/23480508#) (with `LIBURING_INSTALL 	from_repo`)
