### PR TITLE
Move sle12sp5+ppc64le tests to powerVM

### DIFF
--- a/schedule/qam/12-SP5/qam-minimal-full-powervm.yaml
+++ b/schedule/qam/12-SP5/qam-minimal-full-powervm.yaml
@@ -1,0 +1,60 @@
+---
+name: qam minimal full on powervm
+description:    >
+    Maintainer: qe-core@suse.com
+    test is first textmode after system update and RR update is done
+     "gnome" pattern is installed then console and x11 tests run
+    workaround:
+    schedule system_prepare also after install_patterns on 15-SP1 & SP2 ppc64le
+vars:
+  DESKTOP: 'textmode'
+schedule:
+- installation/bootloader
+- installation/welcome
+- installation/scc_registration
+- installation/addon_products_sle
+- installation/system_role
+- installation/partitioning
+- installation/partitioning_finish
+- installation/installer_timezone
+- installation/user_settings
+- installation/user_settings_root
+- installation/resolve_dependency_issues
+- installation/select_patterns
+- installation/installation_overview
+- installation/disable_grub_timeout
+- installation/start_install
+- installation/await_install
+- installation/logs_from_installation_system
+- installation/reboot_after_installation
+- boot/reconnect_mgmt_console
+- installation/grub_test
+- installation/first_boot
+- qam-minimal/install_update
+- qam-minimal/update_minimal
+- qam-minimal/check_logs
+- qam-minimal/install_patterns
+# on SLE 12, 15-SP1 & SP2 ppc64le hvc0 permissions are reset after install_patterns
+- console/system_prepare
+- locale/keymap_or_locale
+- console/force_scheduled_tasks
+- console/textinfo
+- console/installation_snapshots
+- console/zypper_lr
+- console/zypper_ref
+- console/curl_https
+- console/glibc_sanity
+- console/glibc_tunables
+- console/zypper_in
+- console/zypper_log
+- console/yast2_i
+- console/yast2_bootloader
+- console/firewall_enabled
+- console/sshd
+- console/ssh_cleanup
+- console/mtab
+- console/zypper_lifecycle
+- console/orphaned_packages_check
+- console/consoletest_finish
+- console/zypper_log_packages
+- shutdown/shutdown

--- a/schedule/qam/12-SP5/qam-minimal-powervm.yaml
+++ b/schedule/qam/12-SP5/qam-minimal-powervm.yaml
@@ -1,0 +1,28 @@
+---
+name: qam minimal on powervm
+schedule:
+- installation/bootloader
+- installation/welcome
+- installation/scc_registration
+- installation/addon_products_sle
+- installation/system_role
+- installation/partitioning
+- installation/partitioning_finish
+- installation/installer_timezone
+- installation/user_settings
+- installation/user_settings_root
+- installation/resolve_dependency_issues
+- installation/select_patterns
+- installation/installation_overview
+- installation/disable_grub_timeout
+- installation/start_install
+- installation/await_install
+- installation/logs_from_installation_system
+- installation/reboot_after_installation
+- boot/reconnect_mgmt_console
+- installation/grub_test
+- installation/first_boot
+- qam-minimal/install_update
+- qam-minimal/update_minimal
+- qam-minimal/check_logs
+- shutdown/shutdown

--- a/tests/qam-minimal/install_patterns.pm
+++ b/tests/qam-minimal/install_patterns.pm
@@ -24,6 +24,7 @@ use testapi;
 use serial_terminal qw(select_serial_terminal);
 use power_action_utils qw(power_action);
 use Utils::Architectures 'is_s390x';
+use Utils::Backends 'is_pvm';
 
 sub install_packages {
     my $patch_info = shift;
@@ -61,7 +62,7 @@ sub run {
     script_run('sed -i -r "s/^DISPLAYMANAGER_AUTOLOGIN/#DISPLAYMANAGER_AUTOLOGIN/" /etc/sysconfig/displaymanager');
     script_run('sed -i -r "s/^DEFAULT_WM=\"icewm\"/DEFAULT_VM=\"\"/" /etc/sysconfig/windowmanager');
     # now we have gnome installed - restore DESKTOP variable
-    set_var('DESKTOP', 'gnome', reload_needles => 1);
+    set_var('DESKTOP', 'gnome', reload_needles => 1) unless is_pvm;
 
     # https://progress.opensuse.org/issues/184528
     if (is_s390x && is_sle('<15')) {
@@ -76,6 +77,7 @@ sub run {
     install_packages($patch_status) if $patch_status;
 
     power_action('reboot', textmode => 1);
+    reconnect_mgmt_console if is_pvm;
     $self->wait_boot(bootloader_time => get_var('BOOTLOADER_TIMEOUT', 200));
 }
 

--- a/tests/qam-minimal/update_minimal.pm
+++ b/tests/qam-minimal/update_minimal.pm
@@ -20,6 +20,7 @@ use qam;
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use zypper;
+use Utils::Backends 'is_pvm';
 
 sub run {
     my ($self) = @_;
@@ -39,6 +40,7 @@ sub run {
     capture_state('after', 1);
 
     power_action('reboot', textmode => 1);
+    reconnect_mgmt_console if is_pvm;
     $self->wait_boot(bootloader_time => get_var('BOOTLOADER_TIMEOUT', 200));
     select_serial_terminal;
 }


### PR DESCRIPTION
https://progress.opensuse.org/issues/203094
    
    1. We need to handle new installation process on powerVM
    2. We need to handle reboot for new backend
    3. Remove x11 tests as not supported

- [Verification run](https://openqa.suse.de/tests/overview?build=rfan0723&distri=sle&version=12-SP5)