### PR TITLE
Fix timeout issue after network bridge creation on ppc64le

### DIFF
--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -1950,13 +1950,17 @@ sub reselect_openqa_console {
 
 =head2 select_backend_console
 
-Select corresponding ipmi or qemu backend console 'root-ssh' or 'root-console'.
-If argument init is set, select ipmi backend 'sol' console. User can also set
-arguments console or wait to select cusotmized console in desired behavior.
+Select corresponding ipmi, qemu or pvm_hmc backend console, namely 'root-ssh' or
+'root-console'. If argument init is set, select 'sol' console for ipmi backend, 
+or powerhmc-ssh for pvm_hmc backend because test run is in initialization or the
+very beginning phase, for example, pxe boot, host installation or startup. User
+can also set desired console or choose whether to wait for the selected console.
+Argument reset_times specifies the number of times reset_consoles to be done.
 =cut
 
 sub select_backend_console {
     my (%args) = @_;
+    $args{reset_times} //= 1;
     $args{init} //= 1;
     $args{wait} //= 0;
 
@@ -1966,8 +1970,11 @@ sub select_backend_console {
     elsif (is_qemu) {
         $args{console} //= 'root-console';
     }
+    elsif (is_ppc64le) {
+        $args{console} //= ($args{init} ? 'powerhmc-ssh' : 'root-ssh') if (is_pvm_hmc);
+    }
 
-    reset_consoles;
+    reset_consoles for (0 .. $args{reset_times} - 1);
     if (is_ipmi) {
         select_console($args{console}, await_console => $args{wait});
         use_ssh_serial_console if (!$args{init});
@@ -1977,6 +1984,10 @@ sub select_backend_console {
         select_console($args{console}, await_console => $args{wait});
         ensure_serialdev_permissions;
         serial_terminal::prepare_serial_console();
+    }
+    elsif (is_ppc64le) {
+        select_console($args{console}, await_console => $args{wait});
+        select_console('root-ssh') if (!$args{init});
     }
 }
 


### PR DESCRIPTION
* **The** network bridge ```br0``` creating subroutine is as below:
```
# Create a host bridge network interface for sles16 via NetworkManager poo#178708
sub create_host_bridge_nm {
        my $host_bridge = "br0";
        xxxxxxxxxx
        my $script_name = "create_host_bridge.py";
        my $script_url = data_url("virt_autotest/$script_name");
        xxxxxxxxxx
        script_output($execute_script, $wait_script, type_command => 0, proceed_on_failure => 0);
        save_screenshot;
        # Re-establish the backend console connection, poo#187197
        select_backend_console(init => 0);
        # Set metric the lowest to make br0 always be the default route
        script_run("nmcli con modify br0 ipv4.route-metric 50");
        script_run("nmcli con up br0");
        xxxxxxxxxx
}
```
The subroutine ```select_backend_console(init => 0)``` is called before subsequent ```nmcli``` commands to ensure network connectivity is re-established after executing script ```create_host_bridge.py```.

* **But** subroutine ```select_backend_console(init => 0)``` does not support ppc64le which leads to subsequent ```nmcli``` commands timeout, for example, [this failure](https://openqa.suse.de/tests/23644102#step/prepare_non_transactional_server/99), because temporary lost network connection is not re-established.

* **This** pull request aims to add support for ppc64le, including selecting ```pvmhmc-ssh``` console and re-establishing connection to ```root-ssh``` console if it is not just initial initialization at the beginning, for example, host installation phase.

* **This** pull request also enhances existing functionality by introducing the number of times by which previous consoles to be reset.

* **Verification Runs:**
  * [sle-16.1-Full-ppc64le-Build60.3-non-uefi-gi-full-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23689248)
  * [sle-16.1-Online-x86_64-Build60.3-immutable-gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23706316)
  * [sle-16.1-Online-x86_64-Build60.3-sev-snp-guest_developing-on-host_sles15sp7-kvm](https://openqa.suse.de/tests/23706317)
  * [sle-16.1-Online-x86_64-Build60.3-uefi-gi-full-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23706318)
  * [sle-16.1-Online-x86_64-Build60.3-uefi-gi-guest_developing-on-host_sles16_0-kvm](https://openqa.suse.de/tests/23706319)
  * [sle-16.1-Base-SelfInstall-pxe-x86_64-Build12.7-gi-guest_slem6dot2-on-host_developing-kvm](https://openqa.suse.de/tests/23706327)
  * [sle-16.1-Base-SelfInstall-pxe-x86_64-Build12.7-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23706988)
  * [Tried consecutive runs with ppc64le which also passsed 1](https://openqa.suse.de/tests/23709291) [2](https://openqa.suse.de/tests/23709293) [3](https://openqa.suse.de/tests/23709296) [4](https://openqa.suse.de/tests/23709297) [5](https://openqa.suse.de/tests/23709298)