### PR TITLE
fix(hpc): Adjust Slurm master accounting test parameters and login prompt matching

### DIFF
--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -365,19 +365,25 @@ sub t01_accounting() {
     script_run("srun --account=UNI_X_Math -w slave-node00,slave-node01 date");
     type_string("su - $users{user_2}", lf => 1);
     wait_serial("Password:"); type_string("$testapi::password", lf => 1);
+    wait_serial(qr/:~> \s*$/);
+    type_string("export PS1=\"\$ \"", lf => 1);
 
     $testapi::username = $users{user_2};
-    script_run("srun --account=UNI_X_IT -N 2 -x master-node01,slave-node02 hostname");
+    script_run("srun --account=UNI_X_IT -N 2 -x master-node00,slave-node02 hostname");
     $testapi::username = $users{user_3};
     type_string("su - $users{user_3}", lf => 1);
     wait_serial("Password:"); type_string("$testapi::password", lf => 1);
+    wait_serial(qr/:~> \s*$/);
+    type_string("export PS1=\"\$ \"", lf => 1);
 
-    script_run("srun --account=UNI_Y_Biology -N 3 -x master-node01,slave-node02 date");
+    script_run("srun --account=UNI_Y_Biology -N 2 -x master-node00,slave-node02 date");
     $testapi::username = $users{user_4};
     $prompt = $testapi::username . '@' . get_required_var('HOSTNAME') . ':~> ';
     type_string("su - $users{user_4}", lf => 1);
     wait_serial("Password:"); type_string("$testapi::password", lf => 1);
-    script_run("srun --account=UNI_Y_Physics -N 3 -x master-node01,slave-node02 hostname");
+    wait_serial(qr/:~> \s*$/);
+    type_string("export PS1=\"\$ \"", lf => 1);
+    script_run("srun --account=UNI_Y_Physics -N 2 -x master-node00,slave-node02 hostname");
 
     select_serial_terminal;
     # this is required; see: bugzilla#1150565?


### PR DESCRIPTION
- Fix invalid master node name by changing master-node01 to master-node00.
- Reduce requested node count from -N 3 to -N 2 when excluding master-node00 and slave-node02 to match actual node availability.
- Recover prompt after su login transitions by waiting for the SUSE prompt and resetting PS1 to '$ '.

- Related ticket: https://progress.opensuse.org/issues/204891
- Verification run: https://openqa.suse.de/tests/23680994#
