### PR TITLE
fix(publiccloud): Wait for cloud-init before asserting cloud-init.target

### DIFF
--- a/tests/publiccloud/check_services.pm
+++ b/tests/publiccloud/check_services.pm
@@ -62,14 +62,16 @@ sub run {
             $instance->ssh_assert_script_run('systemctl is-enabled waagent-network-setup.service');
         }
         if ((is_azure || is_ec2) && !is_container_host()) {
+            # cloud-init
             # cloud-init.target/cloud-config.target only become active once cloud-final has
             # completed, which can still be running when this module executes (poo#204852).
             # Wait for cloud-init to settle first; the exit code is only informational here,
             # actual pass/fail is judged by the is-active checks below and by check_cloudinit.
             my $rc = $instance->ssh_script_run(cmd => 'sudo cloud-init status --wait', timeout => 300);
-            record_info('cloud-init wait', "cloud-init status --wait returned $rc") if ($rc);
-            # cloud-init
-            record_info('cloud-init', $instance->ssh_script_output('systemctl --no-pager --full status cloud-init* cloud-final.service', proceed_on_failure => 1));
+            if ($rc) {
+                my $cloud_final = $instance->ssh_script_output('systemctl --no-pager --full status cloud-init* cloud-final.service', proceed_on_failure => 1);
+                record_info('cloud-init', "cloud-init status --wait returned '$rc'\n\n$cloud_final");
+            }
             $instance->ssh_assert_script_run('systemctl is-active cloud-init.service');
             $instance->ssh_script_retry('systemctl is-active cloud-init.target', retry => 6, delay => 10);
             $instance->ssh_assert_script_run('systemctl is-active cloud-init-local.service');

--- a/tests/publiccloud/check_services.pm
+++ b/tests/publiccloud/check_services.pm
@@ -62,15 +62,21 @@ sub run {
             $instance->ssh_assert_script_run('systemctl is-enabled waagent-network-setup.service');
         }
         if ((is_azure || is_ec2) && !is_container_host()) {
+            # cloud-init.target/cloud-config.target only become active once cloud-final has
+            # completed, which can still be running when this module executes (poo#204852).
+            # Wait for cloud-init to settle first; the exit code is only informational here,
+            # actual pass/fail is judged by the is-active checks below and by check_cloudinit.
+            my $rc = $instance->ssh_script_run(cmd => 'sudo cloud-init status --wait', timeout => 300);
+            record_info('cloud-init wait', "cloud-init status --wait returned $rc") if ($rc);
             # cloud-init
-            record_info('cloud-init', $instance->ssh_script_output('systemctl --no-pager --full status cloud-init*', proceed_on_failure => 1));
+            record_info('cloud-init', $instance->ssh_script_output('systemctl --no-pager --full status cloud-init* cloud-final.service', proceed_on_failure => 1));
             $instance->ssh_assert_script_run('systemctl is-active cloud-init.service');
-            $instance->ssh_assert_script_run('systemctl is-active cloud-init.target');
+            $instance->ssh_script_retry('systemctl is-active cloud-init.target', retry => 6, delay => 10);
             $instance->ssh_assert_script_run('systemctl is-active cloud-init-local.service');
             # cloud-config
             record_info('cloud-config', $instance->ssh_script_output('systemctl --no-pager --full status cloud-config*', proceed_on_failure => 1));
             $instance->ssh_assert_script_run('systemctl is-active cloud-config.service');
-            $instance->ssh_assert_script_run('systemctl is-active cloud-config.target');
+            $instance->ssh_script_retry('systemctl is-active cloud-config.target', retry => 6, delay => 10);
         }
         if (is_gce) {
             # google-guest-agent & google-osconfig-agent


### PR DESCRIPTION
check_services is now scheduled right after network_test (98e59bd298), before check_cloudinit, which can leave cloud-init.target and cloud-config.target still inactive while cloud-final.service is running. Wait for cloud-init to settle with 'cloud-init status --wait' and retry the target checks instead of asserting immediately.

Also include cloud-final.service in the recorded cloud-init status output for easier debugging.

- Related ticket: https://progress.opensuse.org/issues/204852
- Needles: N/A
- VRs:
  - 15sp5: https://openqa.suse.de/tests/23676538#step/check_services/1
  - 15sp6: https://openqa.suse.de/tests/23676539#step/check_services/1
  - 15sp7 (basic-updates): https://openqa.suse.de/tests/23676540#step/check_services/1
  - 15sp7: https://openqa.suse.de/tests/23676541#step/check_services/1