### PR TITLE
Add migration scenarios registering against RMT for major paths

### DIFF
--- a/data/yam/autoyast/textmode.xml.ep
+++ b/data/yam/autoyast/textmode.xml.ep
@@ -6,6 +6,10 @@
       <email/>
       <reg_code>{{SCC_REGCODE}}</reg_code>
       <reg_server>{{SCC_URL}}</reg_server>
+      % if ( ($get_var->('SCC_URL') // '') =~ /https.*rmt/i ) {
+      <reg_server_cert_fingerprint_type>SHA1</reg_server_cert_fingerprint_type>
+      <reg_server_cert_fingerprint>F6:7A:ED:BB:BC:94:CF:55:9D:B3:BA:74:7A:87:05:EF:67:4E:C2:DB</reg_server_cert_fingerprint>
+      % }
       <install_updates config:type="boolean">true</install_updates>
       <addons config:type="list">
         <addon>

--- a/tests/yam/migration/migration_unattended.pm
+++ b/tests/yam/migration/migration_unattended.pm
@@ -19,8 +19,8 @@ sub run {
 
     select_console('root-console');
 
-    # Add repo for devel:DMS when using proxy
-    if ((get_var('SCC_URL', "") =~ /proxy/)) {
+    # Add repo for devel:DMS when using proxy or rmt
+    if ((get_var('SCC_URL', "") =~ /proxy|rmt/)) {
         my $repo_server = "https://download.opensuse.org/repositories/devel:/DMS/";
         my $repo_url = $repo_server . "SLE_" . (get_var('VERSION_UPGRADE_FROM') =~ s/-/_/gr);
         zypper_call("ar --refresh -p 90 '$repo_url' Migration");
@@ -40,7 +40,7 @@ sub run {
     }
 
     # clean repos before migration
-    if ((get_var('SCC_URL', "") =~ /proxy/)) {
+    if ((get_var('SCC_URL', "") =~ /proxy|rmt/)) {
         zypper_call("rr Migration");
     }
     my $repo_num = script_output(q(zypper lr -u | awk -F '|' '/(cd|ftp):/ {printf $1}'));


### PR DESCRIPTION
Add migration scenarios registering against RMT for major migration paths: Adapt the unattended_migraiton for rmt scenarios, and update the autoyast profile to trust the ssl certification when registering against rmt url with https.

- Related ticket: https://progress.opensuse.org/issues/203655
- Verification runs: [15sp5_rmt](https://openqa.suse.de/tests/overview?test=sles_migration_15sp5_textmode_rmt_test&distri=sle&version=16.1&build=60.1&groupid=576) || [15sp6_rmt](https://openqa.suse.de/tests/overview?test=sles_migration_15sp6_textmode_rmt_test&distri=sle&version=16.1&build=60.1&groupid=576) || [15sp7_rmt](https://openqa.suse.de/tests/overview?test=sles_migration_15sp7_textmode_rmt_test&distri=sle&version=16.1&build=60.1&groupid=576) || [production_proxyscc](https://openqa.suse.de/tests/overview?build=chcao_poo203655&distri=sle&version=16.1) || [16.0_migration_mu](https://openqa.suse.de/tests/23630212#)
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/873