### PR TITLE
fix(check_boottime): Make the test module not fatal

### DIFF
--- a/tests/publiccloud/check_boottime.pm
+++ b/tests/publiccloud/check_boottime.pm
@@ -168,7 +168,7 @@ sub run {
 }
 
 sub test_flags {
-    return {fatal => 1};
+    return {fatal => 0};
 }
 
 1;


### PR DESCRIPTION
Follow up to: #26174
