### PR TITLE
Skip BYOS registercloudguest during registration_lifecycle tests

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -24,7 +24,6 @@ sub load_maintenance_publiccloud_tests {
 
     loadtest "publiccloud/download_repos" unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
     loadtest "publiccloud/prepare_instance", run_args => $args;
-    loadtest "publiccloud/registration", run_args => $args;
     loadtest "publiccloud/network_test", run_args => $args;
     loadtest "publiccloud/check_services", run_args => $args;
     loadtest "publiccloud/kdump", run_args => $args;
@@ -32,6 +31,8 @@ sub load_maintenance_publiccloud_tests {
     loadtest "publiccloud/check_cloudinit", run_args => $args;
     if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
         loadtest("publiccloud/registration_lifecycle", run_args => $args);
+    } else {
+        loadtest "publiccloud/registration", run_args => $args;
     }
     loadtest "publiccloud/transfer_repos", run_args => $args unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
     loadtest "publiccloud/patch_and_reboot", run_args => $args;
@@ -145,7 +146,6 @@ sub load_latest_publiccloud_tests {
         return;    # Do not continue as there is no instance to destroy
     } else {    # All test cases below require prepare_instance
         loadtest "publiccloud/prepare_instance", run_args => $args;
-        loadtest "publiccloud/registration", run_args => $args;
         loadtest "publiccloud/network_test", run_args => $args;
         loadtest "publiccloud/kdump", run_args => $args;
         loadtest "publiccloud/check_boottime", run_args => $args;


### PR DESCRIPTION
Restores the `if (PUBLIC_CLOUD_REGISTRATION_TESTS) { registration_lifecycle } else { registration }` mutual exclusion in `main_publiccloud.pm` that commit 9d33698 ("Unify registration") dropped when it merged `auto_registration.pm` into `registration.pm` and made its `registercloudguest()` call unconditional for BYOS instances. `registration_lifecycle` still assumes the instance starts unregistered on its first run, but `registration` was registering it first, so the test died as soon as it checked `/etc/zypp/credentials.d/`.

* Related ticket: [poo#205257](https://progress.opensuse.org/issues/205257)
* Related failure: [openqa.suse.de/t23779538](https://openqa.suse.de/tests/23779538)
* Fixing: #26262
* Verification runs:
