### PR TITLE
bats/podman: Remove xfail for v6.0.2

### DIFF
--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -64,11 +64,6 @@ sub run_tests {
             ) if (version->parse(numeric_version($version)) >= version->parse("6.0.0"));
         }
     }
-    push @xfails, (
-        # Sporadic issue fixed in
-        # https://github.com/containers/podman/commit/f172ff789b14226b51cea39f9373e7de2a35905a
-        "550-pause-process.bats::podman system migrate works with conmon being killed",
-    ) if (is_ppc64le && !is_sle);
 
     my $ret = bats_tests($log_file, \%env, \@xfails, 6000);
 


### PR DESCRIPTION
The issue is fixed in podman v6.0.2.

Passed: https://openqa.opensuse.org/tests/6142041#step/podman/545