### PR TITLE
security/apparmor: use aa-notify -s 1 instead of -l in aa_notify

### DIFF
--- a/tests/security/apparmor/aa_notify.pm
+++ b/tests/security/apparmor/aa_notify.pm
@@ -6,17 +6,17 @@
 # - Restart auditd
 # - Create temporary apparmor profile on /tmp
 # - Add root to use_group on /etc/apparmor/notify.conf
-# - Run "aa-notify -l"
+# - Run "aa-notify -s 1"
 # - Make smbd fail intentionally, removing "/etc/smbd.conf" entry from
 # /tmp/apparmor.d/usr.sbin.smbd
 # - Run "aa-disable smbd"
 # - Put smbd back in enforce mode: "aa-enforce -d /tmp/apparmor.d smbd"
 # - Restart smbd
-# - Check the errors from "aa-notify -l -v"
+# - Check the errors from "aa-notify -s 1 -v"
 # - Disable temporary profile, put smbd back in enforce mode, restart smbd
 # - Cleanup temporary profiles
 # Maintainer: QE Security <none@suse.de>
-# Tags: poo#36883, tc#1621139
+# Tags: poo#36883, tc#1621139, poo#201084
 
 use Mojo::Base 'apparmortest';
 use testapi;
@@ -69,7 +69,14 @@ sub run {
 
     assert_script_run "echo > $audit_log";
 
-    validate_script_output "aa-notify -l", sub { m/^(AppArmor\sdenials:\s+0\s+\(since.*)?$/ };
+    # Use "-s 1" (since-days) instead of "-l" (last login) as "-l" depends on
+    # having a login recorded in lastlog2.db/wtmp, which is not guaranteed to
+    # exist on freshly installed images (poo#201084). Also match the expected
+    # line with "/m" instead of anchoring the whole output, as newer
+    # apparmor-notify versions can print additional informational lines
+    # (e.g. "ttkthemes not found. Install for best user experience.")
+    # before the actual denial summary.
+    validate_script_output "aa-notify -s 1", sub { m/^AppArmor\sdenials?:\s+0\s+\(since.*$/m };
 
     # Make it failed intentionally to get some audit messages
     assert_script_run "sed -i '/\\/etc\\/nscd.conf/d' $tmp_prof/usr.sbin.nscd" if is_sle('<=15-sp4');
@@ -85,14 +92,14 @@ sub run {
     systemctl("restart $test_service", expect_false => 1);
     upload_logs($audit_log);
 
-    validate_script_output "aa-notify -l -v", sub {
+    validate_script_output "aa-notify -s 1 -v", sub {
         m/
             Name:\s+\/etc\/nscd\.conf.*
             Denied:\s+r.*
             AppArmor\sdenials?:\s+[0-9]+\s+\(since/sxx
     } if is_sle('<=15-sp4');
 
-    validate_script_output "aa-notify -l -v", sub {
+    validate_script_output "aa-notify -s 1 -v", sub {
         m/
             Name:.*samba.*
             Denied:\s+ac.*


### PR DESCRIPTION
aa-notify's -l (--display-last) flag needs a login recorded in lastlog2.db/wtmp for the current user. On freshly installed openQA images logging in only via serial console this record does not necessarily exist, which can make aa-notify -l abort with "ERROR: Could not find last login".

Additionally, newer apparmor-notify (AppArmor 5.0) versions print an extra informational line ("ttkthemes not found. Install for best user experience.") before the actual denial summary, which broke the whole-output regex match used for the first aa-notify invocation.

Switch to "-s 1" (--since-days 1), which reports denials from the last day without depending on login history, and match the denial summary line with /m instead of anchoring the whole captured output, so leading informational lines no longer break the check.

- Related ticket: https://progress.opensuse.org/issues/201084
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/6124844#step/aa_notify/19

The test continues to fail due to an independent [aa_logprof](https://openqa.opensuse.org/tests/6124844#step/aa_logprof/26) issue.

Additional SLE VRs:
- 15sp7: https://openqa.suse.de/tests/23630548#step/aa_notify/19
- 15sp6: https://openqa.suse.de/tests/23630560#step/aa_notify/19
- 15sp5: https://openqa.suse.de/tests/23630561#step/aa_notify/19
- 15sp4: https://openqa.suse.de/tests/23630562#step/aa_notify/19