### PR TITLE
Extract guest registration wait into auto_registration.pm

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -349,6 +349,7 @@ sub load_slem_on_pc_tests {
         # SLEM basic test
         loadtest("boot/boot_to_desktop");
         loadtest("publiccloud/prepare_instance", run_args => $args);
+        loadtest("publiccloud/auto_registration", run_args => $args);
         loadtest("publiccloud/network_test", run_args => $args);
         loadtest("publiccloud/check_boottime", run_args => $args);
         loadtest("publiccloud/check_cloudinit", run_args => $args);

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -24,6 +24,7 @@ sub load_maintenance_publiccloud_tests {
 
     loadtest "publiccloud/download_repos" unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
     loadtest "publiccloud/prepare_instance", run_args => $args;
+    loadtest "publiccloud/auto_registration", run_args => $args;
     loadtest "publiccloud/network_test", run_args => $args;
     loadtest "publiccloud/check_boottime", run_args => $args;
     loadtest "publiccloud/check_cloudinit", run_args => $args;
@@ -127,6 +128,7 @@ sub load_latest_publiccloud_tests {
 
     if (get_var('PUBLIC_CLOUD_LTP')) {
         loadtest "publiccloud/prepare_instance", run_args => $args;
+        loadtest "publiccloud/auto_registration", run_args => $args;
         loadtest "publiccloud/network_test", run_args => $args;
         loadtest "publiccloud/check_boottime", run_args => $args;
         loadtest "publiccloud/check_cloudinit", run_args => $args;
@@ -141,6 +143,7 @@ sub load_latest_publiccloud_tests {
         return;    # Do not continue as there is no instance to destroy
     } else {    # All test cases below require prepare_instance
         loadtest "publiccloud/prepare_instance", run_args => $args;
+        loadtest "publiccloud/auto_registration", run_args => $args;
         loadtest "publiccloud/network_test", run_args => $args;
         loadtest "publiccloud/check_boottime", run_args => $args;
         loadtest "publiccloud/check_cloudinit", run_args => $args;
@@ -231,6 +234,7 @@ sub load_publiccloud_appimg_tests {
     my $args = OpenQA::Test::RunArgs->new();
     my $publiccloud_app_img = get_var('PUBLIC_CLOUD_APP_IMG');
     loadtest "publiccloud/prepare_instance", run_args => $args;
+    loadtest "publiccloud/auto_registration", run_args => $args;
     loadtest "publiccloud/network_test", run_args => $args;
     loadtest "publiccloud/check_boottime", run_args => $args;
     loadtest "publiccloud/check_cloudinit", run_args => $args;

--- a/tests/publiccloud/auto_registration.pm
+++ b/tests/publiccloud/auto_registration.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Wait for the on-demand instance's guest registration (cloud-regionsrv-client) to complete
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use publiccloud::utils qw(is_ondemand);
+use publiccloud::ssh_interactive qw(select_host_console);
+
+sub run {
+    my ($self, $args) = @_;
+    return unless (is_ondemand);
+
+    select_host_console();
+
+    $args->{my_instance}->wait_for_guestregister();
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -44,7 +44,6 @@ sub run {
     my $instance = $args->{my_instance};
     # check needed when not-executed in create_instance
     $instance->wait_for_ssh(scan_ssh_host_key => 1) if ($instance_args{check_connectivity} == 0);
-    $instance->wait_for_guestregister() if (is_ondemand);
 
     $instance->enable_kdump() if (get_var('PUBLIC_CLOUD_ENABLE_KDUMP'));
 


### PR DESCRIPTION
Moves the `wait_for_guestregister()` call out of `prepare_instance` and into `tests/publiccloud/auto_registration.pm`. Scheduled right after `prepare_instance`.

A follow-up, [poo#204606](https://progress.opensuse.org/issues/204606), tracks folding this wait into `registration.pm`/`registercloudguest.pm` so this module can be removed too.

* Previous PR: #26167
* Related ticket: [poo#203838](https://progress.opensuse.org/issues/203838), [poo#204606](https://progress.opensuse.org/issues/204606)
* Verification runs: In comment below
