### PR TITLE
fix:Skip cloud-netconfig test on EC2-ECS

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -42,6 +42,7 @@ our @EXPORT = qw(
   is_ondemand
   is_ec2
   is_ec2_xen
+  is_ecs
   is_azure
   is_gce
   is_container_host
@@ -81,6 +82,11 @@ sub is_ondemand() {
 # Check if we are on an AWS test run
 sub is_ec2() {
     return is_public_cloud && check_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
+}
+
+# check is this is a EC2 ECS instance
+sub is_ecs() {
+    return is_public_cloud && get_var('FLAVOR') =~ /-ECS-/i;
 }
 
 sub is_ec2_xen {

--- a/tests/publiccloud/check_services.pm
+++ b/tests/publiccloud/check_services.pm
@@ -94,7 +94,7 @@ sub run {
     }
     # cloud-netconfig
     # in GCE from 15-SP4 (see bsc#1227507, bsc#1227508)
-    unless ((is_sle('<15-SP4') && is_gce) || is_container_host) {
+    unless ((is_sle('<15-SP4') && is_gce) || is_container_host || is_ecs) {
         record_info('cloud-netconfig', $instance->ssh_script_output('systemctl --no-pager --full status cloud-netconfig*', proceed_on_failure => 1));
         $instance->ssh_assert_script_run('systemctl is-enabled cloud-netconfig.service');
         $instance->ssh_assert_script_run('systemctl is-active cloud-netconfig.timer');


### PR DESCRIPTION
Recent changes in the job schedule makes check_service.pm also being executed for EC2-ECS images. On those images we should not check for `cloud-netconfig.service`.

See https://suse.slack.com/archives/C02ACGUEN82/p1785331661593659

- Related failure: https://openqa.suse.de/tests/23653587#step/check_services/36
- Verification run: https://openqa.suse.de/tests/23682086#step/check_services/29
