### PR TITLE
Create scenario with unattended installation using an LVM with two disks

### DIFF
--- a/data/yam/agama/auto/lib/dasd.libsonnet
+++ b/data/yam/agama/auto/lib/dasd.libsonnet
@@ -1,5 +1,5 @@
 {
-  dasd():: {
+  dasd: {
     devices: [
       {
         channel: "0.0.0150",
@@ -8,4 +8,19 @@
       },
     ],
   },
+
+  dasd_2_disks: {
+    devices: [
+      {
+        channel: "0.0.0150",
+        format: true,
+        state: "active",
+      },
+      {
+        channel: "0.0.0160",
+        format: true,
+        state: "active",
+      },
+    ],
+  }
 }

--- a/data/yam/agama/auto/lib/storage.libsonnet
+++ b/data/yam/agama/auto/lib/storage.libsonnet
@@ -66,6 +66,35 @@ local lvm(encrypted=false, encryption='luks2') = {
   ],
 };
 
+local lvm_2_disks(dasd=false) = {
+  drives: [
+    {
+      search: if dasd == true then '/dev/dasda' else '/dev/vda',
+      alias: 'pvs-disk1',
+    },
+    {
+      search: if dasd == true then '/dev/dasdb' else '/dev/vdb',
+      alias: 'pvs-disk2',
+    },
+  ],
+  volumeGroups: [
+    {
+      name: 'system',
+      physicalVolumes: [
+        {
+          generate: {
+            targetDevices: ['pvs-disk1', 'pvs-disk2'],
+            spacePolicy: 'useAvailable'
+          }
+        },
+      ],
+      logicalVolumes: [
+        { generate: 'default' },
+      ],
+    },
+  ],
+};
+
 local whole_disk_and_boot_unattended() = {
   drives: [
     {
@@ -339,6 +368,8 @@ local btrfs_without_snapshots() = {
   lvm: lvm(false),
   lvm_encrypted: lvm(true),
   lvm_tpm_fde: lvm(true, 'tpmFde'),
+  lvm_2_disks: lvm_2_disks(),
+  lvm_2_disks_dasd: lvm_2_disks(true),
   raid0: raid('raid0'),
   raid0_uefi: raid('raid0', 'uefi'),
   raid0_uefi_search: search_raid0(),

--- a/data/yam/agama/auto/template.libsonnet
+++ b/data/yam/agama/auto/template.libsonnet
@@ -45,7 +45,7 @@ function(access_ssh_enabled=false,
          
         base_lib.bootloader(bootloader, bootloader_timeout, bootloader_extra_kernel_params) +
         {
-          [if dasd == true then 'dasd']: dasd_lib.dasd(),
+          [if dasd == true then 'dasd']: if storage == 'lvm_2_disks_dasd' then dasd_lib['dasd_2_disks'] else dasd_lib['dasd'],
           [if files == true then 'files']: base_lib['files'],
           [if iscsi_target_address != '' then 'iscsi']: iscsi_lib.iscsi(iscsi_target_address),
           [if localization == true then 'localization']: base_lib['localization'],


### PR DESCRIPTION
This PR adds support for LVM configuration across two disks in Agama unattended installations, with specific support for both standard disk devices and DASD (s390x architecture).

The changes introduce two new storage profile options: `lvm_2_disks` for standard two-disk LVM setups and `lvm_2_disks_dasd` for s390x DASD devices. The implementation creates a single volume group named 'system' that spans both physical volumes, using all available space on both disks for the default logical volumes.

Additionally, a new DASD configuration (`dasd_2_disks`) has been added to activate and format two DASD channels (0.0.0150 and 0.0.0160), and the profile template logic has been updated to automatically select the appropriate DASD configuration when using the `lvm_2_disks_dasd` storage option.

- Related ticket: https://progress.opensuse.org/issues/203943
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/874
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?build=okynos%2Fos-autoinst-distri-opensuse%23203943-lvm-2-disks&distri=sle&version=16.1 
