### PR TITLE
Extract network_speed_test into network_test.pm

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -349,6 +349,7 @@ sub load_slem_on_pc_tests {
         # SLEM basic test
         loadtest("boot/boot_to_desktop");
         loadtest("publiccloud/prepare_instance", run_args => $args);
+        loadtest("publiccloud/network_test", run_args => $args);
         loadtest("publiccloud/registration", run_args => $args) unless (get_var('PUBLIC_CLOUD_IGNORE_UNREGISTERED'));
         # 2 next modules of pubcloud needed for sle-micro incidents/repos verification
         if (get_var('PUBLIC_CLOUD_QAM', 0)) {

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -24,6 +24,7 @@ sub load_maintenance_publiccloud_tests {
 
     loadtest "publiccloud/download_repos" unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
     loadtest "publiccloud/prepare_instance", run_args => $args;
+    loadtest "publiccloud/network_test", run_args => $args;
     if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
         loadtest("publiccloud/registercloudguest", run_args => $args);
     } else {
@@ -123,6 +124,7 @@ sub load_latest_publiccloud_tests {
 
     if (get_var('PUBLIC_CLOUD_LTP')) {
         loadtest "publiccloud/prepare_instance", run_args => $args;
+        loadtest "publiccloud/network_test", run_args => $args;
         loadtest("publiccloud/registration", run_args => $args);
         loadtest 'publiccloud/run_ltp', run_args => $args;
     }
@@ -134,6 +136,7 @@ sub load_latest_publiccloud_tests {
         return;    # Do not continue as there is no instance to destroy
     } else {    # All test cases below require prepare_instance
         loadtest "publiccloud/prepare_instance", run_args => $args;
+        loadtest "publiccloud/network_test", run_args => $args;
         if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
             loadtest "publiccloud/registercloudguest", run_args => $args;
         }
@@ -221,6 +224,7 @@ sub load_publiccloud_appimg_tests {
     my $args = OpenQA::Test::RunArgs->new();
     my $publiccloud_app_img = get_var('PUBLIC_CLOUD_APP_IMG');
     loadtest "publiccloud/prepare_instance", run_args => $args;
+    loadtest "publiccloud/network_test", run_args => $args;
     loadtest("publiccloud/registration", run_args => $args);
     loadtest "publiccloud/instance_overview", run_args => $args;
 

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -632,36 +632,6 @@ sub get_state {
     return $self->provider->get_state_from_instance($self, @_);
 }
 
-=head2 network_speed_test
-
-    network_speed_test();
-
-Test the network speed.
-=cut
-
-sub network_speed_test() {
-    my ($self, %args) = @_;
-    my ($cmd, $ret);
-
-    # Curl stats output format
-    my $write_out
-      = 'time_namelookup:\t%{time_namelookup} s\ntime_connect:\t\t%{time_connect} s\ntime_appconnect:\t%{time_appconnect} s\ntime_pretransfer:\t%{time_pretransfer} s\ntime_redirect:\t\t%{time_redirect} s\ntime_starttransfer:\t%{time_starttransfer} s\ntime_total:\t\t%{time_total} s\n';
-    # PC RMT server domain name
-    my $rmt_host = "smt-" . lc(get_required_var('PUBLIC_CLOUD_PROVIDER')) . ".susecloud.net";
-
-    $cmd = "grep \"$rmt_host\" /etc/hosts";
-    $ret = $self->ssh_script_run(cmd => $cmd, apply_graceful_timeout => 1);
-    record_info("RMT_HOST", printf('$ %s\n%s', $cmd, $ret));
-
-    $cmd = "ping -c3 1.1.1.1";
-    $ret = $self->ssh_script_run(cmd => $cmd, apply_graceful_timeout => 1);
-    record_info("PING", printf('$ %s\n%s', $cmd, $ret));
-
-    $cmd = "curl -w '$write_out' -o /dev/null -v https://$rmt_host/";
-    $ret = $self->ssh_script_run(cmd => $cmd, apply_graceful_timeout => 1);
-    record_info("CURL", printf('$ %s\n%s', $cmd, $ret));
-}
-
 sub cleanup_cloudinit() {
     my ($self) = @_;
     $self->ssh_assert_script_run('sudo cloud-init clean --logs');

--- a/schedule/sles4sap/sles4sap_gnome_saptune.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune.yaml
@@ -25,6 +25,7 @@ conditional_schedule:
         - sles4sap/publiccloud/qesap_terraform
         - sles4sap/publiccloud/qesap_instances_preparation
         - sles4sap/publiccloud/mr_test_setup_env
+        - publiccloud/network_test
         - publiccloud/registration
         - publiccloud/transfer_repos
         - publiccloud/patch_and_reboot

--- a/schedule/sles4sap/sles4sap_gnome_saptune_maintenance.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune_maintenance.yaml
@@ -26,6 +26,7 @@ conditional_schedule:
         - sles4sap/publiccloud/qesap_instances_preparation
         - sles4sap/publiccloud/add_server_to_hosts
         - sles4sap/publiccloud/mr_test_setup_env
+        - publiccloud/network_test
         - publiccloud/registration
         - sles4sap/publiccloud/cluster_add_repos
         - publiccloud/patch_and_reboot

--- a/schedule/sles4sap/sles4sap_gnome_saptune_product.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune_product.yaml
@@ -24,6 +24,7 @@ conditional_schedule:
         - sles4sap/publiccloud/qesap_terraform
         - sles4sap/publiccloud/qesap_instances_preparation
         - sles4sap/publiccloud/mr_test_setup_env
+        - publiccloud/network_test
         - publiccloud/registration
         - publiccloud/ssh_interactive_start
         - publiccloud/instance_overview

--- a/tests/publiccloud/network_test.pm
+++ b/tests/publiccloud/network_test.pm
@@ -1,0 +1,48 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Test the network speed of the public cloud instance
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use publiccloud::ssh_interactive qw(select_host_console);
+
+sub network_speed_test {
+    my ($instance) = @_;
+    my ($cmd, $ret);
+
+    # Curl stats output format
+    my $write_out
+      = 'time_namelookup:\t%{time_namelookup} s\ntime_connect:\t\t%{time_connect} s\ntime_appconnect:\t%{time_appconnect} s\ntime_pretransfer:\t%{time_pretransfer} s\ntime_redirect:\t\t%{time_redirect} s\ntime_starttransfer:\t%{time_starttransfer} s\ntime_total:\t\t%{time_total} s\n';
+    # PC RMT server domain name
+    my $rmt_host = "smt-" . lc(get_required_var('PUBLIC_CLOUD_PROVIDER')) . ".susecloud.net";
+
+    $cmd = "grep \"$rmt_host\" /etc/hosts";
+    $ret = $instance->ssh_script_run(cmd => $cmd, apply_graceful_timeout => 1);
+    record_info("RMT_HOST", printf('$ %s\n%s', $cmd, $ret));
+
+    $cmd = "ping -c3 1.1.1.1";
+    $ret = $instance->ssh_script_run(cmd => $cmd, apply_graceful_timeout => 1);
+    record_info("PING", printf('$ %s\n%s', $cmd, $ret));
+
+    $cmd = "curl -w '$write_out' -o /dev/null -v https://$rmt_host/";
+    $ret = $instance->ssh_script_run(cmd => $cmd, apply_graceful_timeout => 1);
+    record_info("CURL", printf('$ %s\n%s', $cmd, $ret));
+}
+
+sub run {
+    my ($self, $args) = @_;
+
+    select_host_console();    # select console on the host, not the PC instance
+
+    network_speed_test($args->{my_instance});
+}
+
+sub test_flags {
+    return {fatal => 0};
+}
+
+1;

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -47,7 +47,6 @@ sub run {
     $instance->check_system_boottime();
     $instance->wait_for_guestregister() if (is_ondemand);
 
-    $instance->network_speed_test();
     $instance->check_cloudinit() if (is_cloudinit_supported && !get_var('PUBLIC_CLOUD_SKIP_INSTANCE_CHECKS'));
     $instance->enable_kdump() if (get_var('PUBLIC_CLOUD_ENABLE_KDUMP'));
 

--- a/tests/sles4sap/publiccloud/mr_test_setup_env.pm
+++ b/tests/sles4sap/publiccloud/mr_test_setup_env.pm
@@ -51,7 +51,6 @@ sub run {
 
     # Clear $instance->ssh_opts which omit the known hosts file and strict host checking by default
     $instance->ssh_opts('');
-    $instance->network_speed_test();
 
     # Set ssh-tunnel
     $testapi::username = 'bernhard';


### PR DESCRIPTION
Moves the `network_speed_test` body out of `publiccloud::instance` and into `tests/publiccloud/network_test.pm`. Scheduled right after `prepare_instance` / `mr_test_setup_env`.

* Previous PR: #26167
* Related ticket: [poo#203838](https://progress.opensuse.org/issues/203838)
* Verification runs: In comment below

