### PR TITLE
Adjust crash_test code to support Immutable Mode

### DIFF
--- a/tests/ha/ha_cluster_crash_test.pm
+++ b/tests/ha/ha_cluster_crash_test.pm
@@ -28,11 +28,13 @@ use hacluster qw(check_cluster_state
   setup_sbd_delay
   wait_until_resources_started
   prepare_console_for_fencing
+  save_state
 );
-use utils qw(zypper_call reconnect_mgmt_console);
+use utils qw(reconnect_mgmt_console);
 use Utils::Backends 'is_pvm';
-use version_utils qw(is_sle);
+use version_utils qw(is_sle is_transactional);
 use Mojo::JSON qw(encode_json);
+use package_utils qw(install_package);
 
 our $dir_log = '/var/lib/crmsh/crash_test/';
 
@@ -74,7 +76,13 @@ sub run {
         record_info($check, "Executing $cmd");
         if ($check eq 'split-brain-iptables') {
             # iptables is not installed in SLE 16 by default
-            zypper_call 'in iptables' if is_sle('>=16');
+            if (is_sle('>=16')) {
+                install_package('iptables', trup_reboot => 1);
+                if (is_transactional) {
+                    wait_until_resources_started();
+                    save_state();
+                }
+            }
             # Wait for a moment and save the screen shot for debugging purpose
             enter_cmd $cmd, wait_still_screen => 10;
             save_screenshot();


### PR DESCRIPTION
Related: https://jira.suse.com/browse/TEAM-11269

VR: 
Immutable Mode: 
hmc: https://openqa.suse.de/tests/23739117#step/ha_cluster_crash_test/200  (passed)
x86: https://openqa.suse.de/tests/23739130#step/ha_cluster_crash_test/161  (passed)

Traditional Mode (16.1):
hmc: https://openqa.suse.de/tests/23739135#step/ha_cluster_crash_test/172  (passed)
aarch64: https://openqa.suse.de/tests/23739136# (failed on time out as expected)
x86:   https://openqa.suse.de/tests/23739277#step/ha_cluster_crash_test/132 (passed)

16.0:
x86: https://openqa.suse.de/tests/23741188#step/ha_cluster_crash_test/160 (Passed)