### PR TITLE
Sync on encrypted image before reboot

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -184,6 +184,9 @@ sub check_reboot_changes {
     die "Error during diff" if $change_happened > 1;
     die "Change expected: $change_expected, happened: $change_happened" if $change_expected != $change_happened;
 
+    # https://progress.opensuse.org/issues/204552
+    assert_script_run 'time sync' if check_var('ENCRYPTED_IMAGE', 1);
+
     # Reboot into new snapshot
     process_reboot(trigger => 1) if $change_happened;
 }


### PR DESCRIPTION
After test Regenerate grub.cfg, sometimes mount does fail and return 32
It does happen only on encrypted image

systemd-remount-fs[709]: /usr/bin/mount for / exited with exit status 32.
systemd[1]: Failed to start Remount Root and Kernel File Systems.

- Related ticket: https://progress.opensuse.org/issues/204552
- Verification run:
https://openqa.suse.de/tests/overview?distri=sle-micro&version=6.0&build=jpupava_encr