### PR TITLE
Update x11 VT on first boot of Plasma as well

### DIFF
--- a/lib/locale.pm
+++ b/lib/locale.pm
@@ -37,7 +37,7 @@ sub verify_default_keymap_textmode {
         select_console($tty{console});
     }
     else {
-        send_key('alt-f3');
+        send_key('alt-f1');
         # remote backends can not provide a "not logged in console" so we use
         # a cleared remote terminal instead
         assert_screen(has_ttys() ? 'linux-login' : 'cleared-console');

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -41,6 +41,7 @@ our @EXPORT = qw(
   close_gui_terminal
   handle_gnome_activities
   save_print_file
+  update_x11_vt
 );
 
 =head1 X11_UTILS
@@ -732,6 +733,22 @@ sub save_print_file {
     send_key 'delete';
     type_string_slow($filename);
     send_key "ret";
+}
+
+=head2 update_x11_vt
+
+  update_x11_vt()
+
+From a graphical session, read $XDG_VTNR to update the VT of the "x11"
+openQA console.
+
+=cut
+
+sub update_x11_vt {
+    x11_start_program_xterm();
+    my $tty = script_output('echo $XDG_VTNR');
+    send_key('alt-f4');    # close xterm
+    console('x11')->set_tty(int($tty));
 }
 
 1;

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -10,6 +10,7 @@ use strict;
 use warnings;
 use testapi;
 use version_utils qw(is_sle is_leap is_plasma6);
+use Mojo::File qw(path);
 use utils qw(assert_and_click_until_screen_change type_string_slow);
 use Utils::Architectures;
 use Utils::Backends qw(is_pvm is_qemu);
@@ -746,8 +747,13 @@ openQA console.
 
 sub update_x11_vt {
     x11_start_program_xterm();
-    my $tty = script_output('echo $XDG_VTNR');
-    send_key('alt-f4');    # close xterm
+    # At this point, permissions for $serialdev may not be set up yet and switching
+    # to root-console won't work either, so (mis)use log upload.
+    enter_cmd('curl --form upload=$XDG_VTNR\;filename=x ' . autoinst_url('/uploadlog/xdgvtnr') . ' && exit');
+    assert_screen('generic-desktop');    # Waits until finished
+
+    my $tty = path('ulogs/xdgvtnr')->slurp;
+    record_info('XDG_VTNR', "Graphical session on VT $tty");
     console('x11')->set_tty(int($tty));
 }
 

--- a/tests/installation/finish_desktop.pm
+++ b/tests/installation/finish_desktop.pm
@@ -10,7 +10,7 @@
 use Mojo::Base 'installbasetest';
 use testapi;
 use main_common 'opensuse_welcome_applicable';
-use x11utils 'turn_off_plasma_tooltips';
+use x11utils qw(turn_off_plasma_tooltips update_x11_vt);
 use Utils::Logging qw(save_and_upload_log export_logs);
 
 # using this as base class means only run when an install is needed
@@ -36,7 +36,10 @@ sub run {
 
     # This only works with generic-desktop. In the opensuse-welcome case,
     # the opensuse-welcome module will handle it instead.
-    turn_off_plasma_tooltips if match_has_tag('generic-desktop');
+    if (check_var('DESKTOP', 'kde') && match_has_tag('generic-desktop')) {
+        turn_off_plasma_tooltips;
+        update_x11_vt;
+    }
 }
 
 sub post_fail_hook {

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -15,7 +15,7 @@
 
 use Mojo::Base 'bootbasetest';
 use testapi;
-use x11utils 'turn_off_plasma_tooltips';
+use x11utils qw(turn_off_plasma_tooltips update_x11_vt);
 
 sub run {
     # Workaround: on vmware or hyperv the 'ret' from grub_test is occasionally
@@ -31,7 +31,10 @@ sub run {
     shift->wait_boot_past_bootloader;
     # This only works with generic-desktop. In the opensuse-welcome case,
     # the opensuse-welcome module will handle it instead.
-    turn_off_plasma_tooltips if match_has_tag('generic-desktop');
+    if (check_var('DESKTOP', 'kde') && match_has_tag('generic-desktop')) {
+        turn_off_plasma_tooltips;
+        update_x11_vt;
+    }
 }
 
 sub test_flags {

--- a/tests/installation/opensuse_welcome.pm
+++ b/tests/installation/opensuse_welcome.pm
@@ -10,7 +10,7 @@
 use Mojo::Base 'x11test';
 use testapi;
 use utils;
-use x11utils qw(handle_welcome_screen turn_off_plasma_tooltips);
+use x11utils qw(handle_welcome_screen turn_off_plasma_tooltips update_x11_vt);
 use version_utils qw(is_upgrade is_leap);
 
 sub run {
@@ -30,7 +30,10 @@ sub run {
         }
     }
 
-    turn_off_plasma_tooltips;
+    if (check_var('DESKTOP', 'kde')) {
+        turn_off_plasma_tooltips;
+        update_x11_vt;
+    }
 }
 
 sub test_flags {

--- a/tests/installation/opensuse_welcome.pm
+++ b/tests/installation/opensuse_welcome.pm
@@ -30,18 +30,6 @@ sub run {
         }
     }
 
-    # Workaround for boo#1211628
-    if (check_var('DESKTOP', 'kde') && match_has_tag('boo1211628')) {
-        # plasmashell crashed and openSUSE theme is not fully applied
-        # Workaround that
-        x11_start_program('rm ~/.config/plasma-org.kde.plasma.desktop-appletsrc', valid => 0);
-        x11_start_program('konsole', valid => 0);
-        x11_start_program('plasmashell --replace', valid => 0);
-        x11_start_program('pkill konsole', valid => 0);
-        assert_screen 'generic-desktop';
-        die 'Workaround for boo#1211628 did not work' if (match_has_tag('boo1211628'));
-    }
-
     turn_off_plasma_tooltips;
 }
 

--- a/tests/x11/reboot_plasma5.pm
+++ b/tests/x11/reboot_plasma5.pm
@@ -11,6 +11,7 @@ use Mojo::Base 'x11test';
 use testapi;
 use utils;
 use power_action_utils;
+use x11utils qw(update_x11_vt);
 
 sub run {
     my ($self) = @_;
@@ -24,10 +25,7 @@ sub run {
     $self->disable_key_repeat;
 
     # After reboot and login the graphical session might be on a different VT again.
-    x11_start_program('xterm');
-    my $tty = script_output('echo $XDG_VTNR');
-    send_key("alt-f4");    # close xterm
-    console('x11')->set_tty(int($tty));
+    update_x11_vt;
 }
 
 sub test_flags {

--- a/tests/x11/start_wayland_plasma5.pm
+++ b/tests/x11/start_wayland_plasma5.pm
@@ -10,7 +10,7 @@
 use Mojo::Base 'x11test';
 use testapi;
 use utils;
-use x11utils 'handle_login';
+use x11utils qw(handle_login update_x11_vt);
 
 sub run {
     my ($self) = @_;
@@ -37,11 +37,7 @@ sub run {
     handle_login;
 
     # We're now in a wayland session, which is in a different VT
-    x11_start_program('xterm');
-    my $tty = script_output('echo $XDG_VTNR');
-    send_key("alt-f4");    # close xterm
-
-    console('x11')->set_tty(int($tty));
+    update_x11_vt;
 }
 
 sub test_flags {


### PR DESCRIPTION
With Plasma defaulting to wayland, the VT can be different depending on
the environment, e.g. autologin disabled or even luck due to VT assignment.
Read the VT unconditionally.

- Failure: https://openqa.opensuse.org/tests/6142053
- Verification run: [![opensuse-Staging:G-Staging-DVD-x86_64-BuildG.977.1-kde-wayland@64bit_virtio test result](https://openqa.opensuse.org/tests/6143968/badge)](https://openqa.opensuse.org/tests/6143968)