### PR TITLE
sudo: reinstall serial marker hook after switching to sudo_test

### DIFF
--- a/tests/console/sudo.pm
+++ b/tests/console/sudo.pm
@@ -32,6 +32,11 @@ sub sudo_with_pw {
     if ($command =~ /sudo -i|sudo -s|sudo su/) {
         enter_cmd "expect -c 'spawn $command;expect \"password for*:\" {send \"$password\\r\";interact} default {exit 1}'";
         assert_screen $args{expected_screen} // 'root-console';
+        # The spawned (login) shell can belong to another user whose ~/.bashrc
+        # does not have the openQA prompt hook for PRETTY_SERIAL_MARKER yet, so
+        # force a re-install on the next command, same as become_root does.
+        # poo#205122
+        $testapi::distri->invalidate_serial_marker_hook();
     }
     else {
         assert_script_run("expect -c '${env}spawn $command;expect \"password for*:\" {send \"$password\\r\";interact} default {exit 1}'$grep", timeout => $args{timeout});


### PR DESCRIPTION
Since os-autoinst PR #2984 enabled `PRETTY_SERIAL_MARKER` by default, `script_run` on non-serial-terminal consoles relies on a `_oap` PROMPT_COMMAND hook installed in the current user's `~/.bashrc`. After `sudo su - sudo_test` we are in a login shell of a freshly created user, which has no hook, so no `OA:DONE` marker is ever emitted and every following `assert_script_run` times out.

Fix: invalidate the cached hook state after spawning the interactive shell, so the next command reinstalls it - the same thing `susedistribution::become_root` already does. It is a no-op with `PRETTY_SERIAL_MARKER=0`/serial terminals, and idempotent for the root-shell cases.

- Related ticket: https://progress.opensuse.org/issues/205122 (and https://progress.opensuse.org/issues/205092)
- Needles: N/A
- Verification runs:
  - publiccloud_consoletests:
    - aarch64: https://openqa.suse.de/tests/23754321#step/sudo/1
    - x86_64: https://openqa.suse.de/tests/23754328#step/sudo/1
  - mau-extratests2: https://openqa.suse.de/tests/23756239#step/sudo/1
  - mau-extra-tests:
    - s390x: https://openqa.suse.de/tests/23756240#step/sudo/1
  - extra_tests_textmode: https://openqa.suse.de/tests/23756241#step/sudo/1
  - fips_ker_mode_textmode_extra: https://openqa.suse.de/tests/23756243#step/sudo/1
- checks for regressions:
  - ppc64le: https://openqa.suse.de/tests/23756611#step/sudo/1
  - tumbleweed: https://openqa.opensuse.org/tests/6142269#step/sudo/1

Note: `tests/security/vsftpd/vsftpd.pm` fails from the same root cause (`su - $user`) and needs a separate fix.