### PR TITLE
Fix insufficient arguments error while getting VM power state

### DIFF
--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -62,9 +62,9 @@ sub cleanup_leftover_vmware_vms {
     # Power off and unregister any leftover VM from a previous openQA job
     # before deleting its files to avoid it becomes an orphaned VM
     my $vm_id = $svirt->get_cmd_output("vim-cmd vmsvc/getallvms 2>&1 | awk '\$2 == \"$name\" { print \$1 }'", {domain => 'sshVMwareServer'});
-    my $power_state = $svirt->get_cmd_output("vim-cmd vmsvc/power.getstate $vm_id", {domain => 'sshVMwareServer'});
     if ($vm_id) {
         record_info('Remove leftover VM', "$vm_id ($name)");
+        my $power_state = $svirt->get_cmd_output("vim-cmd vmsvc/power.getstate $vm_id", {domain => 'sshVMwareServer'});
         $svirt->run_cmd("vim-cmd vmsvc/power.off $vm_id", domain => 'sshVMwareServer') if ($power_state =~ /Powered on/);
         $svirt->run_cmd("vim-cmd vmsvc/destroy $vm_id", domain => 'sshVMwareServer');
     }


### PR DESCRIPTION
Below error is caused by a non-existent value of the variable `$vm_id`. Moving the command into the if condition to fix it.
https://openqa.suse.de/tests/23512144/logfile?filename=autoinst-log.txt
```
[2026-07-21T12:46:15.192851Z] [debug] [pid:2365913] [run_ssh_cmd(vim-cmd vmsvc/getallvms 2>&1 | awk '$2 == "openQA-SUT-4" { print $1 }')] exit-code: 0
[2026-07-21T12:46:15.291399Z] [debug] [pid:2365912] [step:installation,bootloader_svirt,7] tests/installation/bootloader_svirt.pm:97 called bootloader_svirt::cleanup_leftover_vmware_vms -> tests/installation/bootloader_svirt.pm:65 called backend::console_proxy::__ANON__
[2026-07-21T12:46:15.291549Z] [debug] [pid:2365912] <<< backend::console_proxy::__ANON__(wrapped_call={
    "function" => "get_cmd_output",
    "console" => "svirt",
    "wantarray" => !!0,
    "args" => [
                "vim-cmd vmsvc/power.getstate ",
                {
                  "domain" => "sshVMwareServer"
                }
              ]
  })
[2026-07-21T12:46:15.292623Z] [debug] [pid:2365913] <<< backend::baseclass::run_ssh_cmd(cmd="vim-cmd vmsvc/power.getstate ", hostname="rigel.bmt.prg2.suse.org", keep_open=1, timeout=undef, username="root", password="SECRET", wantarray=1)
[2026-07-21T12:46:15.292837Z] [debug] [pid:2365913] <<< backend::baseclass::run_ssh(cmd="vim-cmd vmsvc/power.getstate ", hostname="rigel.bmt.prg2.suse.org", keep_open=1, username="root", timeout=undef, wantarray=1, password="SECRET")
[2026-07-21T12:46:15.293013Z] [debug] [pid:2365913] <<< backend::baseclass::new_ssh_connection(password="SECRET", wantarray=1, timeout=undef, username="root", blocking=1, keep_open=1, hostname="rigel.bmt.prg2.suse.org")
[2026-07-21T12:46:15.406467Z] [debug] [pid:2365913] Using existing SSH connection (key:hostname=rigel.bmt.prg2.suse.org,username=root,port=22)
[2026-07-21T12:46:15.938108Z] [debug] [pid:2365913] [run_ssh_cmd(vim-cmd vmsvc/power.getstate )] stdout:
  Usage: power.getstate vmid
  
  Retrieves the power state of the specified virtual machine.
  
  
[2026-07-21T12:46:15.938197Z] [debug] [pid:2365913] [run_ssh_cmd(vim-cmd vmsvc/power.getstate )] stderr:
  Insufficient arguments.
```

- Related ticket: https://progress.opensuse.org/issues/194843
- Verification run: https://openqa.suse.de/tests/23556993
