### PR TITLE
Remove redundant duplicate linux-login check in process_reboot after soft-reboot

### DIFF
--- a/lib/transactional.pm
+++ b/lib/transactional.pm
@@ -146,13 +146,13 @@ sub process_reboot {
             }
             assert_screen 'grub2', 300;
             wait_screen_change { send_key 'ret' };
+            assert_screen 'linux-login', 400;
         }
         else {
             #Need to wait 3s to start tty6 service refer bsc#1269251
-            assert_screen 'linux-login', 200;
+            assert_screen 'linux-login', 400;
             wait_still_screen(3);
         }
-        assert_screen 'linux-login', 200;
 
         # Login & clear login needle
         select_console 'root-console';


### PR DESCRIPTION
Removes the redundant, unconditional `assert_screen('linux-login', 200)` at the end of `process_reboot()`'s soft-reboot branch — it duplicated the check already done a few lines above in the `else` branch. A systemd soft-reboot re-runs the entire early-boot target chain (remounts, hardware DB rebuild, journal flush, ...), so this second check could time out on its own even though the first one already matched, causing intermittent `rebootmgr` failures. The grub branch, which had no check of its own, now gets the single needed `assert_screen` instead.

* Related ticket: [poo#205134](https://progress.opensuse.org/issues/205134)
* Related failure: [openqa.suse.de/t23752581](https://openqa.suse.de/tests/23752581)
* Related commit: 8967d38fb7 introduced the duplicate check
* Related fix: 566d991508 (poo#202980) fixed a different soft-reboot/console race in the same function on aarch64
* Verification runs: In comment below

