### PR TITLE
Remove release-notes installation on SLE 16.1+

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -71,7 +71,8 @@ sub run {
     assert_script_run('chmod -R u+rwX,og+rX /var/cache/zypp');
     zypper_call('in curl') if (script_run('rpm -qi curl') == 1);
     # force reinstall release notes, package must not come from expected SLE-Product repo e.g. GMC
-    zypper_call('in -f release-notes*');
+    # release-notes has been removed in SLE >=16.1
+    zypper_call('in -f release-notes*') unless (is_sle('>=16.1'));
     zypper_call('in zypper-lifecycle-plugin') if (is_sle('>=16'));
 
     select_user_serial_terminal;


### PR DESCRIPTION
SLE16.1 and newer do not have the `release-notes` package. This PR adds a check and does not run the install step on SLE16.1 or newer.

- Related ticket: https://progress.opensuse.org/issues/204846
- Verification run: SoonTM
