### PR TITLE
podman: Use canonical repo name for artifact

### DIFF
--- a/tests/containers/podman_artifact.pm
+++ b/tests/containers/podman_artifact.pm
@@ -18,7 +18,7 @@ sub run {
     select_serial_terminal;
 
     my $test_file = "$test_dir/test_file";
-    my $artifact = "test-artifact";
+    my $artifact = "localhost/test-artifact";
 
     assert_script_run "mkdir -p $test_dir";
     assert_script_run "touch $test_file";


### PR DESCRIPTION
Otherwise test fails on podman v6.0.x with:
`Error: repository name must be canonical`

Failed job: https://openqa.opensuse.org/tests/6141845#step/podman_artifact/9

VR not needed.  Tested locally with podman v5.8.4 & v6.0.2.
