### PR TITLE
containers/container_diff: Work with CONTAINERS_UNTESTED_IMAGES=1

### DIFF
--- a/lib/containers/urls.pm
+++ b/lib/containers/urls.pm
@@ -188,7 +188,7 @@ sub get_image_uri {
     $args{version} =~ s/^Staging:(?<letter>.)$/Tumbleweed/ if is_tumbleweed || is_microos("Tumbleweed");
 
     my $url = get_var('CONTAINER_IMAGE_TO_TEST');
-    return $url if ($url);
+    return $url if (!$args{released} && $url);
 
     my $type = $args{released} ? 'released' : 'totest';
     if (supports_image_arch($args{distri}, $args{version}, $args{arch})) {

--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -28,7 +28,7 @@ sub run {
     zypper_call("install container-diff") if (script_run("which container-diff") != 0);
 
     my $unreleased_image = get_image_uri(released => 0);
-    my $released_image = get_image_uri();
+    my $released_image = get_image_uri(released => 1);
     # container-diff
     my $image_file = $unreleased_image =~ s/\/|:/-/gr;
     my $container_diff_results = "/tmp/container-diff-$image_file.txt";

--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -34,7 +34,7 @@ sub run {
     my $container_diff_results = "/tmp/container-diff-$image_file.txt";
     assert_script_run("docker pull $unreleased_image", 360);
     assert_script_run("docker pull $released_image", 360);
-    assert_script_run("container-diff diff daemon://$unreleased_image daemon://$released_image --type=rpm --type=file --type=size > $container_diff_results", 300);
+    assert_script_run("container-diff diff daemon://$released_image daemon://$unreleased_image --type=rpm --type=file --type=size > $container_diff_results", 300);
     upload_logs("$container_diff_results");
 
     # Clean container


### PR DESCRIPTION
Explicitly compare against the released image, otherwise it uses the unreleased image twice.

Example: https://openqa.opensuse.org/tests/6115570#step/container_diff/91

openqa: Clone https://openqa.opensuse.org/tests/6140979