### PR TITLE
fix(jeos): Check JeOS Firstboot on serial console before it's consumed

### DIFF
--- a/lib/jeos.pm
+++ b/lib/jeos.pm
@@ -8,6 +8,7 @@ use serial_terminal 'select_serial_terminal';
 use utils qw(ensure_serialdev_permissions);
 use power_action_utils qw(power_action);
 use Utils::Backends qw(is_hyperv);
+use Utils::Architectures qw(is_ppc64le);
 use version_utils qw(is_sle is_community_jeos is_tumbleweed is_wsl is_vmware);
 use bootloader_setup qw(change_grub_config grep_grub_settings grub_mkconfig set_framebuffer_resolution set_extrabootparams_grub_conf);
 
@@ -17,6 +18,7 @@ our @EXPORT = qw(
   reboot_image
   is_translations_preinstalled
   disable_grub_timeout
+  check_jeos_on_serial_terminal
 );
 
 sub expect_mount_by_uuid {
@@ -55,6 +57,24 @@ sub disable_grub_timeout {
 
 sub is_translations_preinstalled {
     return is_community_jeos || is_sle('=12-sp5') || (!is_tumbleweed && is_wsl);
+}
+
+# Ensures the JeOS firstboot wizard dialog is present on the serial terminal.
+# Must be called before anything else consumes the serial log past the point
+# where the "JeOS Firstboot" dialog title is printed, otherwise wait_serial()
+# will never find it again (poo#204390).
+sub check_jeos_on_serial_terminal {
+    return if (wait_serial("JeOS Firstboot", no_regex => 1, timeout => 300));
+
+    if (is_sle("=16.1") && is_ppc64le) {
+        record_soft_failure("bsc#1260359 - No serial terminal on ppc64le");
+        return;
+    }
+    elsif (is_sle("=16.0") && is_ppc64le) {
+        record_soft_failure("bsc#1271468 - No serial terminal on ppc64le");
+        return;
+    }
+    die "JeOS firstboot not detected on serial terminal";
 }
 
 1;

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -13,10 +13,11 @@ use Mojo::Base 'opensusebasetest';
 use lockapi qw(mutex_create mutex_wait);
 use testapi;
 use version_utils qw(is_wsl is_jeos is_sle is_tumbleweed is_leap is_opensuse is_microos is_sle_micro
-  is_leap_micro is_vmware is_bootloader_sdboot is_bootloader_grub2_bls has_selinux_by_default is_community_jeos is_sles4sap is_transactional);
+  is_leap_micro is_vmware is_bootloader_sdboot is_bootloader_grub2_bls has_selinux_by_default is_community_jeos is_sles4sap is_transactional
+  is_selfinstall);
 use Utils::Architectures;
 use Utils::Backends;
-use jeos qw(expect_mount_by_uuid is_translations_preinstalled);
+use jeos qw(expect_mount_by_uuid is_translations_preinstalled check_jeos_on_serial_terminal);
 use utils qw(assert_screen_with_soft_timeout ensure_serialdev_permissions enter_cmd_slow);
 use serial_terminal 'prepare_serial_console';
 use Utils::Logging qw(record_avc_selinux_alerts);
@@ -216,20 +217,6 @@ sub create_user_in_ui {
     $user_created = 1;
 }
 
-sub check_jeos_on_serial_terminal {
-    return if (wait_serial("JeOS Firstboot", no_regex => 1, timeout => 300));
-
-    if (is_sle("=16.1") && is_ppc64le) {
-        record_soft_failure("bsc#1260359 - No serial terminal on ppc64le");
-        return;
-    }
-    elsif (is_sle("=16.0") && is_ppc64le) {
-        record_soft_failure("bsc#1271468 - No serial terminal on ppc64le");
-        return;
-    }
-    die "JeOS firstboot not detected on serial terminal";
-}
-
 sub run {
     my ($self) = @_;
     my $lang = get_var('JEOSINSTLANG', 'en_US');
@@ -255,8 +242,13 @@ sub run {
         $initial_screen_timeout = 420 if is_sle_micro;
     }
 
-    # Ensures the JeOS firstboot wizard is present on the serial terminal
-    check_jeos_on_serial_terminal() unless (is_sle("<15") || is_s390x || check_var('JEOS_CHECK_SERIAL', '0'));
+    # Ensures the JeOS firstboot wizard is present on the serial terminal.
+    # In the selfinstall flow this check already happened earlier, in
+    # microos/selfinstall.pm, right before it waits for 'The initial
+    # configuration' on the same serial log. Doing it again here would
+    # always fail because that earlier wait_serial() call already consumed
+    # the 'JeOS Firstboot' line from the serial log (poo#204390).
+    check_jeos_on_serial_terminal() unless (is_sle("<15") || is_s390x || is_selfinstall || check_var('JEOS_CHECK_SERIAL', '0'));
 
     # https://github.com/openSUSE/jeos-firstboot/pull/82 welcome dialog is shown on all consoles
     # and configuration continues on console where *Start* has been pressed

--- a/tests/microos/selfinstall.pm
+++ b/tests/microos/selfinstall.pm
@@ -9,11 +9,12 @@
 use Mojo::Base 'consoletest';
 use testapi;
 use microos "microos_login";
-use Utils::Architectures qw(is_aarch64);
-use version_utils qw(is_leap_micro is_sle_micro);
+use Utils::Architectures qw(is_aarch64 is_s390x);
+use version_utils qw(is_leap_micro is_sle_micro is_sle);
 use utils;
 use Utils::Backends qw(is_ipmi);
 use ipmi_backend_utils qw(ipmitool set_bootscript_hdd);
+use jeos qw(check_jeos_on_serial_terminal);
 
 sub run {
     my ($self) = @_;
@@ -51,6 +52,13 @@ sub run {
         send_key 'ctrl-alt-delete' unless $no_cd;
         microos_login;
     } elsif (check_var('FIRST_BOOT_CONFIG', 'wizard')) {
+        # Check for the JeOS firstboot wizard on the serial terminal before
+        # waiting for 'The initial configuration' below: both strings are
+        # printed as part of the very same dialog and share the same serial
+        # log, so wait_serial('The initial configuration', ...) would
+        # otherwise consume the 'JeOS Firstboot' line first, making the
+        # equivalent check in jeos/firstrun.pm always fail (poo#204390).
+        check_jeos_on_serial_terminal() unless (is_sle("<15") || is_s390x || check_var('JEOS_CHECK_SERIAL', '0'));
         wait_serial('The initial configuration', 180) or die "jeos-firstboot has not been reached";
         eject_cd() unless ($no_cd || is_usb_boot);
         return 1;


### PR DESCRIPTION
### Problem

check_jeos_on_serial_terminal() (added to tests/jeos/firstrun.pm in #25939) always times out and dies in the SelfInstall FIRST_BOOT_CONFIG=wizard flow, even though JeOS Firstboot is plainly visible in the serial log.

### Root cause

wait_serial() reads from a single, monotonically advancing position in the serial log. In the selfinstall flow, tests/microos/selfinstall.pm runs first and calls wait_serial('The initial configuration', 180). Both strings are printed in the same curses redraw frame, with JeOS Firstboot appearing earlier - so that call consumes past it before jeos/firstrun ever looks. The later wait_serial("JeOS Firstboot") then times out after 300s and dies.

Deterministic, not flaky, and not a product regression.

### Fix

- Move check_jeos_on_serial_terminal() into the shared lib/jeos.pm.
- Call it from tests/microos/selfinstall.pm immediately before wait_serial('The initial configuration', ...), while the string is still unread.
- Skip the now-redundant call in firstrun.pm when is_selfinstall. It is kept for the non-selfinstall wizard flows (disk boot / installation boot), which have no prior wait_serial() and are unaffected.

Introduced-in: #25939

- Related ticket: https://progress.opensuse.org/issues/204390
- Needles: N/A
- Verification runs:
  - https://openqa.suse.de/tests/23657924#step/firstrun/1
  - https://openqa.suse.de/tests/23658491#step/firstrun/1
  - https://openqa.suse.de/tests/23658492#step/firstrun/1