### PR TITLE
publiccloud: PILOT_DEBUG diagnostic wrapper for flake CLIs (poo#205053) [DO NOT MERGE]

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -77,6 +77,24 @@ sub analyze_results {
     }
 }
 
+sub enable_pilot_debug_for_flakes {
+    # Diagnostic-only helper (poo#205053): forces PILOT_DEBUG=1 for the
+    # given flake-pilot registered binaries (e.g. az, aws) on the SUT by
+    # replacing their /usr/bin symlink with a wrapper that re-execs
+    # podman-pilot with PILOT_DEBUG set. This surfaces the otherwise
+    # hidden stdout/stderr of the "systemfiles" host-dependency generator
+    # script directly in the pytest/testinfra failure output.
+    my ($instance, @apps) = @_;
+    for my $app (@apps) {
+        next if ($instance->ssh_script_run("test -L /usr/bin/$app") != 0);
+        my $wrapper_file = "pilot_debug_$app.sh";
+        save_tmp_file($wrapper_file, "#!/bin/bash\nexport PILOT_DEBUG=1\nexec -a $app /usr/bin/podman-pilot \"\$\@\"\n");
+        $instance->ssh_assert_script_run('curl -O ' . autoinst_url . "/files/$wrapper_file");
+        $instance->ssh_assert_script_run("sudo install -m 755 $wrapper_file /usr/bin/$app");
+        record_info('PILOT_DEBUG', "Enabled PILOT_DEBUG=1 wrapper for flake app '$app' (poo#205053 diagnostics)");
+    }
+}
+
 sub run {
     my ($self, $args) = @_;
 
@@ -88,6 +106,10 @@ sub run {
 
     $instance = $args->{my_instance};
     $provider = $args->{my_provider};
+
+    if (my $debug_apps = get_var('PUBLIC_CLOUD_IMG_PROOF_PILOT_DEBUG')) {
+        enable_pilot_debug_for_flakes($instance, split(/,/, $debug_apps));
+    }
 
     # SLES 16 doesn't have AppArmor and stores ssh configuration in /usr/etc
     if (is_hardened && is_sle("<16")) {

--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -89,7 +89,10 @@ sub enable_pilot_debug_for_flakes {
         next if ($instance->ssh_script_run("test -L /usr/bin/$app") != 0);
         my $wrapper_file = "pilot_debug_$app.sh";
         save_tmp_file($wrapper_file, "#!/bin/bash\nexport PILOT_DEBUG=1\nexec -a $app /usr/bin/podman-pilot \"\$\@\"\n");
-        $instance->ssh_assert_script_run('curl -O ' . autoinst_url . "/files/$wrapper_file");
+        # autoinst_url is only reachable from the local tooling instance, not
+        # from the actual cloud SUT, so download locally first, then scp it over.
+        assert_script_run('curl -O ' . autoinst_url . "/files/$wrapper_file");
+        $instance->scp($wrapper_file, "remote:$wrapper_file");
         $instance->ssh_assert_script_run("sudo install -m 755 $wrapper_file /usr/bin/$app");
         record_info('PILOT_DEBUG', "Enabled PILOT_DEBUG=1 wrapper for flake app '$app' (poo#205053 diagnostics)");
     }


### PR DESCRIPTION
## Purpose

Diagnostic-only PR to investigate https://progress.opensuse.org/issues/205053
(SLES 16.0 SAP images: `az --version`/`aws --version` fail via flake-pilot
with `IOError: "system deps generator failed" "Please run with PILOT_DEBUG=1
for details"`, SAP-specific, root cause unknown).

`/usr/bin/az` / `/usr/bin/aws` on the image are plain symlinks to
`podman-pilot`. Setting `PILOT_DEBUG=1` makes podman-pilot log the actual
stdout/stderr of the failing `systemfiles` generator script to stderr,
which testinfra/pytest already captures in the failure output — but that
requires a live reproduction on the SAP instance, which isn't available
to us right now.

This PR adds an opt-in helper (`PUBLIC_CLOUD_IMG_PROOF_PILOT_DEBUG`,
unset by default, zero effect on any existing job) that replaces the
`az`/`aws` symlink on the SUT with a tiny wrapper forcing
`PILOT_DEBUG=1`, so we can capture the real root cause from a cloned
verification run against the already-failing SAP jobs instead of needing
manual live access.

**Not intended to be merged** — will be closed once we've captured the
diagnostic output from the cloned VR jobs. Will report findings back on
poo#205053.