### PR TITLE
Keep classic serial markers for interactive SSH sub-shell in sshd test

### DIFF
--- a/lib/services/sshd.pm
+++ b/lib/services/sshd.pm
@@ -87,18 +87,24 @@ sub ssh_basic_check {
     assert_script_run("echo \"PS1='# '\" >> ~$ssh_testman/.bashrc") unless check_var('VIRTIO_CONSOLE', '0');
 
     # Make interactive SSH connection as the new user
-    enter_cmd "expect -c 'spawn ssh $ssh_testman\@localhost -t;expect \"Are you sure\";send yes\\n;expect sword:;send $ssh_testman_passwd\\n;expect #;send \\n;interact'";
-    sleep(1);
+    # poo#205149: the sub-shell spawned via expect doesn't inherit the outer
+    # shell's PROMPT_COMMAND marker hook, so fall back to classic markers
+    # for this interactive region only.
+    {
+        my $marker_guard = $testapi::distri->pretty_serial_marker_guard(0);
+        enter_cmd "expect -c 'spawn ssh $ssh_testman\@localhost -t;expect \"Are you sure\";send yes\\n;expect sword:;send $ssh_testman_passwd\\n;expect #;send \\n;interact'";
+        sleep(1);
 
-    # Check that we are really in the SSH session
-    assert_script_run 'echo $SSH_TTY | grep "\/dev\/pts\/"';
-    assert_script_run 'ps ux | grep -E ".* \? .* sshd(-session)?\:"';
-    assert_script_run "whoami | grep $ssh_testman";
-    assert_script_run "mkdir .ssh";
+        # Check that we are really in the SSH session
+        assert_script_run 'echo $SSH_TTY | grep "\/dev\/pts\/"';
+        assert_script_run 'ps ux | grep -E ".* \? .* sshd(-session)?\:"';
+        assert_script_run "whoami | grep $ssh_testman";
+        assert_script_run "mkdir .ssh";
 
-    # Exit properly and check we're root again
-    script_run("exit", 0);
-    assert_script_run "whoami | grep root";
+        # Exit properly and check we're root again
+        script_run("exit", 0);
+        assert_script_run "whoami | grep root";
+    }
 
     # Generate RSA key for root and the user
     assert_script_run "ssh-keygen -t rsa -P '' -C 'root\@localhost' -f ~/.ssh/id_rsa";


### PR DESCRIPTION
Wraps the interactive SSH sub-shell region in `services::sshd::ssh_basic_check` with `pretty_serial_marker_guard(0)` so classic serial markers are used there instead of pretty markers.

* Related ticket: [poo#205149](https://progress.opensuse.org/issues/205149)
* Related failure: [openqa.suse.de/t23752964](https://openqa.suse.de/tests/23752964)
* Verification runs: In comment below
