### PR TITLE
buildah: Update merged tags for PRs

### DIFF
--- a/data/containers/patches.yaml
+++ b/data/containers/patches.yaml
@@ -29,10 +29,13 @@ buildah:
     merged: "1.41.0"
   6602:
     min: "1.43.0"
+    merged: "1.44.0"
   6701:
     min: "1.43.0"
+    merged: "1.44.0"
   6791:
     min: "1.39.5"
+    merged: "1.44.0"
 
 buildx:
   # https://github.com/docker/buildx/pull/3475/ - test: Handle version not having the initial 'v'


### PR DESCRIPTION
These were merged on v1.44.0 and we need to tag them to ease patch bookkeeping and to avoid applying them (even though the operation is idempotent), to avoid noise in the reproducer.

https://github.com/podman-container-tools/buildah/releases/tag/v1.44.0