### PR TITLE
xfstests: Fix sporadic loop run not show fail info

### DIFF
--- a/tests/xfstests/run_subtest.pm
+++ b/tests/xfstests/run_subtest.pm
@@ -134,7 +134,6 @@ sub run_sporadic_once {
             $SCRATCH_DEV, $SCRATCH_DEV_POOL, $XFSTESTS_DEEP_CLEAN, $INJECT_INFO,
             $LOOP_DEVICE, $ENABLE_KDUMP, $VIRTIO_CONSOLE, 0, $my_instance);
         ($status, $duration) = ($result->{status}, $result->{time});
-        return ($result->{status}, $result->{time});
     }
     # Heartbeat mode: start the heartbeat, run the test, wait for the done marker
     # and recover the SUT if the heartbeat is lost.


### PR DESCRIPTION
Remove the first return to make the sporadic loop run show fail info.

- Related ticket: https://progress.opensuse.org/issues/199151
- Verification run: Here in the loop run could show output bad log and other logs. https://openqa.suse.de/tests/23542072#step/generic-095/384
