### PR TITLE
fix: avoid interactive sudo in cloud-init test

### DIFF
--- a/tests/jeos/verify_cloudinit.pm
+++ b/tests/jeos/verify_cloudinit.pm
@@ -101,11 +101,9 @@ sub run {
 
     select_console('user-console');
     assert_script_run('sudo sysctl -a');
-    enter_cmd('sudo -u tester_ssh -i');
-    assert_script_run('cat ~/.ssh/authorized_keys | grep rsa');
-    assert_script_run('cat ~/.ssh/authorized_keys | grep ecdsa');
-    assert_script_run('sudo sysctl -a');
-    enter_cmd('exit');
+    assert_script_run('sudo -u tester_ssh -i cat .ssh/authorized_keys | grep rsa');
+    assert_script_run('sudo -u tester_ssh -i cat .ssh/authorized_keys | grep ecdsa');
+    assert_script_run('sudo -u tester_ssh -i sudo sysctl -a');
 
     if (is_public_cloud) {
         select_host_console(force => 1);


### PR DESCRIPTION
Motivation:
The test failed when PRETTY_SERIAL_MARKER=1 because the interactive login shell
spawned via sudo did not have the outer shell's prompt command hook installed.

Design Choices:
Replaced the interactive sudo sub-shell commands with single-line non-interactive
sudo commands to allow prompt/marker tracking to remain on the outer shell.

Benefits:
Ensures reliable test execution with or without pretty serial markers and
avoids potential synchronization/timeout issues from manual interactive shells.

Verification:
```
BADGE=1 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26194 https://openqa.opensuse.org/tests/6126771
```

* [![opensuse-Tumbleweed-Armv9JeOS-for-OpenStack-Cloud-aarch64-Build20260724-jeos-cloud-init@aarch64_armv9](https://openqa.opensuse.org/tests/6128337/badge)](https://openqa.opensuse.org/tests/6128337) (passed verify_cloudinit)

Related issue: https://openqa.opensuse.org/tests/6126771#step/verify_cloudinit/15