### PR TITLE
Wait for transactional-update background tasks in publiccloud tests

### DIFF
--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -15,7 +15,7 @@ use utils qw(random_string script_retry);
 use version_utils qw(is_transactional is_sle);
 use Utils::Architectures qw(is_aarch64);
 use publiccloud::utils qw(is_byos pc_data_url);
-use publiccloud::zypper qw(pc_zypper_call);
+use publiccloud::zypper qw(pc_zypper_call pc_transactional_call);
 use publiccloud::aws_client;
 use publiccloud::ssh_interactive 'select_host_console';
 
@@ -469,9 +469,10 @@ sub _install_ec2_cloudwatch_agent
     );
 
     if (is_transactional) {
-        $instance->ssh_assert_script_run(
-            cmd => "sudo transactional-update run sh -c 'rpm -Uvh --noscripts $download_directory/$rpm_file'",
-            timeout => 300
+        pc_transactional_call(
+            $instance,
+            "run sh -c 'rpm -Uvh --noscripts $download_directory/$rpm_file'",
+            timeout => 300, exitcode => [0], no_reboot => 1
         );
         $instance->softreboot();
     } else {

--- a/lib/publiccloud/zypper.pm
+++ b/lib/publiccloud/zypper.pm
@@ -47,6 +47,8 @@ through plain C<zypper>.
 
 =item L</pc_wait_quit>             - wait for zypper/rpm/etc. to finish
 
+=item L</pc_wait_quit_local>       - like C<pc_wait_quit>, but console-direct
+
 =item L</pc_installed_packages>    - filter list to installed packages
 
 =item L</pc_available_packages>    - filter list to available-but-not-installed
@@ -85,7 +87,17 @@ use constant {
     DEFAULT_RETRY => 1,
     DEFAULT_DELAY => 5,
     ZYPPER_LOG => '/var/log/zypper.log',
+    TRANSACTIONAL_LOG => '/var/log/transactional-update.log',
 };
+
+# Process names pc_wait_quit()/pc_wait_quit_local() poll for (poo#204534).
+# pgrep (without -f) truncates comm to 15 chars, so the 20-char
+# "transactional-update" never matches as-is; substr() mirrors that
+# truncation. -f would dodge it but self-matches the check's own argv.
+use constant BUSY_PROCESS_PATTERN => join('|',
+    qw(zypper packagekit purge-kernels rpm snapper),
+    substr('transactional-update', 0, 15),
+);
 
 our @EXPORT_OK = qw(
   pc_zypper_call
@@ -94,6 +106,7 @@ our @EXPORT_OK = qw(
   pc_refresh
   pc_add_repo
   pc_wait_quit
+  pc_wait_quit_local
   pc_installed_packages
   pc_available_packages
   pc_install_packages_local
@@ -297,8 +310,9 @@ sub pc_add_repo {
 
     pc_wait_quit($instance, [timeout => 20], [delay => 10], [retry => 120]);
 
-Waits until no zypper / packagekit / purge-kernels / rpm processes are
-running on the remote instance. Defaults give a ~20 minute ceiling.
+Waits until no zypper / packagekit / purge-kernels / rpm / transactional-update
+/ snapper processes are running on the remote instance, via SSH. Defaults
+give a ~20 minute ceiling.
 
 =cut
 
@@ -309,7 +323,7 @@ sub pc_wait_quit {
     my $retry = $opts{retry} // 120;
 
     # RC 0 (success) only when no matching processes exist.
-    my $cmd = q{! pgrep -a "zypper|packagekit|purge-kernels|rpm"};
+    my $cmd = q{! pgrep -a "} . BUSY_PROCESS_PATTERN . q{"};
 
     $instance->ssh_script_retry(
         cmd => $cmd,
@@ -317,6 +331,31 @@ sub pc_wait_quit {
         delay => $delay,
         retry => $retry,
     );
+}
+
+=head2 pc_wait_quit_local
+
+    pc_wait_quit_local([timeout => 20], [delay => 10], [retry => 120]);
+
+Console-direct counterpart to L</pc_wait_quit>: waits until no
+zypper/packagekit/purge-kernels/rpm/transactional-update/snapper processes
+are running, using the currently selected console (plain C<script_retry>)
+instead of an SSH-wrapped remote command.
+
+Use this when already directly attached to the target's console (e.g. an
+interactive SSH session opened by C<publiccloud::ssh_interactive>, or a
+local transactional system), where going through C<< $instance->ssh_* >>
+would open a redundant nested SSH connection.
+
+=cut
+
+sub pc_wait_quit_local {
+    my (%opts) = @_;
+    my $timeout = $opts{timeout} // 20;
+    my $delay = $opts{delay} // 10;
+    my $retry = $opts{retry} // 120;
+
+    utils::script_retry(q{! pgrep -a "} . BUSY_PROCESS_PATTERN . q{"}, timeout => $timeout, delay => $delay, retry => $retry);
 }
 
 =head2 pc_installed_packages
@@ -451,24 +490,24 @@ sub _run {
 
     pc_wait_quit($instance) if $wait_quit;
 
-    my $ret = _retry_loop($instance, $full_cmd, $retry, $delay, \%args);
+    my $ret = _retry_loop($instance, $full_cmd, $retry, $delay, \%args, $kind);
 
     unless (grep { $_ == $ret } @$exit_codes) {
-        _report_failure($instance, $full_cmd, $ret, $proceed);
+        _report_failure($instance, $full_cmd, $ret, $proceed, $kind);
     }
     record_info('zypper remote call', "Command: $full_cmd\nResult: $ret");
     return $ret;
 }
 
 sub _retry_loop {
-    my ($instance, $cmd, $retry, $delay, $ssh_args) = @_;
+    my ($instance, $cmd, $retry, $delay, $ssh_args, $kind) = @_;
     my $ret;
     for my $attempt (1 .. $retry) {
         $ret = $instance->ssh_script_run(cmd => $cmd, %$ssh_args);
         return $ret if $ret == EXIT_OK;
         sleep($delay) if defined $ret;
 
-        my $action = _handle_transient_failure($instance, $ret, $attempt, $retry);
+        my $action = _handle_transient_failure($instance, $ret, $attempt, $retry, $kind);
         return $ret if $action eq 'stop';
         next if $action eq 'retry';
         last;    # 'fail'
@@ -479,7 +518,19 @@ sub _retry_loop {
 # Returns 'retry' (try again), 'stop' (give up but don't drop into the
 # generic failure path), or 'fail' (let _run handle it).
 sub _handle_transient_failure {
-    my ($instance, $ret, $attempt, $max) = @_;
+    my ($instance, $ret, $attempt, $max, $kind) = @_;
+    $kind //= 'zypper';
+
+    # transactional-update has no dedicated lock exit code; it exits non-zero
+    # and logs one of two messages, depending on which of its two independent
+    # locks (CLI wrapper or tukit backend) was contended (poo#204534).
+    if ($kind eq 'transactional') {
+        if (_log_grep($instance, "Couldn't get lock|Another instance of tukit is already running", TRANSACTIONAL_LOG) == 0) {
+            record_info("Retry $attempt/$max as a transactional-update background task is still running");
+            return 'retry';
+        }
+        return 'fail';
+    }
 
     if ($ret == EXIT_SOLVER) {
         # bsc#1070851 -- transient 502 from server; zypper should retry
@@ -516,27 +567,42 @@ sub _handle_transient_failure {
 }
 
 sub _report_failure {
-    my ($instance, $cmd, $ret, $proceed) = @_;
+    my ($instance, $cmd, $ret, $proceed, $kind) = @_;
+    $kind //= 'zypper';
+    my $log = $kind eq 'transactional' ? TRANSACTIONAL_LOG : ZYPPER_LOG;
 
-    $instance->ssh_script_run('sudo chmod o+r ' . ZYPPER_LOG);
-    $instance->upload_log(ZYPPER_LOG);
+    $instance->ssh_script_run("sudo chmod o+r $log");
+    $instance->upload_log($log);
 
-    my $info = _classify_failure($instance, $ret);
+    my $info = _classify_failure($instance, $ret, $kind);
     my $msg = "$cmd failed with code: $ret";
     if (defined $info->{label}) {
         $msg .= " ($info->{label})";
     }
-    $msg .= "\n\nRelated zypper logs:\n" . ($info->{excerpt} // '');
+    $msg .= "\n\nRelated " . ($kind eq 'transactional' ? 'transactional-update' : 'zypper') . " logs:\n" . ($info->{excerpt} // '');
 
     die $msg unless $proceed;
     record_info('zypper error', $msg, result => 'fail');
 }
 
 sub _classify_failure {
-    my ($instance, $ret) = @_;
+    my ($instance, $ret, $kind) = @_;
+    $kind //= 'zypper';
+    if ($kind eq 'transactional') {
+        # No session markers in transactional-update.log like zypper's
+        # "Hi, me zypper"; just grab the tail around the failure.
+        return {label => undef, excerpt => _log_tail($instance, TRANSACTIONAL_LOG)};
+    }
     my $cls = $FAILURE_CLASSIFIERS{$ret} // {label => undef, regex => 'Exception\.cc'};
     my $excerpt = _last_zypper_session($instance, $cls->{regex});
     return {label => $cls->{label}, excerpt => $excerpt};
+}
+
+# Last $lines of $log, best-effort (never dies the test on its own).
+sub _log_tail {
+    my ($instance, $log, $lines) = @_;
+    $lines //= 100;
+    return $instance->ssh_script_output("sudo tail -n $lines $log", proceed_on_failure => 1);
 }
 
 # Extract the lines from the last "Hi, me zypper" session that match
@@ -555,9 +621,12 @@ sub _last_zypper_session {
 }
 
 sub _log_grep {
-    my ($instance, $pattern) = @_;
+    my ($instance, $pattern, $log) = @_;
+    $log //= ZYPPER_LOG;
+    # -E (extended regex) so callers can use plain '|' alternation without
+    # needing the GNU BRE '\|' escape.
     return $instance->ssh_script_run(
-        sprintf('sudo grep %s %s', _shell_quote($pattern), ZYPPER_LOG)
+        sprintf('sudo grep -E %s %s', _shell_quote($pattern), $log)
     );
 }
 

--- a/t/13_publiccloud.t
+++ b/t/13_publiccloud.t
@@ -262,7 +262,7 @@ subtest '[pc_wait_quit] uses defaults and expected command' => sub {
 
     is scalar(@calls), 1, 'one call to ssh_script_retry';
     is $calls[0]->{cmd},
-      q{! pgrep -a "zypper|packagekit|purge-kernels|rpm"},
+      q{! pgrep -a "} . publiccloud::zypper::BUSY_PROCESS_PATTERN() . q{"},
       'expected pgrep/false/true command';
     is $calls[0]->{timeout}, 20, 'default timeout=20';
     is $calls[0]->{delay}, 10, 'default delay=10';
@@ -283,7 +283,7 @@ subtest '[pc_wait_quit] honors custom timeout/delay/retry' => sub {
         timeout => 5, delay => 2, retry => 3);
 
     is $seen->{cmd},
-      q{! pgrep -a "zypper|packagekit|purge-kernels|rpm"},
+      q{! pgrep -a "} . publiccloud::zypper::BUSY_PROCESS_PATTERN() . q{"},
       'same command with custom args';
     is $seen->{timeout}, 5, 'custom timeout applied';
     is $seen->{delay}, 2, 'custom delay applied';
@@ -291,7 +291,7 @@ subtest '[pc_wait_quit] honors custom timeout/delay/retry' => sub {
 };
 
 subtest '[pc_wait_quit] succeeds on 5th attempt (4 fail + 1 success)' => sub {
-    my $expected_cmd = q{! pgrep -a "zypper|packagekit|purge-kernels|rpm"};
+    my $expected_cmd = q{! pgrep -a "} . publiccloud::zypper::BUSY_PROCESS_PATTERN() . q{"};
 
     my $inst = Test::MockObject->new;
     my $calls = 0;
@@ -319,7 +319,7 @@ subtest '[pc_wait_quit] succeeds on 5th attempt (4 fail + 1 success)' => sub {
 };
 
 subtest '[pc_wait_quit] times out after 5 failures' => sub {
-    my $expected_cmd = q{! pgrep -a "zypper|packagekit|purge-kernels|rpm"};
+    my $expected_cmd = q{! pgrep -a "} . publiccloud::zypper::BUSY_PROCESS_PATTERN() . q{"};
 
     my $inst = Test::MockObject->new;
     my $calls = 0;

--- a/t/43_publiccloud_zypper.t
+++ b/t/43_publiccloud_zypper.t
@@ -23,6 +23,8 @@ use publiccloud::zypper qw(
   pc_pkg_call
   pc_refresh
   pc_add_repo
+  pc_wait_quit
+  pc_wait_quit_local
   pc_installed_packages
   pc_available_packages
   pc_install_packages_local
@@ -152,6 +154,7 @@ sub _instance_mock {
             return $behaviour{output} // '';
     });
     $inst->mock(softreboot => sub { push @{$_[0]->{calls}}, {m => 'softreboot'}; return });
+    $inst->mock(upload_log => sub { push @{$_[0]->{calls}}, {m => 'upload_log', log => $_[1]}; return });
     return $inst;
 }
 
@@ -286,6 +289,123 @@ subtest '[pc_install_packages_local] transactional vs plain' => sub {
     ok(!defined $zypper_cmd, 'empty package list is a no-op');
 
     throws_ok { pc_install_packages_local('x') } qr/Expected arrayref/, 'non-arrayref dies';
+};
+
+# ---------------------------------------------------------------------------
+# pc_wait_quit / pc_wait_quit_local -- poo#204534
+# ---------------------------------------------------------------------------
+subtest '[BUSY_PROCESS_PATTERN] transactional-update is truncated to avoid pgrep comm truncation' => sub {
+    my $pattern = publiccloud::zypper::BUSY_PROCESS_PATTERN();
+    # Regression guard for poo#204534: pgrep (without -f) truncates comm to
+    # 15 chars, so the full 20-char literal would silently never match.
+    # Assert the truncated prefix is used instead of the untruncated name.
+    unlike($pattern, qr/\|transactional-update(\||$)/, 'full untruncated name is not used as a pgrep branch');
+    like($pattern, qr/\|transactional-u(\||$)/, 'truncated 15-char prefix is used instead');
+    like($pattern, qr/\bsnapper\b/, 'pattern includes snapper');
+    like($pattern, qr/\bzypper\b/, 'pattern still includes zypper');
+};
+
+subtest '[pc_wait_quit] pgrep pattern covers transactional-update/snapper' => sub {
+    my $inst = _instance_mock();
+    pc_wait_quit($inst);
+    my ($call) = grep { $_->{m} eq 'retry' } @{$inst->{calls}};
+    ok($call, 'ssh_script_retry invoked');
+    like($call->{cmd}, qr/pgrep/, 'command greps processes');
+    like($call->{cmd}, qr/\Q@{[publiccloud::zypper::BUSY_PROCESS_PATTERN()]}\E/, 'uses the shared busy-process pattern');
+};
+
+subtest '[pc_wait_quit_local] polls via plain script_retry, no SSH' => sub {
+    my $utils = Test::MockModule->new('utils', no_auto => 1);
+    my ($cmd, %opts_seen);
+    $utils->redefine(script_retry => sub { $cmd = $_[0]; %opts_seen = @_[1 .. $#_]; return 0 });
+    pc_wait_quit_local(timeout => 5, delay => 1, retry => 2);
+    like($cmd, qr/pgrep/, 'command greps processes');
+    like($cmd, qr/\Q@{[publiccloud::zypper::BUSY_PROCESS_PATTERN()]}\E/, 'uses the shared busy-process pattern');
+    is($opts_seen{timeout}, 5, 'timeout forwarded');
+    is($opts_seen{delay}, 1, 'delay forwarded');
+    is($opts_seen{retry}, 2, 'retry forwarded');
+};
+
+# ---------------------------------------------------------------------------
+# _handle_transient_failure -- transactional-update lock detection (poo#204534)
+# ---------------------------------------------------------------------------
+subtest '[_handle_transient_failure] transactional lock message triggers retry' => sub {
+    my $testapi_mock = Test::MockModule->new('publiccloud::zypper');
+    $testapi_mock->redefine(record_info => sub { return 1 });
+    my $inst = _instance_mock();
+    $inst->mock(ssh_script_run => sub {
+            my ($s, $cmd) = @_;
+            push @{$s->{calls}}, {m => 'run', cmd => $cmd};
+            return ($cmd =~ /transactional-update\.log/) ? 0 : 1;    # pattern found
+    });
+    is(publiccloud::zypper::_handle_transient_failure($inst, 1, 1, 3, 'transactional'),
+        'retry', 'retries when log confirms the lock message');
+};
+
+subtest '[_handle_transient_failure] greps for both known lock messages' => sub {
+    my $testapi_mock = Test::MockModule->new('publiccloud::zypper');
+    $testapi_mock->redefine(record_info => sub { return 1 });
+
+    for my $case (
+        {label => 'bashlock (CLI wrapper) message', needle => 'Couldn'},
+        {label => 'tukit backend message', needle => 'Another instance of tukit is already running'},
+      )
+    {
+        my $inst = _instance_mock_positional();
+        $inst->mock(ssh_script_run => sub {
+                my ($s, $cmd) = @_;
+                push @{$s->{calls}}, $cmd;
+                # The composed grep command must reference this case's
+                # message (checked as a plain substring since _shell_quote
+                # escapes the apostrophe in "Couldn't").
+                return (index($cmd, $case->{needle}) >= 0) ? 0 : 1;
+        });
+        is(publiccloud::zypper::_handle_transient_failure($inst, 1, 1, 3, 'transactional'),
+            'retry', "retries on $case->{label}");
+    }
+};
+
+subtest '[_handle_transient_failure] transactional failure without lock message fails' => sub {
+    my $inst = _instance_mock_positional();
+    $inst->mock(ssh_script_run => sub { return 1 });    # grep finds nothing -> non-zero
+    is(publiccloud::zypper::_handle_transient_failure($inst, 1, 1, 3, 'transactional'),
+        'fail', 'does not retry a genuine transactional-update failure');
+};
+
+subtest '[_handle_transient_failure] zypper-kind checks unaffected by kind arg' => sub {
+    my $testapi_mock = Test::MockModule->new('publiccloud::zypper');
+    $testapi_mock->redefine(record_info => sub { return 1 });
+    my $inst = _instance_mock(run_rc => 1);    # log grep misses
+    is(publiccloud::zypper::_handle_transient_failure($inst, publiccloud::zypper::EXIT_LOCKED(), 1, 3),
+        'retry', 'zypp lock still retried when kind defaults to zypper');
+};
+
+sub _instance_mock_positional {
+    my $inst = Test::MockObject->new;
+    $inst->{calls} = [];
+    $inst->mock(ssh_script_run => sub { my ($s, $cmd) = @_; push @{$s->{calls}}, $cmd; return 0 });
+    $inst->mock(ssh_script_output => sub { return 'some log tail' });
+    $inst->mock(upload_log => sub { return });
+    return $inst;
+}
+
+subtest '[_log_grep] defaults to zypper log, accepts an override, uses extended regex' => sub {
+    my $inst = _instance_mock_positional();
+    publiccloud::zypper::_log_grep($inst, 'needle');
+    like($inst->{calls}[0], qr{/var/log/zypper\.log}, 'defaults to zypper.log');
+    like($inst->{calls}[0], qr/grep -E/, 'uses -E so callers can use plain alternation');
+
+    $inst = _instance_mock_positional();
+    publiccloud::zypper::_log_grep($inst, 'needle', '/var/log/transactional-update.log');
+    like($inst->{calls}[0], qr{/var/log/transactional-update\.log}, 'custom log path honoured');
+};
+
+subtest '[_report_failure] uses transactional-update.log for transactional kind' => sub {
+    my $inst = _instance_mock_positional();
+    throws_ok { publiccloud::zypper::_report_failure($inst, 'transactional-update -n up', 1, 0, 'transactional') }
+    qr/Related transactional-update logs/, 'error message references the right log';
+    my ($chmod_cmd) = grep { /chmod/ } @{$inst->{calls}};
+    like($chmod_cmd, qr{/var/log/transactional-update\.log}, 'chmod targets transactional-update.log');
 };
 
 done_testing;

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -15,6 +15,7 @@ use registration;
 use testapi;
 use utils;
 use publiccloud::utils;
+use publiccloud::zypper 'pc_wait_quit_local';
 use version_utils qw(is_sle is_sle_micro);
 use Utils::Logging 'tar_and_upload_log';
 
@@ -46,6 +47,9 @@ sub run {
     # Check for bsc#1165915
     zypper_call("ref");
     my $register = (is_sle_micro) ? "transactional-update register --status-text" : "SUSEConnect --status-text";
+    # poo#204534: a background transactional-update task (e.g. snapper
+    # cleanup) may still hold the lock right after boot/registration.
+    pc_wait_quit_local() if is_sle_micro;
     assert_script_run($register, 300);
 
     zypper_call("lr -d");

--- a/tests/publiccloud/slem_basic.pm
+++ b/tests/publiccloud/slem_basic.pm
@@ -12,6 +12,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use publiccloud::utils qw(is_byos is_azure is_ec2 registercloudguest);
 use publiccloud::ssh_interactive 'select_host_console';
+use publiccloud::zypper 'pc_transactional_call';
 use utils qw(zypper_call systemctl);
 use version_utils qw(is_sle_micro check_version);
 use Mojo::JSON 'j';
@@ -85,7 +86,7 @@ sub run {
         unless ($ret) {
             die("Testing package \'$test_package\' is already installed, choose a different package!");
         }
-        $instance->ssh_assert_script_run(cmd => 'sudo transactional-update -n pkg install ' . $test_package, timeout => 600);
+        pc_transactional_call($instance, 'pkg install ' . $test_package, timeout => 600, exitcode => [0], no_reboot => 1);
         $instance->softreboot();
         $instance->ssh_assert_script_run(cmd => 'rpm -q ' . $test_package);
     }
@@ -99,7 +100,7 @@ sub run {
 
     unless (get_var('PUBLIC_CLOUD_IGNORE_UNREGISTERED')) {
         # additional tr-up tests
-        $instance->ssh_assert_script_run(cmd => 'sudo transactional-update -n up', timeout => 360);
+        pc_transactional_call($instance, 'up', timeout => 360, exitcode => [0], no_reboot => 1);
         $instance->softreboot();
     }
 
@@ -111,7 +112,7 @@ sub run {
     } else {
         die "SELinux should be enforcing" unless ($getenforce =~ /Enforcing/i);
     }
-    $instance->ssh_assert_script_run(cmd => 'sudo transactional-update -n setup-selinux');
+    pc_transactional_call($instance, 'setup-selinux', exitcode => [0], no_reboot => 1);
     $instance->softreboot();
 
     record_info('timers', $instance->ssh_script_output(cmd => 'sudo systemctl list-timers --all'));

--- a/tests/publiccloud/slem_upgrade_next.pm
+++ b/tests/publiccloud/slem_upgrade_next.pm
@@ -10,6 +10,7 @@
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
+use publiccloud::zypper 'pc_transactional_call';
 use version_utils qw(is_sle_micro);
 
 
@@ -39,13 +40,14 @@ sub run {
     $instance->ssh_script_retry("sudo zypper -n ref", retry => 3, timeout => 600, fail_message => "zypper refresh failed");
     record_info('Repos', $instance->ssh_script_output('zypper lr -u'));
 
-    my $exit = $instance->ssh_script_run(cmd => 'sudo transactional-update -n up', timeout => 2700) // -1;
-    die "transactional-update returned error $exit" unless ($exit == 0);
+    # pc_transactional_call() dies with the relevant transactional-update.log
+    # excerpt on failure (exitcode => [0] here, since a reboot is expected
+    # right after, not folded into the accept-list).
+    pc_transactional_call($instance, 'up', timeout => 2700, exitcode => [0], no_reboot => 1);
     $instance->softreboot(timeout => $reboot_timeout);
 
     record_info("SLEM migration", "Initial version: " . get_var('VERSION'));
-    $exit = $instance->ssh_script_run(cmd => 'sudo transactional-update -n migration', timeout => 4500) // -1;
-    die "transactional-update migration returned error $exit" unless ($exit == 0);
+    pc_transactional_call($instance, 'migration', timeout => 4500, exitcode => [0], no_reboot => 1);
     $instance->softreboot(timeout => $reboot_timeout);
 
     my $ver = check_upgraded_version($instance);


### PR DESCRIPTION
Adds background-task awareness to publiccloud's transactional-update handling. `pc_wait_quit()`/`pc_wait_quit_local()` now also poll for `transactional-update` and `snapper` before running a command, and `pc_transactional_call()` retries when the log confirms the CLI wrapper's or the tukit backend's lock is still held by a background task. Migrates `instance_overview.pm`, `slem_basic.pm`, `slem_upgrade_next.pm`, and `ec2.pm` off raw ssh/console calls onto this machinery so they inherit the protection.

* Related ticket: [poo#204534](https://progress.opensuse.org/issues/204534)
* Related failure: [openqa.suse.de/t23547973](https://openqa.suse.de/tests/23547973)
* Verification runs: In the thread below
