### PR TITLE
Check registration status after migration

### DIFF
--- a/schedule/yam/agama_migration_15spx.yaml
+++ b/schedule/yam/agama_migration_15spx.yaml
@@ -17,4 +17,5 @@ schedule:
   - yam/validate/validate_migration_logs
   - yam/validate/validate_connectivity
   - yam/validate/validate_product
+  - yam/validate/validate_registered_products
   - console/validate_repos

--- a/schedule/yam/agama_migration_15spx_product_increment.yaml
+++ b/schedule/yam/agama_migration_15spx_product_increment.yaml
@@ -18,4 +18,5 @@ schedule:
   - yam/validate/validate_migration_logs
   - yam/validate/validate_connectivity
   - yam/validate/validate_product
+  - yam/validate/validate_registered_products
   - console/validate_repos

--- a/schedule/yam/agama_migration_15spx_product_increment_s390x.yaml
+++ b/schedule/yam/agama_migration_15spx_product_increment_s390x.yaml
@@ -17,4 +17,5 @@ schedule:
   - yam/validate/validate_migration_logs
   - yam/validate/validate_connectivity
   - yam/validate/validate_product
+  - yam/validate/validate_registered_products
   - console/validate_repos

--- a/schedule/yam/agama_migration_15spx_s390x.yaml
+++ b/schedule/yam/agama_migration_15spx_s390x.yaml
@@ -16,4 +16,5 @@ schedule:
   - yam/validate/validate_migration_logs
   - yam/validate/validate_connectivity
   - yam/validate/validate_product
+  - yam/validate/validate_registered_products
   - console/validate_repos

--- a/schedule/yam/agama_migration_leap.yaml
+++ b/schedule/yam/agama_migration_leap.yaml
@@ -11,4 +11,5 @@ schedule:
   - yam/migration/zypper_migration
   - yam/validate/validate_migration_logs
   - yam/validate/validate_product
+  - yam/validate/validate_registered_products
   - console/validate_repos

--- a/schedule/yam/agama_migration_sles_sap_15spx.yaml
+++ b/schedule/yam/agama_migration_sles_sap_15spx.yaml
@@ -20,4 +20,5 @@ schedule:
   - yam/validate/validate_migration_logs
   - yam/validate/validate_connectivity
   - yam/validate/validate_product
+  - yam/validate/validate_registered_products
   - console/validate_repos

--- a/schedule/yam/agama_migration_sles_sap_15spx_product_increment.yaml
+++ b/schedule/yam/agama_migration_sles_sap_15spx_product_increment.yaml
@@ -21,4 +21,5 @@ schedule:
   - yam/validate/validate_migration_logs
   - yam/validate/validate_connectivity
   - yam/validate/validate_product
+  - yam/validate/validate_registered_products
   - console/validate_repos

--- a/schedule/yam/agama_minor_migration_16.yaml
+++ b/schedule/yam/agama_minor_migration_16.yaml
@@ -13,4 +13,5 @@ schedule:
   - yam/migration/zypper_migration
   - yam/validate/validate_migration_logs
   - yam/validate/validate_product
+  - yam/validate/validate_registered_products
   - console/validate_repos

--- a/schedule/yam/agama_minor_migration_16_s390x.yaml
+++ b/schedule/yam/agama_minor_migration_16_s390x.yaml
@@ -14,4 +14,5 @@ schedule:
   - yam/migration/zypper_migration
   - yam/validate/validate_migration_logs
   - yam/validate/validate_product
+  - yam/validate/validate_registered_products
   - console/validate_repos


### PR DESCRIPTION
We have test module validate_registered_products available to test this after our default installation and have been added to the existing migrations test suites.

- Related ticket: https://progress.opensuse.org/issues/195869
- Verification run: 
[VRs](https://openqa.suse.de/tests/overview?distri=sle&build=hadeskun%2Fos-autoinst-distri-opensuse%23master&test=sles_migration_15sp5_ha%40hadeskun%2Fos-autoinst-distri-opensuse%23master&test=sles_migration_15sp5_textmode%40hadeskun%2Fos-autoinst-distri-ope%20%20nsuse%23master&test=sles_migration_15sp5_textmode_all_modules_and_extensions%40hadeskun%2Fos-autoinst-distri-opensuse%23master&test=sles_migration_15sp6_ha%40hadeskun%2Fos-autoinst-distri-opensuse%23master&test=sles_migration_15sp6_textmode%40hadeskun%%20%202Fos-autoinst-distri-opensuse%23master&test=sles_migration_15sp6_textmode_all_modules_and_extensions%40hadeskun%2Fos-autoinst-distri-opensuse%23master&test=sles_migration_15sp7_ha%40hadeskun%2Fos-autoinst-distri-opensuse%23master&test=sles_migration_15%20%20sp7_textmode%40hadeskun%2Fos-autoinst-distri-opensuse%23master&test=sles_migration_15sp7_textmode_all_modules_and_extensions%40hadeskun%2Fos-autoinst-distri-opensuse%23master&test=sles_migration_160%40hadeskun%2Fos-autoinst-distri-opensuse%23master&tes%20%20t=sles_migration_leap_161%40hadeskun%2Fos-autoinst-distri-opensuse%23master&test=sles_sap_migration_15sp5%40hadeskun%2Fos-autoinst-distri-opensuse%23master&test=sles_sap_migration_15sp6%40hadeskun%2Fos-autoinst-distri-opensuse%23master&test=sles_sap_mi%20%20gration_15sp7%40hadeskun%2Fos-autoinst-distri-opensuse%23master&test=sles_sap_migration_160%40hadeskun%2Fos-autoinst-distri-opensuse%23master&test=slmicro_migration%40hadeskun%2Fos-autoinst-distri-opensuse%23master)


