### PR TITLE
publiccloud: Simplify tofu run step by removing bash wrapper

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -461,9 +461,8 @@ to a failure.
 sub _tofu_run_step {
     my ($self, %args) = @_;
     my $output_file = "tf_$args{step}_output";
-    my $inner = "set -o pipefail; TF_LOG=" . TERRAFORM_LOG . " $args{cmd} 2>&1 | tee $output_file";
-    $inner =~ s/'/'\\''/g;
-    my $ret = script_retry("bash -c '$inner'", timeout => $args{timeout}, delay => $args{delay}, retry => $args{retry}, die => 0);
+    my $ret = script_retry("env TF_LOG=" . TERRAFORM_LOG . " $args{cmd} > $output_file 2>&1",
+        timeout => $args{timeout}, delay => $args{delay}, retry => $args{retry}, die => 0);
     my $output = script_output("cat $output_file", proceed_on_failure => 1);
     record_info("TFM $args{step} output", "exit code: $ret", result => ($ret) ? 'fail' : 'ok');
     return ($ret, $output);

--- a/t/45_publiccloud_provider.t
+++ b/t/45_publiccloud_provider.t
@@ -154,8 +154,9 @@ subtest '[terraform_apply] vars' => sub {
     # Extract the single recorded call that runs 'tofu ... plan ...'
     my ($plan_cmd) = grep { /tofu.*plan/ } @calls;
     ok($plan_cmd, "tofu plan is executed");
-    # Undo _tofu_run_step()'s bash -c wrapper and '\'' escaping (see _mock_terraform_apply).
-    $plan_cmd =~ s/^bash -c '(.*)'$/$1/s and $plan_cmd =~ s/'\\''/'/g;
+    # Strip _tofu_run_step()'s "env TF_LOG=... " prefix and " > file 2>&1" suffix.
+    $plan_cmd =~ s/^env TF_LOG=\S+ //;
+    $plan_cmd =~ s/ > \S+ 2>&1$//;
 
     # Split the command into its individual -var arguments. Values may contain
     # the shell single-quote escape sequence '"'"', so we split on the ' -var '
@@ -327,9 +328,10 @@ sub _mock_terraform_apply {
     # succeed (exit 0) unless a subtest explicitly scripts them.
     $mock->redefine($_ => sub {
             my ($cmd) = @_;
-            # _tofu_run_step() wraps steps as bash -c 'set -o pipefail; ... <cmd> | tee ...',
-            # escaping single quotes as '\''. Undo both so the assertions below see the plain command.
-            $cmd =~ s/^bash -c '(.*)'$/$1/s and $cmd =~ s/'\\''/'/g;
+            # _tofu_run_step() prefixes with "env TF_LOG=... " and suffixes with " > file 2>&1".
+            # Strip both so the assertions below see the plain command.
+            $cmd =~ s/^env TF_LOG=\S+ //;
+            $cmd =~ s/ > \S+ 2>&1$//;
             push @{$args{calls}}, $cmd;
             my $r = $next_response->($cmd);
             return (defined $r ? ($r->{exit} // 0) : 0);


### PR DESCRIPTION
Simplify the _tofu_run_step method by executing the tofu command directly using env to set the TF_LOG variable, rather than wrapping it in a complex 'bash -c' structure with manual single quote escaping. This removes the regex replacement on single quotes, which could break when executing commands that have nested quotes or shell escapes.
This change drop a `tee` so it change as the tofu output is visualized on the serial_terminal

Follow up of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26183

Related ticket: https://progress.opensuse.org/issues/204060


# Verification run:

 - sle-15-SP6-GCE-BYOS-Incidents-Ext-x86_64-Build:smelt:45554:google-guest-agent-publiccloud_smoketests gce_c3-highcpu-22 -> http://openqa.suse.de/tests/23635762 :green_circle: failure is later in registration, tofu command lines are correctly composed
     1. `tofu init` https://openqa.suse.de/tests/23635762/logfile?filename=serial_terminal.txt#line-654
     2. `tofu plan` https://openqa.suse.de/tests/23635762/logfile?filename=serial_terminal.txt#line-703
     3. `tofu apply` https://openqa.suse.de/tests/23635762/logfile?filename=serial_terminal.txt#line-852
