### PR TITLE
Schedule Tomcat tests for Online-Immutable and stalld for SLE16.0

### DIFF
--- a/lib/Tomcat/ApacheProxyTest.pm
+++ b/lib/Tomcat/ApacheProxyTest.pm
@@ -14,13 +14,14 @@ use warnings;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
+use package_utils 'install_package';
 
 sub mod_proxy_setup() {
     my $self = shift;
     select_serial_terminal();
 
     record_info('install and configure apache2 proxy');
-    zypper_call('in apache2');
+    install_package('apache2', trup_reboot => 1);
     script_output(
         "echo  \"\$(cat <<EOF
 <VirtualHost *:80>
@@ -39,7 +40,15 @@ EOF
     # bsc#1253707 set the booleans that allow httpd_can_network_connect
     # with semanage boolean
     assert_script_run('semanage boolean -m --on httpd_can_network_connect');
-    assert_script_run('curl -L http://localhost/examples/ | grep websocket');
+    # Tomcat serves from /srv/tomcat/webapps. If the examples webapp is
+    # already deployed there, leave it as-is; otherwise symlink it in from
+    # the package location /usr/share/tomcat/tomcat-webapps/examples.
+    assert_script_run(
+        'test -e /srv/tomcat/webapps/examples || ' .
+          'ln -sfn /usr/share/tomcat/tomcat-webapps/examples /srv/tomcat/webapps/examples'
+    );
+    systemctl('restart tomcat');
+    script_retry('systemctl is-active tomcat', retry => 3, delay => 5);
+    script_retry('curl -L -f http://localhost/examples/ | grep websocket', retry => 5, delay => 2);
 }
-
 1;

--- a/lib/Tomcat/ModjkTest.pm
+++ b/lib/Tomcat/ModjkTest.pm
@@ -17,6 +17,7 @@ use serial_terminal 'select_serial_terminal';
 use utils;
 use version_utils 'is_sle';
 use registration;
+use package_utils 'install_package';
 
 # install and configure apache2, apache2-mod_jk and verify the interaction between apache2 and tomcat
 # via the package apache2-mod_jk
@@ -25,7 +26,7 @@ sub mod_jk_setup() {
     select_serial_terminal();
 
     record_info('install and configure apache2 and apache2-mod_jk connector Setup');
-    zypper_call('in apache2 apache2-mod_jk');
+    install_package('apache2 apache2-mod_jk', trup_reboot => 1);
 
     $self->conn_apache2_tomcat();
     $self->load_jk_module();

--- a/lib/Tomcat/Utils.pm
+++ b/lib/Tomcat/Utils.pm
@@ -16,6 +16,7 @@ use utils;
 use version_utils 'is_sle';
 use registration;
 use serial_terminal;
+use package_utils 'install_package';
 
 # allow a 60 second timeout for asserting needles
 use constant TIMEOUT => 90;
@@ -44,8 +45,8 @@ sub tomcat_setup() {
     quit_packagekit if is_sle;
 
     my $tomcat = 'tomcat' . $version;
-    zypper_call("in $tomcat ${tomcat}-webapps ${tomcat}-admin-webapps", timeout => 300);
-    zypper_call('in libtcnative-2-0') if is_sle('>=15-sp4');
+    install_package("$tomcat ${tomcat}-webapps ${tomcat}-admin-webapps", trup_reboot => 1);
+    install_package('libtcnative-2-0', trup_reboot => 1) if is_sle('>=15-sp4');
     assert_script_run("rpm -q $tomcat");
 
     # start the tomcat daemon and check that it is running

--- a/schedule/functional/sle16/extra_tests_textmode_phub.yaml
+++ b/schedule/functional/sle16/extra_tests_textmode_phub.yaml
@@ -10,7 +10,6 @@ schedule:
     - console/libjpeg_turbo
     - console/libgit2
     - console/apache2_php_fpm
-    - console/stalld
     - '{{libaom}}'
     - '{{libvorbis}}'
     - console/zziplib

--- a/schedule/qam/16/mau-extratests-phub.yaml
+++ b/schedule/qam/16/mau-extratests-phub.yaml
@@ -12,6 +12,7 @@ schedule:
   - console/vmstat
   - console/systemd_rpm_macros
   - console/apache2_php_fpm
+  - console/stalld
   - console/coredump_collect
 conditional_schedule:
   sle15_x86_64:

--- a/tests/console/stalld.pm
+++ b/tests/console/stalld.pm
@@ -12,6 +12,7 @@ use Mojo::Base 'consoletest';
 use testapi;
 use utils;
 use serial_terminal 'select_serial_terminal';
+use package_utils qw(install_package uninstall_package);
 
 sub run {
     select_serial_terminal;
@@ -21,7 +22,7 @@ sub run {
     my $srcdir = "/tmp/stalld-src";
 
     # Install stalld package
-    zypper_call("in $pkg");
+    install_package("$pkg", trup_reboot => 1);
     assert_script_run("rpm -q $pkg");
     record_info("VERSION", script_output("stalld --version"));
     # Start service and verify service is active
@@ -40,7 +41,7 @@ sub run {
     systemctl("stop stalld");
     # Running the upstream test suite
     # Install packages required for compiling stalld and running upstream tests
-    zypper_call("in git make clang bpftool libbpf-devel llvm");
+    install_package('git make clang bpftool libbpf-devel llvm', trup_reboot => 1);
     assert_script_run("rm -rf $srcdir");
     assert_script_run("git clone $repo $srcdir", timeout => 120);
 
@@ -64,7 +65,7 @@ sub run {
 sub cleanup {
     my $pkg = "stalld";
     systemctl("stop stalld");
-    zypper_call("rm $pkg");
+    uninstall_package("$pkg", trup_continue => 1, trup_reboot => 1);
     assert_script_run("rm -rf /tmp/stalld-src");
 }
 

--- a/tests/x11/tomcat.pm
+++ b/tests/x11/tomcat.pm
@@ -13,7 +13,7 @@
 # * apache2-mod_jk is not avaialble on sle16, so we use proxy instead
 # Maintainer: QE Core <qe-core@suse.de>
 
-use Mojo::Base 'x11test';
+use Mojo::Base 'consoletest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use Tomcat::Utils;
@@ -21,13 +21,11 @@ use Tomcat::ModjkTest;
 use Tomcat::ApacheProxyTest;
 use utils;
 use version_utils 'is_sle';
-use x11utils qw(turn_off_screensaver);
 
 sub run() {
 
     my ($self) = shift;
     # install and configure tomcat in console
-    turn_off_screensaver;
     Tomcat::Utils->tomcat_setup(get_var('TOMCAT_VER', ''));
 
     # verify that the tomcat manager works
@@ -43,9 +41,6 @@ sub run() {
         # Connection from apache2 to tomcat: Functionality test
         Tomcat::ModjkTest->func_conn_apache2_tomcat();
     }
-
-    # switch to desktop
-    Tomcat::Utils->switch_to_desktop();
 }
 
 1;


### PR DESCRIPTION
Replace zypper_call with install_package in test for immutable images. 
Unschedule the stalld test in SLE16.1-  It will be scheduled later after fixing https://progress.opensuse.org/issues/204396.
Schedule stalld test for SLE16.0

- Related ticket:  https://progress.opensuse.org/issues/203301
- Needles: No
- Verification run:  
 stalld 16.0: https://openqa.suse.de/tests/overview?build=DeepthiYV%2Fos-autoinst-distri-opensuse%2326151&distri=sle&version=16.0
tomcat 16.1: https://openqa.suse.de/tests/overview?distri=sle&build=DeepthiYV%2Fos-autoinst-distri-opensuse%2326151&version=16.1
tomcat 16.1 Immutable online: https://openqa.suse.de/tests/23659027#dependencies