### PR TITLE
Wrap tofu steps in bash -c so timeout and pipefail work

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -461,7 +461,9 @@ to a failure.
 sub _tofu_run_step {
     my ($self, %args) = @_;
     my $output_file = "tf_$args{step}_output";
-    my $ret = script_retry("set -o pipefail; TF_LOG=" . TERRAFORM_LOG . " $args{cmd} 2>&1 | tee $output_file", timeout => $args{timeout}, delay => $args{delay}, retry => $args{retry}, die => 0);
+    my $inner = "set -o pipefail; TF_LOG=" . TERRAFORM_LOG . " $args{cmd} 2>&1 | tee $output_file";
+    $inner =~ s/'/'\\''/g;
+    my $ret = script_retry("bash -c '$inner'", timeout => $args{timeout}, delay => $args{delay}, retry => $args{retry}, die => 0);
     my $output = script_output("cat $output_file", proceed_on_failure => 1);
     record_info("TFM $args{step} output", "exit code: $ret", result => ($ret) ? 'fail' : 'ok');
     return ($ret, $output);

--- a/t/45_publiccloud_provider.t
+++ b/t/45_publiccloud_provider.t
@@ -154,6 +154,8 @@ subtest '[terraform_apply] vars' => sub {
     # Extract the single recorded call that runs 'tofu ... plan ...'
     my ($plan_cmd) = grep { /tofu.*plan/ } @calls;
     ok($plan_cmd, "tofu plan is executed");
+    # Undo _tofu_run_step()'s bash -c wrapper and '\'' escaping (see _mock_terraform_apply).
+    $plan_cmd =~ s/^bash -c '(.*)'$/$1/s and $plan_cmd =~ s/'\\''/'/g;
 
     # Split the command into its individual -var arguments. Values may contain
     # the shell single-quote escape sequence '"'"', so we split on the ' -var '
@@ -325,6 +327,9 @@ sub _mock_terraform_apply {
     # succeed (exit 0) unless a subtest explicitly scripts them.
     $mock->redefine($_ => sub {
             my ($cmd) = @_;
+            # _tofu_run_step() wraps steps as bash -c 'set -o pipefail; ... <cmd> | tee ...',
+            # escaping single quotes as '\''. Undo both so the assertions below see the plain command.
+            $cmd =~ s/^bash -c '(.*)'$/$1/s and $cmd =~ s/'\\''/'/g;
             push @{$args{calls}}, $cmd;
             my $r = $next_response->($cmd);
             return (defined $r ? ($r->{exit} // 0) : 0);


### PR DESCRIPTION
script_retry() unconditionally prepends `timeout` to the command string. Since https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26120 routed init/plan/apply through _tofu_run_step() via script_retry(), the resulting line became:

```
  timeout -k 5 1800 set -o pipefail; TF_LOG= tofu apply ... | tee tf_apply_output
```

This broke in two ways:
- 'timeout' execs a real binary, but 'set' is a shell builtin, so it died with "timeout: failed to run command 'set': No such file or directory".
- The ';' split the line into two statements, so the tofu pipeline ran outside timeout with pipefail never set. The compound exit code was then tee's (0), masking real tofu failures. A failed `tofu apply` reported exit code 0.

Wrap the whole pipeline in `"bash -c '...'"` so timeout execs bash and pipefail is honoured.


- Related ticket: https://progress.opensuse.org/issues/204060

# Verifications

 - sle-15-SP6-GCE-BYOS-Incidents-Ext-x86_64-Buildpdostal_os-autoinst-distri-opensuse_26176-publiccloud_smoketests gce_c3-highcpu-22 -> http://openqa.suse.de/tests/23610783
