### PR TITLE
eal4: soft-fail when spectre-meltdown-checker cannot identify the CPU

### DIFF
--- a/tests/security/eal4/check_processor_vulnerability_mitigations.pm
+++ b/tests/security/eal4/check_processor_vulnerability_mitigations.pm
@@ -30,6 +30,17 @@ sub run {
 
     upload_logs($log_file);
 
+    # spectre-meltdown-checker only maps a handful of ARM CPU implementers (0x41 ARM,
+    # 0x43 Cavium, 0x70 Phytium). On any other one it cannot identify the CPU: it
+    # prints an empty "CPU is" line and every variant falls through to the "assume
+    # affected" default of is_cpu_affected(). The report then claims even x86-only
+    # issues such as CVE-2018-3615 (Foreshadow/SGX) are present, so none of its
+    # verdicts are usable and there is nothing to assert on.
+    if (script_run("grep -qE '^CPU is[[:space:]]*\$' $log_file") == 0) {
+        record_soft_failure("poo#204810 - $script cannot identify this CPU, its vulnerability verdicts are unusable");
+        return;
+    }
+
     my $summary = script_output("grep 'SUMMARY' $log_file");
     record_info('SUMMARY', $summary);
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/204810

`spectre-meltdown-checker.sh` only maps a handful of ARM CPU implementers (0x41 ARM, 0x43 Cavium, 0x70 Phytium). On any other one it leaves `cpu_vendor` and `cpu_friendly_name` empty, prints a bare `CPU is ` line, and every variant falls through to the "assume affected" default of `is_cpu_affected()`. The SUMMARY then reports even x86-only issues such as CVE-2018-3615 (Foreshadow/SGX) as present, so there is nothing meaningful to assert on.

This is what happens on the AmpereOne aarch64 OSD workers (worker-arm3): with `QEMUCPU=host` the guest sees implementer 0xc0, which the checker does not know, and CVE-2018-3640 plus CVE-2018-3615 come back `KO` on every run. Bucketing the last 90 aarch64 `cc_eal4` runs by worker host shows the split cleanly — worker-arm1 51/51 passed, worker-arm2 28/28 passed, worker-arm3 0/11.

The checker itself is being taught about Ampere separately in https://gitlab.suse.de/qe-security/atsec/-/merge_requests/2, which is the actual fix since the test clones that repo at runtime. This change detects the unusable report as well, so an unknown future implementer does not silently turn into a wall of bogus CVE failures.