### PR TITLE
Automate web console access in Agama to access Cockpit in the installed system

### DIFF
--- a/data/yam/agama/auto/lib/base.libsonnet
+++ b/data/yam/agama/auto/lib/base.libsonnet
@@ -25,7 +25,8 @@
     [if password then 'hashedPassword']: true,
     [if sshPublicKey then 'sshPublicKey']: "fake public key to enable sshd and open firewall",
   },
-  access: {
-    ssh: 'enabled',
-  },
+  access(ssh, webConsole):: {
+    [if ssh then 'ssh']: 'enabled',
+    [if webConsole then 'webConsole']: 'enabled',
+  }
 }

--- a/data/yam/agama/auto/template.libsonnet
+++ b/data/yam/agama/auto/template.libsonnet
@@ -11,6 +11,7 @@ local security_lib = import 'lib/security.libsonnet';
 local answers_lib = import 'lib/answers.libsonnet';
 
 function(access_ssh_enabled=false,
+         access_webconsole_enabled=false,
          bootloader=true,
          bootloader_timeout=false,
          bootloader_extra_kernel_params='',
@@ -49,7 +50,7 @@ function(access_ssh_enabled=false,
           [if files == true then 'files']: base_lib['files'],
           [if iscsi_target_address != '' then 'iscsi']: iscsi_lib.iscsi(iscsi_target_address),
           [if localization == true then 'localization']: base_lib['localization'],
-          [if access_ssh_enabled then 'access']: base_lib['access'],
+          [if access_ssh_enabled || access_webconsole_enabled then 'access']: base_lib.access(access_ssh_enabled, access_webconsole_enabled),
           [if patterns != '' || packages != '' || extra_repositories ||
             patterns_to_add != '' || patterns_to_remove != '' ||
             software_only_required then 'software']: std.prune({

--- a/schedule/yam/agama_software_patterns.yaml
+++ b/schedule/yam/agama_software_patterns.yaml
@@ -10,3 +10,4 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - yam/validate/validate_installed_patterns
+  - yam/validate/validate_webconsole

--- a/schedule/yam/agama_software_patterns_s390x.yaml
+++ b/schedule/yam/agama_software_patterns_s390x.yaml
@@ -10,3 +10,4 @@ schedule:
   - boot/reconnect_mgmt_console
   - installation/first_boot
   - yam/validate/validate_installed_patterns
+  - yam/validate/validate_webconsole

--- a/schedule/yam/agama_software_selection_unattended.yaml
+++ b/schedule/yam/agama_software_selection_unattended.yaml
@@ -8,3 +8,4 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - yam/validate/validate_installed_patterns
+  - yam/validate/validate_webconsole

--- a/schedule/yam/agama_software_selection_unattended_s390x.yaml
+++ b/schedule/yam/agama_software_selection_unattended_s390x.yaml
@@ -9,3 +9,4 @@ schedule:
   - boot/reconnect_mgmt_console
   - installation/first_boot
   - yam/validate/validate_installed_patterns
+  - yam/validate/validate_webconsole

--- a/tests/yam/validate/validate_webconsole.pm
+++ b/tests/yam/validate/validate_webconsole.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Validate that Web Console (Cockpit) is enabled and accesible through http.
+# Check Web Console functionality by profiling Agama.
+# See https://agama-project.github.io/docs/user/reference/profile/access
+
+# Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
+
+use Mojo::Base 'Yam::Agama::agama_base';
+use testapi;
+
+sub run {
+    select_console 'root-console';
+    my $webConsole_status = script_output('systemctl status cockpit.socket');
+    if ($webConsole_status !~ /status=0\/SUCCESS/) {
+        die "Self update did not end successfully";
+    }
+
+    my $webConsole_curl = script_output('curl http://localhost:9090');
+    if ($webConsole_curl !~ /cockpit/) {
+        die "Error, Cockpit string not found in curl output";
+    }
+
+    my $webConsole_port = script_output('ss -tulnp | grep :9090');
+    if ($webConsole_port !~ /cockpit-tls/) {
+        die "Error, Cockpit port not found in ss output";
+    }
+}
+
+1;


### PR DESCRIPTION
This PR adds support for automated testing of Cockpit web console access in Agama-installed  systems.

The changes introduce a new `access_webconsole_enabled` parameter to the Agama autoinstallation profile template, which enables the web console (Cockpit) service during installation. A new validation test module (`validate_webconsole.pm`) has been added to verify that Cockpit is running correctly after installation by checking the systemd service status, confirming the service responds to HTTP requests on port 9090, and validating the socket is listening.

The validation test has been integrated into the software patterns test schedules (both x86_64 and s390x architectures) to ensure web console functionality is verified as part of the automated test suite.

- Related ticket: https://progress.opensuse.org/issues/203499
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/871
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?version=16.1&distri=sle&build=okynos%2Fos-autoinst-distri-opensuse%23203499-automate-cockpit
