### PR TITLE
fix(publiccloud): report ssh issues when checking supportconfig

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -672,9 +672,12 @@ sub upload_supportconfig_log {
     # To remove exclusions, _EXCLUDE='-'
     $exclude = undef if ($exclude eq '-');
     $exclude = "-x " . $exclude if ($exclude);
-    my $res = $self->ssh_script_run("sudo which supportconfig");
+    my $res = $self->ssh_script_run("sudo which supportconfig", apply_graceful_timeout => 1);
     unless (isok($res)) {
-        record_info('MISSING supportconfig', 'supportconfig command not found', result => 'fail');
+        record_info('Fail supportconfig',
+            ($res == 255) ? "ssh connectivity issues during remote supportconfig check"
+            : "supportconfig command not found",
+            result => 'fail');
         return;
     }
     $res = $self->ssh_script_run("echo | sudo supportconfig -R " . dirname($logs) . " -B supportconfig $exclude > $logs.txt 2>&1",


### PR DESCRIPTION
Report _ssh issues_ when supportconfig remote check fails with exit code is 255.

See i.e. https://openqa.suse.de/tests/23693000/#step/destroy/91, failed for ssh issues, but it was reported as application issue.

- ref.tkt: https://progress.opensuse.org/issues/204381

- Verification run: see PR posts
