### PR TITLE
Backport fixes for e2e localintegration test on podman v6.0

### DIFF
--- a/data/containers/patches.yaml
+++ b/data/containers/patches.yaml
@@ -128,6 +128,7 @@ podman:
   # https://github.com/containers/podman/pull/28603 - test/system: quadlet - rootfs failure on kernel 7.1
   # https://github.com/containers/podman/pull/28794 - Test fixes/skips for new CI system
   # https://github.com/containers/podman/pull/28804 - More test fixes for new CI
+  # https://github.com/containers/podman/pull/29380 - test/e2e: accept RESTORE in checkpoint tcp error match
   21875:
     merged: "5.0.0"
   24068:
@@ -192,6 +193,8 @@ podman:
   28804:
     merged: "6.0.0"
     min: "5.4.2"
+  29380:
+    min: "6.0"
 
 podman-py:
   # https://github.com/containers/podman-py/pull/623 - Fix pytest flag for rootful test

--- a/data/containers/patches.yaml
+++ b/data/containers/patches.yaml
@@ -129,6 +129,7 @@ podman:
   # https://github.com/containers/podman/pull/28794 - Test fixes/skips for new CI system
   # https://github.com/containers/podman/pull/28804 - More test fixes for new CI
   # https://github.com/containers/podman/pull/29380 - test/e2e: accept RESTORE in checkpoint tcp error match
+  # https://github.com/containers/podman/pull/29381 - test/e2e/healthcheck: skip ignore-result test on non-amd64
   21875:
     merged: "5.0.0"
   24068:
@@ -194,6 +195,8 @@ podman:
     merged: "6.0.0"
     min: "5.4.2"
   29380:
+    min: "6.0"
+  29381:
     min: "6.0"
 
 podman-py:

--- a/data/containers/patches/podman/29380.patch
+++ b/data/containers/patches/podman/29380.patch
@@ -1,0 +1,79 @@
+From b93e731c517ace6b1f3e3c14820dbb6efd75b324 Mon Sep 17 00:00:00 2001
+From: Ricardo Branco <rbranco@suse.de>
+Date: Mon, 3 Aug 2026 14:40:03 +0200
+Subject: [PATCH 1/2] test/e2e: accept RESTORE in checkpoint tcp error match
+
+Both the tcp-established and tcp-close checkpoint/restore tests expect
+a restore rejected due to an established TCP connection to fail with
+"runc: criu failed: type NOTIFY errno 0". criu's RPC server actually
+reports this failure as type RESTORE, not NOTIFY. Widen the regex in
+both tests to accept RESTORE while still tolerating NOTIFY.
+
+Signed-off-by: Ricardo Branco <rbranco@suse.de>
+---
+ test/e2e/checkpoint_test.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/test/e2e/checkpoint_test.go b/test/e2e/checkpoint_test.go
+index 2592da9ce55..92753a4ca0b 100644
+--- a/test/e2e/checkpoint_test.go
++++ b/test/e2e/checkpoint_test.go
+@@ -353,7 +353,7 @@ var _ = Describe("Podman checkpoint", func() {
+ 		// "Error: crun: (00.054135) Error (criu/cgroup.c:1998): cg: cgroupd: recv req error: No such file or directory: OCI runtime attempted to invoke a command that was not found"
+ 		expectStderr := "cg: cgroupd: recv req error|CRIU restoring failed: -52"
+ 		if podmanTest.OCIRuntime == "runc" {
+-			expectStderr = "runc: criu failed: type NOTIFY errno 0"
++			expectStderr = "runc: criu failed: type (NOTIFY|RESTORE) errno 0"
+ 		}
+ 		Expect(result).Should(ExitWithErrorRegex(125, expectStderr))
+ 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+@@ -397,7 +397,7 @@ var _ = Describe("Podman checkpoint", func() {
+ 		// "Error: crun: (00.054135) Error (criu/cgroup.c:1998): cg: cgroupd: recv req error: No such file or directory: OCI runtime attempted to invoke a command that was not found"
+ 		expectStderr := "cg: cgroupd: recv req error|CRIU restoring failed: -52"
+ 		if podmanTest.OCIRuntime == "runc" {
+-			expectStderr = "runc: criu failed: type NOTIFY errno 0"
++			expectStderr = "runc: criu failed: type (NOTIFY|RESTORE) errno 0"
+ 		}
+ 		Expect(result).Should(ExitWithErrorRegex(125, expectStderr))
+ 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+
+From 8555cffd1f733c521b6250c5440f5f451c3e94e1 Mon Sep 17 00:00:00 2001
+From: Ricardo Branco <rbranco@suse.de>
+Date: Mon, 3 Aug 2026 15:29:06 +0200
+Subject: [PATCH 2/2] test/e2e: skip tcp-close restore test on non-crun
+ runtimes
+
+runc doesn't support --tcp-close, so this test always failed there
+once the flag hit the runtime. Skip it entirely for non-crun since
+since --tcp-established already covers runc above.
+
+Signed-off-by: Ricardo Branco <rbranco@suse.de>
+---
+ test/e2e/checkpoint_test.go | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/test/e2e/checkpoint_test.go b/test/e2e/checkpoint_test.go
+index 92753a4ca0b..5aabbb2a287 100644
+--- a/test/e2e/checkpoint_test.go
++++ b/test/e2e/checkpoint_test.go
+@@ -368,6 +368,10 @@ var _ = Describe("Podman checkpoint", func() {
+ 	})
+ 
+ 	It("podman restore container with tcp-close", func() {
++		if podmanTest.OCIRuntime != "crun" {
++			Skip("tcp-close only implemented for crun")
++		}
++
+ 		// Start a container with redis (which listens on tcp port)
+ 		localRunString := getRunString([]string{REDIS_IMAGE})
+ 		session := podmanTest.PodmanExitCleanly(localRunString...)
+@@ -396,9 +400,6 @@ var _ = Describe("Podman checkpoint", func() {
+ 		// Some older versions print "CRIU restoring failed: -52" while others
+ 		// "Error: crun: (00.054135) Error (criu/cgroup.c:1998): cg: cgroupd: recv req error: No such file or directory: OCI runtime attempted to invoke a command that was not found"
+ 		expectStderr := "cg: cgroupd: recv req error|CRIU restoring failed: -52"
+-		if podmanTest.OCIRuntime == "runc" {
+-			expectStderr = "runc: criu failed: type (NOTIFY|RESTORE) errno 0"
+-		}
+ 		Expect(result).Should(ExitWithErrorRegex(125, expectStderr))
+ 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+ 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))

--- a/data/containers/patches/podman/29381.patch
+++ b/data/containers/patches/podman/29381.patch
@@ -1,0 +1,26 @@
+From e421a366f5647362ec84b18a5896c289e8f3d3c2 Mon Sep 17 00:00:00 2001
+From: Ricardo Branco <rbranco@suse.de>
+Date: Mon, 3 Aug 2026 15:10:35 +0200
+Subject: [PATCH] test/e2e/healthcheck: skip ignore-result test on non-amd64
+
+The badhealthcheck image is available only on amd64.
+
+Skip the test on non-amd64 hosts.
+
+Signed-off-by: Ricardo Branco <rbranco@suse.de>
+---
+ test/e2e/healthcheck_run_test.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/test/e2e/healthcheck_run_test.go b/test/e2e/healthcheck_run_test.go
+index 673998cce98..9eb2975b4a2 100644
+--- a/test/e2e/healthcheck_run_test.go
++++ b/test/e2e/healthcheck_run_test.go
+@@ -169,6 +169,7 @@ var _ = Describe("Podman healthcheck run", func() {
+ 	})
+ 
+ 	It("podman healthcheck --ignore-result exits 0 on failing healthcheck", func() {
++		SkipIfNotAMD64() // https://github.com/containers/podman/issues/28269
+ 		session := podmanTest.Podman([]string{"run", "-q", "-dt", "--name", "hc", "quay.io/libpod/badhealthcheck:latest"})
+ 		session.WaitWithDefaultTimeout()
+ 		Expect(session).Should(ExitCleanly())

--- a/tests/containers/podman_e2e.pm
+++ b/tests/containers/podman_e2e.pm
@@ -112,11 +112,6 @@ sub run {
         && version->parse(numeric_version($version)) >= version->parse("5.8.2")
         && version->parse(numeric_version($version)) < version->parse("6.0")
     );
-    push @xfails, (
-        # These tests fail due to https://bugzilla.opensuse.org/show_bug.cgi?id=1273282
-        'Libpod Suite::[It] Podman checkpoint podman checkpoint container with established tcp connections',
-        'Libpod Suite::[It] Podman checkpoint podman restore container with tcp-close',
-    ) if ($oci_runtime eq "runc" && version->parse(numeric_version($version)) >= version->parse("6.0"));
 
     # Skip remoteintegration on SLES as it panics with:
     # Too many RemoteSocket collisions [PANICKED] Test Panicked


### PR DESCRIPTION


- https://github.com/podman-container-tools/podman/pull/29380 to fix test issue with runc.
- https://github.com/podman-container-tools/podman/pull/29381 to fix test issue on non-amd64 hosts.

Verification runs:
- https://openqa.opensuse.org/tests/6142149
