### PR TITLE
virt_autotest: Increase LVM volume clone timeout to 600 seconds

### DIFF
--- a/lib/virt_autotest/virtual_storage_utils.pm
+++ b/lib/virt_autotest/virtual_storage_utils.pm
@@ -33,6 +33,7 @@ sub virt_storage_management {
     my ($vstorage_pool_name, %args) = @_;
     my $vol_size = $args{size};
     my $timeout = $args{timeout} // 120;
+    my $clone_timeout = $args{clone_timeout} // 600;
     my $dir = $args{dir} // 0;
     my $vol_resize = $args{resize} // 0;
     ## Basic Virtualization Storage Pool Management
@@ -65,7 +66,7 @@ sub virt_storage_management {
     record_info "Detached";
     assert_script_run("virsh detach-disk $_ $target", $timeout) foreach (keys %virt_autotest::common::guests);
     record_info "Clone";
-    assert_script_run("virsh vol-clone --pool $vstorage_pool_name $_-storage $_-clone", $timeout) foreach (keys %virt_autotest::common::guests);
+    assert_script_run("virsh vol-clone --pool $vstorage_pool_name $_-storage $_-clone", $clone_timeout) foreach (keys %virt_autotest::common::guests);
     assert_script_run("virsh vol-info --pool $vstorage_pool_name $_-clone", $timeout) foreach (keys %virt_autotest::common::guests);
     # Delete and Remove a Storage Volume from storage pool
     record_info "Remove";


### PR DESCRIPTION
## Problem
The `virsh vol-clone` command was timing out after 120 seconds during libvirt_extend_storage_lvm test on large LVM volumes. The test failed with the following error:
```
Test died: command 'virsh vol-clone --pool guest_image_lvm sles-16-1-64-kvm-hvm-uefi-agama-online-iso-storage sles-16-1-64-kvm-hvm-uefi-agama-online-iso-clone' timed out
```
## Root Cause Analysis
`After extensive testing, the timeout was caused by insufficient timeout budget for cloning large LVM volumes. `

## Solution
Introduce a separate `clone_timeout` parameter with a default value of 600 seconds (10 minutes), which provides adequate headroom for cloning large LVM volumes:
```
- Default timeout for other operations: 120 seconds (unchanged)
- LVM volume clone timeout: 600 seconds (new, 5x increase)
- Configurable via `clone_timeout` parameter in virt_storage_management()
```

- Related ticket: https://progress.opensuse.org/issues/204789

- Verification run:
[uefi-gi-online-guest_developing-on-host_developing-kvm](http://openqa.suse.de/tests/23682637#)