### PR TITLE
security: skip always_rollback on backends without snapshots

### DIFF
--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -34,6 +34,7 @@ use constant {
           is_qemu
           is_svirt
           is_image_backend
+          has_snapshots
           is_ssh_installation
           is_backend_s390x
           is_spvm
@@ -228,6 +229,32 @@ Returns true if the current instance is running on backend with image support
 
 sub is_image_backend {
     return (is_qemu || is_svirt);
+}
+
+=head2 has_snapshots
+
+Returns true if the current backend supports VM snapshots, and therefore the
+C<always_rollback> test flag. Requesting C<always_rollback> where snapshots are
+unavailable makes os-autoinst abort the job.
+
+This mirrors the C<can_handle('snapshots')> implementations of the qemu and
+svirt backends, the only two which implement it; every other backend inherits
+the C<backend::baseclass> version, which always refuses.
+
+Note that C<VIRSH_VMM_FAMILY> must not be defaulted to 'kvm' here as
+C<consoles/sshVirtsh.pm> does: the svirt backend reads it undefaulted, so s390x
+zKVM jobs, which leave it unset, get no snapshot support.
+
+=cut
+
+sub has_snapshots {
+    if (is_qemu) {
+        return 0 if get_var('QEMU_DISABLE_SNAPSHOTS');
+        # snapshotting requires migration, which NVMe drives do not support
+        my @models = map { get_var($_, '') } ('HDDMODEL', map { "HDDMODEL_$_" } 1 .. get_var('NUMDISKS', 1));
+        return (grep { $_ eq 'nvme' } @models) ? 0 : 1;
+    }
+    return (is_svirt && get_var('VIRSH_VMM_FAMILY', '') =~ /kvm|hyperv|vmware/) ? 1 : 0;
 }
 
 =head2 is_backend_s390x

--- a/t/51_utils_backends.t
+++ b/t/51_utils_backends.t
@@ -1,0 +1,65 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Warnings;
+use testapi;
+use Utils::Backends;
+
+## Test backend capability helpers.
+
+# The scenarios below mirror backend::qemu::can_handle() and
+# backend::svirt::can_handle() in os-autoinst, the only two backends
+# implementing snapshot support. Every other backend inherits the
+# backend::baseclass implementation, which always refuses.
+sub with_vars {
+    my (%vars) = @_;
+    %bmwqemu::vars = %vars;
+}
+
+subtest '[has_snapshots] qemu supports snapshots regardless of architecture' => sub {
+    for my $arch (qw(x86_64 s390x ppc64le aarch64)) {
+        with_vars(BACKEND => 'qemu', ARCH => $arch);
+        ok has_snapshots, "qemu on $arch supports snapshots";
+    }
+};
+
+subtest '[has_snapshots] QEMU_DISABLE_SNAPSHOTS turns snapshots off' => sub {
+    with_vars(BACKEND => 'qemu', ARCH => 'x86_64', QEMU_DISABLE_SNAPSHOTS => 1);
+    ok !has_snapshots, 'snapshots disabled by QEMU_DISABLE_SNAPSHOTS';
+};
+
+subtest '[has_snapshots] NVMe drives cannot be migrated' => sub {
+    with_vars(BACKEND => 'qemu', HDDMODEL => 'nvme', NUMDISKS => 1);
+    ok !has_snapshots, 'HDDMODEL=nvme has no snapshots';
+    with_vars(BACKEND => 'qemu', HDDMODEL_2 => 'nvme', NUMDISKS => 2);
+    ok !has_snapshots, 'HDDMODEL_2=nvme has no snapshots';
+    with_vars(BACKEND => 'qemu', HDDMODEL => 'virtio-blk', NUMDISKS => 1);
+    ok has_snapshots, 'a non-NVMe HDDMODEL keeps snapshots';
+};
+
+subtest '[has_snapshots] svirt depends on the VMM family' => sub {
+    for my $family (qw(kvm hyperv vmware)) {
+        with_vars(BACKEND => 'svirt', VIRSH_VMM_FAMILY => $family);
+        ok has_snapshots, "svirt with VIRSH_VMM_FAMILY=$family supports snapshots";
+    }
+    with_vars(BACKEND => 'svirt', VIRSH_VMM_FAMILY => 'xen');
+    ok !has_snapshots, 'svirt with VIRSH_VMM_FAMILY=xen has no snapshots';
+};
+
+subtest '[has_snapshots] s390x zKVM leaves VIRSH_VMM_FAMILY unset' => sub {
+    # poo#204801: the svirt backend reads VIRSH_VMM_FAMILY undefaulted while
+    # consoles/sshVirtsh.pm defaults it to 'kvm'. Defaulting it here too would
+    # wrongly report snapshot support and make these jobs die on
+    # always_rollback.
+    with_vars(BACKEND => 'svirt', ARCH => 's390x', S390_ZKVM => 1);
+    ok !has_snapshots, 'svirt on s390x zKVM has no snapshots';
+};
+
+subtest '[has_snapshots] backends without snapshot support' => sub {
+    for my $backend (qw(ipmi spvm pvm_hmc s390x generalhw)) {
+        with_vars(BACKEND => $backend);
+        ok !has_snapshots, "$backend has no snapshots";
+    }
+};
+
+done_testing;

--- a/test_known_issues.json
+++ b/test_known_issues.json
@@ -1,0 +1,1 @@
+{"testsuite_01":{"test_01":[{"message":"overwrite result 2","product":"^sle:15","retval":"^2$"},{"message":"overwrite for product sle:12","product":"^sle:12","skip":1},{"message":"overwrite ZERO result","product":"^sle:11","retval":"^0$"},{"message":"overwrite TWO result","product":"^sle:11","retval":"^2$"}]}}

--- a/tests/console/aide_check.pm
+++ b/tests/console/aide_check.pm
@@ -17,6 +17,7 @@
 
 use Mojo::Base 'consoletest';
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use utils "zypper_call";
 
@@ -55,7 +56,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/fips/squid/squid_reverse_proxy.pm
+++ b/tests/fips/squid/squid_reverse_proxy.pm
@@ -10,6 +10,7 @@
 
 use Mojo::Base 'consoletest';
 use testapi;
+use Utils::Backends;
 use utils qw(systemctl zypper_call script_retry);
 use serial_terminal qw(select_serial_terminal);
 
@@ -59,7 +60,7 @@ sub post_fail_hook {
 
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/fips/squid/squid_web_proxy.pm
+++ b/tests/fips/squid/squid_web_proxy.pm
@@ -10,6 +10,7 @@
 
 use Mojo::Base 'consoletest';
 use testapi;
+use Utils::Backends;
 use utils qw(systemctl);
 use version_utils 'is_sle';
 
@@ -45,7 +46,7 @@ sub post_fail_hook {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/aarch64_secure_boot/yast2_bootloader.pm
+++ b/tests/security/aarch64_secure_boot/yast2_bootloader.pm
@@ -9,6 +9,7 @@
 
 use Mojo::Base qw(opensusebasetest consoletest);
 use testapi;
+use Utils::Backends;
 use utils;
 use power_action_utils 'power_action';
 use version_utils 'is_sle';
@@ -64,7 +65,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/apparmor_profile/usr_sbin_dnsmasq.pm
+++ b/tests/security/apparmor_profile/usr_sbin_dnsmasq.pm
@@ -14,6 +14,7 @@
 
 use Mojo::Base 'apparmortest';
 use testapi;
+use Utils::Backends;
 use utils;
 
 sub check_audit_log {
@@ -89,7 +90,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/bsc1241678_pam_apparmor.pm
+++ b/tests/security/bsc1241678_pam_apparmor.pm
@@ -9,6 +9,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use utils;
 use serial_terminal 'select_serial_terminal';
 
@@ -49,7 +50,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/cc/apparmor_negative_test.pm
+++ b/tests/security/cc/apparmor_negative_test.pm
@@ -9,6 +9,7 @@
 
 use Mojo::Base 'consoletest';
 use testapi;
+use Utils::Backends;
 use utils;
 use audit_test 'parse_kvm_svirt_apparmor_results';
 
@@ -35,7 +36,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/cc/audit_remote_libvirt.pm
+++ b/tests/security/cc/audit_remote_libvirt.pm
@@ -9,6 +9,7 @@
 
 use Mojo::Base 'consoletest';
 use testapi;
+use Utils::Backends;
 use utils;
 use audit_test qw(run_testcase compare_run_log);
 use version_utils 'is_sle';
@@ -66,7 +67,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/cc/audit_tools.pm
+++ b/tests/security/cc/audit_tools.pm
@@ -9,6 +9,7 @@
 
 use Mojo::Base 'consoletest';
 use testapi;
+use Utils::Backends;
 use utils;
 use version_utils 'is_sle';
 use audit_test qw(run_testcase compare_run_log rerun_fail_cases);
@@ -35,7 +36,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/cc/crypto.pm
+++ b/tests/security/cc/crypto.pm
@@ -9,6 +9,7 @@
 
 use Mojo::Base 'consoletest';
 use testapi;
+use Utils::Backends;
 use utils;
 use audit_test qw(run_testcase compare_run_log);
 
@@ -29,7 +30,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/cc/fail_safe.pm
+++ b/tests/security/cc/fail_safe.pm
@@ -9,6 +9,7 @@
 
 use Mojo::Base 'consoletest';
 use testapi;
+use Utils::Backends;
 use utils;
 use audit_test qw(run_testcase compare_run_log);
 
@@ -26,7 +27,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/cc/ip_eb_tables.pm
+++ b/tests/security/cc/ip_eb_tables.pm
@@ -9,6 +9,7 @@
 
 use Mojo::Base 'consoletest';
 use testapi;
+use Utils::Backends;
 use utils;
 use Utils::Architectures 'is_s390x';
 use version_utils 'is_sle';
@@ -82,7 +83,7 @@ sub post_fail_hook {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/cc/misc.pm
+++ b/tests/security/cc/misc.pm
@@ -9,6 +9,7 @@
 
 use Mojo::Base 'consoletest';
 use testapi;
+use Utils::Backends;
 use utils;
 use audit_test qw(run_testcase compare_run_log);
 use Utils::Architectures qw(is_s390x);
@@ -28,7 +29,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/ima/evm_protection_digital_signatures.pm
+++ b/tests/security/ima/evm_protection_digital_signatures.pm
@@ -8,6 +8,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use bootloader_setup qw(replace_grub_cmdline_settings);
@@ -73,7 +74,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/ima/evm_protection_hmacs.pm
+++ b/tests/security/ima/evm_protection_hmacs.pm
@@ -8,6 +8,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use bootloader_setup qw(replace_grub_cmdline_settings);
@@ -49,7 +50,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/ima/evm_verify.pm
+++ b/tests/security/ima/evm_verify.pm
@@ -7,6 +7,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use security::config;
@@ -36,7 +37,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/ima/evmctl_ima_sign.pm
+++ b/tests/security/ima/evmctl_ima_sign.pm
@@ -8,6 +8,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use security::config;
@@ -46,7 +47,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/ima/ima_appraisal_audit.pm
+++ b/tests/security/ima/ima_appraisal_audit.pm
@@ -8,6 +8,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
@@ -53,7 +54,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/ima/ima_appraisal_hashes.pm
+++ b/tests/security/ima/ima_appraisal_hashes.pm
@@ -7,6 +7,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
@@ -58,7 +59,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/ima/ima_kernel_cmdline_hash.pm
+++ b/tests/security/ima/ima_kernel_cmdline_hash.pm
@@ -7,6 +7,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
@@ -81,7 +82,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/ima/ima_kernel_cmdline_template.pm
+++ b/tests/security/ima/ima_kernel_cmdline_template.pm
@@ -7,6 +7,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
@@ -75,7 +76,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/ima/ima_measurement_audit.pm
+++ b/tests/security/ima/ima_measurement_audit.pm
@@ -7,6 +7,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
@@ -53,7 +54,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/ima/ima_verify.pm
+++ b/tests/security/ima/ima_verify.pm
@@ -8,6 +8,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use utils;
 
@@ -45,7 +46,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/nproc_limits.pm
+++ b/tests/security/nproc_limits.pm
@@ -8,6 +8,7 @@
 use Mojo::Base 'opensusebasetest';
 use power_action_utils "power_action";
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use utils;
 use version_utils qw(check_version is_sle is_leap is_tumbleweed);
@@ -39,7 +40,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/oqa_agnostic/go_post_quantum.pm
+++ b/tests/security/oqa_agnostic/go_post_quantum.pm
@@ -8,6 +8,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use utils 'zypper_call';
 
@@ -47,7 +48,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/oqa_agnostic/openssl_pqc.pm
+++ b/tests/security/oqa_agnostic/openssl_pqc.pm
@@ -8,6 +8,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use security::agnosticTestRunner;
 use version_utils 'is_sle';
@@ -37,7 +38,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/oqa_agnostic/polkit_rules.pm
+++ b/tests/security/oqa_agnostic/polkit_rules.pm
@@ -8,6 +8,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use security::agnosticTestRunner;
 
@@ -23,7 +24,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/oqa_agnostic/yama.pm
+++ b/tests/security/oqa_agnostic/yama.pm
@@ -8,6 +8,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use security::agnosticTestRunner;
 use package_utils 'install_package';
@@ -32,7 +33,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/scap_workbench/scap_workbench.pm
+++ b/tests/security/scap_workbench/scap_workbench.pm
@@ -7,6 +7,7 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
+use Utils::Backends;
 use utils;
 use version_utils 'is_sle';
 
@@ -128,7 +129,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/security/swtpm/swtpm_verify.pm
+++ b/tests/security/swtpm/swtpm_verify.pm
@@ -10,6 +10,7 @@
 use Mojo::Base 'opensusebasetest';
 use swtpmtest;
 use testapi;
+use Utils::Backends;
 use serial_terminal 'select_serial_terminal';
 use Utils::Architectures;
 use version_utils 'is_sle';
@@ -37,7 +38,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;

--- a/tests/x11/x3270_ssl.pm
+++ b/tests/x11/x3270_ssl.pm
@@ -10,6 +10,7 @@
 
 use Mojo::Base 'x11test';
 use testapi;
+use Utils::Backends;
 use Utils::Architectures;
 use utils;
 use power_action_utils 'power_action';
@@ -86,7 +87,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => has_snapshots};
 }
 
 1;


### PR DESCRIPTION
Don't request always_rollback on backends without snapshot support.

Ticket: https://progress.opensuse.org/issues/204801