### PR TITLE
Extract check_system_boottime into check_boottime.pm

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -350,6 +350,7 @@ sub load_slem_on_pc_tests {
         loadtest("boot/boot_to_desktop");
         loadtest("publiccloud/prepare_instance", run_args => $args);
         loadtest("publiccloud/network_test", run_args => $args);
+        loadtest("publiccloud/check_boottime", run_args => $args);
         loadtest("publiccloud/check_cloudinit", run_args => $args);
         loadtest("publiccloud/registration", run_args => $args) unless (get_var('PUBLIC_CLOUD_IGNORE_UNREGISTERED'));
         # 2 next modules of pubcloud needed for sle-micro incidents/repos verification

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -25,6 +25,7 @@ sub load_maintenance_publiccloud_tests {
     loadtest "publiccloud/download_repos" unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
     loadtest "publiccloud/prepare_instance", run_args => $args;
     loadtest "publiccloud/network_test", run_args => $args;
+    loadtest "publiccloud/check_boottime", run_args => $args;
     loadtest "publiccloud/check_cloudinit", run_args => $args;
     if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
         loadtest("publiccloud/registercloudguest", run_args => $args);
@@ -127,6 +128,7 @@ sub load_latest_publiccloud_tests {
     if (get_var('PUBLIC_CLOUD_LTP')) {
         loadtest "publiccloud/prepare_instance", run_args => $args;
         loadtest "publiccloud/network_test", run_args => $args;
+        loadtest "publiccloud/check_boottime", run_args => $args;
         loadtest "publiccloud/check_cloudinit", run_args => $args;
         loadtest("publiccloud/registration", run_args => $args);
         loadtest 'publiccloud/run_ltp', run_args => $args;
@@ -140,6 +142,7 @@ sub load_latest_publiccloud_tests {
     } else {    # All test cases below require prepare_instance
         loadtest "publiccloud/prepare_instance", run_args => $args;
         loadtest "publiccloud/network_test", run_args => $args;
+        loadtest "publiccloud/check_boottime", run_args => $args;
         loadtest "publiccloud/check_cloudinit", run_args => $args;
         if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
             loadtest "publiccloud/registercloudguest", run_args => $args;
@@ -229,6 +232,7 @@ sub load_publiccloud_appimg_tests {
     my $publiccloud_app_img = get_var('PUBLIC_CLOUD_APP_IMG');
     loadtest "publiccloud/prepare_instance", run_args => $args;
     loadtest "publiccloud/network_test", run_args => $args;
+    loadtest "publiccloud/check_boottime", run_args => $args;
     loadtest "publiccloud/check_cloudinit", run_args => $args;
     loadtest("publiccloud/registration", run_args => $args);
     loadtest "publiccloud/instance_overview", run_args => $args;

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -11,15 +11,12 @@ package publiccloud::instance;
 use testapi;
 use Carp 'croak';
 use Mojo::Base -base;
-use Mojo::Util 'trim';
 use File::Basename;
 use publiccloud::utils;
 use Utils::Backends qw(set_sshserial_dev unset_sshserial_dev);
 use publiccloud::ssh_interactive qw(ssh_interactive_tunnel ssh_interactive_leave select_host_console);
 use version_utils;
 use utils;
-use Mojo::Util 'trim';
-use Data::Dumper;
 
 use constant SSH_TIMEOUT => 90;
 
@@ -655,152 +652,6 @@ sub enable_kdump() {
 
     $self->ssh_assert_script_run('sudo systemctl enable kdump.service');
     $self->softreboot();
-}
-
-=head2 check_system_boottime
-
-    check_system_boottime();
-
-Check the system boot time, measured by C<systemd-analyze>, to be under a threshold.
-Assign the threshold in seconds to PUBLIC_CLOUD_BOOTTIME_MAX in test settings.
-The boot time is saved in a local json structure, then printed in the test's logs:
-when the threshold is exceeded the job is stopped.
-The routine is skipped when the threshold is undefined or zero.
-
-=cut
-
-sub check_system_boottime() {
-    my ($instance, %args) = @_;
-    my $max_boot_time = get_var('PUBLIC_CLOUD_BOOTTIME_MAX');
-    return unless ($max_boot_time);
-
-    my $ret = {
-        kernel_release => undef,
-        kernel_version => undef,
-        type => 'boottime',
-        analyze => {},
-        blame => {},
-    };
-
-    record_info("BOOT TIME", 'systemd_analyze');
-    # first deployment analysis
-    my ($systemd_analyze, $systemd_blame) = $instance->do_systemd_analyze_time(%args);
-    die("failed to obtain boottime from systemd") unless ($systemd_analyze && $systemd_blame);
-
-    $ret->{analyze}->{$_} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));
-    $ret->{blame} = $systemd_blame;
-    my $boottime = $ret->{analyze}->{overall};
-
-    # Collect kernel version
-    $ret->{kernel_release} = $instance->ssh_script_output(cmd => 'uname -r', proceed_on_failure => 1);
-    $ret->{kernel_version} = $instance->ssh_script_output(cmd => 'uname -v', proceed_on_failure => 1);
-
-    $Data::Dumper::Sortkeys = 1;
-    record_info("RESULTS", Dumper($ret));
-    my $dir = "/var/log";
-    my @logs = qw(cloudregister cloud-init.log cloud-init-output.log messages NetworkManager);
-    $instance->upload_check_logs_tar(map { "$dir/$_" } @logs);
-
-    # Boot time overall limit check
-    if ($boottime > $max_boot_time) {
-        if (is_azure()) {
-            # Unreliable userspace boot time in Azure.
-            record_soft_failure("bsc#1262587 - openQA publiccloud tests have anomalous-high boot-time from systemd-analyze");
-        } else {
-            # threshold exceeded
-            die("System boot time overall $boottime is out of limit $max_boot_time");
-        }
-    }
-}
-
-sub systemd_time_to_second
-{
-    my $str_time = trim(shift);
-
-    if ($str_time !~ /^(?<check_hour>(?<hour>\d{1,2})\s*h\s*)?(?<check_min>(?<min>\d{1,2})\s*min\s*)?((?<sec>\d{1,2}\.\d{1,3})s|(?<ms>\d+)ms)$/) {
-        record_info("WARN", "Unable to parse systemd time '$str_time'", result => 'fail');
-        return -1;
-    }
-    my $sec = $+{sec} // $+{ms} / 1000;
-    $sec += $+{min} * 60 if (defined($+{check_min}));
-    $sec += $+{hour} * 3600 if (defined($+{check_hour}));
-    return $sec;
-}
-
-sub extract_analyze_time {
-    my $str_time = shift;
-    my $res = {};
-    # Pick the line that actually holds the timing, not blindly the first line:
-    # ssh_script_output may prepend an SSH login banner / MOTD, which would
-    # otherwise leave us parsing an empty or non-timing line (poo#203817).
-    ($str_time) = grep { /Startup finished in/i } split(/\r?\n/, $str_time);
-    return undef unless defined($str_time);
-    $str_time =~ s/Startup finished in\s*//i;
-    $str_time =~ s/=(.+)$/+$1 (overall)/;
-    for my $time (split(/\s*\+\s*/, $str_time)) {
-        $time = trim($time);
-        my ($time, $type) = $time =~ /^(.+)\s*\((\w+)\)$/;
-        $res->{$type} = systemd_time_to_second($time);
-        return undef if ($res->{$type} == -1);
-    }
-    foreach (qw(kernel initrd userspace overall)) { return undef unless exists($res->{$_}); }
-    return $res;
-}
-
-sub extract_blame_time {
-    my $str_time = shift;
-    my $ret = {};
-    for my $line (split(/\r?\n/, $str_time)) {
-        $line = trim($line);
-        # Only <time> <service> lines are blame entries; skip anything else
-        # (e.g. an SSH login banner / MOTD prepended to the output, poo#203817).
-        my ($time, $service) = $line =~ /^(\S+)\s+(\S+)$/;
-        next unless defined($service);
-        my $sec = systemd_time_to_second($time);
-        next unless ($sec >= 0);
-        $ret->{$service} = $sec;
-    }
-    return $ret;
-}
-
-sub do_systemd_analyze_time {
-    my ($instance, %args) = @_;
-    my $timeout = $args{timeout} // 300;
-    my $start_time = time();
-    my $output = "";
-    my $finished = 0;
-    my @ret;
-
-    # Poll systemd-analyze until the system has actually finished booting.
-    # On a freshly-launched Public Cloud instance SSH becomes reachable while
-    # late boot units (e.g. cloud-init) are still running, so systemd-analyze
-    # reports "Bootup is not yet finished (...FinishTimestampMonotonic=0)" and
-    # exits non-zero (poo#203817). "Startup finished in" only appears once boot
-    # is complete, so it is our readiness signal. Break out on the successful
-    # match *before* sleeping so a result arriving near the timeout is not
-    # discarded, and gate success on the match rather than on elapsed time.
-    while (time() - $start_time < $timeout) {
-        # calling systemd-analyze time
-        $output = $instance->ssh_script_output(cmd => 'systemd-analyze time', proceed_on_failure => 1);
-        if ($output =~ /Startup finished in/i) {
-            $finished = 1;
-            last;
-        }
-        sleep 5;
-    }
-    unless ($finished) {
-        record_info("WARN", "Unable to get systemd-analyze in ${timeout}s.\nLast output:" . $output, result => 'fail');
-        return (0, 0);
-    }
-    # log time
-    $instance->ssh_script_run("uptime");
-
-    push @ret, extract_analyze_time($output);
-
-    $output = $instance->ssh_script_output(cmd => 'systemd-analyze blame', proceed_on_failure => 1);
-    push @ret, extract_blame_time($output);
-
-    return @ret;
 }
 
 sub upload_supportconfig_log {

--- a/t/13_publiccloud.t
+++ b/t/13_publiccloud.t
@@ -7,7 +7,6 @@ use Test::MockObject;
 use Test::Exception;
 use Test::Warnings;
 use Test::MockModule;
-use Test::Mock::Time;
 use List::Util qw(any);
 use testapi 'set_var';
 
@@ -446,129 +445,6 @@ subtest '[pc_pkg_call] non-transactional system always uses plain zypper' => sub
     my $cap = _capture_pkg_call(0, 'in -y docker');
     is $cap->{zypper}, 'in -y docker', 'verbatim zypper on non-transactional host';
     ok !defined $cap->{transactional}, 'no transactional-update translation';
-};
-
-# --- do_systemd_analyze_time boot-time race (poo#203817) ----------------------
-#
-# prepare_instance probes `systemd-analyze time` right after SSH is up. On a
-# freshly-launched Public Cloud instance boot may not be finished yet, so the
-# probe returns "Bootup is not yet finished (...FinishTimestampMonotonic=0)".
-# The routine must keep polling until "Startup finished in" appears, must not
-# discard a result that arrives near the timeout, and must fall back to the
-# WARN + (0,0) path only when boot genuinely never finishes.
-
-# Drive do_systemd_analyze_time with a scripted sequence of `systemd-analyze
-# time` outputs and a controllable fake clock (so no real sleeping happens and
-# the timeout is reached deterministically). Each element of @$time_outputs is
-# returned by successive `systemd-analyze time` calls; the last element repeats
-# once the list is exhausted.
-sub _run_systemd_analyze {
-    my ($time_outputs, %args) = @_;
-    my $blame_output = delete $args{blame_output}
-      // "10.000s some.service\n5.000s other.service";
-
-    # Test::Mock::Time advances mocked time() by each sleep() the routine does,
-    # so the loop's `time() - $start_time < $timeout` guard is deterministic and
-    # fast. Capture the fake start time to report elapsed time back to callers.
-    my $clock_start = time();
-
-    my @time_seq = @$time_outputs;
-    my @time_cmds;
-    my $inst = publiccloud::instance->new();
-    my $mocked = Test::MockModule->new('publiccloud::instance', no_auto => 1);
-    $mocked->redefine(ssh_script_output => sub {
-            my ($self, %a) = @_;
-            if ($a{cmd} eq 'systemd-analyze blame') {
-                return $blame_output;
-            }
-            push @time_cmds, $a{cmd};
-            return @time_seq > 1 ? shift(@time_seq) : $time_seq[0];
-    });
-    $mocked->redefine(ssh_script_run => sub { return 0; });
-    $mocked->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
-
-    my @ret = $inst->do_systemd_analyze_time(%args);
-    return {ret => \@ret, time_calls => scalar(@time_cmds), final_time => time() - $clock_start};
-}
-
-subtest '[do_systemd_analyze_time] early success returns parsed times' => sub {
-    my $r = _run_systemd_analyze(
-        ['Startup finished in 1.000s (kernel) + 2.000s (initrd) + 3.000s (userspace) = 6.000s'],
-        timeout => 300);
-
-    my ($analyze, $blame) = @{$r->{ret}};
-    ok ref($analyze) eq 'HASH', 'analyze result is a hashref (not the (0,0) failure)';
-    cmp_ok $analyze->{overall}, '==', 6, 'overall boot time parsed';
-    cmp_ok $analyze->{userspace}, '==', 3, 'userspace boot time parsed';
-    is $r->{time_calls}, 1, 'succeeded on the first probe';
-};
-
-subtest '[do_systemd_analyze_time] retries while "Bootup is not yet finished"' => sub {
-    my $not_finished = 'Bootup is not yet finished (org.freedesktop.systemd1.Manager.FinishTimestampMonotonic=0)';
-    my $r = _run_systemd_analyze(
-        [$not_finished, $not_finished, $not_finished,
-            'Startup finished in 1.000s (kernel) + 2.000s (initrd) + 3.000s (userspace) = 6.000s'],
-        timeout => 300);
-
-    my ($analyze) = @{$r->{ret}};
-    ok ref($analyze) eq 'HASH', 'result parsed after boot finishes';
-    cmp_ok $analyze->{overall}, '==', 6, 'overall boot time parsed after retries';
-    is $r->{time_calls}, 4, 'polled until boot finished (3 not-finished + 1 success)';
-};
-
-subtest '[do_systemd_analyze_time] late success near timeout is NOT discarded' => sub {
-    # Regression guard for the trailing-sleep bug: a successful result arriving
-    # on the final poll (just under the timeout) must be returned, not thrown
-    # away because the clock crossed the timeout during that poll.
-    my $not_finished = 'Bootup is not yet finished (org.freedesktop.systemd1.Manager.FinishTimestampMonotonic=0)';
-    # timeout=20, sleep 5 per iteration: polls happen at t=0,5,10,15; success on
-    # the 4th poll (t=15). The old code's trailing sleep would push t to 20 and
-    # discard this valid result.
-    my $r = _run_systemd_analyze(
-        [$not_finished, $not_finished, $not_finished,
-            'Startup finished in 1.000s (kernel) + 2.000s (initrd) + 3.000s (userspace) = 6.000s'],
-        timeout => 20);
-
-    my ($analyze) = @{$r->{ret}};
-    ok ref($analyze) eq 'HASH', 'late-but-valid result is returned, not discarded';
-    cmp_ok $analyze->{overall}, '==', 6, 'overall boot time parsed on late success';
-};
-
-subtest '[do_systemd_analyze_time] persistent not-finished ends in WARN + (0,0)' => sub {
-    my $not_finished = 'Bootup is not yet finished (org.freedesktop.systemd1.Manager.FinishTimestampMonotonic=0)';
-    my $r = _run_systemd_analyze([$not_finished], timeout => 20);
-
-    is_deeply $r->{ret}, [0, 0], 'returns (0,0) when boot never finishes';
-    ok $r->{final_time} >= 20, 'polled for the full timeout window before giving up';
-};
-
-subtest '[do_systemd_analyze_time] SSH login banner does not break parsing' => sub {
-    # Regression guard for the second failure seen in the poo#203817 VR: SSH
-    # prepends a login banner / MOTD to the command output, so "Startup finished
-    # in" is NOT on the first line. extract_analyze_time must pick the timing
-    # line by content, and extract_blame_time must skip banner lines, instead of
-    # failing with "Unable to parse systemd time ''" and dying.
-    my $banner = join("\n",
-        "",
-        "Welcome to SUSE Linux Enterprise Server 15 SP7  (x86_64)",
-        "",
-        "Authorized users only. All activity may be monitored and reported.",
-    );
-    my $analyze_out = $banner . "\n"
-      . "Startup finished in 2.406s (kernel) + 13.116s (initrd) + 19.353s (userspace) = 34.876s \n"
-      . "graphical.target reached after 19.290s in userspace.";
-    my $blame_out = $banner . "\n"
-      . "14.852s some.device\n" . "5.000s other.service";
-
-    my $r = _run_systemd_analyze([$analyze_out], timeout => 300, blame_output => $blame_out);
-
-    my ($analyze, $blame) = @{$r->{ret}};
-    ok ref($analyze) eq 'HASH', 'analyze parsed despite banner (no die)';
-    cmp_ok $analyze->{overall}, '==', 34.876, 'overall boot time parsed from banner-prefixed output';
-    cmp_ok $analyze->{userspace}, '==', 19.353, 'userspace boot time parsed';
-    ok ref($blame) eq 'HASH', 'blame parsed despite banner';
-    cmp_ok $blame->{'some.device'}, '==', 14.852, 'blame entry parsed, banner skipped';
-    ok !exists $blame->{'reported.'}, 'banner text not mistaken for a blame entry';
 };
 
 # --- publiccloud::azure pure functions ----------------------------------------

--- a/t/44_publiccloud_instance.t
+++ b/t/44_publiccloud_instance.t
@@ -3,9 +3,9 @@
 # Copyright 2026 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 #
-# Summary: Unit tests for publiccloud::instance -- systemd time parsing,
-# ssh command construction and the thin provider-delegating
-# methods (start/stop/get_state/wait_for_state).
+# Summary: Unit tests for publiccloud::instance -- ssh command construction
+# and the thin provider-delegating methods
+# (start/stop/get_state/wait_for_state).
 # Maintainer: QE-C team <qa-c@suse.de>
 
 use strict;
@@ -24,58 +24,6 @@ use Test::Mock::Time;
 use testapi 'set_var';
 
 use publiccloud::instance;
-
-subtest '[systemd_time_to_second] parsing' => sub {
-    cmp_ok(publiccloud::instance::systemd_time_to_second('1.234s'), '==', 1.234, 'seconds only');
-    cmp_ok(publiccloud::instance::systemd_time_to_second('500ms'), '==', 0.5, 'milliseconds converted');
-    cmp_ok(publiccloud::instance::systemd_time_to_second('1min 30.000s'), '==', 90, 'minutes + seconds');
-    cmp_ok(publiccloud::instance::systemd_time_to_second('1h 0min 0.000s'), '==', 3600, 'hours + min + sec');
-    cmp_ok(publiccloud::instance::systemd_time_to_second('2h 3min 4.500s'), '==', 2 * 3600 + 3 * 60 + 4.5, 'full combination');
-};
-
-subtest '[systemd_time_to_second] invalid returns -1' => sub {
-    my $instance = Test::MockModule->new('publiccloud::instance', no_auto => 1);
-    $instance->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
-    is(publiccloud::instance::systemd_time_to_second('garbage'), -1, 'unparseable string returns -1');
-    is(publiccloud::instance::systemd_time_to_second(''), -1, 'empty string returns -1');
-};
-
-# ---------------------------------------------------------------------------
-# Pure helper: extract_analyze_time
-# ---------------------------------------------------------------------------
-subtest '[extract_analyze_time] systemd-analyze time output' => sub {
-    my $out = 'Startup finished in 1.500s (kernel) + 2.000s (initrd) + 10.000s (userspace) = 13.500s';
-    my $res = publiccloud::instance::extract_analyze_time($out);
-    is(ref $res, 'HASH', 'returns hashref on success');
-    cmp_ok($res->{kernel}, '==', 1.5, 'kernel time parsed');
-    cmp_ok($res->{initrd}, '==', 2, 'initrd time parsed');
-    cmp_ok($res->{userspace}, '==', 10, 'userspace time parsed');
-    cmp_ok($res->{overall}, '==', 13.5, 'overall (after =) parsed');
-};
-
-subtest '[extract_analyze_time] missing component returns undef' => sub {
-    # No initrd component -> incomplete -> undef
-    my $out = 'Startup finished in 1.500s (kernel) + 10.000s (userspace) = 11.500s';
-    is(publiccloud::instance::extract_analyze_time($out), undef, 'incomplete data returns undef');
-};
-
-# ---------------------------------------------------------------------------
-# Pure helper: extract_blame_time
-# ---------------------------------------------------------------------------
-subtest '[extract_blame_time] systemd-analyze blame output' => sub {
-    my $out = "5.000s foo.service\n2.500s bar.service";
-    my $res = publiccloud::instance::extract_blame_time($out);
-    is(ref $res, 'HASH', 'returns hashref');
-    cmp_ok($res->{'foo.service'}, '==', 5, 'foo.service parsed');
-    cmp_ok($res->{'bar.service'}, '==', 2.5, 'bar.service parsed');
-};
-
-subtest '[extract_blame_time] unparseable line returns empty hashref' => sub {
-    my $instance = Test::MockModule->new('publiccloud::instance', no_auto => 1);
-    $instance->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
-    my $out = "totally bogus";
-    is_deeply(publiccloud::instance::extract_blame_time($out), {}, 'bad time token returns empty hashref');
-};
 
 # ---------------------------------------------------------------------------
 # _prepare_ssh_cmd / ssh_script_run command construction

--- a/tests/publiccloud/check_boottime.pm
+++ b/tests/publiccloud/check_boottime.pm
@@ -1,0 +1,174 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Check the public cloud instance boot time against a threshold
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use Data::Dumper;
+use Mojo::Util 'trim';
+use publiccloud::utils qw(is_azure);
+use publiccloud::ssh_interactive qw(select_host_console);
+
+sub systemd_time_to_second
+{
+    my $str_time = trim(shift);
+
+    if ($str_time !~ /^(?<check_hour>(?<hour>\d{1,2})\s*h\s*)?(?<check_min>(?<min>\d{1,2})\s*min\s*)?((?<sec>\d{1,2}\.\d{1,3})s|(?<ms>\d+)ms)$/) {
+        record_info("WARN", "Unable to parse systemd time '$str_time'", result => 'fail');
+        return -1;
+    }
+    my $sec = $+{sec} // $+{ms} / 1000;
+    $sec += $+{min} * 60 if (defined($+{check_min}));
+    $sec += $+{hour} * 3600 if (defined($+{check_hour}));
+    return $sec;
+}
+
+sub extract_analyze_time {
+    my $str_time = shift;
+    my $res = {};
+    # Pick the line that actually holds the timing, not blindly the first line:
+    # ssh_script_output may prepend an SSH login banner / MOTD, which would
+    # otherwise leave us parsing an empty or non-timing line (poo#203817).
+    ($str_time) = grep { /Startup finished in/i } split(/\r?\n/, $str_time);
+    return undef unless defined($str_time);
+    $str_time =~ s/Startup finished in\s*//i;
+    $str_time =~ s/=(.+)$/+$1 (overall)/;
+    for my $time (split(/\s*\+\s*/, $str_time)) {
+        $time = trim($time);
+        my ($time, $type) = $time =~ /^(.+)\s*\((\w+)\)$/;
+        $res->{$type} = systemd_time_to_second($time);
+        return undef if ($res->{$type} == -1);
+    }
+    foreach (qw(kernel initrd userspace overall)) { return undef unless exists($res->{$_}); }
+    return $res;
+}
+
+sub extract_blame_time {
+    my $str_time = shift;
+    my $ret = {};
+    for my $line (split(/\r?\n/, $str_time)) {
+        $line = trim($line);
+        # Only <time> <service> lines are blame entries; skip anything else
+        # (e.g. an SSH login banner / MOTD prepended to the output, poo#203817).
+        my ($time, $service) = $line =~ /^(\S+)\s+(\S+)$/;
+        next unless defined($service);
+        my $sec = systemd_time_to_second($time);
+        next unless ($sec >= 0);
+        $ret->{$service} = $sec;
+    }
+    return $ret;
+}
+
+sub do_systemd_analyze_time {
+    my ($instance, %args) = @_;
+    my $timeout = $args{timeout} // 300;
+    my $start_time = time();
+    my $output = "";
+    my $finished = 0;
+    my @ret;
+
+    # Poll systemd-analyze until the system has actually finished booting.
+    # On a freshly-launched Public Cloud instance SSH becomes reachable while
+    # late boot units (e.g. cloud-init) are still running, so systemd-analyze
+    # reports "Bootup is not yet finished (...FinishTimestampMonotonic=0)" and
+    # exits non-zero (poo#203817). "Startup finished in" only appears once boot
+    # is complete, so it is our readiness signal. Break out on the successful
+    # match *before* sleeping so a result arriving near the timeout is not
+    # discarded, and gate success on the match rather than on elapsed time.
+    while (time() - $start_time < $timeout) {
+        # calling systemd-analyze time
+        $output = $instance->ssh_script_output(cmd => 'systemd-analyze time', proceed_on_failure => 1);
+        if ($output =~ /Startup finished in/i) {
+            $finished = 1;
+            last;
+        }
+        sleep 5;
+    }
+    unless ($finished) {
+        record_info("WARN", "Unable to get systemd-analyze in ${timeout}s.\nLast output:" . $output, result => 'fail');
+        return (0, 0);
+    }
+    # log time
+    $instance->ssh_script_run("uptime");
+
+    push @ret, extract_analyze_time($output);
+
+    $output = $instance->ssh_script_output(cmd => 'systemd-analyze blame', proceed_on_failure => 1);
+    push @ret, extract_blame_time($output);
+
+    return @ret;
+}
+
+=head2 check_system_boottime
+
+    check_system_boottime($instance);
+
+Check the system boot time, measured by C<systemd-analyze>, to be under a threshold.
+Assign the threshold in seconds to PUBLIC_CLOUD_BOOTTIME_MAX in test settings.
+The boot time is saved in a local json structure, then printed in the test's logs:
+when the threshold is exceeded the job is stopped.
+The routine is skipped when the threshold is undefined or zero.
+
+=cut
+
+sub check_system_boottime {
+    my ($instance, %args) = @_;
+    my $max_boot_time = get_var('PUBLIC_CLOUD_BOOTTIME_MAX');
+    return unless ($max_boot_time);
+
+    my $ret = {
+        kernel_release => undef,
+        kernel_version => undef,
+        type => 'boottime',
+        analyze => {},
+        blame => {},
+    };
+
+    record_info("BOOT TIME", 'systemd_analyze');
+    # first deployment analysis
+    my ($systemd_analyze, $systemd_blame) = do_systemd_analyze_time($instance, %args);
+    die("failed to obtain boottime from systemd") unless ($systemd_analyze && $systemd_blame);
+
+    $ret->{analyze}->{$_} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));
+    $ret->{blame} = $systemd_blame;
+    my $boottime = $ret->{analyze}->{overall};
+
+    # Collect kernel version
+    $ret->{kernel_release} = $instance->ssh_script_output(cmd => 'uname -r', proceed_on_failure => 1);
+    $ret->{kernel_version} = $instance->ssh_script_output(cmd => 'uname -v', proceed_on_failure => 1);
+
+    $Data::Dumper::Sortkeys = 1;
+    record_info("RESULTS", Dumper($ret));
+    my $dir = "/var/log";
+    my @logs = qw(cloudregister cloud-init.log cloud-init-output.log messages NetworkManager);
+    $instance->upload_check_logs_tar(map { "$dir/$_" } @logs);
+
+    # Boot time overall limit check
+    if ($boottime > $max_boot_time) {
+        if (is_azure()) {
+            # Unreliable userspace boot time in Azure.
+            record_soft_failure("bsc#1262587 - openQA publiccloud tests have anomalous-high boot-time from systemd-analyze");
+        } else {
+            # threshold exceeded
+            die("System boot time overall $boottime is out of limit $max_boot_time");
+        }
+    }
+}
+
+sub run {
+    my ($self, $args) = @_;
+
+    select_host_console();    # select console on the host, not the PC instance
+
+    check_system_boottime($args->{my_instance});
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -44,7 +44,6 @@ sub run {
     my $instance = $args->{my_instance};
     # check needed when not-executed in create_instance
     $instance->wait_for_ssh(scan_ssh_host_key => 1) if ($instance_args{check_connectivity} == 0);
-    $instance->check_system_boottime();
     $instance->wait_for_guestregister() if (is_ondemand);
 
     $instance->enable_kdump() if (get_var('PUBLIC_CLOUD_ENABLE_KDUMP'));


### PR DESCRIPTION
Moves `check_system_boottime()` and its systemd-analyze parsing helpers (`do_systemd_analyze_time`, `systemd_time_to_second`, `extract_analyze_time`, `extract_blame_time`) out of `publiccloud::instance` and into `tests/publiccloud/check_boottime.pm`. Scheduled right after `prepare_instance`.

* Previous PR: #26167
* Related ticket: [poo#203838](https://progress.opensuse.org/issues/203838)
* Verification runs: In comment below
