### PR TITLE
publiccloud: capture guestregister diagnostics before dying

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -319,6 +319,22 @@ In case of BYOS images we checking that service is inactive and quit
 Returns the time needed to wait for the guestregister to complete.
 =cut
 
+=head2 _upload_guestregister_diagnostics
+
+    $self->_upload_guestregister_diagnostics($log, $name);
+
+Upload C<$log> (e.g. C</var/log/cloudregister>) and a short C<journalctl -u
+guestregister.service> excerpt. Used by C<wait_for_guestregister> right
+before dying, so a failure carries the actual registration error instead of
+just the systemd state.
+=cut
+
+sub _upload_guestregister_diagnostics {
+    my ($self, $log, $name) = @_;
+    $self->upload_log($log, log_name => $name, failok => 1);
+    record_info('guestregister journal', $self->ssh_script_output(cmd => 'sudo journalctl -u guestregister.service --no-pager -n 200', proceed_on_failure => 1), result => 'fail');
+}
+
 sub wait_for_guestregister {
     my ($self, %args) = @_;
     $args{timeout} //= 300;
@@ -344,11 +360,15 @@ sub wait_for_guestregister {
             # we have some cases where it is known that guestregister service will fail
             # ( e.g. when we testing images not published on Market hence w/o product codes)
             return 1 if (get_var('PUBLIC_CLOUD_IGNORE_UNREGISTERED'));
+            $self->_upload_guestregister_diagnostics($log, $name);
             die('guestregister failed');
         }
         elsif ($out =~ m/active$/) {
             diag("guestregister active");
-            die "guestregister should not be active on BYOS" if (is_byos);
+            if (is_byos) {
+                $self->_upload_guestregister_diagnostics($log, $name);
+                die "guestregister should not be active on BYOS";
+            }
             $self->upload_log($log, log_name => $name);
         }
 
@@ -359,6 +379,7 @@ sub wait_for_guestregister {
         sleep 1;
     }
     diag("guestregister timeout");
+    $self->_upload_guestregister_diagnostics($log, $name);
     die('guestregister didn\'t end in expected timeout=' . $args{timeout});
 }
 

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -323,16 +323,18 @@ Returns the time needed to wait for the guestregister to complete.
 
     $self->_upload_guestregister_diagnostics($log, $name);
 
-Upload C<$log> (e.g. C</var/log/cloudregister>) and a short C<journalctl -u
-guestregister.service> excerpt. Used by C<wait_for_guestregister> right
-before dying, so a failure carries the actual registration error instead of
-just the systemd state.
+Upload C<$log> (e.g. C</var/log/cloudregister>) and the full C<journalctl -u
+guestregister.service> output, as a separate asset file. Used by
+C<wait_for_guestregister> right before dying, so a failure carries the
+actual registration error instead of just the systemd state.
 =cut
 
 sub _upload_guestregister_diagnostics {
     my ($self, $log, $name) = @_;
     $self->upload_log($log, log_name => $name, failok => 1);
-    record_info('guestregister journal', $self->ssh_script_output(cmd => 'sudo journalctl -u guestregister.service --no-pager -n 200', proceed_on_failure => 1), result => 'fail');
+    my $journal_log = '/tmp/guestregister-journal.log';
+    $self->ssh_script_run(cmd => "sudo journalctl -u guestregister.service --no-pager > $journal_log", proceed_on_failure => 1);
+    $self->upload_log($journal_log, log_name => $autotest::current_test->{name} . '-guestregister-journal.log.txt', failok => 1);
 }
 
 sub wait_for_guestregister {

--- a/t/44_publiccloud_instance.t
+++ b/t/44_publiccloud_instance.t
@@ -311,4 +311,83 @@ subtest '[wait_for_ssh_login] timeout/delay/retry argument propagation' => sub {
     is($call_args[-1]->{retry}, 900 / 30, 'retry derives from PUBLIC_CLOUD_SSH_TIMEOUT var');
     set_var('PUBLIC_CLOUD_SSH_TIMEOUT', undef);
 };
+
+# ---------------------------------------------------------------------------
+# wait_for_guestregister -- diagnostics (log + journal excerpt) must be
+# captured before every die on the failure paths (poo#204360)
+# ---------------------------------------------------------------------------
+$autotest::current_test = {name => 'wait_for_guestregister_test'};
+
+subtest '[wait_for_guestregister] failed captures diagnostics before dying' => sub {
+    my $instmod = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+    my (@uploads, @journal_cmds);
+    $instmod->redefine(ssh_script_run => sub { return 0 });
+    $instmod->redefine(ssh_script_output => sub {
+            my ($self, %args) = @_;
+            push @journal_cmds, $args{cmd} if $args{cmd} =~ /journalctl/;
+            return 'guestregister.service - failed';
+    });
+    $instmod->redefine(upload_log => sub { my ($self, $log, %args) = @_; push @uploads, [$log, \%args] });
+    $instmod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)) });
+
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
+    throws_ok { $inst->wait_for_guestregister() } qr/guestregister failed/, 'dies with guestregister failed';
+    is(scalar @uploads, 1, 'upload_log called exactly once');
+    is($uploads[0][0], '/var/log/cloudregister', 'uploads /var/log/cloudregister');
+    is(scalar @journal_cmds, 1, 'journalctl excerpt captured exactly once');
+    like($journal_cmds[0], qr/journalctl -u guestregister\.service/, 'journal command targets guestregister.service');
+};
+
+subtest '[wait_for_guestregister] failed + PUBLIC_CLOUD_IGNORE_UNREGISTERED skips diagnostics' => sub {
+    my $instmod = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+    my @uploads;
+    $instmod->redefine(ssh_script_run => sub { return 0 });
+    $instmod->redefine(ssh_script_output => sub { return 'guestregister.service - failed' });
+    $instmod->redefine(upload_log => sub { push @uploads, 1 });
+    $instmod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)) });
+
+    set_var('PUBLIC_CLOUD_IGNORE_UNREGISTERED', 1);
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
+    is($inst->wait_for_guestregister(), 1, 'returns 1 for known/expected failure');
+    is(scalar @uploads, 0, 'no diagnostics captured for an ignored failure');
+    set_var('PUBLIC_CLOUD_IGNORE_UNREGISTERED', undef);
+};
+
+subtest '[wait_for_guestregister] active on BYOS captures diagnostics before dying' => sub {
+    my $instmod = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+    my (@uploads, @journal_cmds);
+    $instmod->redefine(ssh_script_run => sub { return 0 });
+    $instmod->redefine(ssh_script_output => sub {
+            my ($self, %args) = @_;
+            push @journal_cmds, $args{cmd} if $args{cmd} =~ /journalctl/;
+            return 'guestregister.service - active';
+    });
+    $instmod->redefine(upload_log => sub { my ($self, $log, %args) = @_; push @uploads, [$log, \%args] });
+    $instmod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)) });
+    $instmod->redefine(is_byos => sub { return 1 });
+
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
+    throws_ok { $inst->wait_for_guestregister() } qr/should not be active on BYOS/, 'dies for active-on-BYOS';
+    is(scalar @uploads, 1, 'upload_log called exactly once before dying');
+    is(scalar @journal_cmds, 1, 'journalctl excerpt captured exactly once before dying');
+};
+
+subtest '[wait_for_guestregister] timeout captures diagnostics before dying' => sub {
+    my $instmod = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+    my (@uploads, @journal_cmds);
+    $instmod->redefine(ssh_script_run => sub { return 0 });
+    $instmod->redefine(ssh_script_output => sub {
+            my ($self, %args) = @_;
+            push @journal_cmds, $args{cmd} if $args{cmd} =~ /journalctl/;
+            return 'guestregister.service - activating';
+    });
+    $instmod->redefine(upload_log => sub { my ($self, $log, %args) = @_; push @uploads, [$log, \%args] });
+    $instmod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)) });
+
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
+    throws_ok { $inst->wait_for_guestregister(timeout => 0) } qr/didn't end in expected timeout/, 'dies on timeout';
+    is(scalar @uploads, 1, 'upload_log called exactly once before dying');
+    is(scalar @journal_cmds, 1, 'journalctl excerpt captured exactly once before dying');
+};
+
 done_testing;

--- a/t/44_publiccloud_instance.t
+++ b/t/44_publiccloud_instance.t
@@ -321,20 +321,20 @@ $autotest::current_test = {name => 'wait_for_guestregister_test'};
 subtest '[wait_for_guestregister] failed captures diagnostics before dying' => sub {
     my $instmod = Test::MockModule->new('publiccloud::instance', no_auto => 1);
     my (@uploads, @journal_cmds);
-    $instmod->redefine(ssh_script_run => sub { return 0 });
-    $instmod->redefine(ssh_script_output => sub {
+    $instmod->redefine(ssh_script_run => sub {
             my ($self, %args) = @_;
             push @journal_cmds, $args{cmd} if $args{cmd} =~ /journalctl/;
-            return 'guestregister.service - failed';
+            return 0;
     });
+    $instmod->redefine(ssh_script_output => sub { return 'guestregister.service - failed' });
     $instmod->redefine(upload_log => sub { my ($self, $log, %args) = @_; push @uploads, [$log, \%args] });
     $instmod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)) });
 
     my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
     throws_ok { $inst->wait_for_guestregister() } qr/guestregister failed/, 'dies with guestregister failed';
-    is(scalar @uploads, 1, 'upload_log called exactly once');
+    is(scalar @uploads, 2, 'upload_log called for the cloudregister log and the guestregister journal');
     is($uploads[0][0], '/var/log/cloudregister', 'uploads /var/log/cloudregister');
-    is(scalar @journal_cmds, 1, 'journalctl excerpt captured exactly once');
+    is(scalar @journal_cmds, 1, 'journalctl command run exactly once');
     like($journal_cmds[0], qr/journalctl -u guestregister\.service/, 'journal command targets guestregister.service');
 };
 
@@ -356,38 +356,38 @@ subtest '[wait_for_guestregister] failed + PUBLIC_CLOUD_IGNORE_UNREGISTERED skip
 subtest '[wait_for_guestregister] active on BYOS captures diagnostics before dying' => sub {
     my $instmod = Test::MockModule->new('publiccloud::instance', no_auto => 1);
     my (@uploads, @journal_cmds);
-    $instmod->redefine(ssh_script_run => sub { return 0 });
-    $instmod->redefine(ssh_script_output => sub {
+    $instmod->redefine(ssh_script_run => sub {
             my ($self, %args) = @_;
             push @journal_cmds, $args{cmd} if $args{cmd} =~ /journalctl/;
-            return 'guestregister.service - active';
+            return 0;
     });
+    $instmod->redefine(ssh_script_output => sub { return 'guestregister.service - active' });
     $instmod->redefine(upload_log => sub { my ($self, $log, %args) = @_; push @uploads, [$log, \%args] });
     $instmod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)) });
     $instmod->redefine(is_byos => sub { return 1 });
 
     my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
     throws_ok { $inst->wait_for_guestregister() } qr/should not be active on BYOS/, 'dies for active-on-BYOS';
-    is(scalar @uploads, 1, 'upload_log called exactly once before dying');
-    is(scalar @journal_cmds, 1, 'journalctl excerpt captured exactly once before dying');
+    is(scalar @uploads, 2, 'upload_log called for the cloudregister log and the guestregister journal');
+    is(scalar @journal_cmds, 1, 'journalctl command run exactly once before dying');
 };
 
 subtest '[wait_for_guestregister] timeout captures diagnostics before dying' => sub {
     my $instmod = Test::MockModule->new('publiccloud::instance', no_auto => 1);
     my (@uploads, @journal_cmds);
-    $instmod->redefine(ssh_script_run => sub { return 0 });
-    $instmod->redefine(ssh_script_output => sub {
+    $instmod->redefine(ssh_script_run => sub {
             my ($self, %args) = @_;
             push @journal_cmds, $args{cmd} if $args{cmd} =~ /journalctl/;
-            return 'guestregister.service - activating';
+            return 0;
     });
+    $instmod->redefine(ssh_script_output => sub { return 'guestregister.service - activating' });
     $instmod->redefine(upload_log => sub { my ($self, $log, %args) = @_; push @uploads, [$log, \%args] });
     $instmod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)) });
 
     my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
     throws_ok { $inst->wait_for_guestregister(timeout => 0) } qr/didn't end in expected timeout/, 'dies on timeout';
-    is(scalar @uploads, 1, 'upload_log called exactly once before dying');
-    is(scalar @journal_cmds, 1, 'journalctl excerpt captured exactly once before dying');
+    is(scalar @uploads, 2, 'upload_log called for the cloudregister log and the guestregister journal');
+    is(scalar @journal_cmds, 1, 'journalctl command run exactly once before dying');
 };
 
 done_testing;

--- a/t/44_publiccloud_instance.t
+++ b/t/44_publiccloud_instance.t
@@ -16,6 +16,7 @@ use Test::MockObject;
 use Test::MockModule;
 use Test::Exception;
 use Test::Warnings;
+use List::Util qw(any);
 # Deterministic fake clock: sleep() advances mocked time() instead of spending
 # real wall-clock seconds, so the retry_ssh_command and wait_for_state polling
 # loops run fast. Must be loaded before the module under test is compiled.
@@ -312,82 +313,71 @@ subtest '[wait_for_ssh_login] timeout/delay/retry argument propagation' => sub {
     set_var('PUBLIC_CLOUD_SSH_TIMEOUT', undef);
 };
 
-# ---------------------------------------------------------------------------
-# wait_for_guestregister -- diagnostics (log + journal excerpt) must be
-# captured before every die on the failure paths (poo#204360)
-# ---------------------------------------------------------------------------
 $autotest::current_test = {name => 'wait_for_guestregister_test'};
 
 subtest '[wait_for_guestregister] failed captures diagnostics before dying' => sub {
+    # wait_for_guestregister -- diagnostics (log + full journal) must be captured before every die on the failure paths (poo#204360)
     my $instmod = Test::MockModule->new('publiccloud::instance', no_auto => 1);
-    my (@uploads, @journal_cmds);
-    $instmod->redefine(ssh_script_run => sub {
-            my ($self, %args) = @_;
-            push @journal_cmds, $args{cmd} if $args{cmd} =~ /journalctl/;
-            return 0;
-    });
-    $instmod->redefine(ssh_script_output => sub { return 'guestregister.service - failed' });
+    my (@uploads, @calls);
+    $instmod->redefine(ssh_script_run => sub { my ($self, %args) = @_; push @calls, $args{cmd}; return 0 });
+    $instmod->redefine(ssh_script_output => sub { my ($self, %args) = @_; push @calls, $args{cmd}; return 'guestregister.service - failed' });
     $instmod->redefine(upload_log => sub { my ($self, $log, %args) = @_; push @uploads, [$log, \%args] });
     $instmod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)) });
 
     my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
     throws_ok { $inst->wait_for_guestregister() } qr/guestregister failed/, 'dies with guestregister failed';
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
     is(scalar @uploads, 2, 'upload_log called for the cloudregister log and the guestregister journal');
     is($uploads[0][0], '/var/log/cloudregister', 'uploads /var/log/cloudregister');
-    is(scalar @journal_cmds, 1, 'journalctl command run exactly once');
-    like($journal_cmds[0], qr/journalctl -u guestregister\.service/, 'journal command targets guestregister.service');
+    ok((any { /journalctl -u guestregister\.service/ } @calls), 'journal command targets guestregister.service');
 };
 
 subtest '[wait_for_guestregister] failed + PUBLIC_CLOUD_IGNORE_UNREGISTERED skips diagnostics' => sub {
     my $instmod = Test::MockModule->new('publiccloud::instance', no_auto => 1);
-    my @uploads;
-    $instmod->redefine(ssh_script_run => sub { return 0 });
-    $instmod->redefine(ssh_script_output => sub { return 'guestregister.service - failed' });
+    my (@uploads, @calls);
+    $instmod->redefine(ssh_script_run => sub { my ($self, %args) = @_; push @calls, $args{cmd}; return 0 });
+    $instmod->redefine(ssh_script_output => sub { my ($self, %args) = @_; push @calls, $args{cmd}; return 'guestregister.service - failed' });
     $instmod->redefine(upload_log => sub { push @uploads, 1 });
     $instmod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)) });
 
     set_var('PUBLIC_CLOUD_IGNORE_UNREGISTERED', 1);
     my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
     is($inst->wait_for_guestregister(), 1, 'returns 1 for known/expected failure');
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
     is(scalar @uploads, 0, 'no diagnostics captured for an ignored failure');
+    ok(!(any { /journalctl/ } @calls), 'journal is never queried for an ignored failure');
     set_var('PUBLIC_CLOUD_IGNORE_UNREGISTERED', undef);
 };
 
 subtest '[wait_for_guestregister] active on BYOS captures diagnostics before dying' => sub {
     my $instmod = Test::MockModule->new('publiccloud::instance', no_auto => 1);
-    my (@uploads, @journal_cmds);
-    $instmod->redefine(ssh_script_run => sub {
-            my ($self, %args) = @_;
-            push @journal_cmds, $args{cmd} if $args{cmd} =~ /journalctl/;
-            return 0;
-    });
-    $instmod->redefine(ssh_script_output => sub { return 'guestregister.service - active' });
+    my (@uploads, @calls);
+    $instmod->redefine(ssh_script_run => sub { my ($self, %args) = @_; push @calls, $args{cmd}; return 0 });
+    $instmod->redefine(ssh_script_output => sub { my ($self, %args) = @_; push @calls, $args{cmd}; return 'guestregister.service - active' });
     $instmod->redefine(upload_log => sub { my ($self, $log, %args) = @_; push @uploads, [$log, \%args] });
     $instmod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)) });
     $instmod->redefine(is_byos => sub { return 1 });
 
     my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
     throws_ok { $inst->wait_for_guestregister() } qr/should not be active on BYOS/, 'dies for active-on-BYOS';
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
     is(scalar @uploads, 2, 'upload_log called for the cloudregister log and the guestregister journal');
-    is(scalar @journal_cmds, 1, 'journalctl command run exactly once before dying');
+    ok((any { /journalctl -u guestregister\.service/ } @calls), 'journal command targets guestregister.service');
 };
 
 subtest '[wait_for_guestregister] timeout captures diagnostics before dying' => sub {
     my $instmod = Test::MockModule->new('publiccloud::instance', no_auto => 1);
-    my (@uploads, @journal_cmds);
-    $instmod->redefine(ssh_script_run => sub {
-            my ($self, %args) = @_;
-            push @journal_cmds, $args{cmd} if $args{cmd} =~ /journalctl/;
-            return 0;
-    });
-    $instmod->redefine(ssh_script_output => sub { return 'guestregister.service - activating' });
+    my (@uploads, @calls);
+    $instmod->redefine(ssh_script_run => sub { my ($self, %args) = @_; push @calls, $args{cmd}; return 0 });
+    $instmod->redefine(ssh_script_output => sub { my ($self, %args) = @_; push @calls, $args{cmd}; return 'guestregister.service - activating' });
     $instmod->redefine(upload_log => sub { my ($self, $log, %args) = @_; push @uploads, [$log, \%args] });
     $instmod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)) });
 
     my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
     throws_ok { $inst->wait_for_guestregister(timeout => 0) } qr/didn't end in expected timeout/, 'dies on timeout';
+    note("\n  C-->  " . join("\n  C-->  ", @calls));
     is(scalar @uploads, 2, 'upload_log called for the cloudregister log and the guestregister journal');
-    is(scalar @journal_cmds, 1, 'journalctl command run exactly once before dying');
+    ok((any { /journalctl -u guestregister\.service/ } @calls), 'journal command targets guestregister.service');
 };
 
 done_testing;


### PR DESCRIPTION
`wait_for_guestregister()` now uploads `/var/log/cloudregister` and a short `journalctl -u` guestregister.service excerpt before dying on the failed, active-on-BYOS, and timeout paths, matching what it already did on the success path. Added unit tests covering all three die paths plus the PUBLIC_CLOUD_IGNORE_UNREGISTERED skip case.

* Related ticket: [poo#204360](https://progress.opensuse.org/issues/204360)
* Verification runs: In comment below
