### PR TITLE
vsftpd: reinstall serial marker hook after switching to ftpuser

### DIFF
--- a/tests/security/vsftpd/vsftpd.pm
+++ b/tests/security/vsftpd/vsftpd.pm
@@ -24,6 +24,10 @@ sub run {
     }
 
     enter_cmd("su - $user");
+    # The login shell of $user does not have the openQA prompt hook for
+    # PRETTY_SERIAL_MARKER in its ~/.bashrc yet, so force a re-install on the
+    # next command, same as become_root does. poo#205122
+    $testapi::distri->invalidate_serial_marker_hook();
 
     # Download/upload file using atomatic SSL method selection
     assert_script_run("curl -v -k --ssl ftp://$user:$pwd\@localhost/served/f1.txt -o $ftp_users_path/$user/$ftp_received_dir/f1.txt");


### PR DESCRIPTION
`enter_cmd("su - $user")` enters a login shell of `ftpuser`, whose `~/.bashrc` does
not have the `_oap` PROMPT_COMMAND hook that os-autoinst installs for
`PRETTY_SERIAL_MARKER` (enabled by default since os-autoinst#2984). No `OA:DONE`
marker is ever printed, so every following `assert_script_run` times out.

Same one-line fix as `become_root` (lib/susedistribution.pm) and
tests/console/sudo.pm (#26271): invalidate the cached hook state so it gets
reinstalled in the new shell. It is a no-op at marker level 1
(`PRETTY_SERIAL_MARKER=0` or serial terminal).

- Related ticket: https://progress.opensuse.org/issues/205203
- Needles: N/A
- Verification runs: all 16 latest production jobs of
  `fips_env_mode_textmode_extra` + `fips_ker_mode_textmode_extra` (SLE15
  SP4/SP5/SP6/SP7 x 64bit/uefi) currently fail `vsftpd` with `command 'curl -v -k
  --ssl ftp://...' timed out`. Paired A/B on 4 of them, control = same branch
  without the 4 added lines:

  | scenario | control | with fix |
  |---|---|---|
  | SP4 uefi env_mode | [23767992](https://openqa.suse.de/tests/23767992#step/vsftpd/3) failed | [23767991](https://openqa.suse.de/tests/23767991#step/vsftpd/3) passed |
  | SP5 64bit env_mode | [23767994](https://openqa.suse.de/tests/23767994#step/vsftpd/3) failed | [23767993](https://openqa.suse.de/tests/23767993#step/vsftpd/3) passed |
  | SP6 64bit ker_mode | [23767996](https://openqa.suse.de/tests/23767996#step/vsftpd/3) failed | [23767995](https://openqa.suse.de/tests/23767995#step/vsftpd/3) passed |
  | SP7 uefi ker_mode | [23767999](https://openqa.suse.de/tests/23767999#step/vsftpd/3) failed | [23767997](https://openqa.suse.de/tests/23767997#step/vsftpd/3) passed |

On SLE16.1 `fips_ker_mode_textmode_extra` the module still fails, but with curl
exit 18 instead of a hang — a pre-existing bug that also happened before pretty
markers existed (e.g. [23629191](https://openqa.suse.de/tests/23629191) from
2026-07-27), unrelated to this change.