### PR TITLE
traceroute: add no_rollback flag

### DIFF
--- a/tests/console/traceroute.pm
+++ b/tests/console/traceroute.pm
@@ -31,4 +31,6 @@ sub run {
     assert_script_run("test -s $log", fail_message => "Log file is empty");
 }
 
+sub test_flags { return {no_rollback => 1} }
+
 1;


### PR DESCRIPTION
This test runs a network probe and writes a temporary log file. It does not modify system state, so rolling back the VM on failure serves no purpose and discards any work done since the last milestone.