### PR TITLE
Split publiccloud/prepare_instance checks into dedicated test modules

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -359,6 +359,7 @@ sub load_slem_on_pc_tests {
         if (get_var('PUBLIC_CLOUD_QAM', 0)) {
             loadtest("publiccloud/transfer_repos", run_args => $args) unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
             loadtest("publiccloud/patch_and_reboot", run_args => $args);
+            loadtest("publiccloud/check_cloudinit", run_args => $args);
         }
         if (get_var('PUBLIC_CLOUD_LTP', 0)) {
             loadtest 'publiccloud/run_ltp', run_args => $args;

--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -349,6 +349,11 @@ sub load_slem_on_pc_tests {
         # SLEM basic test
         loadtest("boot/boot_to_desktop");
         loadtest("publiccloud/prepare_instance", run_args => $args);
+        loadtest("publiccloud/check_boottime", run_args => $args);
+        loadtest("publiccloud/auto_registration", run_args => $args);
+        loadtest("publiccloud/network_test", run_args => $args);
+        loadtest("publiccloud/check_cloudinit", run_args => $args);
+        loadtest("publiccloud/kdump", run_args => $args);
         loadtest("publiccloud/registration", run_args => $args) unless (get_var('PUBLIC_CLOUD_IGNORE_UNREGISTERED'));
         # 2 next modules of pubcloud needed for sle-micro incidents/repos verification
         if (get_var('PUBLIC_CLOUD_QAM', 0)) {

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -48,6 +48,7 @@ sub load_maintenance_publiccloud_tests {
     } elsif (get_var('PUBLIC_CLOUD_LTP')) {
         loadtest 'publiccloud/run_ltp', run_args => $args;
     } elsif (get_var('PUBLIC_CLOUD_FUNCTIONAL')) {
+        loadtest "publiccloud/check_services", run_args => $args;
         loadtest('publiccloud/metadata', run_args => $args);
         loadtest('publiccloud/cloud_netconfig', run_args => $args);
         loadtest('publiccloud/suspending', run_args => $args) if (is_sle('15-SP6+'));
@@ -78,6 +79,7 @@ sub load_maintenance_publiccloud_tests {
             loadtest "xfstests/run", run_args => $args;
             return;
         } elsif (get_var('PUBLIC_CLOUD_SMOKETEST')) {
+            loadtest "publiccloud/check_services", run_args => $args;
             loadtest "publiccloud/smoketest";
             # flavor_check is concentrated on checking things which make sense only for image which is registered
             # against internal Public Cloud infra, so whenever we using SUSEConnect whole module does not make much sense
@@ -153,10 +155,12 @@ sub load_latest_publiccloud_tests {
             loadtest "publiccloud/registercloudguest", run_args => $args;
         }
         elsif (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
+            loadtest "publiccloud/check_services", run_args => $args;
             loadtest "publiccloud/img_proof", run_args => $args;
         } else {    # All test cases below require registration
             loadtest("publiccloud/registration", run_args => $args);
             if (get_var('PUBLIC_CLOUD_FUNCTIONAL')) {
+                loadtest "publiccloud/check_services", run_args => $args;
                 loadtest('publiccloud/metadata', run_args => $args);
                 loadtest('publiccloud/cloud_netconfig', run_args => $args);
                 loadtest('publiccloud/suspending', run_args => $args) if (is_sle('15-SP6+'));

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -24,6 +24,11 @@ sub load_maintenance_publiccloud_tests {
 
     loadtest "publiccloud/download_repos" unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
     loadtest "publiccloud/prepare_instance", run_args => $args;
+    loadtest "publiccloud/check_boottime", run_args => $args;
+    loadtest "publiccloud/auto_registration", run_args => $args;
+    loadtest "publiccloud/network_test", run_args => $args;
+    loadtest "publiccloud/check_cloudinit", run_args => $args;
+    loadtest "publiccloud/kdump", run_args => $args;
     if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
         loadtest("publiccloud/registercloudguest", run_args => $args);
     } else {
@@ -123,6 +128,11 @@ sub load_latest_publiccloud_tests {
 
     if (get_var('PUBLIC_CLOUD_LTP')) {
         loadtest "publiccloud/prepare_instance", run_args => $args;
+        loadtest "publiccloud/check_boottime", run_args => $args;
+        loadtest "publiccloud/auto_registration", run_args => $args;
+        loadtest "publiccloud/network_test", run_args => $args;
+        loadtest "publiccloud/check_cloudinit", run_args => $args;
+        loadtest "publiccloud/kdump", run_args => $args;
         loadtest("publiccloud/registration", run_args => $args);
         loadtest 'publiccloud/run_ltp', run_args => $args;
     }
@@ -134,6 +144,11 @@ sub load_latest_publiccloud_tests {
         return;    # Do not continue as there is no instance to destroy
     } else {    # All test cases below require prepare_instance
         loadtest "publiccloud/prepare_instance", run_args => $args;
+        loadtest "publiccloud/check_boottime", run_args => $args;
+        loadtest "publiccloud/auto_registration", run_args => $args;
+        loadtest "publiccloud/network_test", run_args => $args;
+        loadtest "publiccloud/check_cloudinit", run_args => $args;
+        loadtest "publiccloud/kdump", run_args => $args;
         if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
             loadtest "publiccloud/registercloudguest", run_args => $args;
         }
@@ -221,6 +236,11 @@ sub load_publiccloud_appimg_tests {
     my $args = OpenQA::Test::RunArgs->new();
     my $publiccloud_app_img = get_var('PUBLIC_CLOUD_APP_IMG');
     loadtest "publiccloud/prepare_instance", run_args => $args;
+    loadtest "publiccloud/check_boottime", run_args => $args;
+    loadtest "publiccloud/auto_registration", run_args => $args;
+    loadtest "publiccloud/network_test", run_args => $args;
+    loadtest "publiccloud/check_cloudinit", run_args => $args;
+    loadtest "publiccloud/kdump", run_args => $args;
     loadtest("publiccloud/registration", run_args => $args);
     loadtest "publiccloud/instance_overview", run_args => $args;
 

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -36,6 +36,7 @@ sub load_maintenance_publiccloud_tests {
     }
     loadtest "publiccloud/transfer_repos", run_args => $args unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
     loadtest "publiccloud/patch_and_reboot", run_args => $args;
+    loadtest "publiccloud/check_cloudinit", run_args => $args;
     if (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
         loadtest "publiccloud/check_services", run_args => $args;
         loadtest("publiccloud/img_proof", run_args => $args);

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -632,36 +632,6 @@ sub get_state {
     return $self->provider->get_state_from_instance($self, @_);
 }
 
-=head2 network_speed_test
-
-    network_speed_test();
-
-Test the network speed.
-=cut
-
-sub network_speed_test() {
-    my ($self, %args) = @_;
-    my ($cmd, $ret);
-
-    # Curl stats output format
-    my $write_out
-      = 'time_namelookup:\t%{time_namelookup} s\ntime_connect:\t\t%{time_connect} s\ntime_appconnect:\t%{time_appconnect} s\ntime_pretransfer:\t%{time_pretransfer} s\ntime_redirect:\t\t%{time_redirect} s\ntime_starttransfer:\t%{time_starttransfer} s\ntime_total:\t\t%{time_total} s\n';
-    # PC RMT server domain name
-    my $rmt_host = "smt-" . lc(get_required_var('PUBLIC_CLOUD_PROVIDER')) . ".susecloud.net";
-
-    $cmd = "grep \"$rmt_host\" /etc/hosts";
-    $ret = $self->ssh_script_run(cmd => $cmd, apply_graceful_timeout => 1);
-    record_info("RMT_HOST", printf('$ %s\n%s', $cmd, $ret));
-
-    $cmd = "ping -c3 1.1.1.1";
-    $ret = $self->ssh_script_run(cmd => $cmd, apply_graceful_timeout => 1);
-    record_info("PING", printf('$ %s\n%s', $cmd, $ret));
-
-    $cmd = "curl -w '$write_out' -o /dev/null -v https://$rmt_host/";
-    $ret = $self->ssh_script_run(cmd => $cmd, apply_graceful_timeout => 1);
-    record_info("CURL", printf('$ %s\n%s', $cmd, $ret));
-}
-
 sub cleanup_cloudinit() {
     my ($self) = @_;
     $self->ssh_assert_script_run('sudo cloud-init clean --logs');

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -641,62 +641,6 @@ sub cleanup_cloudinit() {
     }
 }
 
-=head2 check_system_boottime
-
-    check_system_boottime();
-
-Check the system boot time, measured by C<systemd-analyze>, to be under a threshold.
-Assign the threshold in seconds to PUBLIC_CLOUD_BOOTTIME_MAX in test settings.
-The boot time is saved in a local json structure, then printed in the test's logs:
-when the threshold is exceeded the job is stopped.
-The routine is skipped when the threshold is undefined or zero.
-
-=cut
-
-sub check_system_boottime() {
-    my ($instance, %args) = @_;
-    my $max_boot_time = get_var('PUBLIC_CLOUD_BOOTTIME_MAX');
-    return unless ($max_boot_time);
-
-    my $ret = {
-        kernel_release => undef,
-        kernel_version => undef,
-        type => 'boottime',
-        analyze => {},
-        blame => {},
-    };
-
-    record_info("BOOT TIME", 'systemd_analyze');
-    # first deployment analysis
-    my ($systemd_analyze, $systemd_blame) = $instance->do_systemd_analyze_time(%args);
-    die("failed to obtain boottime from systemd") unless ($systemd_analyze && $systemd_blame);
-
-    $ret->{analyze}->{$_} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));
-    $ret->{blame} = $systemd_blame;
-    my $boottime = $ret->{analyze}->{overall};
-
-    # Collect kernel version
-    $ret->{kernel_release} = $instance->ssh_script_output(cmd => 'uname -r', proceed_on_failure => 1);
-    $ret->{kernel_version} = $instance->ssh_script_output(cmd => 'uname -v', proceed_on_failure => 1);
-
-    $Data::Dumper::Sortkeys = 1;
-    record_info("RESULTS", Dumper($ret));
-    my $dir = "/var/log";
-    my @logs = qw(cloudregister cloud-init.log cloud-init-output.log messages NetworkManager);
-    $instance->upload_check_logs_tar(map { "$dir/$_" } @logs);
-
-    # Boot time overall limit check
-    if ($boottime > $max_boot_time) {
-        if (is_azure()) {
-            # Unreliable userspace boot time in Azure.
-            record_soft_failure("bsc#1262587 - openQA publiccloud tests have anomalous-high boot-time from systemd-analyze");
-        } else {
-            # threshold exceeded
-            die("System boot time overall $boottime is out of limit $max_boot_time");
-        }
-    }
-}
-
 sub systemd_time_to_second
 {
     my $str_time = trim(shift);

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -641,65 +641,6 @@ sub cleanup_cloudinit() {
     }
 }
 
-sub check_cloudinit() {
-    my ($self) = @_;
-
-    # cloud-init status
-    my $rc = $self->ssh_script_run(cmd => "sudo cloud-init status --wait", timeout => 300);
-    record_info("cloud-init", $self->ssh_script_output("sudo cloud-init status --long", proceed_on_failure => 1, timeout => 300), result => $rc == 0 ? 'ok' : 'fail');
-    # Cloud-init error codes: 0 - success, 1 - unrecoverable error, 2 - recoverable error (See cloud-init documentation)
-    # As of https://bugzilla.suse.com/show_bug.cgi?id=1266207 we ignore recoverable errors
-    if (get_var('PUBLIC_CLOUD_IGNORE_CLOUDINIT_ERRORS') != 1) {
-        if ($rc == 1) {
-            die "unrecoverable cloud-init error";
-        } elsif ($rc == 2) {
-            record_info("cloud-init", "recoverable error (return code 2)");
-        } elsif ($rc != 0) {
-            die "unknown cloud-init return code $rc";
-        }
-    }
-
-    # cloud-id
-    my $cloud_id = (is_azure) ? 'azure' : 'aws';
-    $self->ssh_assert_script_run(cmd => "sudo cloud-id | grep '^$cloud_id\$'");
-
-    # cloud-init collect-logs
-    $self->ssh_assert_script_run('sudo cloud-init collect-logs');
-    $self->upload_log('~/cloud-init.tar.gz', failok => 1);
-
-    if (get_var('PUBLIC_CLOUD_CLOUD_INIT')) {
-        # Check for bootcmd, runcmd and write_files module
-        $self->ssh_assert_script_run('sudo grep pookie /root/test_cloud-init.txt');
-        $self->ssh_assert_script_run('sudo grep Mithrandir /root/test_cloud-init.txt');
-        $self->ssh_assert_script_run('sudo grep snickerdoodle /root/test_cloud-init.txt');
-
-        # Check for packages module
-        $self->ssh_assert_script_run('ed -V');
-
-        # Check for final_message module
-        $self->ssh_assert_script_run('sudo journalctl -b | grep "cloud-init qa has finished"');
-
-        # cloud-init schema
-        $self->ssh_assert_script_run('sudo cloud-init schema --system') unless (is_sle('=12-SP5'));
-    }
-}
-
-sub enable_kdump() {
-    my ($self) = @_;
-
-    $self->ssh_assert_script_run(q(sudo sed -i "/^GRUB_CMDLINE_LINUX_DEFAULT/ s/\\\\\\"$/ crashkernel=256M,high crashkernel=128M,low \\\\\\"/" /etc/default/grub));
-    $self->ssh_assert_script_run('sudo grub2-mkconfig -o /boot/grub2/grub.cfg');
-
-    if ($self->ssh_script_run('sudo grep -q "^KDUMP_CRASHKERNEL=" /etc/sysconfig/kdump') == 0) {
-        $self->ssh_assert_script_run(q(sudo sed -i "/^KDUMP_CRASHKERNEL/ s/\\\\\\"$/ crashkernel=256M,high crashkernel=128M,low \\\\\\"/" /etc/sysconfig/kdump));
-    } else {
-        $self->ssh_assert_script_run(q(echo "KDUMP_CRASHKERNEL=\"crashkernel=256M,high crashkernel=128M,low\"" | sudo tee -a /etc/sysconfig/kdump));
-    }
-
-    $self->ssh_assert_script_run('sudo systemctl enable kdump.service');
-    $self->softreboot();
-}
-
 =head2 check_system_boottime
 
     check_system_boottime();

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -11,15 +11,12 @@ package publiccloud::instance;
 use testapi;
 use Carp 'croak';
 use Mojo::Base -base;
-use Mojo::Util 'trim';
 use File::Basename;
 use publiccloud::utils;
 use Utils::Backends qw(set_sshserial_dev unset_sshserial_dev);
 use publiccloud::ssh_interactive qw(ssh_interactive_tunnel ssh_interactive_leave select_host_console);
 use version_utils;
 use utils;
-use Mojo::Util 'trim';
-use Data::Dumper;
 
 use constant SSH_TIMEOUT => 90;
 
@@ -639,96 +636,6 @@ sub cleanup_cloudinit() {
         $self->ssh_assert_script_run('sudo rm /root/test_cloud-init.txt');
         $self->ssh_assert_script_run('sudo zypper -n rm ed');
     }
-}
-
-sub systemd_time_to_second
-{
-    my $str_time = trim(shift);
-
-    if ($str_time !~ /^(?<check_hour>(?<hour>\d{1,2})\s*h\s*)?(?<check_min>(?<min>\d{1,2})\s*min\s*)?((?<sec>\d{1,2}\.\d{1,3})s|(?<ms>\d+)ms)$/) {
-        record_info("WARN", "Unable to parse systemd time '$str_time'", result => 'fail');
-        return -1;
-    }
-    my $sec = $+{sec} // $+{ms} / 1000;
-    $sec += $+{min} * 60 if (defined($+{check_min}));
-    $sec += $+{hour} * 3600 if (defined($+{check_hour}));
-    return $sec;
-}
-
-sub extract_analyze_time {
-    my $str_time = shift;
-    my $res = {};
-    # Pick the line that actually holds the timing, not blindly the first line:
-    # ssh_script_output may prepend an SSH login banner / MOTD, which would
-    # otherwise leave us parsing an empty or non-timing line (poo#203817).
-    ($str_time) = grep { /Startup finished in/i } split(/\r?\n/, $str_time);
-    return undef unless defined($str_time);
-    $str_time =~ s/Startup finished in\s*//i;
-    $str_time =~ s/=(.+)$/+$1 (overall)/;
-    for my $time (split(/\s*\+\s*/, $str_time)) {
-        $time = trim($time);
-        my ($time, $type) = $time =~ /^(.+)\s*\((\w+)\)$/;
-        $res->{$type} = systemd_time_to_second($time);
-        return undef if ($res->{$type} == -1);
-    }
-    foreach (qw(kernel initrd userspace overall)) { return undef unless exists($res->{$_}); }
-    return $res;
-}
-
-sub extract_blame_time {
-    my $str_time = shift;
-    my $ret = {};
-    for my $line (split(/\r?\n/, $str_time)) {
-        $line = trim($line);
-        # Only <time> <service> lines are blame entries; skip anything else
-        # (e.g. an SSH login banner / MOTD prepended to the output, poo#203817).
-        my ($time, $service) = $line =~ /^(\S+)\s+(\S+)$/;
-        next unless defined($service);
-        my $sec = systemd_time_to_second($time);
-        next unless ($sec >= 0);
-        $ret->{$service} = $sec;
-    }
-    return $ret;
-}
-
-sub do_systemd_analyze_time {
-    my ($instance, %args) = @_;
-    my $timeout = $args{timeout} // 300;
-    my $start_time = time();
-    my $output = "";
-    my $finished = 0;
-    my @ret;
-
-    # Poll systemd-analyze until the system has actually finished booting.
-    # On a freshly-launched Public Cloud instance SSH becomes reachable while
-    # late boot units (e.g. cloud-init) are still running, so systemd-analyze
-    # reports "Bootup is not yet finished (...FinishTimestampMonotonic=0)" and
-    # exits non-zero (poo#203817). "Startup finished in" only appears once boot
-    # is complete, so it is our readiness signal. Break out on the successful
-    # match *before* sleeping so a result arriving near the timeout is not
-    # discarded, and gate success on the match rather than on elapsed time.
-    while (time() - $start_time < $timeout) {
-        # calling systemd-analyze time
-        $output = $instance->ssh_script_output(cmd => 'systemd-analyze time', proceed_on_failure => 1);
-        if ($output =~ /Startup finished in/i) {
-            $finished = 1;
-            last;
-        }
-        sleep 5;
-    }
-    unless ($finished) {
-        record_info("WARN", "Unable to get systemd-analyze in ${timeout}s.\nLast output:" . $output, result => 'fail');
-        return (0, 0);
-    }
-    # log time
-    $instance->ssh_script_run("uptime");
-
-    push @ret, extract_analyze_time($output);
-
-    $output = $instance->ssh_script_output(cmd => 'systemd-analyze blame', proceed_on_failure => 1);
-    push @ret, extract_blame_time($output);
-
-    return @ret;
 }
 
 sub upload_supportconfig_log {

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -361,24 +361,19 @@ publiccloud::instance objects.
 C<image>         defines the image_id to create the instance.
 C<instance_type> defines the flavor of the instance. If not specified, it will load it
                      from PUBLIC_CLOUD_INSTANCE_TYPE.
-C<timeout>             Parameter to pass to instance::wait_for_ssh.
-C<proceed_on_failure>  Same as timeout.
+
+Note: this does not wait for SSH to become available on the created instances,
+callers are expected to call C<< $instance->wait_for_ssh() >> themselves.
 
 =cut
 
 sub create_instances {
     my ($self, %args) = @_;
-    $args{check_connectivity} //= 1;
     my @vms = $self->terraform_apply(%args);
 
     foreach my $instance (@vms) {
         record_info("INSTANCE", $instance->{instance_id});
         $self->show_instance_details();
-        if ($args{check_connectivity}) {
-            # An error in VM-up causes test to stop
-            $instance->wait_for_ssh(timeout => $args{timeout},
-                proceed_on_failure => $args{proceed_on_failure}, scan_ssh_host_key => 1);
-        }
     }
     return @vms;
 }

--- a/schedule/sles4sap/sles4sap_gnome_saptune.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune.yaml
@@ -25,6 +25,7 @@ conditional_schedule:
         - sles4sap/publiccloud/qesap_terraform
         - sles4sap/publiccloud/qesap_instances_preparation
         - sles4sap/publiccloud/mr_test_setup_env
+        - publiccloud/network_test
         - publiccloud/registration
         - publiccloud/transfer_repos
         - publiccloud/patch_and_reboot

--- a/schedule/sles4sap/sles4sap_gnome_saptune_maintenance.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune_maintenance.yaml
@@ -26,6 +26,7 @@ conditional_schedule:
         - sles4sap/publiccloud/qesap_instances_preparation
         - sles4sap/publiccloud/add_server_to_hosts
         - sles4sap/publiccloud/mr_test_setup_env
+        - publiccloud/network_test
         - publiccloud/registration
         - sles4sap/publiccloud/cluster_add_repos
         - publiccloud/patch_and_reboot

--- a/schedule/sles4sap/sles4sap_gnome_saptune_product.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune_product.yaml
@@ -24,6 +24,7 @@ conditional_schedule:
         - sles4sap/publiccloud/qesap_terraform
         - sles4sap/publiccloud/qesap_instances_preparation
         - sles4sap/publiccloud/mr_test_setup_env
+        - publiccloud/network_test
         - publiccloud/registration
         - publiccloud/ssh_interactive_start
         - publiccloud/instance_overview

--- a/t/13_publiccloud.t
+++ b/t/13_publiccloud.t
@@ -7,7 +7,6 @@ use Test::MockObject;
 use Test::Exception;
 use Test::Warnings;
 use Test::MockModule;
-use Test::Mock::Time;
 use List::Util qw(any);
 use testapi 'set_var';
 
@@ -446,129 +445,6 @@ subtest '[pc_pkg_call] non-transactional system always uses plain zypper' => sub
     my $cap = _capture_pkg_call(0, 'in -y docker');
     is $cap->{zypper}, 'in -y docker', 'verbatim zypper on non-transactional host';
     ok !defined $cap->{transactional}, 'no transactional-update translation';
-};
-
-# --- do_systemd_analyze_time boot-time race (poo#203817) ----------------------
-#
-# prepare_instance probes `systemd-analyze time` right after SSH is up. On a
-# freshly-launched Public Cloud instance boot may not be finished yet, so the
-# probe returns "Bootup is not yet finished (...FinishTimestampMonotonic=0)".
-# The routine must keep polling until "Startup finished in" appears, must not
-# discard a result that arrives near the timeout, and must fall back to the
-# WARN + (0,0) path only when boot genuinely never finishes.
-
-# Drive do_systemd_analyze_time with a scripted sequence of `systemd-analyze
-# time` outputs and a controllable fake clock (so no real sleeping happens and
-# the timeout is reached deterministically). Each element of @$time_outputs is
-# returned by successive `systemd-analyze time` calls; the last element repeats
-# once the list is exhausted.
-sub _run_systemd_analyze {
-    my ($time_outputs, %args) = @_;
-    my $blame_output = delete $args{blame_output}
-      // "10.000s some.service\n5.000s other.service";
-
-    # Test::Mock::Time advances mocked time() by each sleep() the routine does,
-    # so the loop's `time() - $start_time < $timeout` guard is deterministic and
-    # fast. Capture the fake start time to report elapsed time back to callers.
-    my $clock_start = time();
-
-    my @time_seq = @$time_outputs;
-    my @time_cmds;
-    my $inst = publiccloud::instance->new();
-    my $mocked = Test::MockModule->new('publiccloud::instance', no_auto => 1);
-    $mocked->redefine(ssh_script_output => sub {
-            my ($self, %a) = @_;
-            if ($a{cmd} eq 'systemd-analyze blame') {
-                return $blame_output;
-            }
-            push @time_cmds, $a{cmd};
-            return @time_seq > 1 ? shift(@time_seq) : $time_seq[0];
-    });
-    $mocked->redefine(ssh_script_run => sub { return 0; });
-    $mocked->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
-
-    my @ret = $inst->do_systemd_analyze_time(%args);
-    return {ret => \@ret, time_calls => scalar(@time_cmds), final_time => time() - $clock_start};
-}
-
-subtest '[do_systemd_analyze_time] early success returns parsed times' => sub {
-    my $r = _run_systemd_analyze(
-        ['Startup finished in 1.000s (kernel) + 2.000s (initrd) + 3.000s (userspace) = 6.000s'],
-        timeout => 300);
-
-    my ($analyze, $blame) = @{$r->{ret}};
-    ok ref($analyze) eq 'HASH', 'analyze result is a hashref (not the (0,0) failure)';
-    cmp_ok $analyze->{overall}, '==', 6, 'overall boot time parsed';
-    cmp_ok $analyze->{userspace}, '==', 3, 'userspace boot time parsed';
-    is $r->{time_calls}, 1, 'succeeded on the first probe';
-};
-
-subtest '[do_systemd_analyze_time] retries while "Bootup is not yet finished"' => sub {
-    my $not_finished = 'Bootup is not yet finished (org.freedesktop.systemd1.Manager.FinishTimestampMonotonic=0)';
-    my $r = _run_systemd_analyze(
-        [$not_finished, $not_finished, $not_finished,
-            'Startup finished in 1.000s (kernel) + 2.000s (initrd) + 3.000s (userspace) = 6.000s'],
-        timeout => 300);
-
-    my ($analyze) = @{$r->{ret}};
-    ok ref($analyze) eq 'HASH', 'result parsed after boot finishes';
-    cmp_ok $analyze->{overall}, '==', 6, 'overall boot time parsed after retries';
-    is $r->{time_calls}, 4, 'polled until boot finished (3 not-finished + 1 success)';
-};
-
-subtest '[do_systemd_analyze_time] late success near timeout is NOT discarded' => sub {
-    # Regression guard for the trailing-sleep bug: a successful result arriving
-    # on the final poll (just under the timeout) must be returned, not thrown
-    # away because the clock crossed the timeout during that poll.
-    my $not_finished = 'Bootup is not yet finished (org.freedesktop.systemd1.Manager.FinishTimestampMonotonic=0)';
-    # timeout=20, sleep 5 per iteration: polls happen at t=0,5,10,15; success on
-    # the 4th poll (t=15). The old code's trailing sleep would push t to 20 and
-    # discard this valid result.
-    my $r = _run_systemd_analyze(
-        [$not_finished, $not_finished, $not_finished,
-            'Startup finished in 1.000s (kernel) + 2.000s (initrd) + 3.000s (userspace) = 6.000s'],
-        timeout => 20);
-
-    my ($analyze) = @{$r->{ret}};
-    ok ref($analyze) eq 'HASH', 'late-but-valid result is returned, not discarded';
-    cmp_ok $analyze->{overall}, '==', 6, 'overall boot time parsed on late success';
-};
-
-subtest '[do_systemd_analyze_time] persistent not-finished ends in WARN + (0,0)' => sub {
-    my $not_finished = 'Bootup is not yet finished (org.freedesktop.systemd1.Manager.FinishTimestampMonotonic=0)';
-    my $r = _run_systemd_analyze([$not_finished], timeout => 20);
-
-    is_deeply $r->{ret}, [0, 0], 'returns (0,0) when boot never finishes';
-    ok $r->{final_time} >= 20, 'polled for the full timeout window before giving up';
-};
-
-subtest '[do_systemd_analyze_time] SSH login banner does not break parsing' => sub {
-    # Regression guard for the second failure seen in the poo#203817 VR: SSH
-    # prepends a login banner / MOTD to the command output, so "Startup finished
-    # in" is NOT on the first line. extract_analyze_time must pick the timing
-    # line by content, and extract_blame_time must skip banner lines, instead of
-    # failing with "Unable to parse systemd time ''" and dying.
-    my $banner = join("\n",
-        "",
-        "Welcome to SUSE Linux Enterprise Server 15 SP7  (x86_64)",
-        "",
-        "Authorized users only. All activity may be monitored and reported.",
-    );
-    my $analyze_out = $banner . "\n"
-      . "Startup finished in 2.406s (kernel) + 13.116s (initrd) + 19.353s (userspace) = 34.876s \n"
-      . "graphical.target reached after 19.290s in userspace.";
-    my $blame_out = $banner . "\n"
-      . "14.852s some.device\n" . "5.000s other.service";
-
-    my $r = _run_systemd_analyze([$analyze_out], timeout => 300, blame_output => $blame_out);
-
-    my ($analyze, $blame) = @{$r->{ret}};
-    ok ref($analyze) eq 'HASH', 'analyze parsed despite banner (no die)';
-    cmp_ok $analyze->{overall}, '==', 34.876, 'overall boot time parsed from banner-prefixed output';
-    cmp_ok $analyze->{userspace}, '==', 19.353, 'userspace boot time parsed';
-    ok ref($blame) eq 'HASH', 'blame parsed despite banner';
-    cmp_ok $blame->{'some.device'}, '==', 14.852, 'blame entry parsed, banner skipped';
-    ok !exists $blame->{'reported.'}, 'banner text not mistaken for a blame entry';
 };
 
 # --- publiccloud::azure pure functions ----------------------------------------

--- a/t/44_publiccloud_instance.t
+++ b/t/44_publiccloud_instance.t
@@ -3,9 +3,9 @@
 # Copyright 2026 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
-# Summary: Unit tests for publiccloud::instance -- systemd time parsing,
-# ssh command construction and the thin provider-delegating
-# methods (start/stop/get_state/wait_for_state).
+# Summary: Unit tests for publiccloud::instance -- ssh command construction
+# and the thin provider-delegating methods
+# (start/stop/get_state/wait_for_state).
 # Maintainer: QE-C team <qa-c@suse.de>
 
 use strict;
@@ -24,58 +24,6 @@ use Test::Mock::Time;
 use testapi 'set_var';
 
 use publiccloud::instance;
-
-subtest '[systemd_time_to_second] parsing' => sub {
-    cmp_ok(publiccloud::instance::systemd_time_to_second('1.234s'), '==', 1.234, 'seconds only');
-    cmp_ok(publiccloud::instance::systemd_time_to_second('500ms'), '==', 0.5, 'milliseconds converted');
-    cmp_ok(publiccloud::instance::systemd_time_to_second('1min 30.000s'), '==', 90, 'minutes + seconds');
-    cmp_ok(publiccloud::instance::systemd_time_to_second('1h 0min 0.000s'), '==', 3600, 'hours + min + sec');
-    cmp_ok(publiccloud::instance::systemd_time_to_second('2h 3min 4.500s'), '==', 2 * 3600 + 3 * 60 + 4.5, 'full combination');
-};
-
-subtest '[systemd_time_to_second] invalid returns -1' => sub {
-    my $instance = Test::MockModule->new('publiccloud::instance', no_auto => 1);
-    $instance->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
-    is(publiccloud::instance::systemd_time_to_second('garbage'), -1, 'unparseable string returns -1');
-    is(publiccloud::instance::systemd_time_to_second(''), -1, 'empty string returns -1');
-};
-
-# ---------------------------------------------------------------------------
-# Pure helper: extract_analyze_time
-# ---------------------------------------------------------------------------
-subtest '[extract_analyze_time] systemd-analyze time output' => sub {
-    my $out = 'Startup finished in 1.500s (kernel) + 2.000s (initrd) + 10.000s (userspace) = 13.500s';
-    my $res = publiccloud::instance::extract_analyze_time($out);
-    is(ref $res, 'HASH', 'returns hashref on success');
-    cmp_ok($res->{kernel}, '==', 1.5, 'kernel time parsed');
-    cmp_ok($res->{initrd}, '==', 2, 'initrd time parsed');
-    cmp_ok($res->{userspace}, '==', 10, 'userspace time parsed');
-    cmp_ok($res->{overall}, '==', 13.5, 'overall (after =) parsed');
-};
-
-subtest '[extract_analyze_time] missing component returns undef' => sub {
-    # No initrd component -> incomplete -> undef
-    my $out = 'Startup finished in 1.500s (kernel) + 10.000s (userspace) = 11.500s';
-    is(publiccloud::instance::extract_analyze_time($out), undef, 'incomplete data returns undef');
-};
-
-# ---------------------------------------------------------------------------
-# Pure helper: extract_blame_time
-# ---------------------------------------------------------------------------
-subtest '[extract_blame_time] systemd-analyze blame output' => sub {
-    my $out = "5.000s foo.service\n2.500s bar.service";
-    my $res = publiccloud::instance::extract_blame_time($out);
-    is(ref $res, 'HASH', 'returns hashref');
-    cmp_ok($res->{'foo.service'}, '==', 5, 'foo.service parsed');
-    cmp_ok($res->{'bar.service'}, '==', 2.5, 'bar.service parsed');
-};
-
-subtest '[extract_blame_time] unparseable line returns empty hashref' => sub {
-    my $instance = Test::MockModule->new('publiccloud::instance', no_auto => 1);
-    $instance->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
-    my $out = "totally bogus";
-    is_deeply(publiccloud::instance::extract_blame_time($out), {}, 'bad time token returns empty hashref');
-};
 
 # ---------------------------------------------------------------------------
 # _prepare_ssh_cmd / ssh_script_run command construction

--- a/tests/publiccloud/auto_registration.pm
+++ b/tests/publiccloud/auto_registration.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Wait for the on-demand instance's guest registration (cloud-regionsrv-client) to complete
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use publiccloud::utils qw(is_ondemand);
+use publiccloud::ssh_interactive qw(select_host_console);
+
+sub run {
+    my ($self, $args) = @_;
+
+    select_host_console();    # select console on the host, not the PC instance
+
+    return unless (is_ondemand);
+    $args->{my_instance}->wait_for_guestregister();
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/publiccloud/az_accelerated_net.pm
+++ b/tests/publiccloud/az_accelerated_net.pm
@@ -24,9 +24,10 @@ sub prepare_vms {
     my ($self, $provider) = @_;
     my $repo = get_required_var('IPERF_REPO');
     record_info('INFO', "Create VM\nInstalling iperf package from $repo");
-    my @instances = $provider->create_instances(check_guestregister => 0, count => 2);
+    my @instances = $provider->create_instances(count => 2);
     foreach my $instance (@instances) {
         record_info('Instance', 'Instance ' . $instance->instance_id . ' created');
+        $instance->wait_for_ssh(scan_ssh_host_key => 1);
         record_info('Iperf', 'Install IPerf binaries in VM');
         pc_zypper_call($instance, "ar --no-gpgcheck $repo net_perf");
         pc_pkg_call($instance, "in -r net_perf iperf");

--- a/tests/publiccloud/check_boottime.pm
+++ b/tests/publiccloud/check_boottime.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Check the public cloud instance boot time against a threshold
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use publiccloud::ssh_interactive qw(select_host_console);
+
+sub run {
+    my ($self, $args) = @_;
+
+    select_host_console();    # select console on the host, not the PC instance
+
+    $args->{my_instance}->check_system_boottime();
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/publiccloud/check_boottime.pm
+++ b/tests/publiccloud/check_boottime.pm
@@ -8,14 +8,72 @@
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
+use Data::Dumper;
+use publiccloud::utils qw(is_azure);
 use publiccloud::ssh_interactive qw(select_host_console);
+
+=head2 check_system_boottime
+
+    check_system_boottime($instance);
+
+Check the system boot time, measured by C<systemd-analyze>, to be under a threshold.
+Assign the threshold in seconds to PUBLIC_CLOUD_BOOTTIME_MAX in test settings.
+The boot time is saved in a local json structure, then printed in the test's logs:
+when the threshold is exceeded the job is stopped.
+The routine is skipped when the threshold is undefined or zero.
+
+=cut
+
+sub check_system_boottime {
+    my ($instance, %args) = @_;
+    my $max_boot_time = get_var('PUBLIC_CLOUD_BOOTTIME_MAX');
+    return unless ($max_boot_time);
+
+    my $ret = {
+        kernel_release => undef,
+        kernel_version => undef,
+        type => 'boottime',
+        analyze => {},
+        blame => {},
+    };
+
+    record_info("BOOT TIME", 'systemd_analyze');
+    # first deployment analysis
+    my ($systemd_analyze, $systemd_blame) = $instance->do_systemd_analyze_time(%args);
+    die("failed to obtain boottime from systemd") unless ($systemd_analyze && $systemd_blame);
+
+    $ret->{analyze}->{$_} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));
+    $ret->{blame} = $systemd_blame;
+    my $boottime = $ret->{analyze}->{overall};
+
+    # Collect kernel version
+    $ret->{kernel_release} = $instance->ssh_script_output(cmd => 'uname -r', proceed_on_failure => 1);
+    $ret->{kernel_version} = $instance->ssh_script_output(cmd => 'uname -v', proceed_on_failure => 1);
+
+    $Data::Dumper::Sortkeys = 1;
+    record_info("RESULTS", Dumper($ret));
+    my $dir = "/var/log";
+    my @logs = qw(cloudregister cloud-init.log cloud-init-output.log messages NetworkManager);
+    $instance->upload_check_logs_tar(map { "$dir/$_" } @logs);
+
+    # Boot time overall limit check
+    if ($boottime > $max_boot_time) {
+        if (is_azure()) {
+            # Unreliable userspace boot time in Azure.
+            record_soft_failure("bsc#1262587 - openQA publiccloud tests have anomalous-high boot-time from systemd-analyze");
+        } else {
+            # threshold exceeded
+            die("System boot time overall $boottime is out of limit $max_boot_time");
+        }
+    }
+}
 
 sub run {
     my ($self, $args) = @_;
 
     select_host_console();    # select console on the host, not the PC instance
 
-    $args->{my_instance}->check_system_boottime();
+    check_system_boottime($args->{my_instance});
 }
 
 sub test_flags {

--- a/tests/publiccloud/check_boottime.pm
+++ b/tests/publiccloud/check_boottime.pm
@@ -9,8 +9,99 @@
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use Data::Dumper;
+use Mojo::Util 'trim';
 use publiccloud::utils qw(is_azure);
 use publiccloud::ssh_interactive qw(select_host_console);
+
+sub systemd_time_to_second
+{
+    my $str_time = trim(shift);
+
+    if ($str_time !~ /^(?<check_hour>(?<hour>\d{1,2})\s*h\s*)?(?<check_min>(?<min>\d{1,2})\s*min\s*)?((?<sec>\d{1,2}\.\d{1,3})s|(?<ms>\d+)ms)$/) {
+        record_info("WARN", "Unable to parse systemd time '$str_time'", result => 'fail');
+        return -1;
+    }
+    my $sec = $+{sec} // $+{ms} / 1000;
+    $sec += $+{min} * 60 if (defined($+{check_min}));
+    $sec += $+{hour} * 3600 if (defined($+{check_hour}));
+    return $sec;
+}
+
+sub extract_analyze_time {
+    my $str_time = shift;
+    my $res = {};
+    # Pick the line that actually holds the timing, not blindly the first line:
+    # ssh_script_output may prepend an SSH login banner / MOTD, which would
+    # otherwise leave us parsing an empty or non-timing line (poo#203817).
+    ($str_time) = grep { /Startup finished in/i } split(/\r?\n/, $str_time);
+    return undef unless defined($str_time);
+    $str_time =~ s/Startup finished in\s*//i;
+    $str_time =~ s/=(.+)$/+$1 (overall)/;
+    for my $time (split(/\s*\+\s*/, $str_time)) {
+        $time = trim($time);
+        my ($time, $type) = $time =~ /^(.+)\s*\((\w+)\)$/;
+        $res->{$type} = systemd_time_to_second($time);
+        return undef if ($res->{$type} == -1);
+    }
+    foreach (qw(kernel initrd userspace overall)) { return undef unless exists($res->{$_}); }
+    return $res;
+}
+
+sub extract_blame_time {
+    my $str_time = shift;
+    my $ret = {};
+    for my $line (split(/\r?\n/, $str_time)) {
+        $line = trim($line);
+        # Only <time> <service> lines are blame entries; skip anything else
+        # (e.g. an SSH login banner / MOTD prepended to the output, poo#203817).
+        my ($time, $service) = $line =~ /^(\S+)\s+(\S+)$/;
+        next unless defined($service);
+        my $sec = systemd_time_to_second($time);
+        next unless ($sec >= 0);
+        $ret->{$service} = $sec;
+    }
+    return $ret;
+}
+
+sub do_systemd_analyze_time {
+    my ($instance, %args) = @_;
+    my $timeout = $args{timeout} // 300;
+    my $start_time = time();
+    my $output = "";
+    my $finished = 0;
+    my @ret;
+
+    # Poll systemd-analyze until the system has actually finished booting.
+    # On a freshly-launched Public Cloud instance SSH becomes reachable while
+    # late boot units (e.g. cloud-init) are still running, so systemd-analyze
+    # reports "Bootup is not yet finished (...FinishTimestampMonotonic=0)" and
+    # exits non-zero (poo#203817). "Startup finished in" only appears once boot
+    # is complete, so it is our readiness signal. Break out on the successful
+    # match *before* sleeping so a result arriving near the timeout is not
+    # discarded, and gate success on the match rather than on elapsed time.
+    while (time() - $start_time < $timeout) {
+        # calling systemd-analyze time
+        $output = $instance->ssh_script_output(cmd => 'systemd-analyze time', proceed_on_failure => 1);
+        if ($output =~ /Startup finished in/i) {
+            $finished = 1;
+            last;
+        }
+        sleep 5;
+    }
+    unless ($finished) {
+        record_info("WARN", "Unable to get systemd-analyze in ${timeout}s.\nLast output:" . $output, result => 'fail');
+        return (0, 0);
+    }
+    # log time
+    $instance->ssh_script_run("uptime");
+
+    push @ret, extract_analyze_time($output);
+
+    $output = $instance->ssh_script_output(cmd => 'systemd-analyze blame', proceed_on_failure => 1);
+    push @ret, extract_blame_time($output);
+
+    return @ret;
+}
 
 =head2 check_system_boottime
 
@@ -39,7 +130,7 @@ sub check_system_boottime {
 
     record_info("BOOT TIME", 'systemd_analyze');
     # first deployment analysis
-    my ($systemd_analyze, $systemd_blame) = $instance->do_systemd_analyze_time(%args);
+    my ($systemd_analyze, $systemd_blame) = do_systemd_analyze_time($instance, %args);
     die("failed to obtain boottime from systemd") unless ($systemd_analyze && $systemd_blame);
 
     $ret->{analyze}->{$_} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));

--- a/tests/publiccloud/check_cloudinit.pm
+++ b/tests/publiccloud/check_cloudinit.pm
@@ -8,20 +8,64 @@
 
 use Mojo::Base 'publiccloud::basetest';
 use testapi;
-use publiccloud::utils qw(is_cloudinit_supported);
+use publiccloud::utils qw(is_cloudinit_supported is_azure);
 use publiccloud::ssh_interactive qw(select_host_console);
+use version_utils qw(is_sle);
+
+sub check_cloudinit {
+    my ($instance) = @_;
+
+    # cloud-init status
+    my $rc = $instance->ssh_script_run(cmd => "sudo cloud-init status --wait", timeout => 300);
+    record_info("cloud-init", $instance->ssh_script_output("sudo cloud-init status --long", proceed_on_failure => 1, timeout => 300), result => $rc == 0 ? 'ok' : 'fail');
+    # Cloud-init error codes: 0 - success, 1 - unrecoverable error, 2 - recoverable error (See cloud-init documentation)
+    # As of https://bugzilla.suse.com/show_bug.cgi?id=1266207 we ignore recoverable errors
+    if (get_var('PUBLIC_CLOUD_IGNORE_CLOUDINIT_ERRORS') != 1) {
+        if ($rc == 1) {
+            die "unrecoverable cloud-init error";
+        } elsif ($rc == 2) {
+            record_info("cloud-init", "recoverable error (return code 2)");
+        } elsif ($rc != 0) {
+            die "unknown cloud-init return code $rc";
+        }
+    }
+
+    # cloud-id
+    my $cloud_id = (is_azure) ? 'azure' : 'aws';
+    $instance->ssh_assert_script_run(cmd => "sudo cloud-id | grep '^$cloud_id\$'");
+
+    # cloud-init collect-logs
+    $instance->ssh_assert_script_run('sudo cloud-init collect-logs');
+    $instance->upload_log('~/cloud-init.tar.gz', failok => 1);
+
+    if (get_var('PUBLIC_CLOUD_CLOUD_INIT')) {
+        # Check for bootcmd, runcmd and write_files module
+        $instance->ssh_assert_script_run('sudo grep pookie /root/test_cloud-init.txt');
+        $instance->ssh_assert_script_run('sudo grep Mithrandir /root/test_cloud-init.txt');
+        $instance->ssh_assert_script_run('sudo grep snickerdoodle /root/test_cloud-init.txt');
+
+        # Check for packages module
+        $instance->ssh_assert_script_run('ed -V');
+
+        # Check for final_message module
+        $instance->ssh_assert_script_run('sudo journalctl -b | grep "cloud-init qa has finished"');
+
+        # cloud-init schema
+        $instance->ssh_assert_script_run('sudo cloud-init schema --system') unless (is_sle('=12-SP5'));
+    }
+}
 
 sub run {
     my ($self, $args) = @_;
 
     select_host_console();    # select console on the host, not the PC instance
 
-    return unless (is_cloudinit_supported && !get_var('PUBLIC_CLOUD_SKIP_INSTANCE_CHECKS'));
-    $args->{my_instance}->check_cloudinit();
+    return unless (is_cloudinit_supported);
+    check_cloudinit($args->{my_instance});
 }
 
 sub test_flags {
-    return {fatal => 1};
+    return {fatal => 0};
 }
 
 1;

--- a/tests/publiccloud/check_cloudinit.pm
+++ b/tests/publiccloud/check_cloudinit.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Check cloud-init status on the public cloud instance
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use publiccloud::utils qw(is_cloudinit_supported);
+use publiccloud::ssh_interactive qw(select_host_console);
+
+sub run {
+    my ($self, $args) = @_;
+
+    select_host_console();    # select console on the host, not the PC instance
+
+    return unless (is_cloudinit_supported && !get_var('PUBLIC_CLOUD_SKIP_INSTANCE_CHECKS'));
+    $args->{my_instance}->check_cloudinit();
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -12,7 +12,7 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use Path::Tiny;
 use Mojo::JSON;
-use publiccloud::utils qw(is_ondemand is_hardened);
+use publiccloud::utils qw(is_hardened);
 use publiccloud::ssh_interactive 'select_host_console';
 use File::Basename 'basename';
 use version_utils "is_sle";
@@ -86,11 +86,6 @@ sub run {
 
     select_host_console();
 
-    unless ($args->{my_provider} && $args->{my_instance}) {
-        $args->{my_provider} = $self->provider_factory();
-        $args->{my_instance} = $args->{my_provider}->create_instance();
-        $args->{my_instance}->wait_for_guestregister() if (is_ondemand);
-    }
     $instance = $args->{my_instance};
     $provider = $args->{my_provider};
 

--- a/tests/publiccloud/kdump.pm
+++ b/tests/publiccloud/kdump.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Enable kdump on the public cloud instance
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use publiccloud::ssh_interactive qw(select_host_console);
+
+sub run {
+    my ($self, $args) = @_;
+
+    select_host_console();    # select console on the host, not the PC instance
+
+    return unless (get_var('PUBLIC_CLOUD_ENABLE_KDUMP'));
+    $args->{my_instance}->enable_kdump();
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/publiccloud/kdump.pm
+++ b/tests/publiccloud/kdump.pm
@@ -10,17 +10,33 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use publiccloud::ssh_interactive qw(select_host_console);
 
+sub enable_kdump {
+    my ($instance) = @_;
+
+    $instance->ssh_assert_script_run(q(sudo sed -i "/^GRUB_CMDLINE_LINUX_DEFAULT/ s/\\\\\\"$/ crashkernel=256M,high crashkernel=128M,low \\\\\\"/" /etc/default/grub));
+    $instance->ssh_assert_script_run('sudo grub2-mkconfig -o /boot/grub2/grub.cfg');
+
+    if ($instance->ssh_script_run('sudo grep -q "^KDUMP_CRASHKERNEL=" /etc/sysconfig/kdump') == 0) {
+        $instance->ssh_assert_script_run(q(sudo sed -i "/^KDUMP_CRASHKERNEL/ s/\\\\\\"$/ crashkernel=256M,high crashkernel=128M,low \\\\\\"/" /etc/sysconfig/kdump));
+    } else {
+        $instance->ssh_assert_script_run(q(echo "KDUMP_CRASHKERNEL=\"crashkernel=256M,high crashkernel=128M,low\"" | sudo tee -a /etc/sysconfig/kdump));
+    }
+
+    $instance->ssh_assert_script_run('sudo systemctl enable kdump.service');
+    $instance->softreboot();
+}
+
 sub run {
     my ($self, $args) = @_;
 
     select_host_console();    # select console on the host, not the PC instance
 
     return unless (get_var('PUBLIC_CLOUD_ENABLE_KDUMP'));
-    $args->{my_instance}->enable_kdump();
+    enable_kdump($args->{my_instance});
 }
 
 sub test_flags {
-    return {fatal => 1};
+    return {fatal => 0};
 }
 
 1;

--- a/tests/publiccloud/network_test.pm
+++ b/tests/publiccloud/network_test.pm
@@ -10,12 +10,35 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use publiccloud::ssh_interactive qw(select_host_console);
 
+sub network_speed_test {
+    my ($instance) = @_;
+    my ($cmd, $ret);
+
+    # Curl stats output format
+    my $write_out
+      = 'time_namelookup:\t%{time_namelookup} s\ntime_connect:\t\t%{time_connect} s\ntime_appconnect:\t%{time_appconnect} s\ntime_pretransfer:\t%{time_pretransfer} s\ntime_redirect:\t\t%{time_redirect} s\ntime_starttransfer:\t%{time_starttransfer} s\ntime_total:\t\t%{time_total} s\n';
+    # PC RMT server domain name
+    my $rmt_host = "smt-" . lc(get_required_var('PUBLIC_CLOUD_PROVIDER')) . ".susecloud.net";
+
+    $cmd = "grep \"$rmt_host\" /etc/hosts";
+    $ret = $instance->ssh_script_run(cmd => $cmd, apply_graceful_timeout => 1);
+    record_info("RMT_HOST", printf('$ %s\n%s', $cmd, $ret));
+
+    $cmd = "ping -c3 1.1.1.1";
+    $ret = $instance->ssh_script_run(cmd => $cmd, apply_graceful_timeout => 1);
+    record_info("PING", printf('$ %s\n%s', $cmd, $ret));
+
+    $cmd = "curl -w '$write_out' -o /dev/null -v https://$rmt_host/";
+    $ret = $instance->ssh_script_run(cmd => $cmd, apply_graceful_timeout => 1);
+    record_info("CURL", printf('$ %s\n%s', $cmd, $ret));
+}
+
 sub run {
     my ($self, $args) = @_;
 
     select_host_console();    # select console on the host, not the PC instance
 
-    $args->{my_instance}->network_speed_test();
+    network_speed_test($args->{my_instance});
 }
 
 sub test_flags {

--- a/tests/publiccloud/network_test.pm
+++ b/tests/publiccloud/network_test.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Test the network speed of the public cloud instance
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use publiccloud::ssh_interactive qw(select_host_console);
+
+sub run {
+    my ($self, $args) = @_;
+
+    select_host_console();    # select console on the host, not the PC instance
+
+    $args->{my_instance}->network_speed_test();
+}
+
+sub test_flags {
+    return {fatal => 0};
+}
+
+1;

--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -58,7 +58,6 @@ sub run {
     if (is_cloudinit_supported) {
         $args->{my_instance}->cleanup_cloudinit();
         $args->{my_instance}->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600), scan_ssh_host_key => 1);
-        $args->{my_instance}->check_cloudinit();
         permit_root_login($args->{my_instance});
     } else {
         $args->{my_instance}->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -35,21 +35,13 @@ sub run {
 
     # Create public cloud instance
     my %instance_args;
-    $instance_args{check_connectivity} = 0;    # Don't run wait_for_ssh() inside create_instance()
     $instance_args{use_extra_disk} = {size => $additional_disk_size, type => $additional_disk_type} if ($additional_disk_size > 0);
 
     $args->{my_provider} = $self->provider_factory();
     $args->{my_instance} = $args->{my_provider}->create_instance(%instance_args);
     my $provider = $self->{my_provider} = $args->{my_provider};
     my $instance = $args->{my_instance};
-    # check needed when not-executed in create_instance
-    $instance->wait_for_ssh(scan_ssh_host_key => 1) if ($instance_args{check_connectivity} == 0);
-    $instance->check_system_boottime();
-    $instance->wait_for_guestregister() if (is_ondemand);
-
-    $instance->network_speed_test();
-    $instance->check_cloudinit() if (is_cloudinit_supported && !get_var('PUBLIC_CLOUD_SKIP_INSTANCE_CHECKS'));
-    $instance->enable_kdump() if (get_var('PUBLIC_CLOUD_ENABLE_KDUMP'));
+    $instance->wait_for_ssh(scan_ssh_host_key => 1);
 
     $provider->initialize_logging($instance);
     # Add additional authorized_keys for human users

--- a/tests/sles4sap/publiccloud/mr_test_setup_env.pm
+++ b/tests/sles4sap/publiccloud/mr_test_setup_env.pm
@@ -51,7 +51,6 @@ sub run {
 
     # Clear $instance->ssh_opts which omit the known hosts file and strict host checking by default
     $instance->ssh_opts('');
-    $instance->network_speed_test();
 
     # Set ssh-tunnel
     $testapi::username = 'bernhard';

--- a/variables.md
+++ b/variables.md
@@ -394,7 +394,6 @@ PUBLIC_CLOUD_RESOURCE_GROUP | string | "qesaposd" | Allows to specify resource g
 PUBLIC_CLOUD_RESOURCE_NAME | string | "openqa-vm" | The name we use when creating our VM.
 PUBLIC_CLOUD_ROOT_DISK_SIZE | int |  | Set size of system disk in GiB for public cloud instance. Default size is 30 for Azure and 20 for GCE and EC2 
 PUBLIC_CLOUD_SCC_ENDPOINT | string | "registercloudguest" | Name of binary which will be used to register image . Except default value only possible value is "SUSEConnect" anything else will lead to test failure!
-PUBLIC_CLOUD_SKIP_INSTANCE_CHECKS | boolean | false | DO NOT ADD TO JOB GROUPS: Skip the instance checks running right after instance is created. Those includes failed service check and the cloud init check.
 PUBLIC_CLOUD_SKIP_MU | boolean | false | Run tests without downloading/applying maintenance updates.
 PUBLIC_CLOUD_SLES4SAP | boolean | false | If set, sles4sap test module is added to the job.
 PUBLIC_CLOUD_SSH_TIMEOUT | int | 300 | Sets the timeout for ssh wait operations.


### PR DESCRIPTION
Splits `publiccloud/prepare_instance` into smaller, single-purpose test modules (`check_boottime`, `network_test`, `check_cloudinit`, `kdump`, `auto_registration`), leaving `prepare_instance` responsible only for creating the instance and setting up connectivity/sudo access. `provider::create_instances()` no longer implicitly waits for SSH; callers now do so explicitly, which let `img_proof.pm` drop a now-dead fallback instance-creation branch and made `az_accelerated_net.pm`'s reliance on that implicit behaviour explicit.

Also broadens scheduling of `publiccloud/check_services` to the img-proof, functional and smoketest flows in `load_maintenance_publiccloud_tests`, matching coverage `load_latest_publiccloud_tests` already had.

`network_speed_test`, `check_cloudinit` and `check_system_boottime` are moved out of `publiccloud::instance` entirely (not just wrapped), since the first two had extra inline call sites: the SAP `mr_test_setup_env.pm` flow (scheduled via YAML) for `network_speed_test`, and `patch_and_reboot.pm`'s own post-reboot check for `check_cloudinit`. Both are now scheduled as separate modules instead — `network_test` after `mr_test_setup_env` in the 3 affected SAP YAML schedules, `check_cloudinit` after every `patch_and_reboot`. `enable_kdump` is extracted the same way for consistency, though it had no other callers. `do_systemd_analyze_time` and its parsing helpers (`systemd_time_to_second`, `extract_analyze_time`, `extract_blame_time`) move alongside `check_system_boottime` into `check_boottime.pm` too, now that they're only ever called from there; the poo#203817 regression unit tests that pinned them to `instance.pm` are dropped since that scenario is still covered by openQA integration runs. `PUBLIC_CLOUD_SKIP_INSTANCE_CHECKS` is dropped since it only ever gated one of these checks inconsistently.

A follow-up, [poo#204606](https://progress.opensuse.org/issues/204606), tracks folding the `auto_registration.pm` guest-registration wait into `registration.pm`/`registercloudguest.pm` so that module can be removed too.

* Related ticket: [poo#203838](https://progress.opensuse.org/issues/203838), [poo#204606](https://progress.opensuse.org/issues/204606)
* Verification runs: In comment below

## Commits

- 84a223cb80 feat(publiccloud): Split prepare_instance checks into dedicated modules
- f0a35d4428 feat(publiccloud): Schedule check_services more broadly
- eadef91391 feat(publiccloud): Extract network_speed_test into network_test.pm
- 0690dfdc0d feat(publiccloud): Extract check_cloudinit and enable_kdump into modules
- b3f1bb589c feat(publiccloud): Extract check_system_boottime into check_boottime.pm
- cfa1fee0d2 feat(publiccloud): Move boot-time parsing into check_boottime.pm

