### PR TITLE
fix: Avoid PRETTY_SERIAL_MARKER timeouts in nested shells

### DIFF
--- a/tests/console/sudo.pm
+++ b/tests/console/sudo.pm
@@ -102,6 +102,11 @@ sub full_test {
 }
 
 sub run {
+    # Disable PRETTY_SERIAL_MARKER because this test uses nested expect/su shells
+    # which drop the bash prompt hook
+    my $prev_pretty = get_var('PRETTY_SERIAL_MARKER');
+    set_var('PRETTY_SERIAL_MARKER', 0) if $prev_pretty;
+
     select_console 'root-console';
     install_package('sudo expect', trup_reboot => 1) if (script_run('rpm -qi sudo expect'));
     select_console 'user-console';
@@ -128,6 +133,8 @@ sub run {
         prepare_sudoers("$num");
         full_test;
     }
+
+    set_var('PRETTY_SERIAL_MARKER', $prev_pretty) if defined $prev_pretty;
 }
 
 sub post_run_hook {

--- a/tests/security/pam/pam_mount.pm
+++ b/tests/security/pam/pam_mount.pm
@@ -109,10 +109,16 @@ END
     upload_logs($pam_mount_cfg);
 
     # Test and make sure user's home directory can mount/unmount during login/logout
+    # Disable PRETTY_SERIAL_MARKER for the sub-shell execution which
+    # does not have the bash prompt hook injected
+    my $prev_pretty = get_var("PRETTY_SERIAL_MARKER");
+    set_var("PRETTY_SERIAL_MARKER", 0) if $prev_pretty;
+
     enter_cmd "su - $user";
     assert_script_run "df -k | grep /home/$user";
     enter_cmd "exit";
     validate_script_output "df -k | grep /home/$user || echo 'check pass'", sub { m/check pass/ };
+    set_var("PRETTY_SERIAL_MARKER", $prev_pretty) if defined $prev_pretty;
 
     # Tear down, clear the pam configuration changes
     assert_script_run "mv $pam_session_bak $pam_session";


### PR DESCRIPTION
The sudo and pam_mount tests use nested subshells (su - / expect) that do not inherit or load the bash PROMPT_COMMAND injected by pretty serial markers. This resulted in assert_script_run timing out because the expected markers were never printed.

Dynamically disable PRETTY_SERIAL_MARKER during these sections to fallback to the more robust standard script_run marker which works inside nested shells.

Related issue: https://progress.opensuse.org/issues/199934