### PR TITLE
io_uring: include reason in the list of excluded tests

### DIFF
--- a/tests/kernel/io_uring.pm
+++ b/tests/kernel/io_uring.pm
@@ -84,9 +84,15 @@ sub run {
         my @sorted = sort @skipped;
         $test_exclude = join(' ', @sorted);
         my $count = scalar @sorted;
+        my @details;
+        for my $test (@sorted) {
+            my $entry = $whitelist->find_whitelist_entry($environment, 'liburing', $test);
+            my $message = ($entry && $entry->{message}) ? $entry->{message} : '';
+            push @details, $message ? "$test: $message" : $test;
+        }
         record_info(
             "Exclude ($count)",
-            "Excluding tests ($count):\n" . join("\n", @sorted),
+            "Excluding tests ($count):\n" . join("\n", @details),
             result => 'softfail'
         );
     }


### PR DESCRIPTION
we exclude some io_uring tests based on their entry in the known issues file, also print the reasoning of the test failure being a known issue.

- Related ticket: https://progress.opensuse.org/issues/192289
- Verification run: [Tumbleweed](https://openqa.opensuse.org/tests/6114814#step/io_uring/71), [SLE](https://openqa.suse.de/tests/23481966#step/io_uring/41)
