### PR TITLE
Skip network requests for valgrind

### DIFF
--- a/tests/console/valgrind.pm
+++ b/tests/console/valgrind.pm
@@ -40,6 +40,7 @@ sub run {
     prepare();
     record_info("valgrind", script_output("valgrind --version"));
 
+    script_run 'export DEBUGINFOD_URLS=""';
     # Run valgrind memchecks
     assert_script_run 'valgrind --tool=memcheck --trace-children=yes ./valgrind-test';
     my $cmd = 'valgrind -s --log-fd=1';    # command with common options


### PR DESCRIPTION
Skip network requests for valgrind
Disable debuginfod network checks

- Related ticket: https://progress.opensuse.org/issues/204411
- Verification run: https://openqa.suse.de/tests/23534486#step/valgrind/27
