### PR TITLE
bats/runc: Fix the merged tags for some PRs

### DIFF
--- a/data/containers/patches.yaml
+++ b/data/containers/patches.yaml
@@ -210,10 +210,12 @@ runc:
   4842:
     merged: "1.4.3"
     min: "1.3.4"
+  # Also merged in v1.3.6
   5124:
-    merged: "1.3.6"
+    merged: "1.4.1"
+  # Also merged in v1.3.6
   5269:
-    merged: "1.3.6"
+    merged: "1.4.3"
   5295:
     merged: "1.4.3"
   5307:


### PR DESCRIPTION
Partially revert the [previous commit](https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/c9a7eb453488441c1e5609ea3f62a3500e02cd58) on the same file.  It fails on SLES 16.1.  Turns out Leap 16.0 & SLES 16.0 are not exactly in sync so I thought SLES 16.0 would have the same runc v1.3.6 as Leap 16.0.

Both PRs can be dropped when v1.3.6 & v1.4.3 arrive on SLES 15-SP4+ & SLES 16.1 respectively.

Verification runs: https://openqa.suse.de/tests/23623574

Note: VR failing due to https://bugzilla.suse.com/show_bug.cgi?id=1260949