### PR TITLE
Kselftests: Run tests individually

### DIFF
--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -16,6 +16,7 @@ use utils;
 use Kselftests::parser;
 use LTP::WhiteList;
 use version_utils qw(is_sle has_selinux is_tumbleweed is_transactional);
+use Kernel::utils qw(is_debugfs_mounted enable_debugfs);
 use base 'opensusebasetest';
 use File::Basename qw(basename);
 use repo_tools qw(add_qa_head_repo);
@@ -179,6 +180,8 @@ sub install_from_repo
 sub install_dependencies
 {
     my ($collection) = @_;
+
+    enable_debugfs() unless is_debugfs_mounted();
 
     # selftests may manipulate namespaces and devices in ways that
     # trigger AVC denials on SELinux-enabled systems

--- a/lib/known_bugs.pm
+++ b/lib/known_bugs.pm
@@ -68,6 +68,7 @@ sub create_list_of_serial_failures {
         push @$serial_failures, {type => $type, message => 'WARNING CPU in kernel messages', pattern => quotemeta 'WARNING: CPU', post_boot_type => 'hard', soft_on_expect_warn => 1};
         push @$serial_failures, {type => $type, message => 'Kernel stack is corrupted', pattern => quotemeta 'stack-protector: Kernel stack is corrupted', post_boot_type => 'hard'};
         push @$serial_failures, {type => $type, message => 'Kernel BUG found', pattern => quotemeta 'BUG: failure at', post_boot_type => 'hard'};
+        push @$serial_failures, {type => $type, message => 'Kernel BUG found', pattern => quotemeta 'BUG: unable to', post_boot_type => 'hard'};
         push @$serial_failures, {type => $type, message => 'Kernel Oops found', pattern => quotemeta '-[ cut here ]-', post_boot_type => 'hard', soft_on_expect_warn => 1};
         # bsc#1229025, but must be soft because any LTP test which intentionally triggers OOM killer will produce this call trace as well
         push @$serial_failures, {type => 'soft', message => 'Kernel Call Trace found', pattern => quotemeta 'Call Trace:'};

--- a/tests/kernel/kselftests_run.pm
+++ b/tests/kernel/kselftests_run.pm
@@ -55,63 +55,28 @@ sub run {
     $self->{tests} = [@tests];
     die 'No tests to run.' unless @tests > 0;
 
-    # Always use --per-test-log so each test's subtest output goes to its own
-    # /tmp/<test> file and the summary only holds the top-level results. This
-    # keeps a single, uniform post-processing path for both single and multiple
-    # tests (see post_process).
-    my $test_opt = '--per-test-log';
-    if (@selected == @available && !@skip) {
-        # No tests were selected nor skipped, run full collection
-        $test_opt .= " --collection $collection";
-    } elsif (@selected == @available && @skip) {
-        # No tests were selected but some must be skipped
-        if (script_output('./run_kselftest.sh -h') =~ m/--skip/) {
-            # Use `--skip` if runner allows, this is important for collections that have a high number of tests
-            $test_opt .= " --collection $collection " . join(' ', map { "--skip $_" } @skip);
-        } else {
-            $test_opt .= ' ' . join(' ', map { "--test $_" } @tests);
-        }
-    } else {
-        # Some tests were selected and/or skipped, simply use `--test`
-        $test_opt .= ' ' . join(' ', map { "--test $_" } @tests);
-    }
-
     validate_kconfig($collection);
 
-    my $stamp = 'OpenQA::kselftest_run.pm';
     my $timeout = get_var('KSELFTEST_TIMEOUT') // 300;
-    my $test_timeout = get_var('KSELFTEST_TEST_TIMEOUT') ? "--override-timeout " . get_var('KSELFTEST_TEST_TIMEOUT') : '';
-    my $runner = get_var('KSELFTEST_RUNNER') // "export PATH=\"\$PWD/$collection:\$PATH\"; ./run_kselftest.sh $test_timeout $test_opt";
+    my $stamp = 'OpenQA::kselftest_run.pm';
 
-    # Helper script that stamps /dev/kmsg with each subtest starting point
-    my $annotate_kmsg_script = <<'EOF';
-my %seen;
-while (my $line = <STDIN>) {
-    if ($line =~ /^#\sselftests:\s\S+:\s(\S+)/) {
-        my $test = $1;
-        if (!$seen{$test}++ && open(my $kmsg, '>', '/dev/kmsg')) {
-            print {$kmsg} "OpenQA::kselftest_run.pm: Starting $test\n";
-            close($kmsg);
-        }
-    }
-    print $line;
-}
-EOF
-    write_sut_file('/tmp/kselftest_kmsg_annotate.pl', $annotate_kmsg_script);
-    my $annotate_kmsg = 'perl /tmp/kselftest_kmsg_annotate.pl';
-
-    $runner .= " 2>&1 | $annotate_kmsg | tee -a \$HOME/summary.tap; echo $stamp END";
     export_kselftest_env();
 
-    script_run("echo '$stamp BEGIN' > /dev/kmsg");
-    wait_serial(serial_term_prompt(), undef, 0, no_regex => 1);
-    type_string($runner);
-    wait_serial($runner, undef, 0, no_regex => 1);
-    send_key 'ret';
+    for my $test (@tests) {
+        # Stamp the kernel ring buffer before each test
+        script_run("echo '$stamp: Starting $test' > /dev/kmsg");
 
-    my $finished = wait_serial(qr/$stamp END/, timeout => $timeout, expect_not_found => 0, record_output => 1);
-    if (not defined $finished) {
-        die "Timed out waiting for Kselftests runner which may still be running or the OS may have crashed!";
+        my $cmd = "./run_kselftest.sh --override-timeout $timeout --per-test-log --test $test 2>&1 | tee -a \$HOME/summary.tap; echo '$stamp $test END'";
+
+        wait_serial(serial_term_prompt(), undef, 0, no_regex => 1);
+        type_string($cmd);
+        wait_serial($cmd, undef, 0, no_regex => 1);
+        send_key 'ret';
+
+        # Give the harness's own --override-timeout a 10s head start so it can
+        # print its TIMEOUT result and the END stamp before openQA gives up.
+        my $finished = wait_serial(qr/\Q$stamp\E \Q$test\E END/, timeout => $timeout + 10, record_output => 1);
+        die "Timed out waiting for kselftest '$test' which may still be running or the OS may have crashed!" unless defined $finished;
     }
 }
 
@@ -139,19 +104,13 @@ This module runs Linux Kernel Selftests (kselftests) inside openQA.
 It expects C<kselftests_prepare> to have already installed the selftests
 and their dependencies.
 
-The module groups tests by a collection, as listed in
-F<kselftest-list.txt>, and allows selecting individual tests, skipping
-tests, and injecting custom environment variables into the test harness.
+Each test in the collection is run individually so that kernel crashes or
+hangs are caught per-test rather than aborting the entire run with a
+single opaque timeout.
 
 Test results are collected from KTAP output produced by the
 F<run_kselftest.sh> harness and exported into the openQA result
-directory. When multiple tests are executed, per-test logs are enabled
-automatically.
-
-A serial console stamp is written before and after the test run to
-detect hangs or kernel crashes. A global timeout is applied to the
-overall test run, while an optional per-test timeout can be used to
-override the default 45-second limit built into the kselftest harness.
+directory.
 
 =head1 Configuration
 
@@ -174,23 +133,10 @@ Optional list of tests that should be skipped. This is applied after
 KSELFTEST_TESTS, so it can exclude tests even when running a full
 collection.
 
-=head2 KSELFTEST_RUNNER
-
-Overrides the default runner command. Useful for debugging or running
-custom wrappers. Example:
-
-  KSELFTEST_RUNNER="cd bpf; strace ./test_progs -t dummy_st_ops"
-
 =head2 KSELFTEST_TIMEOUT
 
-Applies a global timeout (in seconds) to the entire kselftest run. If
-the tests do not complete within this time, the module fails.
-
-=head2 KSELFTEST_TEST_TIMEOUT
-
-Optional per-test timeout passed to F<run_kselftest.sh> via the
-C<--override-timeout> argument. This overrides the default kselftest
-per-test timeout (typically 45 seconds). Useful for long-running tests.
+Per-test timeout in seconds. If a single test does not complete within
+this time, the module fails. Defaults to 300 seconds.
 
 =head2 KSELFTEST_ENV
 
@@ -209,6 +155,5 @@ Example:
 
   KSELFTEST_COLLECTION=cgroup
   KSELFTEST_TESTS=test_cpucg_stats,test_cpucg_max
-  KSELFTEST_TEST_TIMEOUT=120
   KSELFTEST_TIMEOUT=1800
   KSELFTEST_FROM_GIT=0

--- a/tests/kernel/kselftests_run.pm
+++ b/tests/kernel/kselftests_run.pm
@@ -61,12 +61,21 @@ sub run {
     my $stamp = 'OpenQA::kselftest_run.pm';
 
     export_kselftest_env();
+    my $test_count = scalar(@tests);
+    script_run("printf 'TAP version 13\\n1..${test_count}\\n' > \$HOME/summary.tap");
 
+    my $i = 0;
     for my $test (@tests) {
+        $i++;
         # Stamp the kernel ring buffer before each test
         script_run("echo '$stamp: Starting $test' > /dev/kmsg");
 
-        my $cmd = "./run_kselftest.sh --override-timeout $timeout --per-test-log --test $test 2>&1 | tee -a \$HOME/summary.tap; echo '$stamp $test END'";
+        my $test_bare = ($test =~ s/^[^:]+://r);
+        my $cmd = "./run_kselftest.sh --override-timeout $timeout --test $test 2>&1 | tee /tmp/$test_bare;"
+          . " echo '# selftests: $collection: $test_bare' >> \$HOME/summary.tap;"
+          . " grep -m1 -E '^(not )?ok [0-9]+ selftests: ' /tmp/$test_bare"
+          . " | sed 's/ok [0-9]*/ok $i/' >> \$HOME/summary.tap;"
+          . " echo '$stamp $test END'";
 
         wait_serial(serial_term_prompt(), undef, 0, no_regex => 1);
         type_string($cmd);

--- a/tests/kernel/kselftests_run.pm
+++ b/tests/kernel/kselftests_run.pm
@@ -13,6 +13,13 @@ use testapi;
 use utils qw(write_sut_file);
 use serial_terminal qw(serial_term_prompt select_serial_terminal);
 use Kselftests::utils;
+use LTP::utils qw(unmask_serial_failures);
+
+sub pre_run_hook {
+    my ($self) = @_;
+    $self->{serial_failures} = unmask_serial_failures($self->{serial_failures});
+    $self->SUPER::pre_run_hook;
+}
 
 sub run {
     my ($self) = @_;


### PR DESCRIPTION
Hi, please consider these commits:

- Kselftests: Mount debugfs when applicable
Small fix for SLE16.1+

- Kselftests: Unmask serial failures before the test run
Serial failures should mark jobs as failed.

- known_bugs: Add 'BUG: unable to' serial failure pattern for kernel tests
A known pattern must be added to the list to be marked as a serial failure.

- Kselftests: Run tests individually
This allows for better control when timeouts happen, reducing resource usage on these kind of failures.

- Kselftests: Make subtest output visible in openQA
We are unable to see which subtest triggered a test timeout, and when a timeout happens we simply lose all information. Fix this here.

Verification runs:
- https://openqa.suse.de/tests/23521872 `livepatch run with no regressions`
- https://openqa.suse.de/tests/23521873#step/kselftests_run/1107 `BPF test_progs with partial logs available for debugging` -- original job with lost information and 2h run: https://openqa.suse.de/tests/23512102