### PR TITLE
Restart getty on tty5 alongside tty2-4 in ssh_interactive_start

### DIFF
--- a/tests/publiccloud/ssh_interactive_start.pm
+++ b/tests/publiccloud/ssh_interactive_start.pm
@@ -21,10 +21,12 @@ sub run {
     my ($self, $args) = @_;
     die "tunnel-console requires the TUNNELED=1 setting" unless (is_tunneled());
 
-    # activate tty2/tty3/tty4 in advance, as under some circumstances test fails
-    # on assert_screen() if too much time has passed without activity in the tty
+    # activate tty2/tty3/tty4/tty5 in advance, as under some circumstances test
+    # fails on assert_screen() if too much time has passed without activity in
+    # the tty. tty5 (log-console) is rarely used during a passing run, so it's
+    # especially prone to this - see poo#204498.
     select_serial_terminal();
-    systemctl("restart getty\@tty$_.service", timeout => 60) for (2 .. 4);
+    systemctl("restart getty\@tty$_.service", timeout => 60) for (2 .. 5);
 
     # Initialize ssh tunnel for the serial device, if not yet happened
     ssh_interactive_tunnel($args->{my_instance}) if (get_var('_SSH_TUNNELS_INITIALIZED', 0) == 0);


### PR DESCRIPTION
Extend the existing proactive getty restart in `ssh_interactive_start.pm` to also cover tty5 (`log-console`), alongside tty2-4. log-console is rarely activated during a passing run, so it's the most likely candidate to sit idle long enough to fail `assert_screen()` when a test finally switches to it — this is what caused the stall in poo#204498.

* Related ticket: [poo#204498](https://progress.opensuse.org/issues/204498)
* Related merge requests: os-autoinst/os-autoinst-distri-opensuse#26221
* Verification runs: In comment below

