### PR TITLE
Restart host installed from pre-built image immediately

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -99,7 +99,8 @@ sub login_to_console {
     }
 
     my @bootup_needles = is_ipxe_boot ? qw(grub2) : qw(grub2 grub1 prague-pxe-menu);
-    unless (get_var('UPGRADE_AFTER_REBOOT') or is_agama or is_tumbleweed or check_screen(\@bootup_needles, get_var('AUTOYAST') && !get_var("NOT_DIRECT_REBOOT_AFTER_AUTOYAST") ? 1 : 180)) {
+    my $check_screen_timer = ((get_var('AUTOYAST') && !get_var("NOT_DIRECT_REBOOT_AFTER_AUTOYAST")) or is_disk_image) ? 1 : 180;
+    unless (get_var('UPGRADE_AFTER_REBOOT') or is_agama or is_tumbleweed or check_screen(\@bootup_needles, $check_screen_timer)) {
         ipmitool("chassis power reset");
         reset_consoles;
         select_console 'sol', await_console => 0;


### PR DESCRIPTION
* **Host** installed from pre-built image boots into system directly without bootloader displaying at any moment, restarting such host immediately in ```login_console.pm``` makes more sense instead of waiting for bootloader that will not be shown up at all.

* **Calling** ```is_disk_image``` is a handy way to let ```check_screen``` times out in one second which leads to host restarting immediately.

* **Verification Runs:**
  * [sle-16.1-Base-SelfInstall-pxe-x86_64-Build12.7-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23741798)
  * [sle-16.1-Online-x86_64-Build60.3-snapshot-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23741263)
  * [sle-16.1-Online-x86_64-Build60.3-uefi-gi-guest_developing-on-host_sles15sp7-kvm](https://openqa.suse.de/tests/23741279)
  * [sle-16.1-Online-x86_64-Build60.3-uefi-gi-guest_developing-on-host_sles16_0-kvm](https://openqa.suse.de/tests/23741293)
  * [sle-16.1-Online-x86_64-Build60.3-immutable-gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23741309)