### PR TITLE
Disable workaround for OS version

### DIFF
--- a/tests/sles4sap/bone_install.pm
+++ b/tests/sles4sap/bone_install.pm
@@ -55,9 +55,6 @@ sub run {
     # change some default values
     file_content_replace("/tmp/$b1_cfg", '%SERVER%' => $hostname, '%INSTANCE%' => $instid, '%TENANT_DB%' => $sid, '%PASSWORD%' => $sles4sap::instance_password);
 
-    # initial workaround for 15-SP7 and b1 installer 2502
-    $self->b1_workaround_os_version;
-
     # Install
     assert_script_run "$install_bin -i silent -f /tmp/$b1_cfg --debug", $tout;
 

--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -57,9 +57,6 @@ sub run {
     my $wiz_name = (is_sle('15-SP5+') and get_var('BONE')) ? "bone-installation-wizard" : "sap-installation-wizard";
     my $wizard_package_version = script_output("rpm -q --qf '%{VERSION}\n' $wiz_name");
 
-    # initial workaround for 15-SP7 and b1 installer 2505
-    $self->b1_workaround_os_version;
-
     # start wizard
     if (check_var('DESKTOP', 'textmode')) {
         script_run "yast2 sap-installation-wizard; echo yast2-sap-installation-wizard-status-\$? > /dev/$serialdev", 0;


### PR DESCRIPTION
Since 2605 supports 15-SP7 os version workaround is no longer necessary.

Fixes:
TEAM-11047

VR:
http://10.168.195.63/tests/1832
http://10.168.195.63/tests/1837
http://10.168.195.63/tests/1838
http://10.168.195.63/tests/1840