### PR TITLE
Retry amazon-cloudwatch-agent installation on EC2

### DIFF
--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -477,7 +477,7 @@ sub _install_ec2_cloudwatch_agent
         $instance->softreboot();
     } else {
         if (is_sle(">12-SP5")) {
-            pc_zypper_call($instance, "install --no-recommends --allow-unsigned-rpm $download_directory/$rpm_file");
+            pc_zypper_call($instance, "install --no-recommends --allow-unsigned-rpm $download_directory/$rpm_file", retry => 3);
         } else {
             $instance->ssh_assert_script_run("sudo rpm -Uvh $download_directory/$rpm_file");
         }


### PR DESCRIPTION
Add retry parameter to the pc_zypper_call command inside _install_ec2_cloudwatch_agent to retry the Amazon CloudWatch agent installation up to 3 times on SLE > 12-SP5 instances.

Related ticket: https://progress.opensuse.org/issues/204834

# Verification
sle-15-SP7-EC2-Incidents-x86_64-Build:smelt:45685:grub2-publiccloud_smoketests ec2_i3.8xlarge
 - http://openqa.suse.de/tests/23682091 :red_circle: fails after retry for 3 times :-( 
 - https://openqa.suse.de/tests/23682620