### PR TITLE
feat(jeos-firstboot): BETA license is no longer needed

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -281,16 +281,13 @@ sub run {
     send_key 'ret';
 
     # Show license
-    # EULA license applies for sle products that are in GM(C) phase
-    my $license = 'jeos-license';
-    if ((is_sle || is_sle_micro) && !get_var('BETA')) {
-        $license = 'jeos-license-eula';
-    }
+    # EULA license applies for suse products only
+    my $license = is_opensuse ? 'jeos-license' : 'jeos-license-eula';
     assert_screen $license;
     send_key 'ret';
 
     # Accept EULA if required
-    if (is_sle || is_sle_micro) {
+    unless (is_opensuse) {
         assert_screen 'jeos-doyouaccept';
         send_key 'ret';
     }


### PR DESCRIPTION
Products based on 16.x codestream will always have an EULA license

- Related ticket: https://progress.opensuse.org/issues/204888
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz

### Verification runs
* [tw](https://openqa.opensuse.org/tests/6131835#step/firstrun/6)
* [leap16.0](https://openqa.opensuse.org/tests/6131837#step/firstrun/6)
