### PR TITLE
xfstests: drop obsolete pNFS server configuration

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -557,8 +557,6 @@ lease-time=$nfsgrace
 END
         write_sut_file('/etc/nfs.conf', $content);
         if ($nfsversion =~ 'pnfs') {
-            assert_script_run('mkdir -p /srv/pnfs_data && chown nobody:nogroup /srv/pnfs_data && echo \'/srv/pnfs_data *(rw,pnfs,no_subtree_check,no_root_squash,fsid=10)\' >> /etc/exports');
-            assert_script_run('sed -i \'/^\[nfsd\\]$/a pnfs_dlm_device = localhost:/srv/pnfs_data\' /etc/nfs.conf');
             assert_script_run("echo '[NFSMount_Global_Options]' >> /etc/nfsmount.conf && echo 'Defaultvers=4.1' >> /etc/nfsmount.conf && echo 'Nfsvers=4.1' >> /etc/nfsmount.conf");
         }
         enable_rdma_in_nfs if $nfsversion =~ 'rdma';


### PR DESCRIPTION
pnfs_dlm_device is not a valid /etc/nfs.conf option, it came from an out-of-tree patch set that never went upstream, so the dedicated /srv/pnfs_data export is pointless too. The pnfs keyword on the regular test/scratch exports is all that is needed, and pNFS activity is already verified from /proc/self/mountstats in setup_nfs_client.

- Related ticket: https://progress.opensuse.org/issues/194266
- Verification run: https://openqa.suse.de/tests/23786139#step/partition/52 (after removing duplicate configuration, it still could show "pnfs=LAYOUT_FLEX_FILES", which is expected)