### PR TITLE
podman: Use "latest" tag when inspecting artifact

### DIFF
--- a/tests/containers/podman_artifact.pm
+++ b/tests/containers/podman_artifact.pm
@@ -28,7 +28,8 @@ sub run {
     assert_script_run "! podman artifact add $artifact $test_file";
 
     # Test inspect
-    validate_script_output "podman artifact inspect $artifact", qr/"Name": "$artifact"/;
+    # Note: podman 6.0+ appends the "latest" tag to the artifact name
+    validate_script_output "podman artifact inspect $artifact", qr/"Name": "$artifact(:latest)?"/;
     assert_script_run "! podman artifact inspect noexist";
 
     # Test ls


### PR DESCRIPTION
Otherwise test fails to match the complete string within double-quotes.

Failed job: https://openqa.opensuse.org/tests/6141969#step/podman_artifact/13
Verification run: https://openqa.opensuse.org/tests/6142023