### PR TITLE
Refactor public cloud cloud-init to use a template-based profile

### DIFF
--- a/data/publiccloud/cloud-init.yaml.ep
+++ b/data/publiccloud/cloud-init.yaml.ep
@@ -11,8 +11,7 @@ write_files:
   path: /root/test_cloud-init.txt
   append: true
 
-packages:
-- ed
+%PACKAGES%
 
 final_message: |
   cloud-init qa has finished

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -657,7 +657,7 @@ sub cleanup_cloudinit() {
     $self->ssh_assert_script_run('sudo cloud-init clean --logs');
     if (get_var('PUBLIC_CLOUD_CLOUD_INIT')) {
         $self->ssh_assert_script_run('sudo rm /root/test_cloud-init.txt');
-        $self->ssh_assert_script_run('sudo zypper -n rm ed');
+        $self->ssh_assert_script_run('sudo zypper -n rm ed') if check_var('PUBLIC_CLOUD_CLOUD_INIT', 'install');
     }
 }
 

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -420,7 +420,14 @@ sub terraform_prepare_env {
     assert_script_run('mkdir -p ' . TERRAFORM_DIR);
     $file = get_var('PUBLIC_CLOUD_TERRAFORM_FILE', "publiccloud/terraform/$file.tf");
     assert_script_run('curl ' . data_url("$file") . ' -o ' . TERRAFORM_DIR . '/plan.tf');
-    assert_script_run('curl ' . data_url("publiccloud/cloud-init.yaml") . ' -o ' . TERRAFORM_DIR . "/cloud-init.yaml") if (get_var('PUBLIC_CLOUD_CLOUD_INIT'));
+    if (get_var('PUBLIC_CLOUD_CLOUD_INIT')) {
+        assert_script_run('curl ' . data_url("publiccloud/cloud-init.yaml.ep") . ' -o ' . TERRAFORM_DIR . "/cloud-init.yaml");
+        if (check_var('PUBLIC_CLOUD_CLOUD_INIT', 'install')) {
+            file_content_replace(TERRAFORM_DIR . "/cloud-init.yaml", '%PACKAGES%' => 'packages:\n- ed');
+        } else {
+            file_content_replace(TERRAFORM_DIR . "/cloud-init.yaml", '%PACKAGES%' => '');
+        }
+    }
     $self->terraform_env_prepared(1);
 }
 

--- a/tests/publiccloud/check_cloudinit.pm
+++ b/tests/publiccloud/check_cloudinit.pm
@@ -43,7 +43,7 @@ sub check_cloudinit {
         $instance->ssh_assert_script_run('sudo grep snickerdoodle /root/test_cloud-init.txt');
 
         # Check for packages module
-        $instance->ssh_assert_script_run('ed -V');
+        $instance->ssh_assert_script_run('ed -V') if check_var('PUBLIC_CLOUD_CLOUD_INIT', 'install');
 
         # Check for final_message module
         $instance->ssh_assert_script_run('sudo journalctl -b | grep "cloud-init qa has finished"');

--- a/variables.md
+++ b/variables.md
@@ -332,7 +332,7 @@ PUBLIC_CLOUD_BOOTTIME_MAX | integer | undef | To set the 'overall' `boot time` t
 PUBLIC_CLOUD_BTRFS | boolean | false | If set, it schedules `publiccloud/btrfs` job.
 PUBLIC_CLOUD_BUILD | string | "" | The image build number. Used only when we use custom built image.
 PUBLIC_CLOUD_BUILD_KIWI | string | "" | The image kiwi build number. Used only when we use custom built image.
-PUBLIC_CLOUD_CLOUD_INIT | boolean | false | If this is true custom `cloud-config` will be attached to the instance.
+PUBLIC_CLOUD_CLOUD_INIT | string | "" | If this is defined and not empty custom `cloud-config` will be attached to the instance. If it is "install" the used `cloud-config` also contain a section to install ed.
 PUBLIC_CLOUD_CONFIDENTIAL_VM | boolean | false | GCE Confidential VM instance
 PUBLIC_CLOUD_CONSOLE_TESTS | boolean | false | If set, console tests are added to the job.
 PUBLIC_CLOUD_CONTAINERS | boolean | false | If set, containers tests are added to the job.


### PR DESCRIPTION
Converts the static data/publiccloud/cloud-init.yaml into a templated data/publiccloud/cloud-init.yaml.ep.

A %PACKAGES% template placeholder is introduced to control the inclusion of a packages installation section.
During Terraform environment preparation, the template is downloaded to SUT and dynamically customized using PUBLIC_CLOUD_CLOUD_INIT setting. If set to 'install', the packages block is dynamically injected, while any other value completely omits it.

- Related ticket: https://progress.opensuse.org/issues/204834

Replace https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26250

# Verification run:

## PUBLIC_CLOUD_CLOUD_INIT 1
 - sle-15-SP7-EC2-Incidents-x86_64-Build:smelt:45685:grub2-publiccloud_smoketests ec2_i3.8xlarge -> http://openqa.suse.de/tests/23753092

## PUBLIC_CLOUD_CLOUD_INIT 'install'
 - sle-15-SP7-EC2-Incidents-x86_64-Build:smelt:45685:grub2-publiccloud_smoketests@ec2_i3.8xlarge -> http://openqa.suse.de/tests/23754319

## No PUBLIC_CLOUD_CLOUD_INIT
 - sle-15-SP7-Azure-BYOS-Updates-x86_64-Build20260802-1-publiccloud_cloud_functional az_Standard_B2s -> http://openqa.suse.de/tests/23753134
