### PR TITLE
Update the pc_tools to az cli 2.88.0

### DIFF
--- a/data/publiccloud/venv/az.txt
+++ b/data/publiccloud/venv/az.txt
@@ -5,17 +5,17 @@ azure-ai-agents==1.1.0
 azure-ai-projects==1.0.0
 azure-appconfiguration==1.7.2
 azure-batch==15.0.0b1
-azure-cli==2.87.0
-azure-cli-core==2.87.0
+azure-cli==2.88.0
+azure-cli-core==2.88.0
 azure-cli-telemetry==1.1.0
 azure-common==1.1.28
 azure-core==1.39.0
 azure-cosmos==3.2.0
 azure-data-tables==12.4.0
 azure-datalake-store==1.0.1
-azure-keyvault-administration==4.4.0
+azure-keyvault-administration==4.8.0b1
 azure-keyvault-certificates==4.7.0
-azure-keyvault-keys==4.11.0
+azure-keyvault-keys==4.12.0b2
 azure-keyvault-secrets==4.7.0
 azure-keyvault-securitydomain==1.0.0b1
 azure-mgmt-advisor==9.0.0
@@ -23,7 +23,7 @@ azure-mgmt-apimanagement==4.0.0
 azure-mgmt-appconfiguration==6.0.0b2
 azure-mgmt-appcontainers==2.0.0
 azure-mgmt-applicationinsights==1.0.0
-azure-mgmt-authorization==5.0.0b1
+azure-mgmt-authorization==5.0.0b2
 azure-mgmt-batch==17.3.0
 azure-mgmt-batchai==7.0.0b1
 azure-mgmt-billing==6.0.0
@@ -34,7 +34,7 @@ azure-mgmt-compute==34.1.0
 azure-mgmt-containerinstance==10.2.0b1
 azure-mgmt-containerregistry==15.1.0b1
 azure-mgmt-containerregistrytasks==1.0.0b1
-azure-mgmt-containerservice==41.2.0
+azure-mgmt-containerservice==41.3.0
 azure-mgmt-core==1.6.0
 azure-mgmt-cosmosdb==9.9.0
 azure-mgmt-datalake-store==1.1.0b1
@@ -59,7 +59,7 @@ azure-mgmt-msi==7.1.0
 azure-mgmt-mysqlflexibleservers==1.1.0b2
 azure-mgmt-netapp==10.1.0
 azure-mgmt-policyinsights==1.1.0b4
-azure-mgmt-postgresqlflexibleservers==3.0.0b1
+azure-mgmt-postgresqlflexibleservers==3.0.0b2
 azure-mgmt-privatedns==1.0.0
 azure-mgmt-rdbms==10.2.0b17
 azure-mgmt-recoveryservices==4.0.1
@@ -75,7 +75,7 @@ azure-mgmt-search==9.2.0
 azure-mgmt-security==6.0.0
 azure-mgmt-servicebus==10.0.0b1
 azure-mgmt-servicefabric==2.1.0
-azure-mgmt-servicefabricmanagedclusters==2.1.0b1
+azure-mgmt-servicefabricmanagedclusters==2.1.0b3
 azure-mgmt-servicelinker==1.2.0b3
 azure-mgmt-signalr==2.0.0b2
 azure-mgmt-sql==4.0.0b22


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/204630

# Verification run:

# ahb
sle-15-SP6-Azure-BYOS-Updates-x86_64-Buildmpagot_VR-publiccloud_ahb az_Standard_B2s 
http://openqaworker15.qe.prg2.suse.org/tests/380077 :green_circle:  http://openqaworker15.qe.prg2.suse.org/tests/380077#step/ahb/9


# crash
 - sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-crash_test -> http://openqaworker15.qe.prg2.suse.org/tests/380081 :green_circle: 

## ipaddr2
- sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-ipaddr2_azure_test@az_Standard_B1s -> http://openqaworker15.qe.prg2.suse.org/tests/380082 :green_circle: 

 - sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-ipaddr2_azure_test_cloud_init az_Standard_B1s -> http://openqaworker15.qe.prg2.suse.org/tests/380083 :green_circle:  failure is later after the deployment end


# other qe-sap cloud
- sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-cloud_netconfig_azure_test -> http://openqaworker15.qe.prg2.suse.org/tests/380079

 - sle-15-SP7-SapCloud-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7-cloud_zypper_patch_azure_test -> http://openqaworker15.qe.prg2.suse.org/tests/380080

