### PR TITLE
publiccloud: soft-fail cleanoldsepoldir.service

### DIFF
--- a/tests/publiccloud/check_services.pm
+++ b/tests/publiccloud/check_services.pm
@@ -22,7 +22,8 @@ sub run {
     my $instance = $args->{my_instance};
     my %known_failing_services = (
         'systemd-vconsole-setup' => 'bsc#1249902 - systemd-vconsole-setup.service failed to load',
-        augenrules => 'bsc#1250320 - augenrules.service fails at startup on Hardened Images'
+        augenrules => 'bsc#1250320 - augenrules.service fails at startup on Hardened Images',
+        cleanoldsepoldir => 'bsc#1271814 - snapper is intentionally not installed on Public Cloud images',
     );
     $known_failing_services{guestregister} = 'Custom ignore of guestregister via openQA variable' if (get_var('PUBLIC_CLOUD_IGNORE_UNREGISTERED'));
     my $failed_services_output = $instance->ssh_script_output(


### PR DESCRIPTION
snapper is intentionally excluded from Public Cloud images, so cleanoldsepoldir.service fails with "snapper command not found" on Btrfs SLE 16.1 EC2/Azure/GCE instances. Treat it as a known failing service instead of failing check_services (poo#204357).

Related ticket: https://progress.opensuse.org/issues/204357
Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1271814

Failed job: https://openqa.suse.de/tests/23487567#step/check_services/13
Verification run: https://openqa.suse.de/tests/23557434