### PR TITLE
Extract enable_kdump into kdump.pm

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -351,6 +351,7 @@ sub load_slem_on_pc_tests {
         loadtest("publiccloud/prepare_instance", run_args => $args);
         loadtest("publiccloud/auto_registration", run_args => $args);
         loadtest("publiccloud/network_test", run_args => $args);
+        loadtest("publiccloud/kdump", run_args => $args);
         loadtest("publiccloud/check_boottime", run_args => $args);
         loadtest("publiccloud/check_cloudinit", run_args => $args);
         loadtest("publiccloud/registration", run_args => $args) unless (get_var('PUBLIC_CLOUD_IGNORE_UNREGISTERED'));

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -26,6 +26,7 @@ sub load_maintenance_publiccloud_tests {
     loadtest "publiccloud/prepare_instance", run_args => $args;
     loadtest "publiccloud/auto_registration", run_args => $args;
     loadtest "publiccloud/network_test", run_args => $args;
+    loadtest "publiccloud/kdump", run_args => $args;
     loadtest "publiccloud/check_boottime", run_args => $args;
     loadtest "publiccloud/check_cloudinit", run_args => $args;
     if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
@@ -130,6 +131,7 @@ sub load_latest_publiccloud_tests {
         loadtest "publiccloud/prepare_instance", run_args => $args;
         loadtest "publiccloud/auto_registration", run_args => $args;
         loadtest "publiccloud/network_test", run_args => $args;
+        loadtest "publiccloud/kdump", run_args => $args;
         loadtest "publiccloud/check_boottime", run_args => $args;
         loadtest "publiccloud/check_cloudinit", run_args => $args;
         loadtest("publiccloud/registration", run_args => $args);
@@ -145,6 +147,7 @@ sub load_latest_publiccloud_tests {
         loadtest "publiccloud/prepare_instance", run_args => $args;
         loadtest "publiccloud/auto_registration", run_args => $args;
         loadtest "publiccloud/network_test", run_args => $args;
+        loadtest "publiccloud/kdump", run_args => $args;
         loadtest "publiccloud/check_boottime", run_args => $args;
         loadtest "publiccloud/check_cloudinit", run_args => $args;
         if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
@@ -236,6 +239,7 @@ sub load_publiccloud_appimg_tests {
     loadtest "publiccloud/prepare_instance", run_args => $args;
     loadtest "publiccloud/auto_registration", run_args => $args;
     loadtest "publiccloud/network_test", run_args => $args;
+    loadtest "publiccloud/kdump", run_args => $args;
     loadtest "publiccloud/check_boottime", run_args => $args;
     loadtest "publiccloud/check_cloudinit", run_args => $args;
     loadtest("publiccloud/registration", run_args => $args);

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -638,22 +638,6 @@ sub cleanup_cloudinit() {
     }
 }
 
-sub enable_kdump() {
-    my ($self) = @_;
-
-    $self->ssh_assert_script_run(q(sudo sed -i "/^GRUB_CMDLINE_LINUX_DEFAULT/ s/\\\\\\"$/ crashkernel=256M,high crashkernel=128M,low \\\\\\"/" /etc/default/grub));
-    $self->ssh_assert_script_run('sudo grub2-mkconfig -o /boot/grub2/grub.cfg');
-
-    if ($self->ssh_script_run('sudo grep -q "^KDUMP_CRASHKERNEL=" /etc/sysconfig/kdump') == 0) {
-        $self->ssh_assert_script_run(q(sudo sed -i "/^KDUMP_CRASHKERNEL/ s/\\\\\\"$/ crashkernel=256M,high crashkernel=128M,low \\\\\\"/" /etc/sysconfig/kdump));
-    } else {
-        $self->ssh_assert_script_run(q(echo "KDUMP_CRASHKERNEL=\"crashkernel=256M,high crashkernel=128M,low\"" | sudo tee -a /etc/sysconfig/kdump));
-    }
-
-    $self->ssh_assert_script_run('sudo systemctl enable kdump.service');
-    $self->softreboot();
-}
-
 sub upload_supportconfig_log {
     my ($self, %args) = @_;
     my $timeout = 600 + (is_sle('=12-SP5') ? 1400 : 0);

--- a/tests/publiccloud/kdump.pm
+++ b/tests/publiccloud/kdump.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Enable kdump on the public cloud instance
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use publiccloud::ssh_interactive qw(select_host_console);
+
+sub enable_kdump {
+    my ($instance) = @_;
+
+    $instance->ssh_assert_script_run(q(sudo sed -i "/^GRUB_CMDLINE_LINUX_DEFAULT/ s/\\\\\\"$/ crashkernel=256M,high crashkernel=128M,low \\\\\\"/" /etc/default/grub));
+    $instance->ssh_assert_script_run('sudo grub2-mkconfig -o /boot/grub2/grub.cfg');
+
+    if ($instance->ssh_script_run('sudo grep -q "^KDUMP_CRASHKERNEL=" /etc/sysconfig/kdump') == 0) {
+        $instance->ssh_assert_script_run(q(sudo sed -i "/^KDUMP_CRASHKERNEL/ s/\\\\\\"$/ crashkernel=256M,high crashkernel=128M,low \\\\\\"/" /etc/sysconfig/kdump));
+    } else {
+        $instance->ssh_assert_script_run(q(echo "KDUMP_CRASHKERNEL=\"crashkernel=256M,high crashkernel=128M,low\"" | sudo tee -a /etc/sysconfig/kdump));
+    }
+
+    $instance->ssh_assert_script_run('sudo systemctl enable kdump.service');
+    $instance->softreboot();
+}
+
+sub run {
+    my ($self, $args) = @_;
+
+    return unless (get_var('PUBLIC_CLOUD_ENABLE_KDUMP'));
+    select_host_console();    # select console on the host, not the PC instance
+    enable_kdump($args->{my_instance});
+}
+
+sub test_flags {
+    return {fatal => 0};
+}
+
+1;

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -45,8 +45,6 @@ sub run {
     # check needed when not-executed in create_instance
     $instance->wait_for_ssh(scan_ssh_host_key => 1) if ($instance_args{check_connectivity} == 0);
 
-    $instance->enable_kdump() if (get_var('PUBLIC_CLOUD_ENABLE_KDUMP'));
-
     $provider->initialize_logging($instance);
     # Add additional authorized_keys for human users
     add_additional_authorized_keys($instance);


### PR DESCRIPTION
Moves `enable_kdump()` out of `publiccloud::instance` and into `tests/publiccloud/kdump.pm`. Scheduled right after `network_test`.

* Previous PR: #26167
* Related ticket: [poo#203838](https://progress.opensuse.org/issues/203838)
* Verification runs: In comment below


