### PR TITLE
Check gcemetadata binary instead of package name on GCE

### DIFF
--- a/tests/publiccloud/metadata.pm
+++ b/tests/publiccloud/metadata.pm
@@ -37,7 +37,7 @@ sub run {
         record_info('azuremetadata detail', $instance->ssh_script_output('sudo /usr/bin/azuremetadata --api latest --subscriptionId --billingTag --attestedData --signature --xml'));
     }
     elsif (is_gce) {
-        pc_zypper_call($instance, 'in python3-gcemetadata') unless $instance->ssh_script_run('rpm -q python3-gcemetadata') == 0;
+        pc_zypper_call($instance, 'in python3-gcemetadata') unless $instance->ssh_script_run('which gcemetadata') == 0;
         # Dump all instance metadata
         record_info('gcemetadata instance', $instance->ssh_script_output('gcemetadata --query instance'));
         # XML output format - skipped due to upstream gcemetadata bug: passing --xml with --query


### PR DESCRIPTION
Checks whether the `gcemetadata` binary is already available before installing `python3-gcemetadata` on GCE.

* Related ticket: [poo#204864](https://progress.opensuse.org/issues/204864)
* Related failure: [openqa.suse.de/t23646831](https://openqa.suse.de/tests/23646831)
* Verification runs: In comment below
