### PR TITLE
Use sudo when checking for zypper collisions

### DIFF
--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -477,7 +477,7 @@ sub _install_ec2_cloudwatch_agent
         $instance->softreboot();
     } else {
         if (is_sle(">12-SP5")) {
-            pc_zypper_call($instance, "install --no-recommends --allow-unsigned-rpm $download_directory/$rpm_file");
+            pc_zypper_call($instance, "install --no-recommends --allow-unsigned-rpm $download_directory/$rpm_file", retry => 3);
         } else {
             $instance->ssh_assert_script_run("sudo rpm -Uvh $download_directory/$rpm_file");
         }

--- a/lib/publiccloud/zypper.pm
+++ b/lib/publiccloud/zypper.pm
@@ -336,20 +336,60 @@ give a ~20 minute ceiling.
 
 =cut
 
+# Poll until no BUSY_PROCESS_PATTERN process is running, or time out.
+#
+# Shared implementation behind pc_wait_quit (remote/SSH) and pc_wait_quit_local
+# (console-direct). The only thing that varies between the two is how the raw
+# process list is obtained, so callers pass that in as C<fetch> (a code-ref
+# returning the C<ps -eo comm> output); C<label> is used to tag record_info.
+sub _wait_for_busy_processes {
+    my (%args) = @_;
+    my $fetch = $args{fetch};
+    my $label = $args{label};
+    my $delay = $args{delay};
+    my $retry = $args{retry};
+
+    my $pattern = BUSY_PROCESS_PATTERN;
+    my $regex = qr/^(?:$pattern)$/;
+
+    record_info($label, 'Waiting for system processes to finish...');
+
+    for (my $try = 0; $try < $retry; $try++) {
+        my $output = $fetch->() // '';
+        my $found = 0;
+
+        for my $proc (split(/\r?\n/, $output)) {
+            $proc =~ s/^\s+|\s+$//g;
+            if ($proc =~ $regex) {
+                record_info('busy process', "Active busy process found: $proc (waiting $delay seconds)");
+                $found = 1;
+                last;
+            }
+        }
+
+        if (!$found) {
+            record_info($label, 'No busy processes found. Proceeding.');
+            return;
+        }
+
+        sleep($delay);
+    }
+
+    die "Timed out waiting for busy processes (" . BUSY_PROCESS_PATTERN . ") to finish!";
+}
+
 sub pc_wait_quit {
     my ($instance, %opts) = @_;
     my $timeout = $opts{timeout} // 20;
     my $delay = $opts{delay} // 10;
     my $retry = $opts{retry} // 120;
 
-    # RC 0 (success) only when no matching processes exist.
-    my $cmd = q{! pgrep -a "} . BUSY_PROCESS_PATTERN . q{"};
-
-    $instance->ssh_script_retry(
-        cmd => $cmd,
-        timeout => $timeout,
+    _wait_for_busy_processes(
+        label => 'wait_quit',
         delay => $delay,
         retry => $retry,
+        # Fetch remote processes using sudo ps -eo comm
+        fetch => sub { eval { $instance->ssh_script_output(cmd => 'sudo ps -eo comm', proceed_on_failure => 1, quiet => 1) } },
     );
 }
 
@@ -375,7 +415,13 @@ sub pc_wait_quit_local {
     my $delay = $opts{delay} // 10;
     my $retry = $opts{retry} // 120;
 
-    utils::script_retry(q{! pgrep -a "} . BUSY_PROCESS_PATTERN . q{"}, timeout => $timeout, delay => $delay, retry => $retry);
+    _wait_for_busy_processes(
+        label => 'wait_quit_local',
+        delay => $delay,
+        retry => $retry,
+        # Fetch local processes using sudo ps -eo comm
+        fetch => sub { eval { testapi::script_output('sudo ps -eo comm', proceed_on_failure => 1, quiet => 1) } },
+    );
 }
 
 =head2 pc_installed_packages


### PR DESCRIPTION
In lib/publiccloud/zypper.pm, root-owned package management processes running in the background may not be visible to user-level pgrep calls. Add privileged checks using sudo pgrep in pc_wait_quit and pc_wait_quit_local to ensure zypper and related package managers are completely finished before proceeding.
Additionally, in lib/publiccloud/ec2.pm, add a retry parameter of 3 to pc_zypper_call when installing the CloudWatch agent RPM. This helps mitigate transient package manager or network failures.

- Related ticket: https://progress.opensuse.org/issues/204834


# Verification run:

sle-15-SP7-EC2-Incidents-x86_64-Build:smelt:45685:grub2-publiccloud_smoketests ec2_i3.8xlarge 
 - http://openqa.suse.de/tests/23669213
 - http://openqa.suse.de/tests/23669663
 - https://openqa.suse.de/tests/23677164

---
 - https://openqa.suse.de/tests/23682092