### PR TITLE
publiccloud: honor PUBLIC_CLOUD_USER in img_proof SSH user

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -376,7 +376,7 @@ sub load_slem_on_pc_tests {
         } else {
             loadtest "publiccloud/check_services", run_args => $args;
             loadtest("publiccloud/slem_upgrade_next", run_args => $args) if (get_var('PUBLIC_CLOUD_MIGRATE_SLEM'));
-            if (get_var("TEST") =~ /img_proof/) {
+            if (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
                 loadtest("publiccloud/img_proof", run_args => $args);
             } else {
                 loadtest("publiccloud/slem_basic", run_args => $args);

--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -489,7 +489,7 @@ sub img_proof {
 
     $args{credentials_file} = $credentials_file;
     $args{instance_type} //= 'Standard_A2';
-    $args{user} //= 'azureuser';
+    $args{user} //= $self->provider_client->username;
     $args{provider} //= 'azure';
 
     if (my $parsed_id = $self->parse_instance_id($args{instance})) {

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -210,7 +210,7 @@ sub img_proof {
     my ($self, %args) = @_;
 
     $args{instance_type} //= 't3a.large';
-    $args{user} //= 'ec2-user';
+    $args{user} //= $self->provider_client->username;
     $args{provider} //= 'ec2';
     $args{ssh_private_key_file} //= SSH_KEY_PEM;
     $args{key_name} //= $self->ssh_key;

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -194,7 +194,7 @@ sub img_proof {
 
     $args{credentials_file} = $self->provider_client->get_credentials_file_name();
     $args{instance_type} //= 'n1-standard-2';
-    $args{user} //= 'susetest';
+    $args{user} //= $self->provider_client->username;
     $args{provider} //= 'gce';
 
     return $self->run_img_proof(%args);


### PR DESCRIPTION
The img_proof methods in azure, ec2 & gce hardcoded the img-proof SSH user ignoring `PUBLIC_CLOUD_USER`. Default to `provider_client->username` instead, which already resolves `PUBLIC_CLOUD_USER` with the same per-provider fallbacks.

Also fix the scheduling of img-proof tests on SLEM.  We should use `PUBLIC_CLOUD_IMG_PROOF_TESTS` instead of `TEST`.

Related ticket: https://progress.opensuse.org/issues/204555

Failed job: https://openqa.suse.de/tests/23553283
Verification run: https://openqa.suse.de/tests/23556816 (failing for unrelated issues).