### PR TITLE
Fix SSH login retry attempt count message

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -506,7 +506,7 @@ sub wait_for_ssh_login {
 
     ## ssh options to avoid issues with pipelining and host key validation
     my $ssh_opts = $self->ssh_opts() . ' -o ControlPath=none -o ConnectTimeout=10 -o strictHostKeyChecking=no -o UserKnownHostsFile=/dev/null';
-    $self->ssh_script_retry("true", ssh_opts => $ssh_opts, retry => $retry, delay => $delay, fail_message => "ssh connection failed ($delay attempts in $timeout seconds)");
+    $self->ssh_script_retry("true", ssh_opts => $ssh_opts, retry => $retry, delay => $delay, fail_message => "ssh connection failed ($retry attempts in $timeout seconds)");
 }
 
 =head2 isok

--- a/t/44_publiccloud_instance.t
+++ b/t/44_publiccloud_instance.t
@@ -299,7 +299,7 @@ subtest '[wait_for_ssh_login] timeout/delay/retry argument propagation' => sub {
     $inst->wait_for_ssh_login(timeout => 600);
     is($call_args[-1]->{delay}, 30, 'delay still defaults to 30');
     is($call_args[-1]->{retry}, 600 / 30, 'retry scales with custom timeout (20)');
-    like($call_args[-1]->{fail_message}, qr/30 attempts in 600 seconds/, 'fail_message reflects custom timeout');
+    like($call_args[-1]->{fail_message}, qr/20 attempts in 600 seconds/, 'fail_message reflects custom timeout');
 
     # Explicit delay propagates and drives retry = timeout/delay
     $inst->wait_for_ssh_login(delay => 10);


### PR DESCRIPTION
Fixes `wait_for_ssh_login()` reporting the delay (30) as the attempt count instead of the actual retry count in its failure message.

* Related ticket: [poo#204540](https://progress.opensuse.org/issues/204540)
* Related failure: [openqa.suse.de/t23547999](https://openqa.suse.de/tests/23547999)
* Verification runs:
