### PR TITLE
Avoid hardcoding test known issues file in ltp unit test

### DIFF
--- a/t/07_ltp_whitelist.t
+++ b/t/07_ltp_whitelist.t
@@ -1,6 +1,6 @@
 use Mojo::Base -strict;
 
-use Mojo::File;
+use Mojo::File qw(tempfile);
 use Mojo::JSON;
 use Test::More;
 use Test::MockModule;
@@ -44,7 +44,8 @@ subtest 'whitelist_entry_match' => sub {
 
 
 subtest override_known_failures => sub {
-    set_var('LTP_KNOWN_ISSUES_LOCAL' => 'test_known_issues.json');
+    my $tmpfile = tempfile;
+    set_var('LTP_KNOWN_ISSUES_LOCAL' => "$tmpfile");
     my $self = Test::MockObject->new();
     my $msg;
     $self->{result} = 'not_set';
@@ -82,7 +83,7 @@ subtest override_known_failures => sub {
         }
     };
 
-    Mojo::File::path('test_known_issues.json')->spew(Mojo::JSON::encode_json($known_issues_json));
+    $tmpfile->spew(Mojo::JSON::encode_json($known_issues_json));
 
     my $env = {product => 'sle:15', retval => 0};
     my $whitelist = LTP::WhiteList->new();


### PR DESCRIPTION
The unit test `t/07_ltp_whitelist.t` previously hardcoded the local known issues file name as `test_known_issues.json`. This left a leftover untracked file in the repository after running tests.
This change switches to using a secure temporary file created via `Mojo::File qw(tempfile)` and points `LTP_KNOWN_ISSUES_LOCAL` to it, ensuring tests are isolated and don't leak files in the repository.