### PR TITLE
Kselftests: Don't mistake the harness's closing line for a subtest

### DIFF
--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -335,6 +335,7 @@ sub post_process_single
     my $hardfails = 0;
     my $softfails = 0;
     for my $test_ln (@log) {
+        next if $test_ln =~ /^(not )?ok \d+ selftests: \S+: \S+/;
         $test_ln = $parser->parse_line($test_ln);
         if (!$test_ln) {
             next;


### PR DESCRIPTION
Removing --per-test-log means the per-test log now also captures the harness's own closing line (e.g. 'not ok 1 selftests: net: foo.sh # exit=1'), which the subtest-detection regex misreads as a failing subtest with no whitelist match. This poisons the hardfail count and makes openQA's KTAP parser close the test group as failed before it reaches the real, whitelist-rewritten closing line.

Skip that line before subtest detection; the correct closing line is already produced elsewhere.

- Fixes: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26140
- Verification run: https://openqa.opensuse.org/tests/6121935
