### PR TITLE
Schedule SMOKETEST check_services before tunnel setup

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -66,6 +66,7 @@ sub load_maintenance_publiccloud_tests {
     } elsif (get_var('PUBLIC_CLOUD_EC2_ENCLAVE_TESTS')) {
         loadtest "publiccloud/aws_enclave", run_args => $args;
     } else {
+        loadtest("publiccloud/check_services", run_args => $args) if (get_var('PUBLIC_CLOUD_SMOKETEST'));
         loadtest "publiccloud/ssh_interactive_start", run_args => $args;
         loadtest "publiccloud/instance_overview", run_args => $args;
         if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
@@ -81,7 +82,6 @@ sub load_maintenance_publiccloud_tests {
             loadtest "xfstests/run", run_args => $args;
             return;
         } elsif (get_var('PUBLIC_CLOUD_SMOKETEST')) {
-            loadtest "publiccloud/check_services", run_args => $args;
             loadtest "publiccloud/smoketest";
             # flavor_check is concentrated on checking things which make sense only for image which is registered
             # against internal Public Cloud infra, so whenever we using SUSEConnect whole module does not make much sense


### PR DESCRIPTION
Moved the `check_services` call in the `PUBLIC_CLOUD_SMOKETEST` branch of `load_maintenance_publiccloud_tests` to before `ssh_interactive_start`, so it still runs after `patch_and_reboot` but before the SSH tunnel is established.

* Related ticket: [poo#204906](https://progress.opensuse.org/issues/204906)
* Related failure: [openqa.suse.de/t23678772](https://openqa.suse.de/tests/23678772)
* Verification runs:
