### PR TITLE
Extract check_cloudinit into check_cloudinit.pm

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -350,11 +350,13 @@ sub load_slem_on_pc_tests {
         loadtest("boot/boot_to_desktop");
         loadtest("publiccloud/prepare_instance", run_args => $args);
         loadtest("publiccloud/network_test", run_args => $args);
+        loadtest("publiccloud/check_cloudinit", run_args => $args);
         loadtest("publiccloud/registration", run_args => $args) unless (get_var('PUBLIC_CLOUD_IGNORE_UNREGISTERED'));
         # 2 next modules of pubcloud needed for sle-micro incidents/repos verification
         if (get_var('PUBLIC_CLOUD_QAM', 0)) {
             loadtest("publiccloud/transfer_repos", run_args => $args) unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
             loadtest("publiccloud/patch_and_reboot", run_args => $args);
+            loadtest("publiccloud/check_cloudinit", run_args => $args);
         }
         if (get_var('PUBLIC_CLOUD_LTP', 0)) {
             loadtest 'publiccloud/run_ltp', run_args => $args;

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -25,6 +25,7 @@ sub load_maintenance_publiccloud_tests {
     loadtest "publiccloud/download_repos" unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
     loadtest "publiccloud/prepare_instance", run_args => $args;
     loadtest "publiccloud/network_test", run_args => $args;
+    loadtest "publiccloud/check_cloudinit", run_args => $args;
     if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
         loadtest("publiccloud/registercloudguest", run_args => $args);
     } else {
@@ -32,6 +33,7 @@ sub load_maintenance_publiccloud_tests {
     }
     loadtest "publiccloud/transfer_repos", run_args => $args unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
     loadtest "publiccloud/patch_and_reboot", run_args => $args;
+    loadtest "publiccloud/check_cloudinit", run_args => $args;
     if (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
         loadtest "publiccloud/check_services", run_args => $args;
         loadtest("publiccloud/img_proof", run_args => $args);
@@ -125,6 +127,7 @@ sub load_latest_publiccloud_tests {
     if (get_var('PUBLIC_CLOUD_LTP')) {
         loadtest "publiccloud/prepare_instance", run_args => $args;
         loadtest "publiccloud/network_test", run_args => $args;
+        loadtest "publiccloud/check_cloudinit", run_args => $args;
         loadtest("publiccloud/registration", run_args => $args);
         loadtest 'publiccloud/run_ltp', run_args => $args;
     }
@@ -137,6 +140,7 @@ sub load_latest_publiccloud_tests {
     } else {    # All test cases below require prepare_instance
         loadtest "publiccloud/prepare_instance", run_args => $args;
         loadtest "publiccloud/network_test", run_args => $args;
+        loadtest "publiccloud/check_cloudinit", run_args => $args;
         if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
             loadtest "publiccloud/registercloudguest", run_args => $args;
         }
@@ -225,6 +229,7 @@ sub load_publiccloud_appimg_tests {
     my $publiccloud_app_img = get_var('PUBLIC_CLOUD_APP_IMG');
     loadtest "publiccloud/prepare_instance", run_args => $args;
     loadtest "publiccloud/network_test", run_args => $args;
+    loadtest "publiccloud/check_cloudinit", run_args => $args;
     loadtest("publiccloud/registration", run_args => $args);
     loadtest "publiccloud/instance_overview", run_args => $args;
 

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -641,49 +641,6 @@ sub cleanup_cloudinit() {
     }
 }
 
-sub check_cloudinit() {
-    my ($self) = @_;
-
-    # cloud-init status
-    my $rc = $self->ssh_script_run(cmd => "sudo cloud-init status --wait", timeout => 300);
-    record_info("cloud-init", $self->ssh_script_output("sudo cloud-init status --long", proceed_on_failure => 1, timeout => 300), result => $rc == 0 ? 'ok' : 'fail');
-    # Cloud-init error codes: 0 - success, 1 - unrecoverable error, 2 - recoverable error (See cloud-init documentation)
-    # As of https://bugzilla.suse.com/show_bug.cgi?id=1266207 we ignore recoverable errors
-    if (get_var('PUBLIC_CLOUD_IGNORE_CLOUDINIT_ERRORS') != 1) {
-        if ($rc == 1) {
-            die "unrecoverable cloud-init error";
-        } elsif ($rc == 2) {
-            record_info("cloud-init", "recoverable error (return code 2)");
-        } elsif ($rc != 0) {
-            die "unknown cloud-init return code $rc";
-        }
-    }
-
-    # cloud-id
-    my $cloud_id = (is_azure) ? 'azure' : 'aws';
-    $self->ssh_assert_script_run(cmd => "sudo cloud-id | grep '^$cloud_id\$'");
-
-    # cloud-init collect-logs
-    $self->ssh_assert_script_run('sudo cloud-init collect-logs');
-    $self->upload_log('~/cloud-init.tar.gz', failok => 1);
-
-    if (get_var('PUBLIC_CLOUD_CLOUD_INIT')) {
-        # Check for bootcmd, runcmd and write_files module
-        $self->ssh_assert_script_run('sudo grep pookie /root/test_cloud-init.txt');
-        $self->ssh_assert_script_run('sudo grep Mithrandir /root/test_cloud-init.txt');
-        $self->ssh_assert_script_run('sudo grep snickerdoodle /root/test_cloud-init.txt');
-
-        # Check for packages module
-        $self->ssh_assert_script_run('ed -V');
-
-        # Check for final_message module
-        $self->ssh_assert_script_run('sudo journalctl -b | grep "cloud-init qa has finished"');
-
-        # cloud-init schema
-        $self->ssh_assert_script_run('sudo cloud-init schema --system') unless (is_sle('=12-SP5'));
-    }
-}
-
 sub enable_kdump() {
     my ($self) = @_;
 

--- a/tests/publiccloud/check_cloudinit.pm
+++ b/tests/publiccloud/check_cloudinit.pm
@@ -1,0 +1,71 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Check cloud-init status on the public cloud instance
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use publiccloud::utils qw(is_cloudinit_supported is_azure);
+use publiccloud::ssh_interactive qw(select_host_console);
+use version_utils qw(is_sle);
+
+sub check_cloudinit {
+    my ($instance) = @_;
+
+    # cloud-init status
+    my $rc = $instance->ssh_script_run(cmd => "sudo cloud-init status --wait", timeout => 300);
+    record_info("cloud-init", $instance->ssh_script_output("sudo cloud-init status --long", proceed_on_failure => 1, timeout => 300), result => $rc == 0 ? 'ok' : 'fail');
+    # Cloud-init error codes: 0 - success, 1 - unrecoverable error, 2 - recoverable error (See cloud-init documentation)
+    # As of https://bugzilla.suse.com/show_bug.cgi?id=1266207 we ignore recoverable errors
+    if (get_var('PUBLIC_CLOUD_IGNORE_CLOUDINIT_ERRORS') != 1) {
+        if ($rc == 1) {
+            die "unrecoverable cloud-init error";
+        } elsif ($rc == 2) {
+            record_info("cloud-init", "recoverable error (return code 2)");
+        } elsif ($rc != 0) {
+            die "unknown cloud-init return code $rc";
+        }
+    }
+
+    # cloud-id
+    my $cloud_id = (is_azure) ? 'azure' : 'aws';
+    $instance->ssh_assert_script_run(cmd => "sudo cloud-id | grep '^$cloud_id\$'");
+
+    # cloud-init collect-logs
+    $instance->ssh_assert_script_run('sudo cloud-init collect-logs');
+    $instance->upload_log('~/cloud-init.tar.gz', failok => 1);
+
+    if (get_var('PUBLIC_CLOUD_CLOUD_INIT')) {
+        # Check for bootcmd, runcmd and write_files module
+        $instance->ssh_assert_script_run('sudo grep pookie /root/test_cloud-init.txt');
+        $instance->ssh_assert_script_run('sudo grep Mithrandir /root/test_cloud-init.txt');
+        $instance->ssh_assert_script_run('sudo grep snickerdoodle /root/test_cloud-init.txt');
+
+        # Check for packages module
+        $instance->ssh_assert_script_run('ed -V');
+
+        # Check for final_message module
+        $instance->ssh_assert_script_run('sudo journalctl -b | grep "cloud-init qa has finished"');
+
+        # cloud-init schema
+        $instance->ssh_assert_script_run('sudo cloud-init schema --system') unless (is_sle('=12-SP5'));
+    }
+}
+
+sub run {
+    my ($self, $args) = @_;
+
+    select_host_console();    # select console on the host, not the PC instance
+
+    return unless (is_cloudinit_supported);
+    check_cloudinit($args->{my_instance});
+}
+
+sub test_flags {
+    return {fatal => 0};
+}
+
+1;

--- a/tests/publiccloud/check_cloudinit.pm
+++ b/tests/publiccloud/check_cloudinit.pm
@@ -20,14 +20,12 @@ sub check_cloudinit {
     record_info("cloud-init", $instance->ssh_script_output("sudo cloud-init status --long", proceed_on_failure => 1, timeout => 300), result => $rc == 0 ? 'ok' : 'fail');
     # Cloud-init error codes: 0 - success, 1 - unrecoverable error, 2 - recoverable error (See cloud-init documentation)
     # As of https://bugzilla.suse.com/show_bug.cgi?id=1266207 we ignore recoverable errors
-    if (get_var('PUBLIC_CLOUD_IGNORE_CLOUDINIT_ERRORS') != 1) {
-        if ($rc == 1) {
-            die "unrecoverable cloud-init error";
-        } elsif ($rc == 2) {
-            record_info("cloud-init", "recoverable error (return code 2)");
-        } elsif ($rc != 0) {
-            die "unknown cloud-init return code $rc";
-        }
+    if ($rc == 1) {
+        die "unrecoverable cloud-init error";
+    } elsif ($rc == 2) {
+        record_info("cloud-init", "recoverable error (return code 2)");
+    } elsif ($rc != 0) {
+        die "unknown cloud-init return code $rc";
     }
 
     # cloud-id

--- a/tests/publiccloud/patch_and_reboot.pm
+++ b/tests/publiccloud/patch_and_reboot.pm
@@ -58,7 +58,6 @@ sub run {
     if (is_cloudinit_supported) {
         $args->{my_instance}->cleanup_cloudinit();
         $args->{my_instance}->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600), scan_ssh_host_key => 1);
-        $args->{my_instance}->check_cloudinit();
         permit_root_login($args->{my_instance});
     } else {
         $args->{my_instance}->softreboot(timeout => get_var('PUBLIC_CLOUD_REBOOT_TIMEOUT', 600));

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -47,7 +47,6 @@ sub run {
     $instance->check_system_boottime();
     $instance->wait_for_guestregister() if (is_ondemand);
 
-    $instance->check_cloudinit() if (is_cloudinit_supported && !get_var('PUBLIC_CLOUD_SKIP_INSTANCE_CHECKS'));
     $instance->enable_kdump() if (get_var('PUBLIC_CLOUD_ENABLE_KDUMP'));
 
     $provider->initialize_logging($instance);

--- a/variables.md
+++ b/variables.md
@@ -394,7 +394,6 @@ PUBLIC_CLOUD_RESOURCE_GROUP | string | "qesaposd" | Allows to specify resource g
 PUBLIC_CLOUD_RESOURCE_NAME | string | "openqa-vm" | The name we use when creating our VM.
 PUBLIC_CLOUD_ROOT_DISK_SIZE | int |  | Set size of system disk in GiB for public cloud instance. Default size is 30 for Azure and 20 for GCE and EC2 
 PUBLIC_CLOUD_SCC_ENDPOINT | string | "registercloudguest" | Name of binary which will be used to register image . Except default value only possible value is "SUSEConnect" anything else will lead to test failure!
-PUBLIC_CLOUD_SKIP_INSTANCE_CHECKS | boolean | false | DO NOT ADD TO JOB GROUPS: Skip the instance checks running right after instance is created. Those includes failed service check and the cloud init check.
 PUBLIC_CLOUD_SKIP_MU | boolean | false | Run tests without downloading/applying maintenance updates.
 PUBLIC_CLOUD_SLES4SAP | boolean | false | If set, sles4sap test module is added to the job.
 PUBLIC_CLOUD_SSH_TIMEOUT | int | 300 | Sets the timeout for ssh wait operations.

--- a/variables.md
+++ b/variables.md
@@ -357,7 +357,6 @@ PUBLIC_CLOUD_HDD2_TYPE | string | "" | If PUBLIC_CLOUD_ADDITIONAL_DISK_SIZE is s
 PUBLIC_CLOUD_IGNORE_EMPTY_REPO | boolean | false | Ignore empty maintenance update repos
 PUBLIC_CLOUD_IGNORE_UNREGISTERED | boolean | false | Ignore any failure related to the fact that system is unregistered.
 PUBLIC_CLOUD_IGNORE_EMPTY_UPDATES | boolean | false | Ignore no rpm list changes in patch_and_reboot
-PUBLIC_CLOUD_IGNORE_CLOUDINIT_ERRORS | boolean | false | Do not fail on cloud-init errors
 PUBLIC_CLOUD_IMAGE_ID | string | "" | The image ID we start the instance from
 PUBLIC_CLOUD_IMAGE_LOCATION | string | "" | The URL where the image gets downloaded from. The name of the image gets extracted from this URL.
 PUBLIC_CLOUD_IMAGE_PROJECT | string | "" | Google Compute Engine image project


### PR DESCRIPTION
Moves `check_cloudinit()` out of `publiccloud::instance` and into `tests/publiccloud/check_cloudinit.pm`. Scheduled right after `prepare_instance` and after `patch_and_reboot` (replacing its inline `check_cloudinit` call).

Also drops `PUBLIC_CLOUD_IGNORE_CLOUDINIT_ERRORS`: it was added for bsc#1268067, that bug is resolved, and no job has set it since, so unrecoverable/unknown cloud-init errors always fail the check again.

* Previous PR: #26167
* Related ticket: [poo#203838](https://progress.opensuse.org/issues/203838)
* Verification runs: In comment below

## Commits

- 6982fc9848 feat(publiccloud): Extract check_cloudinit into check_cloudinit.pm
- 39ffc8b776 fix(publiccloud): Remove PUBLIC_CLOUD_IGNORE_CLOUDINIT_ERRORS

The `fix` commit is a behavior change layered on top of the pure extraction and warrants its own look.
