### PR TITLE
coverage_setup: tolerate per-binary failures in funkoverage install

### DIFF
--- a/tests/coverage/coverage_setup.pm
+++ b/tests/coverage/coverage_setup.pm
@@ -70,8 +70,13 @@ sub run {
     # set up eBPF capabilities required by funkoverage
     assert_script_run 'funkoverage setup';
 
-    # install shims around the binaries to be instrumented for coverage
-    assert_script_run "funkoverage install " . join ' ', @{$test_data->{coverage_targets}};
+    # install shims around the binaries to be instrumented for coverage.
+    # funkoverage install exits non-zero if any single binary fails (e.g. ELF
+    # type mismatch, wrong path, package rename).  Use script_run so that a
+    # partial failure does not abort the whole setup module and discard all
+    # successfully-installed shims.  The log is preserved for post-mortem.
+    script_run("funkoverage install " . join(' ', @{$test_data->{coverage_targets}}) . " 2>&1 | tee /tmp/fv_install.log", timeout => 300);
+    assert_script_run 'cat /tmp/fv_install.log';
 }
 
 sub test_flags {


### PR DESCRIPTION
## Problem

`funkoverage install` processes each binary independently and exits
non-zero if any single binary fails instrumentation.  The current code
wraps it in `assert_script_run`, which treats any non-zero exit as fatal
and aborts the entire setup module.

Since `coverage_setup` is flagged `fatal => 1`, one failed binary causes
the whole coverage job to die with zero shims installed — producing 0%
coverage silently, with no indication of which binary was the problem.

Known failure modes that trigger this:

| Cause | Example |
|-------|---------|
| ELF type mismatch (`eu-unstrip`) | `git`, `perf` |
| Binary is not an ELF file | Python-based tools |
| Wrong path / package renamed between snapshots | Any binary |

From a real job log:
```
[info] Test died: command 'funkoverage install /usr/bin/git ...' failed
       at /usr/lib/os-autoinst/testapi.pm line 963
```

## Fix

Switch to `script_run` so that partial failures do not abort setup.
Successfully-instrumented binaries continue to produce coverage data even
when others fail.  The full install log is captured to `/tmp/fv_install.log`
and echoed to the test transcript for post-mortem inspection.

The `timeout` is raised to 300 s (from the default 90 s) because installing
shims for many binaries and their shared libraries takes longer than 90 s.

## Note for `coverage-tools` maintainers

A cleaner long-term fix would be a `--best-effort` flag in
`funkoverage install` that exits 0 when individual binary failures are
non-fatal.  This PR works around the current behaviour at the openQA layer.