### PR TITLE
Soft-fail cases when no updates are found for SL Micro

### DIFF
--- a/tests/transactional/install_updates.pm
+++ b/tests/transactional/install_updates.pm
@@ -51,7 +51,7 @@ sub run {
     add_test_repositories;
     my $updates = script_output('zypper lu');
     record_info('Updates', $updates);
-    die 'No updates found in the test repositories' if ($updates =~ /No updates found/);
+    record_soft_failure("poo#195497 No updates found in the test repositories.") if ($updates =~ /No updates found/);
     update_system unless get_var('DISABLE_UPDATE_WITH_PATCH');
 
     # after update, clean the audit log to make sure there aren't any leftovers that were already fixed


### PR DESCRIPTION
maintenance updates are triggered for SLES and SLMicro regardless of if the update is SLES-only.
This PR is to avoid failing in those cases.

Issue: https://openqa.suse.de/tests/23510014#step/install_updates/99
VR: https://openqa.suse.de/tests/23514055#step/install_updates/98
