### PR TITLE
Add fallback for instance-flavor-check AttributeError crash

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -1760,10 +1760,13 @@ sub ipaddr2_billing_model_get(%args) {
 
     # bsc#1267739: instance-flavor-check crashes with FileNotFoundError
     # on fresh BYOS images where /var/cache/cloudregister/ does not exist.
-    # Detect the known bug signature and return UNKNOWN so the caller can
+    # bsc#1261166: instance-flavor-check crashes with AttributeError
+    # when update servers are unreachable.
+    # Detect the known bug signatures and return UNKNOWN so the caller can
     # fall back to SUSEConnect -s.
+    my $out = '';
     if ($ret == 1) {
-        my $out = ipaddr2_ssh_internal_output(id => $args{id},
+        $out = ipaddr2_ssh_internal_output(id => $args{id},
             cmd => 'sudo instance-flavor-check 2>&1 || true',
             bastion_ip => $args{bastion_ip});
 
@@ -1771,10 +1774,16 @@ sub ipaddr2_billing_model_get(%args) {
             record_soft_failure('bsc#1267739 - instance-flavor-check crashed with FileNotFoundError');
             return 'UNKNOWN';
         }
+        if ($out =~ /AttributeError.*get_ipv4/) {
+            record_soft_failure('bsc#1261166 - instance-flavor-check crashed with AttributeError: get_ipv4');
+            return 'UNKNOWN';
+        }
     }
 
     # Any other unexpected exit code or rc=1 without known signature
-    die "instance-flavor-check unexpected result ret:$ret";
+    my $err_msg = "instance-flavor-check unexpected result ret:$ret";
+    $err_msg .= "\nCommand output: $out" if ($ret == 1 && $out);
+    die $err_msg;
 }
 
 =head2 ipaddr2_configure_web_server

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -1548,7 +1548,20 @@ subtest '[ipaddr2_billing_model_get] UNKNOWN bsc#1267739' => sub {
     ok(($ret eq 'UNKNOWN'), "Ret:'$ret' expected to be 'UNKNOWN' for bsc#1267739");
 };
 
-subtest '[ipaddr2_billing_model_get] die on rc=1 without FileNotFoundError' => sub {
+subtest '[ipaddr2_billing_model_get] UNKNOWN bsc#1261166' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2');
+
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub { return 1; });
+    $ipaddr2->redefine(ipaddr2_ssh_internal_output => sub {
+            return "AttributeError: 'NoneType' object has no attribute 'get_ipv4'";
+    });
+    $ipaddr2->redefine(record_soft_failure => sub { note("SOFT_FAILURE --> $_[0]"); });
+
+    my $ret = ipaddr2_billing_model_get(id => 1, bastion_ip => '2.3.4.5');
+    ok(($ret eq 'UNKNOWN'), "Ret:'$ret' expected to be 'UNKNOWN' for bsc#1261166");
+};
+
+subtest '[ipaddr2_billing_model_get] die on rc=1 without FileNotFoundError or AttributeError' => sub {
     my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2');
 
     $ipaddr2->redefine(ipaddr2_ssh_internal => sub { return 1; });
@@ -1557,7 +1570,7 @@ subtest '[ipaddr2_billing_model_get] die on rc=1 without FileNotFoundError' => s
     });
 
     dies_ok { ipaddr2_billing_model_get(id => 1, bastion_ip => '2.3.4.5') }
-    "Die on rc=1 without FileNotFoundError signature";
+    "Die on rc=1 without known traceback signatures";
 };
 
 subtest '[ipaddr2_billing_model_get] die on unexpected rc' => sub {


### PR DESCRIPTION
During registration checks in ipaddr2 tests, instance-flavor-check can fail and return exit code 1 with an AttributeError when the update servers are unreachable.
Extend ipaddr2_billing_model_get() to catch this AttributeError traceback signature and gracefully return 'UNKNOWN'. This triggers the fallback registration check (SUSEConnect -s) and prevents test failures. Also, append the full command output to the die message if no known pattern is matched to improve future debugging.

# Verification run:

 - sle-12-SP5-Azure-SAP-BYOS-Incidents-x86_64-Build:smelt:45483:saptune-ipaddr2 -> http://openqaworker15.qe.prg2.suse.org/tests/380637