### PR TITLE
bats/podman: Add xfail for podman v6.0 on ppc64le

### DIFF
--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -64,6 +64,10 @@ sub run_tests {
             ) if (version->parse(numeric_version($version)) >= version->parse("6.0.0"));
         }
     }
+    push @xfails, (
+        # This test is racy on ppc64le:
+        "090-events.bats::events - died event contains OOMKilled attribute",
+    ) if (is_ppc64le && version->parse(numeric_version($version)) >= version->parse("6.0.0"));
 
     my $ret = bats_tests($log_file, \%env, \@xfails, 6000);
 


### PR DESCRIPTION
Failed job: https://openqa.opensuse.org/tests/6141693

Notified in https://matrix.to/#/!dEOtPtLYATRcPwrPhS:matrix.org/$mn6OwM8bpfhdKLw5mB3tgw2ylI4Nj6126YtPe6mFu54?via=matrix.org&via=fedora.im&via=holzinger.dev