### PR TITLE
coverage_setup: set type=rpm-md after zypper ar to prevent CDN 404

### DIFF
--- a/tests/coverage/coverage_setup.pm
+++ b/tests/coverage/coverage_setup.pm
@@ -54,6 +54,12 @@ sub run {
     }
     while (my ($name, $url) = each(%repositories)) {
         assert_script_run "zypper ar -e -f $url $name";
+        # Set repo type explicitly so zypper does not probe for media.1/media.
+        # Several of these HTTP repos (debug, update, devtools) do not serve
+        # media.1/media; the CDN returns 404, which zypper treats as a fatal
+        # refresh error.  Writing type=rpm-md directly to the .repo file is the
+        # reliable fix that survives subsequent zypper refresh calls.
+        assert_script_run "echo type=rpm-md >> /etc/zypp/repos.d/$name.repo";
     }
 
     # install coverage tools and any extra packages + debug info


### PR DESCRIPTION
## Problem

`zypper ar` without an explicit `--type` causes zypper to probe for
`media.1/media` on the first repo refresh. Three of the four Tumbleweed
repos added by this module do not serve that file; the openSUSE CDN returns
HTTP 404, which zypper treats as a fatal error and aborts the refresh entirely,
so no packages can be installed.

Verified by direct HTTP probe (`curl -I media.1/media`):

| Repo URL | `media.1/media` |
|----------|-----------------|
| `download.opensuse.org/tumbleweed/repo/oss/` | **200 OK** |
| `download.opensuse.org/update/tumbleweed/` | **404** |
| `download.opensuse.org/debug/tumbleweed/repo/oss/` | **404** |
| `download.opensuse.org/repositories/devel:/tools/openSUSE_Tumbleweed/` | **404** |

The resulting zypper error from the job log:
```
Problem retrieving the repository index file for repository 'debug'.
[debug|http://download.opensuse.org/debug/tumbleweed/repo/oss/]:
Error reading from server. Aborting.
```

## Fix

Write `type=rpm-md` directly to the `.repo` file immediately after
`zypper ar`. This is equivalent to `--type rpm-md` but is robust against
zypper re-probing on subsequent refresh calls.

## Why this is not caught on openqa.opensuse.org

Production workers resolve `download.opensuse.org` to a local mirror
(`openqa.opensuse.org/assets/repo/...`) at the network level, and that
mirror does serve `media.1/media`. The issue manifests on any openQA
instance that routes through the real CDN — including local developer
setups and alternative openQA deployments.