### PR TITLE
Add installation using SCC server and validate the registration server

### DIFF
--- a/schedule/yam/agama.yaml
+++ b/schedule/yam/agama.yaml
@@ -16,4 +16,5 @@ schedule:
   - yam/validate/validate_hostname
   - yam/validate/validate_snapshots
   - yam/validate/validate_registered_products
+  - yam/validate/validate_registration_server
   - console/validate_repos

--- a/schedule/yam/agama_remote_s390x.yaml
+++ b/schedule/yam/agama_remote_s390x.yaml
@@ -16,4 +16,5 @@ schedule:
   - yam/validate/validate_first_user
   - yam/validate/validate_snapshots
   - yam/validate/validate_registered_products
+  - yam/validate/validate_registration_server
   - console/validate_repos

--- a/schedule/yam/agama_s390x.yaml
+++ b/schedule/yam/agama_s390x.yaml
@@ -15,4 +15,5 @@ schedule:
   - yam/validate/validate_first_user
   - yam/validate/validate_snapshots
   - yam/validate/validate_registered_products
+  - yam/validate/validate_registration_server
   - console/validate_repos

--- a/schedule/yam/agama_unattended.yaml
+++ b/schedule/yam/agama_unattended.yaml
@@ -15,6 +15,7 @@ schedule:
   - yam/validate/validate_hostname
   - yam/validate/validate_snapshots
   - yam/validate/validate_registered_products
+  - yam/validate/validate_registration_server
   - console/validate_repos
   - shutdown/grub_set_bootargs
   - shutdown/cleanup_before_shutdown

--- a/tests/yam/validate/validate_registration_server.pm
+++ b/tests/yam/validate/validate_registration_server.pm
@@ -1,0 +1,49 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Validate that the system registered against the expected registration server
+#          (SCC or proxySCC) based on /etc/SUSEConnect and the openQA SCC_URL variable.
+#
+# Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
+
+use Mojo::Base 'consoletest';
+use testapi;
+use version_utils qw(is_sle);
+use List::Util 'first';
+
+sub run {
+    select_console 'root-console';
+
+    # Skip the validation for SLES16.0 if it is registered against SCC, there isn't /etc/SUSEConnect file
+    return 1 if is_sle('<16.1') && get_var('SCC_URL', '') eq '';
+
+    my $scc_url = get_var('SCC_URL', '');
+    my $system_url = script_output("awk '/^url:/ {print \$2}' /etc/SUSEConnect");
+
+    record_info('REG_SERVER', "openQA SCC_URL: '$scc_url'\nDetected/Fallback url: '$system_url'");
+
+    my @validation_rules = (
+        {
+            type => 'SCC',
+            env_pattern => qr/^$/,
+            sys_pattern => qr{^https://scc\.suse\.com},
+            error_message => "Expected direct SCC 'https://scc.suse.com', but found '$system_url'",
+        },
+        {
+            type => 'proxySCC',
+            env_pattern => qr/proxy/i,
+            sys_pattern => qr/proxy/i,
+            error_message => "openQA SCC_URL contains 'proxy', but /etc/SUSEConnect ('$system_url') does not",
+        },
+    );
+
+    my $matched_rule = first { $scc_url =~ $_->{env_pattern} } @validation_rules
+      or die("Unknown or unhandled SCC_URL format in openQA setting: '$scc_url'");
+
+    $system_url =~ $matched_rule->{sys_pattern}
+      or die("Registration server mismatch! $matched_rule->{error_message}");
+}
+
+1;


### PR DESCRIPTION
Add the default installation scenarios using SCC instead of proxySCC, and validate the registration server, the validation check both SCC and proxySCC server.

- Related ticket: https://progress.opensuse.org/issues/203682
- Verification runs: [sles16.1_scc](https://openqa.suse.de/tests/overview?distri=sle&version=16.1&build=57.2&groupid=576) || [sles16.1_proxy](https://openqa.suse.de/tests/overview?version=16.1&distri=sle&build=chcao_poo203682) || [sles16.0_scc](https://openqa.suse.de/tests/overview?build=chcao_poo203682&version=16.0&distri=sle)
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/870