### PR TITLE
kernel/shutdown_ltp: Allow up to 120s for ver_linux execution

### DIFF
--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -52,7 +52,7 @@ sub run {
 
     if (get_var('LTP_COMMAND_FILE')) {
         my $ver_linux_log = '/tmp/ver_linux_after.txt';
-        script_run("\$LTPROOT/ver_linux > $ver_linux_log 2>&1");
+        script_run("\$LTPROOT/ver_linux > $ver_linux_log 2>&1", 120);
         upload_logs($ver_linux_log, failok => 1);
     }
 


### PR DESCRIPTION
When memory is low and the system is under swapping pressure (e.g. after running the full LTP filesystem/LVM suite), executing ver_linux (which spawns ~30 external commands sequentially) can take longer than the default 30-second timeout. Increasing the timeout to 120 seconds prevents spurious timeouts.

- Verification run: https://openqa.suse.de/tests/23638505 (failure: https://openqa.suse.de/tests/23602121#step/shutdown_ltp/19)
