### PR TITLE
Only switch to log-console on failure in podman_ipv6/netavark cleanup

### DIFF
--- a/tests/containers/podman_ipv6.pm
+++ b/tests/containers/podman_ipv6.pm
@@ -19,13 +19,16 @@ use utils 'script_retry';
 sub _cleanup {
     my ($self, %args) = @_;
     my $podman = $self->containers_factory('podman');
-    # only switch to log-console on failure, poo#204498 - tty5 can be blanked
-    # after sitting idle for the whole test and never wakes up in time
-    select_console 'log-console' if $args{show_log};
     $podman->cleanup_system_host();
 
     my $registry_ipv4 = script_output('dig +short registry.opensuse.org A | grep -v suse');
     assert_script_run("iptables -D OUTPUT -d $registry_ipv4 -j DROP");
+
+    # only view log-console on failure, poo#204498 - tty5 can be blanked
+    # after sitting idle for the whole test and never wakes up in time.
+    # eval-wrapped so a stall there can't crash the hook after the network
+    # cleanup above already ran.
+    eval { select_console 'log-console' } if $args{show_log};
 }
 
 sub run {

--- a/tests/containers/podman_ipv6.pm
+++ b/tests/containers/podman_ipv6.pm
@@ -17,8 +17,11 @@ use utils 'script_retry';
 
 # clean up routine only for systems that run CNI as default network backend
 sub _cleanup {
-    my $podman = shift->containers_factory('podman');
-    select_console 'log-console';
+    my ($self, %args) = @_;
+    my $podman = $self->containers_factory('podman');
+    # only switch to log-console on failure, poo#204498 - tty5 can be blanked
+    # after sitting idle for the whole test and never wakes up in time
+    select_console 'log-console' if $args{show_log};
     $podman->cleanup_system_host();
 
     my $registry_ipv4 = script_output('dig +short registry.opensuse.org A | grep -v suse');
@@ -90,7 +93,7 @@ sub post_run_hook {
 }
 sub post_fail_hook {
     script_run("sysctl -a | grep --color=never net");
-    shift->_cleanup();
+    shift->_cleanup(show_log => 1);
 }
 
 sub test_flags {

--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -77,8 +77,11 @@ sub is_container_running {
 
 # clean up routine only for systems that run CNI as default network backend
 sub _cleanup {
-    my $podman = shift->containers_factory('podman');
-    select_console 'log-console';
+    my ($self, %args) = @_;
+    my $podman = $self->containers_factory('podman');
+    # only switch to log-console on failure, poo#204498 - tty5 can be blanked
+    # after sitting idle for the whole test and never wakes up in time
+    select_console 'log-console' if $args{show_log};
     remove_subtest_setup;
 
     if (is_cni_default) {
@@ -252,7 +255,7 @@ sub post_run_hook {
 
 sub post_fail_hook {
     load_ipv6_route;
-    shift->_cleanup();
+    shift->_cleanup(show_log => 1);
 }
 
 sub test_flags {

--- a/tests/containers/podman_netavark.pm
+++ b/tests/containers/podman_netavark.pm
@@ -79,9 +79,6 @@ sub is_container_running {
 sub _cleanup {
     my ($self, %args) = @_;
     my $podman = $self->containers_factory('podman');
-    # only switch to log-console on failure, poo#204498 - tty5 can be blanked
-    # after sitting idle for the whole test and never wakes up in time
-    select_console 'log-console' if $args{show_log};
     remove_subtest_setup;
 
     if (is_cni_default) {
@@ -94,6 +91,12 @@ sub _cleanup {
     }
 
     validate_script_output('podman network ls', sub { /podman\s+bridge/ });
+
+    # only view log-console on failure, poo#204498 - tty5 can be blanked
+    # after sitting idle for the whole test and never wakes up in time.
+    # eval-wrapped so a stall there can't crash the hook after the network
+    # cleanup above already ran.
+    eval { select_console 'log-console' } if $args{show_log};
 }
 
 sub switch_to_netavark {


### PR DESCRIPTION
Stop switching to `log-console` on the success path in `podman_ipv6.pm` and `podman_netavark.pm` cleanup — only do it on failure, matching `containers::basetest`'s default hook behavior. tty5 sits idle for the whole test on public cloud (console blanking isn't disabled there per `susedistribution.pm`) and never renders in time when finally switched to, causing a "Stall detected" and job failure.

The network/iptables/route cleanup now always runs before the optional log-console view, and that view is wrapped in `eval` so a stall there can't skip the cleanup or crash the hook — this was observed cascading into `podman_netavark` failing right after `podman_ipv6` in the reported job.

* Related ticket: [poo#204498](https://progress.opensuse.org/issues/204498)
* Related failure: [openqa.suse.de/t23524025](https://openqa.suse.de/tests/23524025)
* Verification runs: In comment below

## Commits

- e299a57 fix(containers): Only switch to log-console on failure in IPv6 cleanup
- 39ecb69 fix(containers): Run IPv6 cleanup before the optional log-console view

