### PR TITLE
LTP: upload full 'rpm -qa' package manifest

### DIFF
--- a/lib/LTP/utils.pm
+++ b/lib/LTP/utils.pm
@@ -104,11 +104,16 @@ sub log_versions {
       (is_rt ? 'kernel-rt' : get_kernel_flavor);
     my $kernel_pkg_log = '/tmp/kernel-pkg.txt';
     my $ver_linux_log = '/tmp/ver_linux_before.txt';
+    my $rpm_qa_log = '/tmp/rpm-qa.txt';
     my $kernel_config = script_output('for f in "/boot/config-$(uname -r)" "/usr/lib/modules/$(uname -r)/config" /proc/config.gz; do if [ -f "$f" ]; then echo "$f"; break; fi; done');
     my $run_cmd = is_transactional ? 'transactional-update -c run ' : '';
 
     script_run("$run_cmd rpm -qi $kernel_pkg > $kernel_pkg_log 2>&1", timeout => 120);
     upload_logs($kernel_pkg_log, failok => 1);
+
+    # Full package manifest (sorted for stable diffing across runs)
+    script_run("$run_cmd rpm -qa | sort > $rpm_qa_log 2>&1", timeout => 120);
+    upload_logs($rpm_qa_log, failok => 1);
 
     if (get_var('LTP_COMMAND_FILE') || get_var('LIBC_LIVEPATCH')) {
         script_run("$run_cmd " . get_ltproot . "/ver_linux > $ver_linux_log 2>&1");


### PR DESCRIPTION
LTP tests are sometimes affected by an obscure package update unrelated to the kernel under test. Having a complete, sorted manifest per job makes it possible to diff two runs and pinpoint which package version changed.

- Related ticket: https://progress.opensuse.org/issues/204240
- Verification run: https://openqa.opensuse.org/tests/6141954
