### PR TITLE
Wait for pacemaker startup before configuration edit

### DIFF
--- a/tests/ha/qnetd.pm
+++ b/tests/ha/qnetd.pm
@@ -114,6 +114,9 @@ sub run {
         my $qnet_node_host = choose_node(3);
         my $qnet_node_ip = get_ip($qnet_node_host);
 
+        # Wait until pacemaker and resources are fully started and online (especially after reboot)
+        wait_until_resources_started;
+
         # Add a promotable resource to check if the current node is hosting
         # master instance of the resource. If so, this cluster partition
         # is preferred to be given the vote from qnetd.


### PR DESCRIPTION
In immutable/transactional mode on SLE >= 16, installing packages like iptables triggers a system reboot via trup_reboot.

After the system boots back up, openQA immediately executes crm configure commands. However, the Pacemaker and CIB services might still be starting, resulting in CIB API connection failures:

"cibadmin: Could not connect to the CIB API: Transport endpoint is not connected"

To prevent this race condition, wait for pacemaker and its resources to be fully started and online using `wait_until_resources_started` before running the configuration edit.

Failure: https://openqa.suse.de/tests/23657312#step/qnetd/37

VR: https://openqa.suse.de/tests/23676462# (Passed)
