### PR TITLE
Replace CPU selection test with log-only validation for stalld

### DIFF
--- a/tests/console/stalld.pm
+++ b/tests/console/stalld.pm
@@ -58,13 +58,14 @@ sub run {
         # Modify run_tests.sh to use the system binary
         assert_script_run("sed -i 's|STALLD_BIN=.*|STALLD_BIN=\"$system_stalld\"|' tests/run_tests.sh");
 
-        validate_script_output("./tests/run_tests.sh --test test_cpu_selection", sub { m/Test PASSED/ }, timeout => 120);
+        validate_script_output("./tests/run_tests.sh --test test_log_only", sub { m/Test PASSED/ }, timeout => 120);
     }
 }
 
 sub cleanup {
     my $pkg = "stalld";
     systemctl("stop stalld");
+    assert_script_run("cd /");
     uninstall_package("$pkg", trup_continue => 1, trup_reboot => 1);
     assert_script_run("rm -rf /tmp/stalld-src");
 }


### PR DESCRIPTION
Updated the test to run `test_log_only` instead of `test_cpu_selection` and Configured QEMUCPUS=2 for running stalld upstream test execution. 

MR: https://gitlab.suse.de/qa-maintenance/qam-openqa-yml/-/merge_requests/1028
VRs: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=DeepthiYV%2Fos-autoinst-distri-opensuse%2326290