### PR TITLE
security/apparmor: upload logs via /tmp to satisfy AppArmor 5.0 curl profile

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -13,6 +13,7 @@ package apparmortest;
 
 use strict;
 use warnings;
+use File::Basename 'basename';
 use testapi;
 use utils;
 use version_utils qw(is_sle is_leap is_tumbleweed);
@@ -675,6 +676,8 @@ sub yast2_apparmor_is_enabled {
 
 # Yast2 Apparmor clean up
 sub yast2_apparmor_cleanup {
+    my ($self) = @_;
+
     # Exit x11 and turn to console
     close_gui_terminal;
     select_console("root-console");
@@ -683,7 +686,7 @@ sub yast2_apparmor_cleanup {
     select_serial_terminal;
 
     # Upload logs for reference
-    upload_logs("$audit_log");
+    $self->upload_logs_from_tmp("$audit_log");
 }
 
 # Create a test profile with name contains '('
@@ -761,6 +764,27 @@ sub create_log_content_is_special {
     validate_script_output("cat $audit_log", sub { m/.*type=AVC.*profile=.*$test_special.*/sx });
 }
 
+=head2 upload_logs_from_tmp
+
+ $self->upload_logs_from_tmp($file [, %args]);
+
+Since AppArmor 5.0, the shipped curl profile only allows curl to read
+files below C</tmp/> and C<$HOME> (poo#204771), so C<upload_logs()> fails
+with C<curl: (26) read error getting mime data> for files elsewhere, e.g.
+C</var/log/**>. Work around this by copying C<$file> to C</tmp/> (keeping
+its basename, so the uploaded name is unaffected) before uploading it.
+
+=cut
+
+sub upload_logs_from_tmp {
+    my ($self, $file, %args) = @_;
+
+    my $tmp_file = '/tmp/' . basename($file);
+    assert_script_run("cp $file $tmp_file");
+    upload_logs($tmp_file, %args);
+    script_run("rm -f $tmp_file");
+}
+
 =head2 upload_logs_mail
 
  upload_logs_mail();
@@ -770,15 +794,17 @@ Upload mail warn, err and info logs for reference
 =cut
 
 sub upload_logs_mail {
+    my ($self) = @_;
+
     # Upload mail warn, err and info logs for reference
     if (script_run("! [[ -e $mail_err_log ]]")) {
-        upload_logs("$mail_err_log");
+        $self->upload_logs_from_tmp("$mail_err_log");
     }
     if (script_run("! [[ -e $mail_warn_log ]]")) {
-        upload_logs("$mail_warn_log");
+        $self->upload_logs_from_tmp("$mail_warn_log");
     }
     if (script_run("! [[ -e $mail_info_log ]]")) {
-        upload_logs("$mail_info_log");
+        $self->upload_logs_from_tmp("$mail_info_log");
     }
 }
 
@@ -818,7 +844,7 @@ sub post_fail_hook {
     send_key("alt-f4");
     select_console("root-console");
     if (script_run("! [[ -e $audit_log ]]")) {
-        upload_logs("$audit_log");
+        $self->upload_logs_from_tmp("$audit_log");
     }
     $self->SUPER::post_fail_hook;
 }

--- a/tests/security/apparmor/aa_logprof.pm
+++ b/tests/security/apparmor/aa_logprof.pm
@@ -14,7 +14,7 @@
 # - Check if smb could start with the temporary apparmor profiles
 # - Cleanup temporary directory
 # Maintainer: QE Security <none@suse.de>
-# Tags: poo#36892, poo#45803, poo#81730, tc#1767574
+# Tags: poo#36892, poo#45803, poo#81730, tc#1767574, poo#204771
 
 use Mojo::Base 'apparmortest';
 use testapi;
@@ -63,7 +63,7 @@ sub run {
     assert_script_run "aa-status | tee /dev/$serialdev";
 
     # Upload audit.log for reference
-    upload_logs "$log_file";
+    $self->upload_logs_from_tmp("$log_file");
 
     select_console 'root-console';
     script_run_interactive("aa-logprof -d $aa_tmp_prof", $interactive_str, 30);

--- a/tests/security/apparmor/aa_notify.pm
+++ b/tests/security/apparmor/aa_notify.pm
@@ -16,7 +16,7 @@
 # - Disable temporary profile, put smbd back in enforce mode, restart smbd
 # - Cleanup temporary profiles
 # Maintainer: QE Security <none@suse.de>
-# Tags: poo#36883, tc#1621139, poo#201084
+# Tags: poo#36883, tc#1621139, poo#201084, poo#204771
 
 use Mojo::Base 'apparmortest';
 use testapi;
@@ -96,7 +96,7 @@ sub run {
     smbd_service_autorestart(DISABLED) unless is_sle('<=15-sp4');
 
     systemctl("restart $test_service", expect_false => 1);
-    upload_logs($audit_log);
+    $self->upload_logs_from_tmp($audit_log);
 
     validate_script_output "aa-notify -s 1 -v", sub {
         m/

--- a/tests/security/apparmor_profile/apache2_changehat.pm
+++ b/tests/security/apparmor_profile/apache2_changehat.pm
@@ -36,7 +36,7 @@
 #   $audit_log" and fail test.
 # - upload /var/log/apache2/error_log and audit.log
 # Maintainer: QE Security <none@suse.de>
-# Tags: poo#48773, tc#1695946, poo#111036
+# Tags: poo#48773, tc#1695946, poo#111036, poo#204771
 
 
 use Mojo::Base 'apparmortest';
@@ -183,8 +183,8 @@ sub run {
     }
 
     # Upload logs for reference
-    upload_logs("/var/log/apache2/error_log");
-    upload_logs("$audit_log");
+    $self->upload_logs_from_tmp("/var/log/apache2/error_log");
+    $self->upload_logs_from_tmp("$audit_log");
 }
 
 1;

--- a/tests/security/apparmor_profile/usr_sbin_smbd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_smbd.pm
@@ -18,7 +18,7 @@
 # - Create and delete a test folder inside the share
 # - Check audit.log for error messages related to smbd
 # Maintainer: QE Security <none@suse.de>
-# Tags: poo#48776, poo#134780
+# Tags: poo#48776, poo#134780, poo#204771
 
 use Mojo::Base 'apparmortest';
 use testapi;
@@ -120,8 +120,8 @@ sub run {
     }
 
     # Upload logs for reference
-    upload_logs("/var/log/samba/log.smbd");
-    upload_logs("$audit_log");
+    $self->upload_logs_from_tmp("/var/log/samba/log.smbd");
+    $self->upload_logs_from_tmp("$audit_log");
 }
 
 1;

--- a/tests/security/yast2_apparmor/scan_audit_logs_ncurses.pm
+++ b/tests/security/yast2_apparmor/scan_audit_logs_ncurses.pm
@@ -3,7 +3,7 @@
 #
 # Summary: Test "# yast2 apparmor" can scan audit logs
 # Maintainer: QE Security <none@suse.de>
-# Tags: poo#67933, tc#1741266, poo#103341
+# Tags: poo#67933, tc#1741266, poo#103341, poo#204771
 
 use Mojo::Base qw(apparmortest y2_module_consoletest);
 use testapi;
@@ -98,11 +98,11 @@ sub run {
     select_serial_terminal;
 
     # Upload test profile for reference
-    upload_logs($test_profile);
+    $self->upload_logs_from_tmp($test_profile);
 
     # Yast2 AppArmor clean up
     assert_script_run("mv $test_profile_bk $test_profile");
-    upload_logs($apparmortest::audit_log);
+    $self->upload_logs_from_tmp($audit_log);
 }
 
 1;


### PR DESCRIPTION
Since AppArmor 5.0, `/etc/apparmor.d/curl` only allows curl to read files
below `/tmp/` and `$HOME`. This breaks `upload_logs()` on any `/var/log/**`
path used by the AppArmor test modules (audit.log, mail logs, apache2
error_log, samba log.smbd, ...), which fails with:

    curl: (26) read error getting mime data

Add `apparmortest::upload_logs_from_tmp()`, which copies the file to
`/tmp/` (keeping its basename) before uploading, and use it everywhere
the AppArmor test modules upload logs from `/var/log/`:

- `lib/apparmortest.pm`: new helper, used by `yast2_apparmor_cleanup`,
  `upload_logs_mail`, and `post_fail_hook`
- `tests/security/apparmor/aa_notify.pm`
- `tests/security/apparmor/aa_logprof.pm`
- `tests/security/apparmor_profile/usr_sbin_smbd.pm`
- `tests/security/apparmor_profile/apache2_changehat.pm`
- `tests/security/yast2_apparmor/scan_audit_logs_ncurses.pm`

Verified on a personal openQA instance by cloning
https://openqa.opensuse.org/tests/6128243 with this branch as CASEDIR:
the `aa_notify` module's `curl --form upload=@/tmp/audit.log ...` call now
returns `OK: aa_notify-audit.log` instead of `curl: (26)`.

Two unrelated, pre-existing AppArmor 5.0 issues were newly exposed once
the test could progress past the curl crash (aa_logprof intermittent
profile parse error, aa_notify samba denial format change); these are
out of scope here and will be filed as separate tickets.

- Related ticket: https://progress.opensuse.org/issues/204771
- Verification run:
  - primary: http://prg2e-d58.qe.prg2.suse.org/tests/10#step/aa_notify/49
  - 15sp7: http://prg2e-d58.qe.prg2.suse.org/tests/22#step/aa_notify/49