### PR TITLE
coverage_report: raise funkoverage report timeout to 600 s

### DIFF
--- a/tests/coverage/coverage_report.pm
+++ b/tests/coverage/coverage_report.pm
@@ -11,7 +11,12 @@ use serial_terminal 'select_serial_terminal';
 sub run {
     select_serial_terminal;
     assert_script_run 'mkdir -p /var/coverage/report';
-    assert_script_run 'funkoverage report /var/coverage/data /var/coverage/report';
+    # funkoverage report reads eBPF trace logs, resolves symbols via eu-unstrip
+    # and DWARF debug info, and writes XML + HTML for every instrumented binary
+    # and shared library.  With the default 90 s timeout this reliably fails
+    # once the schedule tracks more than ~5 binaries.  600 s is sufficient for
+    # schedules with up to ~20 targets and their transitive shared libraries.
+    assert_script_run 'funkoverage report /var/coverage/data /var/coverage/report', timeout => 600;
     # Upload the coverage report files
     my @files = split("\n", script_output 'ls -1 /var/coverage/report/*');
     # parse the XML reports


### PR DESCRIPTION
## Problem

`funkoverage report` reads eBPF trace logs, resolves symbols via
`eu-unstrip` and DWARF debug info, and writes XML + HTML report files
for every instrumented binary and each of its transitive shared libraries.

The current code relies on the default `assert_script_run` timeout of
90 s.  Observed wall-clock times:

| Schedule size | Observed time |
|---------------|---------------|
| ~16 targets (current production) | ~7 s |
| ~20 targets + shared libraries | ~180 s |

The 90 s default is already uncomfortably close to the limit with the
current production schedule, and any addition of new coverage targets
will push it over.  Two consecutive jobs with 19 targets failed with:

```
Test died: typing command 'funkoverage report ...' timed out
at /usr/lib/os-autoinst/distribution.pm line 119.
```

## Fix

Set an explicit `timeout => 600` on the `funkoverage report` call.
600 s is conservative enough to cover schedules of 20+ targets while
still providing a safety net against genuine hangs.

The fix is a single-line addition with no functional side effects.