### PR TITLE
fix:Remove check for waagent-network-setup.service

### DIFF
--- a/tests/publiccloud/check_services.pm
+++ b/tests/publiccloud/check_services.pm
@@ -59,7 +59,6 @@ sub run {
             # waagent (Azure Linux VM Agent)
             record_info('waagent', $instance->ssh_script_output('systemctl --no-pager --full status waagent*', proceed_on_failure => 1));
             $instance->ssh_assert_script_run('systemctl is-active waagent.service');
-            $instance->ssh_assert_script_run('systemctl is-enabled waagent-network-setup.service');
         }
         if ((is_azure || is_ec2) && !is_container_host()) {
             # cloud-init


### PR DESCRIPTION
This service is not included by SUSE so it should not be checked.

See https://suse.slack.com/archives/C02CANHLANP/p1785241667895569


- Related failure: https://openqa.suse.de/tests/23653577#step/check_services/20
- Check introduced in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19659
- Verification run: https://openqa.suse.de/tests/23681729#step/check_services/40
