### PR TITLE
Add GCP namespace override

### DIFF
--- a/lib/publiccloud/gcp_client.pm
+++ b/lib/publiccloud/gcp_client.pm
@@ -28,8 +28,11 @@ has availability_zone => sub { get_required_var('PUBLIC_CLOUD_AVAILABILITY_ZONE'
 has username => sub { get_var('PUBLIC_CLOUD_USER', 'susetest') };
 
 sub init {
-    my ($self) = @_;
-    my $data = get_credentials(url_suffix => 'gce.json', output_json => CREDENTIALS_FILE);
+    my ($self, %args) = @_;
+    # Namespace precedence:  1. *_GOOGLE_NAMESPACE, 2. *_NAMESPACE
+    my $namespace = get_var('PUBLIC_CLOUD_GOOGLE_NAMESPACE') // get_required_var('PUBLIC_CLOUD_NAMESPACE');
+
+    my $data = get_credentials(url_suffix => 'gce.json', namespace => $namespace, output_json => CREDENTIALS_FILE);
     $self->project_id($data->{project_id});
     $self->account($data->{client_id});
     assert_script_run('source ~/.bashrc');

--- a/variables.md
+++ b/variables.md
@@ -352,6 +352,7 @@ PUBLIC_CLOUD_GCE_STACK_TYPE | string | IPV4_ONLY | Network stack type, possible 
 PUBLIC_CLOUD_GCE_NIC_TYPE | string | "" | Network Interface Card type, possible values: GVNIC, VIRTIO_NET, IDPF, MRDMA or IRDMA 
 PUBLIC_CLOUD_GOOGLE_ACCOUNT | string | "" | GCE only, used to specify the account id.
 PUBLIC_CLOUD_GOOGLE_PROJECT_ID | string | "" | GCP only, used to specify the project id.
+PUBLIC_CLOUD_GOOGLE_NAMESPACE | string | "" | Special override for GCP only. Overrides the Public Cloud Namespace name that will be used to compose the full credentials URL together with `PUBLIC_CLOUD_CREDENTIALS_URL`.
 PUBLIC_CLOUD_HDD2_SIZE | integer | "" | If set, the instance will have an additional disk with the given capacity in GB
 PUBLIC_CLOUD_HDD2_TYPE | string | "" | If PUBLIC_CLOUD_ADDITIONAL_DISK_SIZE is set, this defines the additional disk type (optional). The required value depends on the cloud service provider.
 PUBLIC_CLOUD_IGNORE_EMPTY_REPO | boolean | false | Ignore empty maintenance update repos


### PR DESCRIPTION
For Google Cloud we can use a different account with different credentials. This MR adds a new variable `PUBLIC_CLOUD_GOOGLE_NAMESPACE` that allows us to override the account (namespace) used for Google when testing multiple modules / providers in the same test job.

- Verification runs: 
  - Only Google: https://openqa.suse.de/tests/24105650/logfile?filename=serial_terminal.txt#line-826
  - All 3 providers: https://openqa.suse.de/tests/24107921#
