### PR TITLE
data/journal_check: Ignore pam_wtmpdb session logout row count mismatch

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -2107,5 +2107,18 @@
             ]
         },
         "type": "bug"
+    },
+    "bsc#1272527": {
+        "description": "pam_wtmpdb\\(login:session\\): Update of logout time changed wrong number of rows, expected \\d+, got \\d+",
+        "products": {
+            "opensuse": [
+                "Tumbleweed"
+            ],
+            "microos": [
+                "Tumbleweed"
+            ]
+        },
+        "type": "bug"
     }
 }
+


### PR DESCRIPTION
Failure: https://openqa.opensuse.org/tests/6122772#step/journal_check/23

Sporadically, when new users log in for the first time, a race
condition can occur in pam_wtmpdb. This results in the following
harmless warning in the system journal:

  pam_wtmpdb(login:session): Update of logout time changed wrong number of rows, expected 1, got 0

openqa: clone https://openqa.opensuse.org/tests/6122772
