### PR TITLE
Add shutdown module for pvm SUT

### DIFF
--- a/schedule/yam/agama_ppc64le.yaml
+++ b/schedule/yam/agama_ppc64le.yaml
@@ -12,3 +12,4 @@ schedule:
   - yam/validate/validate_base_product
   - yam/validate/validate_product
   - yam/validate/validate_first_user
+  - shutdown/shutdown


### PR DESCRIPTION
##
### Add module shutdown at the end of schedule file for PVM SUT.
- Related ticket: 
  - https://progress.opensuse.org/issues/186759
- VR:
  - [**sles_default_standard_unattended**](https://openqa.suse.de/tests/overview?build=hjluo_sles_default_standard_unattended_888&distri=sle)

##
