### PR TITLE
Improve wait_for_ssh_unreachable documentation and fix caller

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -425,6 +425,62 @@ sub wait_for_ssh_reachable {
     script_retry('nc -vz -w 1 ' . $self->public_ip . ' ' . $port, delay => $delay, retry => $retry, fail_message => "ssh port unreachable after $timeout seconds (port probed via nc)");
 }
 
+=head2 wait_for_ssh_unreachable
+
+    my $rc = $instance->wait_for_ssh_unreachable([delay => 2] [, timeout => 300] [, port => 22] [, die => 1]);
+
+Wait until the SSH port of this instance stops accepting connections, i.e.
+when the instance goes down. Retrying continues until the port becomes
+unreachable or C<timeout> seconds elapse (the number of attempts is derived
+as C<timeout / delay>).
+
+This is typically used to detect the reboot/shutdown window (e.g. from
+C<softreboot>). The default C<delay> is intentionally small so the short
+interval during which SSH becomes unreachable is not missed.
+
+Returns the exit code of the last C<nc> probe, as forwarded by C<script_retry>.
+The value tells whether the port is still connectable: C<0> means "not
+connected" (unreachable), a non-zero value means "still connected" (reachable).
+
+=over
+
+=item * C<0> when the port became unreachable within the timeout (success).
+
+=item * a non-zero value when the port is still reachable after the timeout,
+        but only if C<die> is set to a false value.
+
+=item * with the default C<die =E<gt> 1>, a still-reachable port makes
+        C<script_retry> B<die> instead of returning, so the only value ever
+        returned in that mode is C<0>.
+
+=item * C<undef> as a corner case: C<script_retry> returns C<undef> when the
+        last probe attempt is killed by its C<timeout> wrapper before an exit
+        code is reported. This is unlikely here (the probe is C<nc -w 1>), but
+        callers relying on the return value should treat C<undef> as "not
+        unreachable".
+
+=back
+
+Arguments:
+
+=over
+
+=item B<delay> - seconds to wait between two probes. Defaults to C<2>. Keep it
+                 low to avoid missing the brief window where SSH is unreachable.
+
+=item B<timeout> - overall time budget in seconds. Defaults to the test setting
+                   C<PUBLIC_CLOUD_SSH_TIMEOUT> or C<300> if unset.
+
+=item B<port> - TCP port to probe. Defaults to C<22>.
+
+=item B<die> - when true (the default C<1>) the function dies if the port is
+               still reachable after C<timeout>. Set to C<0> to instead return
+               the non-zero return code.
+
+=back
+
+=cut
+
 sub wait_for_ssh_unreachable {
     my ($self, %args) = @_;
 
@@ -435,7 +491,11 @@ sub wait_for_ssh_unreachable {
     my $port = $args{port} // 22;
     my $die = ${args}{die} // 1;
 
-    my $rc = script_retry('! nc -vz -w 1 ' . $self->public_ip . ' ' . $port, delay => $delay, retry => $retry, fail_message => "ssh port still reachable after $timeout seconds (port probed via nc)", die => $die);
+    my $rc = script_retry('! nc -vz -w 1 ' . $self->public_ip . ' ' . $port,
+        delay => $delay,
+        retry => $retry,
+        fail_message => "ssh port still reachable after $timeout seconds (port probed via nc)",
+        die => $die);
     # Print a warning message, if we don't want to `die` here in the previous check
     record_info("ssh still reachable", "WARNING: ssh port is still reachable", result => 'fail') if ($rc != 0);
     return $rc;

--- a/lib/sles4sap/crash.pm
+++ b/lib/sles4sap/crash.pm
@@ -551,11 +551,12 @@ sub crash_softrestart(%args) {
 
     my $start_time = time();
     # wait till ssh disappear
-    my $out = $args{instance}->wait_for_ssh_unreachable(timeout => $args{timeout});
-    # ok ssh port closed
+    my $rc = $args{instance}->wait_for_ssh_unreachable(timeout => $args{timeout}, die => 0);
+    # $rc == 0 means the ssh port became unreachable (ok). Anything else (still open,
+    # or undef when the last probe was killed before reporting) is treated as not ok.
     record_info("Shutdown failed",
-        "WARNING: while stopping the system, ssh port still open after timeout,\nreporting: $out->{duration}")
-      if ($out->{timed_out} || $args{instance}->isok($out->{exit_code}));    # not ok port still open
+        "WARNING: while stopping the system, ssh port still open after timeout")
+      if (!defined($rc) || $rc != 0);
 
     my $shutdown_time = time() - $start_time;
     $args{instance}->wait_for_ssh(

--- a/t/37_sles4sap_crash.t
+++ b/t/37_sles4sap_crash.t
@@ -308,13 +308,28 @@ subtest '[crash_system_ready]' => sub {
 subtest '[crash_softrestart]' => sub {
     my $crash = Test::MockModule->new('sles4sap::crash', no_auto => 1);
     my $mock_pc = Test::MockObject->new();
-    $mock_pc->mock('wait_for_ssh_unreachable', sub {
-            return {
-                exit_code => 1,
-                timed_out => 0,
-                duration => 10,
-            };
-    });
+    # 0 means the ssh port became unreachable, i.e. the instance went down as expected
+    $mock_pc->mock('wait_for_ssh_unreachable', sub { return 0; });
+    $mock_pc->mock('wait_for_ssh', sub { return; });
+    my @calls;
+    $mock_pc->mock('ssh_assert_script_run', sub {
+            my ($self, %args) = @_;
+            push @calls, $args{cmd};
+            return; });
+    $crash->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    crash_softrestart(instance => $mock_pc);
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    ok((any { /shutdown.*\-r/ } @calls), 'Shutdown command');
+};
+
+subtest '[crash_softrestart] ssh never unreachable' => sub {
+    my $crash = Test::MockModule->new('sles4sap::crash', no_auto => 1);
+    my $mock_pc = Test::MockObject->new();
+    # non-zero means the ssh port is still reachable after the timeout, i.e. the instance never went down
+    $mock_pc->mock('wait_for_ssh_unreachable', sub { return 1; });
+    $mock_pc->mock('wait_for_ssh', sub { return; });
     my @calls;
     $mock_pc->mock('ssh_assert_script_run', sub {
             my ($self, %args) = @_;

--- a/t/44_publiccloud_instance.t
+++ b/t/44_publiccloud_instance.t
@@ -4,40 +4,27 @@
 # SPDX-License-Identifier: FSFAP
 #
 # Summary: Unit tests for publiccloud::instance -- systemd time parsing,
-# the isok helper, ssh command construction and the thin provider-delegating
+# ssh command construction and the thin provider-delegating
 # methods (start/stop/get_state/wait_for_state).
 # Maintainer: QE-C team <qa-c@suse.de>
 
 use strict;
 use warnings;
 
-# Deterministic fake clock: sleep() advances mocked time() instead of spending
-# real wall-clock seconds, so the retry_ssh_command and wait_for_state polling
-# loops run fast. Must be loaded before the module under test is compiled.
-use Test::Mock::Time;
-
 use Test::More;
 use Test::MockObject;
 use Test::MockModule;
 use Test::Exception;
 use Test::Warnings;
+# Deterministic fake clock: sleep() advances mocked time() instead of spending
+# real wall-clock seconds, so the retry_ssh_command and wait_for_state polling
+# loops run fast. Must be loaded before the module under test is compiled.
+use Test::Mock::Time;
+
 use testapi 'set_var';
 
 use publiccloud::instance;
 
-# ---------------------------------------------------------------------------
-# Pure helper: isok
-# ---------------------------------------------------------------------------
-subtest '[isok] shell exit code truthiness' => sub {
-    ok(publiccloud::instance::isok(0), '0 is ok');
-    ok(!publiccloud::instance::isok(1), '1 is not ok');
-    ok(!publiccloud::instance::isok(undef), 'undef is not ok');
-    ok(!publiccloud::instance::isok(255), '255 is not ok');
-};
-
-# ---------------------------------------------------------------------------
-# Pure helper: systemd_time_to_second
-# ---------------------------------------------------------------------------
 subtest '[systemd_time_to_second] parsing' => sub {
     cmp_ok(publiccloud::instance::systemd_time_to_second('1.234s'), '==', 1.234, 'seconds only');
     cmp_ok(publiccloud::instance::systemd_time_to_second('500ms'), '==', 0.5, 'milliseconds converted');
@@ -309,6 +296,20 @@ subtest '[wait_for_state] dies on timeout' => sub {
     local $SIG{__WARN__} = sub { };
     throws_ok { $inst->wait_for_state('running', 0) }
     qr/instance state is not 'running'/, 'dies when state never matches before timeout';
+};
+
+subtest '[wait_for_ssh_unreachable]' => sub {
+    my $instmod = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+    my @calls;
+    $instmod->redefine(script_retry => sub { push @calls, $_[0]; return 0; });
+    $instmod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    my $provider = Test::MockObject->new;
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u', provider => $provider);
+
+    $inst->wait_for_ssh_unreachable();
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    like($calls[0], qr/nc.*10\.0\.0\.1.*22/, 'nc command composed with the instance public ip');
 };
 
 done_testing;


### PR DESCRIPTION
Add docustring for wait_for_ssh_unreachable in publiccloud::instance. Remove isok helper as only used internally and once, and only implement simple logic.
Fix crash test library using wait_for_ssh_unreachable, now it uses proper datatype for the return.
Add minimal unit tests for wait_for_ssh_unreachable. Small generic UT cleanup in crash test.
Follow up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26108

- Related ticket: https://progress.opensuse.org/issues/204063

# Verification run:

sle-15-SP7-GCE-Updates-x86_64-Build20260715-1-publiccloud_containers gce_n1_standard_2 
 -  http://openqa.suse.de/tests/23481466

sle-micro-6.1-GCE-BYOS-Updates-x86_64-Build124.1-publiccloud_slem_containers gce_n1_standard_2
 - http://openqa.suse.de/tests/23481471

sle-micro-6.1-GCE-BYOS-Updates-aarch64-Build124.1-publiccloud_slem_containers gce_t2a_standard_1 
 - http://openqa.suse.de/tests/23481479

sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-crash_test  
 - http://openqaworker15.qe.prg2.suse.org/tests/378451