### PR TITLE
coverage_setup: update funkoverage API to use install instead of wrap

### DIFF
--- a/tests/coverage/coverage_setup.pm
+++ b/tests/coverage/coverage_setup.pm
@@ -65,18 +65,13 @@ sub run {
     push @packages, 'coverage-tools';
     zypper_call '--gpg-auto-import-keys in ' . join ' ', @packages;
 
-    # sets up the environment for coverage
-    assert_script_run 'export LOG_DIR=/var/coverage/data';
-    assert_script_run 'export PIN_ROOT=/usr/lib64/coverage-tools/pin';
+    assert_script_run 'mkdir -m 0777 -p /var/coverage/data';
 
-    # add the environment setup to .bashrc for future sessions (root and plain user)
-    assert_script_run 'echo "LOG_DIR=/var/coverage/data" > /etc/bash.bashrc.local';
-    assert_script_run 'echo "PIN_ROOT=/usr/lib64/coverage-tools/pin" >> /etc/bash.bashrc.local';
+    # set up eBPF capabilities required by funkoverage
+    assert_script_run 'funkoverage setup';
 
-    assert_script_run "mkdir -m 0777 -p \$LOG_DIR";
-
-    # wrap the binaries that will be instrumented for 'coverage'
-    assert_script_run "funkoverage wrap " . join ' ', @{$test_data->{coverage_targets}};
+    # install shims around the binaries to be instrumented for coverage
+    assert_script_run "funkoverage install " . join ' ', @{$test_data->{coverage_targets}};
 }
 
 sub test_flags {


### PR DESCRIPTION
## Problem

`coverage_setup.pm` calls `funkoverage wrap` and sets PIN-based environment
variables (`LOG_DIR`, `PIN_ROOT`) that were part of the old Intel PIN tracer.
Since `coverage-tools` 0.7 the tool switched to an eBPF-based tracer and the
API changed:

- `funkoverage wrap` was renamed to `funkoverage install`
- a new `funkoverage setup` subcommand was introduced to set the required eBPF
  capabilities on the host
- the PIN-specific environment variables are no longer used

As a result, the coverage schedule fails at the `coverage_setup` module on any
system running `coverage-tools` >= 0.7 (current Tumbleweed ships 0.7.2).

## Fix

- Replace `funkoverage wrap` with `funkoverage setup` + `funkoverage install`
- Remove the now-obsolete `LOG_DIR`/`PIN_ROOT` export lines and the
  `/etc/bash.bashrc.local` writes

## Testing

Verified locally by running the full `schedule/coverage/tw_textmode.yaml`
schedule against openSUSE Tumbleweed Snapshot20260728 in an openQA
single-instance container. The `coverage_setup` module passes green with
`coverage-tools` 0.7.2.