### PR TITLE
Do not install release-note on sle16.1, as it has been removed

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -71,7 +71,8 @@ sub run {
     assert_script_run('chmod -R u+rwX,og+rX /var/cache/zypp');
     zypper_call('in curl') if (script_run('rpm -qi curl') == 1);
     # force reinstall release notes, package must not come from expected SLE-Product repo e.g. GMC
-    zypper_call('in -f release-notes*');
+    # Refer jira feature: https://jira.suse.com/browse/PED-16485
+    zypper_call('in -f release-notes*') unless (is_sle('>=16.1'));
     zypper_call('in zypper-lifecycle-plugin') if (is_sle('>=16'));
 
     select_user_serial_terminal;


### PR DESCRIPTION
Do not install release-note on sle16.1, as it has been removed

- Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1272549 
- Verification run: https://openqa.suse.de/tests/overview?build=tinawang123%2Fos-autoinst-distri-opensuse%23release-note&distri=sle&version=16.1

