### PR TITLE
Disconnect cdrom device to avoid booting from installation

### DIFF
--- a/lib/virt_autotest/esxi_utils.pm
+++ b/lib/virt_autotest/esxi_utils.pm
@@ -25,6 +25,7 @@ our @EXPORT = qw(
   esxi_vm_network_binding
   esxi_vm_public_ip
   esxi_vm_mac_address
+  esxi_vm_disconnect_cdrom
   get_host_timestamp
   disable_vm_time_synchronization
   revert_vm_timesync_setting
@@ -119,6 +120,22 @@ sub esxi_vm_mac_address {
         $vm_mac = script_output(qq(ssh -o StrictHostKeyChecking=no root\@$hypervisor "$vim_cmd"));
     }
     return $vm_mac;
+}
+
+sub esxi_vm_disconnect_cdrom {
+    my $vm_id = shift;
+    my $vim_cmd;
+    my $device_key;
+
+    if (is_svirt) {
+        $vim_cmd = qq(vim-cmd vmsvc/device.getdevices $vm_id | awk '/VirtualCdrom/{f=1} f&&/key = /{gsub(/[^0-9]/,\"\");print;exit}' | head -c -1);
+        (undef, $device_key) = console('svirt')->run_cmd($vim_cmd, domain => 'sshVMwareServer', wantarray => 1);
+        if ($device_key) {
+            # Usage: vim-cmd vmsvc/device.connection <Vmid> <DeviceId = Key> <1 for enable / 0 for disable>
+            $vim_cmd = "vim-cmd vmsvc/device.connection $vm_id $device_key 0 && vim-cmd vmsvc/reload $vm_id";
+            return console('svirt')->run_cmd($vim_cmd, domain => 'sshVMwareServer', wantarray => 1);
+        }
+    }
 }
 
 sub get_host_timestamp {

--- a/tests/virt_autotest/esxi_open_vm_tools.pm
+++ b/tests/virt_autotest/esxi_open_vm_tools.pm
@@ -94,6 +94,8 @@ sub do_power_mgmt_tests {
     check_vmtools_service() if (is_svirt);
     $powerops_ret = take_vm_power_ops($vm_id, $powerops, $VM_POWER_ON);
     check_vm_power_state($vm_id, $vm_ip, $powerops, $powerops_ret, 0, $VM_POWER_OFF);
+    # Disconnect CD-ROM
+    esxi_vm_disconnect_cdrom($vm_id);
 
     record_info('Guest Power On');
     $powerops = 'power.on';


### PR DESCRIPTION
VM will boot from ISO installation after power off and power on, that will block the tests. Disconnecting the cdrom device by vmware command can solve the problem.
https://openqa.suse.de/tests/23488917#step/esxi_open_vm_tools/61

- Related ticket: https://progress.opensuse.org/issues/199928
- Verification run: https://openqa.suse.de/tests/23554228

Logs:
```
[2026-07-23T08:09:07.712560Z] [debug] [pid:2612225] <<< backend::console_proxy::__ANON__(wrapped_call={
    "args" => [
                "vim-cmd vmsvc/device.connection 204 3000 0 && vim-cmd vmsvc/reload 204",
                "domain",
                "sshVMwareServer",
                "wantarray",
                1
              ],
    "console" => "svirt",
    "wantarray" => undef,
    "function" => "run_cmd"
  })
[2026-07-23T08:09:07.712974Z] [debug] [pid:2612226] <<< backend::baseclass::run_ssh_cmd(cmd="vim-cmd vmsvc/device.connection 204 3000 0 && vim-cmd vmsvc/reload 204", wantarray=1, username="root", hostname="orion.bmt.prg2.suse.org", keep_open=1, password="SECRET")
[2026-07-23T08:09:07.713114Z] [debug] [pid:2612226] <<< backend::baseclass::run_ssh(cmd="vim-cmd vmsvc/device.connection 204 3000 0 && vim-cmd vmsvc/reload 204", username="root", wantarray=1, keep_open=1, password="SECRET", hostname="orion.bmt.prg2.suse.org")
[2026-07-23T08:09:07.713229Z] [debug] [pid:2612226] <<< backend::baseclass::new_ssh_connection(keep_open=1, password="SECRET", hostname="orion.bmt.prg2.suse.org", wantarray=1, username="root", blocking=1)
[2026-07-23T08:09:07.875970Z] [debug] [pid:2612226] Using existing SSH connection (key:hostname=orion.bmt.prg2.suse.org,username=root,port=22)
[2026-07-23T08:09:09.023783Z] [debug] [pid:2612226] [run_ssh_cmd(vim-cmd vmsvc/device.connection 204 3000 0 && vim-cmd vmsvc/reload 204)] exit-code: 0
```
