### PR TITLE
Add pacemaker_cts_regression in Immutable Mode

### DIFF
--- a/tests/ha/pacemaker_cts_regression.pm
+++ b/tests/ha/pacemaker_cts_regression.pm
@@ -10,7 +10,7 @@
 use Mojo::Base 'haclusterbasetest';
 use testapi;
 use Utils::Architectures;
-use utils 'zypper_call';
+use package_utils qw(install_package);
 use hacluster;
 
 sub run {
@@ -31,15 +31,26 @@ sub run {
     # This increases the timeout in that ARCH
     $timeout *= 2 if is_aarch64;
 
-    zypper_call 'in pacemaker-cts';
+    install_package('pacemaker-cts', trup_reboot => 1);
 
     foreach my $cts_tests (@tests_to_run) {
         record_info("$cts_tests", "Starting $cts_tests");
+        assert_script_run("echo ==== Starting $cts_tests ==== >> $log");
         assert_script_run "$cts_path/$cts_tests -V | tee -a $log 2>&1 ; ( exit \${PIPESTATUS[0]} )", timeout => $timeout;
         save_screenshot;
     }
 
     upload_logs $log;
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+
+    # Upload the logs
+    upload_logs '/tmp/cts_regression.log';
+
+    # Execute the common part
+    $self->SUPER::post_fail_hook();
 }
 
 1;


### PR DESCRIPTION
Replace `zypper_call` with `install_package`
Upload the log  whenever passed or failed

- Related ticket: [TEAM-11271](https://jira.suse.com/browse/TEAM-11271?filter=-1) - [16.1][ppc64le] Add pacemaker_cts_regression Test for SLES in Immutable Mode
  
- Related MR:  
https://gitlab.suse.de/qa-css/openqa_ha_sap/-/merge_requests/1365  
  
- Verification run:
16.1 ppc64le immutable mode: 
https://openqa.suse.de/tests/23541380#step/pacemaker_cts_regression/34 (failed and log was uploaded, but will open bugs/tickets)
16.1 ppc64le traditional mode: 
https://openqa.suse.de/tests/23541381#downloads (passed and the log was uploaded)
16.1 x86 immutable mode: 
http://openqa.suse.de/tests/23554706#step/pacemaker_cts_regression/34 (ailed and log was uploaded, but will open bugs/tickets)