### PR TITLE
Fix vmware sut console reconnect issue

### DIFF
--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -20,6 +20,10 @@ use x11utils 'turn_off_plasma_tooltips';
 sub run {
     # Workaround: on vmware or hyperv the 'ret' from grub_test is occasionally
     # lost across a VNC reconnect, leaving the SUT at the GRUB menu.
+    if (check_var('VIRSH_VMM_FAMILY', 'vmware') || check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
+        console('sut')->disable_vnc_stalls;
+        select_console('sut');
+    }
     if (check_screen('grub2', 5)) {
         record_info('bootloader still visible, resending ret');
         send_key 'ret';

--- a/tests/virt_autotest/esxi_open_vm_tools.pm
+++ b/tests/virt_autotest/esxi_open_vm_tools.pm
@@ -117,8 +117,6 @@ sub do_power_mgmt_tests {
     check_vmtools_service() if (is_svirt);
     $powerops_ret = take_vm_power_ops($vm_id, $powerops, $VM_POWER_ON);
     check_vm_power_state($vm_id, $vm_ip, $powerops, $powerops_ret, 0, $VM_POWER_OFF);
-
-    # Boot up the VM if it's powered off
     $powerops = 'power.on';
     $powerops_ret = take_vm_power_ops($vm_id, $powerops, $VM_POWER_OFF);
     check_vm_power_state($vm_id, $vm_ip, $powerops, $powerops_ret, 1, $VM_POWER_ON);
@@ -274,11 +272,12 @@ sub wait_for_vm_network {
 }
 
 sub login_vm_console {
+    console('sut')->disable_vnc_stalls;
+    console('svirt')->stop_serial_grab;
     reset_consoles;
     console('svirt')->start_serial_grab;
     select_console('sut');
-    assert_screen('grub2', 200);
-    wait_screen_change { send_key 'ret' };
+    send_key 'ret' if (check_screen('grub2', 180));
     assert_screen('linux-login', 120);
     select_console('root-console');
 }


### PR DESCRIPTION
VNC stall issue occurs in first_boot module, which leading to vmware websocket console reconnected.
https://openqa.suse.de/tests/22261406#step/first_boot/3
```
[2026-05-11T17:16:17.363183Z] [debug] [pid:1764467] no match: 382.7s, best candidate: firstrun-linux-login-20241023 (0.00)
[2026-05-11T17:16:17.921214Z] [debug] [pid:1764467] considering VNC stalled, no update for 35.24 seconds
[2026-05-11 17:16:17.92145] [1781116] [info] Client closed connection
```

- Related ticket: https://progress.opensuse.org/issues/200967
- Verification run: 
default_svirt_sle16@svirt-vmware80:
https://openqa.suse.de/tests/23439288
https://openqa.suse.de/tests/23439308
https://openqa.suse.de/tests/23478242
https://openqa.suse.de/tests/23478241
https://openqa.suse.de/tests/23479915
https://openqa.suse.de/tests/23479920
https://openqa.suse.de/tests/23480495
https://openqa.suse.de/tests/23480496
https://openqa.suse.de/tests/23481447
https://openqa.suse.de/tests/23488793
default_svirt_sle16@svirt-hyperv2022-uefi:
https://openqa.suse.de/tests/23488812
https://openqa.suse.de/tests/23488804
default_svirt_sle16@svirt-hyperv2025-uefi:
https://openqa.suse.de/tests/23488808
https://openqa.suse.de/tests/23488853