### PR TITLE
Stop implicitly waiting for SSH in create_instances

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -361,24 +361,19 @@ publiccloud::instance objects.
 C<image>         defines the image_id to create the instance.
 C<instance_type> defines the flavor of the instance. If not specified, it will load it
                      from PUBLIC_CLOUD_INSTANCE_TYPE.
-C<timeout>             Parameter to pass to instance::wait_for_ssh.
-C<proceed_on_failure>  Same as timeout.
+
+Note: this does not wait for SSH to become available on the created instances,
+callers are expected to call C<< $instance->wait_for_ssh() >> themselves.
 
 =cut
 
 sub create_instances {
     my ($self, %args) = @_;
-    $args{check_connectivity} //= 1;
     my @vms = $self->terraform_apply(%args);
 
     foreach my $instance (@vms) {
         record_info("INSTANCE", $instance->{instance_id});
         $self->show_instance_details();
-        if ($args{check_connectivity}) {
-            # An error in VM-up causes test to stop
-            $instance->wait_for_ssh(timeout => $args{timeout},
-                proceed_on_failure => $args{proceed_on_failure}, scan_ssh_host_key => 1);
-        }
     }
     return @vms;
 }

--- a/tests/publiccloud/az_accelerated_net.pm
+++ b/tests/publiccloud/az_accelerated_net.pm
@@ -24,9 +24,10 @@ sub prepare_vms {
     my ($self, $provider) = @_;
     my $repo = get_required_var('IPERF_REPO');
     record_info('INFO', "Create VM\nInstalling iperf package from $repo");
-    my @instances = $provider->create_instances(check_guestregister => 0, count => 2);
+    my @instances = $provider->create_instances(count => 2);
     foreach my $instance (@instances) {
         record_info('Instance', 'Instance ' . $instance->instance_id . ' created');
+        $instance->wait_for_ssh(scan_ssh_host_key => 1);
         record_info('Iperf', 'Install IPerf binaries in VM');
         pc_zypper_call($instance, "ar --no-gpgcheck $repo net_perf");
         pc_pkg_call($instance, "in -r net_perf iperf");

--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -12,7 +12,7 @@ use Mojo::Base 'publiccloud::basetest';
 use testapi;
 use Path::Tiny;
 use Mojo::JSON;
-use publiccloud::utils qw(is_ondemand is_hardened);
+use publiccloud::utils qw(is_hardened);
 use publiccloud::ssh_interactive 'select_host_console';
 use File::Basename 'basename';
 use version_utils "is_sle";
@@ -86,11 +86,6 @@ sub run {
 
     select_host_console();
 
-    unless ($args->{my_provider} && $args->{my_instance}) {
-        $args->{my_provider} = $self->provider_factory();
-        $args->{my_instance} = $args->{my_provider}->create_instance();
-        $args->{my_instance}->wait_for_guestregister() if (is_ondemand);
-    }
     $instance = $args->{my_instance};
     $provider = $args->{my_provider};
 

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -35,15 +35,13 @@ sub run {
 
     # Create public cloud instance
     my %instance_args;
-    $instance_args{check_connectivity} = 0;    # Don't run wait_for_ssh() inside create_instance()
     $instance_args{use_extra_disk} = {size => $additional_disk_size, type => $additional_disk_type} if ($additional_disk_size > 0);
 
     $args->{my_provider} = $self->provider_factory();
     $args->{my_instance} = $args->{my_provider}->create_instance(%instance_args);
     my $provider = $self->{my_provider} = $args->{my_provider};
     my $instance = $args->{my_instance};
-    # check needed when not-executed in create_instance
-    $instance->wait_for_ssh(scan_ssh_host_key => 1) if ($instance_args{check_connectivity} == 0);
+    $instance->wait_for_ssh(scan_ssh_host_key => 1);
 
     $instance->enable_kdump() if (get_var('PUBLIC_CLOUD_ENABLE_KDUMP'));
 


### PR DESCRIPTION
`provider::create_instances()` no longer implicitly waits for SSH (`check_connectivity` dropped entirely); callers now call `wait_for_ssh()` explicitly. `img_proof.pm`'s dead fallback instance-creation branch is removed since every scheduling path already runs `prepare_instance` first with a shared `$args`. `az_accelerated_net.pm` gains an explicit `wait_for_ssh()` call it was implicitly relying on before.

* Previous PR: #26167
* Related ticket: [poo#203838](https://progress.opensuse.org/issues/203838)
* Verification runs: In comment below
