### PR TITLE
Add --gpg-auto-import-keys option for zypper

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -2348,7 +2348,7 @@ sub ipaddr2_patch_system(%args) {
         push @vms, $vm_private_ip;
 
         ipaddr2_ssh_internal(id => $id,
-            cmd => "sudo zypper -n ref",
+            cmd => "sudo zypper -n --gpg-auto-import-keys ref",
             timeout => 1500,
             bastion_ip => $args{bastion_ip});
     }


### PR DESCRIPTION
I am trying to add tests for Azure-SAP-BYOS-Staging, and get an issue like this:
https://openqaworker15.qe.prg2.suse.org/tests/379121#step/patch_system/13
https://openqaworker15.qe.prg2.suse.org/tests/379121#step/patch_system/11

this PR adds the option `--gpg-auto-import-keys` for zypper to fix the above issue

- Related ticket: https://jira.suse.com/browse/TEAM-11078
- Verification run:
    https://openqaworker15.qe.prg2.suse.org/tests/379134#step/patch_system/14

