### PR TITLE
feat: Remove softfailure for boo#1226676

### DIFF
--- a/tests/transactional/trup_smoke.pm
+++ b/tests/transactional/trup_smoke.pm
@@ -11,7 +11,7 @@ use Mojo::Base 'consoletest';
 use testapi;
 use transactional;
 use Utils::Architectures qw(is_s390x);
-use version_utils qw(is_bootloader_sdboot is_sle_micro is_bootloader_grub2_bls);
+use version_utils qw(is_sle_micro);
 use serial_terminal;
 
 sub action {
@@ -36,12 +36,7 @@ sub run {
     action('bootloader', 'Reinstall bootloader');
     action('grub.cfg', 'Regenerate grub.cfg');
     action('initrd', 'Regenerate initrd');
-    if (is_bootloader_sdboot || is_bootloader_grub2_bls) {
-        record_soft_failure("boo#1226676: kdump not yet implemented with sdbootutil");
-    }
-    else {
-        action('kdump', 'Regenerate kdump') if is_sle_micro;
-    }
+    action('kdump', 'Regenerate kdump') if is_sle_micro;
     action('cleanup', 'Run cleanup', 0);
 }
 


### PR DESCRIPTION
[boo#1226676](https://bugzilla.suse.com/show_bug.cgi?id=1226676) is resolved so the softfailure should be removed.

- Verification run: [Tumbleweed](https://openqa.opensuse.org/tests/6144343) [MicroOS](https://openqa.opensuse.org/tests/6144344) and [SLEM 5.5](https://openqa.suse.de/tests/23776003)