### PR TITLE
Prevent ipaddr2 test abort on curl timeout

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -2064,6 +2064,25 @@ sub ipaddr2_wait_for_takeover(%args) {
             record_info("TAKE_OVER", "Webserver now reply from $dest_vm");
             return 1;
         }
+
+        record_info("DIAGNOSE_LOOP_$counter", "Probe failed, capturing real-time loop diagnostics");
+        ipaddr2_ssh_bastion_script_output(
+            bastion_ip => $args{bastion_ip},
+            cmd => "echo '--- Verbose Web Probe ---' && curl -iv --connect-timeout 3 http://$frontend_ip || true"
+        );
+        ipaddr2_ssh_bastion_script_output(
+            bastion_ip => $args{bastion_ip},
+            cmd => "echo '--- Ping Test ---' && ping -c 3 $frontend_ip || true"
+        );
+        ipaddr2_ssh_internal(id => 1, bastion_ip => $args{bastion_ip},
+            cmd => "echo '--- CRM Status at retry $counter ---' && sudo crm status || true"
+        );
+        for my $i (1, 2) {
+            ipaddr2_ssh_internal(id => $i, bastion_ip => $args{bastion_ip},
+                cmd => "echo '--- VM-$i Network Listeners ---' && ss -tlnp | grep -E '80|62500' || true"
+            );
+        }
+
         sleep 10;
         $counter++;
     }

--- a/tests/sles4sap/ipaddr2/test_move_resource.pm
+++ b/tests/sles4sap/ipaddr2/test_move_resource.pm
@@ -70,6 +70,14 @@ sub run {
 
     my $bastion_ip = ipaddr2_bastion_pubip();
 
+    record_info("DEBUG_BEFORE", "Capture cluster and network state before move");
+    for my $node_id (1, 2) {
+        my $node_name = sles4sap::ipaddr2::ipaddr2_get_internal_vm_name(id => $node_id);
+        sles4sap::ipaddr2::ipaddr2_ssh_internal(id => $node_id, bastion_ip => $bastion_ip,
+            cmd => "echo '=== $node_name IP ===' && ip addr show && echo '=== $node_name Listeners ===' && ss -tlnp");
+    }
+    sles4sap::ipaddr2::ipaddr2_ssh_internal(id => 1, bastion_ip => $bastion_ip, cmd => "echo '=== CRM STATUS ===' && sudo crm status && echo '=== CRM CONFIG ===' && sudo crm configure show");
+
     # 1. get the webpage using the LB floating IP. It should be from VM1 at the test beginning
     # 2. move the cluster resource on the VM2
     # 3. get the webpage using the LB floating IP. It should be from VM2
@@ -81,6 +89,9 @@ sub run {
     # backend IP of the VM-02
     ipaddr2_crm_move(bastion_ip => $bastion_ip, destination => 2);
     sleep 30;
+
+    record_info("DEBUG_AFTER", "Capture cluster constraints and state after crm move");
+    sles4sap::ipaddr2::ipaddr2_ssh_internal(id => 1, bastion_ip => $bastion_ip, cmd => "echo '=== CRM STATUS AFTER MOVE ===' && sudo crm status && echo '=== CRM CONSTRAINTS ===' && sudo crm configure show xml | grep -i rsc_location");
 
     # probe the webserver using the frontend IP
     # until the reply come from the VM-02


### PR DESCRIPTION
I added `ipaddr2` test in Azure cloud, but there is failure like this:
https://openqaworker15.qe.prg2.suse.org/tests/379263#step/test_move_resource/21
this PR takes `rsc_grp_00` instead `rsc_web_00`, and fixes this issue.

- Related ticket: https://jira.suse.com/browse/TEAM-11078
- Verification run:
    https://openqaworker15.qe.prg2.suse.org/tests/380477 (16.0 BYOS)
    https://openqaworker15.qe.prg2.suse.org/tests/380540 (16.0 PAYG)
    https://openqa.suse.de/tests/23689880                            (15-SP7 BYOS)
    https://openqa.suse.de/tests/23705491                            (15-SP7 PAYG)
    https://openqaworker15.qe.prg2.suse.org/tests/380533 (15-SP5 BYOS)
    https://openqaworker15.qe.prg2.suse.org/tests/380534 (15-SP5 PAYG)
    https://openqaworker15.qe.prg2.suse.org/tests/380535 (12-SP5 BYOS)
    https://openqaworker15.qe.prg2.suse.org/tests/380536 (12-SP5 PAYG)
All tests passed
