### PR TITLE
coverage: add rsync to tw_textmode coverage schedule

### DIFF
--- a/schedule/coverage/tw_textmode.yaml
+++ b/schedule/coverage/tw_textmode.yaml
@@ -36,6 +36,7 @@ schedule:
   - console/tcpdump
   - console/unzip
   - console/vim
+  - console/rsync
   - console/wavpack
   - coverage/coverage_report
 test_data:
@@ -61,6 +62,7 @@ test_data:
     - tcpdump
     - traceroute
     - wavpack
+    - rsync
     - wget    # to download the test data
     - vim
   # the following section is an array of binaries that we want to instrument
@@ -87,6 +89,7 @@ test_data:
     - /usr/sbin/powertop
     - /usr/sbin/tcpdump
     - /usr/sbin/traceroute
+    - /usr/bin/rsync
     - /usr/bin/unzip
     - /usr/bin/wavpack
     - /usr/bin/wvunpack


### PR DESCRIPTION
Add `console/rsync` to the test schedule and `/usr/bin/rsync` to the coverage targets in `schedule/coverage/tw_textmode.yaml`.

## Why rsync

- Already tested by an existing test module (`tests/console/rsync.pm`)
- Appears in 3 production schedules: `extra_tests_textmode`, `mau-extratests2`, `fips_env_mode_textmode_extra`
- `rsync-debuginfo` is available in the Tumbleweed debug repo
- The test exercises meaningful code paths: directory sync, file integrity (md5sum), hard link preservation (`-H`)

## Changes

Exactly two additions to `tw_textmode.yaml`:
1. `console/rsync` added to the `schedule` list
2. `rsync` added to `extra_packages` and `/usr/bin/rsync` added to `coverage_targets`