### PR TITLE
Increase zypper update timeout in registration_lifecycle

### DIFF
--- a/tests/publiccloud/registration_lifecycle.pm
+++ b/tests/publiccloud/registration_lifecycle.pm
@@ -180,7 +180,7 @@ sub new_registration {
     check_instance_registered($instance);
     # https://progress.opensuse.org/issues/196370 workaround for a known issue on 15-SP5
     if (is_sle('=15-SP5')) {
-        $instance->ssh_assert_script_run("sudo zypper update -y");
+        pc_pkg_call($instance, "update -y", retry => 3, delay => 60, timeout => 600);
         $instance->softreboot(timeout => 3600);
     }
     return 0;
@@ -250,7 +250,7 @@ sub force_new_registration {
     $instance->ssh_script_retry(cmd => "sudo registercloudguest $regcode_param --force-new", timeout => 300, retry => 3, delay => 120);
     # https://progress.opensuse.org/issues/196370 workaround for a known issue on 15-SP5
     if (is_sle('=15-SP5')) {
-        $instance->ssh_assert_script_run("sudo zypper update -y");
+        pc_pkg_call($instance, "update -y", retry => 3, delay => 60, timeout => 600);
         $instance->softreboot(timeout => 3600);
     }
     check_instance_registered($instance);


### PR DESCRIPTION
Increase the timeout for the `sudo zypper update -y` workaround calls in registration_lifecycle.pm from the default 90s to 600s.

* Related ticket: [poo#204861](https://progress.opensuse.org/issues/204861)
* Related failure: [openqa.suse.de/t23616376](https://openqa.suse.de/tests/23616376)
