### PR TITLE
Set correct hostname in validate_hostname on s390x

### DIFF
--- a/schedule/yam/agama_autoyast_supported_s390x.yaml
+++ b/schedule/yam/agama_autoyast_supported_s390x.yaml
@@ -10,5 +10,6 @@ schedule:
   - installation/first_boot
   - yam/validate/validate_base_product
   - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
   - yam/validate/validate_deployed_files
   - console/verify_separate_home

--- a/schedule/yam/agama_cli_s390x.yaml
+++ b/schedule/yam/agama_cli_s390x.yaml
@@ -13,6 +13,7 @@ schedule:
   - yam/validate/validate_product
   - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
   - yam/validate/validate_snapshots
   - yam/validate/validate_registered_products
   - console/validate_repos

--- a/schedule/yam/agama_headless_s390x.yaml
+++ b/schedule/yam/agama_headless_s390x.yaml
@@ -13,3 +13,4 @@ schedule:
   - installation/first_boot
   - yam/validate/validate_base_product
   - yam/validate/validate_first_user
+  - yam/validate/validate_hostname

--- a/schedule/yam/agama_immutable_s390x.yaml
+++ b/schedule/yam/agama_immutable_s390x.yaml
@@ -13,6 +13,7 @@ schedule:
   - yam/validate/validate_product
   - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
   - yam/validate/validate_snapshots
   - yam/validate/validate_registered_products
   - console/validate_repos

--- a/schedule/yam/agama_remote_full_immutable_s390x.yaml
+++ b/schedule/yam/agama_remote_full_immutable_s390x.yaml
@@ -15,6 +15,7 @@ schedule:
   - yam/validate/validate_product
   - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
   - yam/validate/validate_snapshots
   - yam/validate/validate_registered_products
   - yam/validate/validate_installed_patterns

--- a/schedule/yam/agama_remote_full_s390x.yaml
+++ b/schedule/yam/agama_remote_full_s390x.yaml
@@ -14,5 +14,6 @@ schedule:
   - yam/validate/validate_product
   - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
   - yam/validate/validate_snapshots
   - yam/validate/validate_registered_products

--- a/schedule/yam/agama_remote_immutable_s390x.yaml
+++ b/schedule/yam/agama_remote_immutable_s390x.yaml
@@ -14,6 +14,7 @@ schedule:
   - yam/validate/validate_product
   - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
   - yam/validate/validate_snapshots
   - yam/validate/validate_registered_products
   - console/validate_repos

--- a/schedule/yam/agama_remote_s390x.yaml
+++ b/schedule/yam/agama_remote_s390x.yaml
@@ -14,6 +14,7 @@ schedule:
   - yam/validate/validate_product
   - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
   - yam/validate/validate_snapshots
   - yam/validate/validate_registered_products
   - console/validate_repos

--- a/schedule/yam/agama_s390x.yaml
+++ b/schedule/yam/agama_s390x.yaml
@@ -13,6 +13,7 @@ schedule:
   - yam/validate/validate_product
   - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
   - yam/validate/validate_snapshots
   - yam/validate/validate_registered_products
   - console/validate_repos

--- a/schedule/yam/agama_self_update_unattended_s390x.yaml
+++ b/schedule/yam/agama_self_update_unattended_s390x.yaml
@@ -14,6 +14,7 @@ schedule:
   - yam/validate/validate_product
   - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
   - yam/validate/validate_snapshots
   - yam/validate/validate_registered_products
   - console/validate_repos

--- a/schedule/yam/agama_zfcp_s390x.yaml
+++ b/schedule/yam/agama_zfcp_s390x.yaml
@@ -14,6 +14,7 @@ schedule:
   - yam/validate/validate_product
   - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
   - yam/validate/validate_snapshots
   - yam/validate/validate_registered_products
   - console/validate_repos

--- a/schedule/yam/slmicro_migration_s390x.yaml
+++ b/schedule/yam/slmicro_migration_s390x.yaml
@@ -14,6 +14,7 @@ schedule:
   - yam/validate/validate_product
   - yam/validate/validate_connectivity
   - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
   - yam/validate/validate_snapshots
   - yam/validate/validate_registered_products
   - console/validate_repos

--- a/tests/yam/validate/validate_hostname.pm
+++ b/tests/yam/validate/validate_hostname.pm
@@ -12,10 +12,13 @@ use Mojo::Base 'consoletest';
 use testapi;
 use scheduler 'get_test_suite_data';
 use Test::Assert ':assert';
+use Utils::Architectures qw(is_s390x is_zvm);
 
 sub run {
     select_console 'root-console';
-    my $expected_install_hostname = get_test_suite_data()->{hostname} // 'localhost';
+    my $expected_install_hostname = is_zvm ? get_required_var('ZVM_GUEST')
+      : is_s390x ? (split(/\./, get_required_var('SUT_IP')))[0]
+      : get_test_suite_data()->{hostname} // 'localhost';
     my $hostname = script_output('hostnamectl hostname');
     assert_str_equals($expected_install_hostname, $hostname, "Wrong hostname. Expected: '$expected_install_hostname', got '$hostname'");
 }


### PR DESCRIPTION
## 
### Set correct hostname in validate_hostname on s390x
- Related ticket: 
  - https://progress.opensuse.org/issues/188691

```zsh
# on zvm
# hostnamectl hostname
  osdzvm07.oqa.prg2.suse.org
# on kvm
# hostnamectl hostname
  s390kvm093
```

- Verification run: 
  - [__validate_hostname__](https://openqa.suse.de/tests/overview?version=16.1&build=hjluo_sles_default_standard_cli_888&distri=sle)


##