### PR TITLE
security/apparmor: accept empty aa-notify output in aa_notify

### DIFF
--- a/tests/security/apparmor/aa_notify.pm
+++ b/tests/security/apparmor/aa_notify.pm
@@ -75,8 +75,10 @@ sub run {
     # line with "/m" instead of anchoring the whole output, as newer
     # apparmor-notify versions can print additional informational lines
     # (e.g. "ttkthemes not found. Install for best user experience.")
-    # before the actual denial summary.
-    validate_script_output "aa-notify -s 1", sub { m/^AppArmor\sdenials?:\s+0\s+\(since.*$/m };
+    # before the actual denial summary. Older apparmor versions (e.g. 2.8.2 on
+    # SLE 12-SP5) print no output at all when there are no denials, so accept
+    # empty output as well (poo#204807).
+    validate_script_output "aa-notify -s 1", sub { !/\S/ || m/^AppArmor\sdenials?:\s+0\s+\(since/m };
 
     # Make it failed intentionally to get some audit messages
     assert_script_run "sed -i '/\\/etc\\/nscd.conf/d' $tmp_prof/usr.sbin.nscd" if is_sle('<=15-sp4');

--- a/tests/security/apparmor/aa_notify.pm
+++ b/tests/security/apparmor/aa_notify.pm
@@ -75,10 +75,14 @@ sub run {
     # line with "/m" instead of anchoring the whole output, as newer
     # apparmor-notify versions can print additional informational lines
     # (e.g. "ttkthemes not found. Install for best user experience.")
-    # before the actual denial summary. Older apparmor versions (e.g. 2.8.2 on
-    # SLE 12-SP5) print no output at all when there are no denials, so accept
-    # empty output as well (poo#204807).
-    validate_script_output "aa-notify -s 1", sub { !/\S/ || m/^AppArmor\sdenials?:\s+0\s+\(since/m };
+    # before the actual denial summary.
+    if (is_sle('<=12-sp5')) {
+        # apparmor-utils 2.8.2 (SLE 12-SP5) prints no output at all when
+        # there are no denials (poo#204807).
+        validate_script_output "aa-notify -s 1", sub { !/\S/ };
+    } else {
+        validate_script_output "aa-notify -s 1", sub { m/^AppArmor\sdenials?:\s+0\s+\(since.*$/m };
+    }
 
     # Make it failed intentionally to get some audit messages
     assert_script_run "sed -i '/\\/etc\\/nscd.conf/d' $tmp_prof/usr.sbin.nscd" if is_sle('<=15-sp4');


### PR DESCRIPTION
The regex tightening in [poo#201084](https://progress.opensuse.org/issues/201084) removed the optional-group tolerance
that used to accept empty `aa-notify` output. apparmor-utils 2.8.2 on
SLE 12-SP5 prints nothing at all when there are no denials, so aa_notify
now fails there.

Note the regression is caused by the stricter regex, not by `-s 1` --
`-s 1` and `-l` behave identically on 2.8.2.

Accept empty output again while keeping the `-s 1` switch and the
multi-line match. 15-SP4..SP7 and Tumbleweed are unaffected.

- Related ticket: https://progress.opensuse.org/issues/204807
- Needles: N/A
- Verification runs:
  - 12sp5: https://openqa.suse.de/tests/23681710#step/aa_notify/19
  - 15sp4: https://openqa.suse.de/tests/23681712#step/aa_notify/19
  - 15sp7: https://openqa.suse.de/tests/23681713#step/aa_notify/19