### PR TITLE
curl_ipv6: add no_rollback flag

### DIFF
--- a/tests/console/curl_ipv6.pm
+++ b/tests/console/curl_ipv6.pm
@@ -21,4 +21,6 @@ sub run {
     assert_script_run('rpm -q curl libcurl4');
 }
 
+sub test_flags { return {no_rollback => 1} }
+
 1;


### PR DESCRIPTION
This test only makes a network request and checks installed packages. It does not modify system state, so rolling back the VM on failure serves no purpose and discards any work done since the last milestone.