### PR TITLE
kselftests_run: Relax grep pattern for TAP summary line

### DIFF
--- a/tests/kernel/kselftests_run.pm
+++ b/tests/kernel/kselftests_run.pm
@@ -73,7 +73,7 @@ sub run {
         my $test_bare = ($test =~ s/^[^:]+://r);
         my $cmd = "./run_kselftest.sh --override-timeout $timeout --test $test 2>&1 | tee /tmp/$test_bare;"
           . " echo '# selftests: $collection: $test_bare' >> \$HOME/summary.tap;"
-          . " grep -m1 -E '^(not )?ok [0-9]+ selftests: ' /tmp/$test_bare"
+          . " grep -m1 -o -E '(not )?ok [0-9]+ selftests: .*' /tmp/$test_bare"
           . " | sed 's/ok [0-9]*/ok $i/' >> \$HOME/summary.tap;"
           . " echo '$stamp $test END'";
 


### PR DESCRIPTION
If a test crashes or exits without printing a final newline to stderr/stdout, the TAP summary line appended by `run_kselftest.sh` gets concatenated with the unterminated output line.

This was seen in `net:reuseaddr_conflict` test which prints "Success" instead of "Success\n", which made the script write "# Successok 1 selftests: net: reuseaddr_conflict". The resulting line was thus missed and triggered an off-by-one bug in `Kselftests::utils::post_process()`.

Use `grep -o` and drop the `^` anchor so that the TAP summary is correctly extracted even when appended to an unterminated log output.

- Verification run: https://openqa.suse.de/tests/23755246/logfile?filename=summary.tap.txt#line-12
