### PR TITLE
Do not let the AVC collection fail a module that already passed

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -602,10 +602,27 @@ sub record_avc_selinux_alerts {
     my $self = shift;
 
     return if (current_console() !~ /root|log/);
-    return if (script_run('test -d /sys/fs/selinux') != 0);
 
-    my @logged = split(/\n/, script_output('ausearch -m avc,user_avc,selinux_err,user_selinux_err -r',
-            timeout => 300, proceed_on_failure => 1));
+    # This runs from consoletest::post_run_hook, so the module body has already passed
+    # by the time we get here and collecting AVCs must never be the reason it goes red.
+    # Both script_run() and script_output() croak when the console does not answer in
+    # time, which happens on loaded workers, so gather the alerts opportunistically and
+    # report what we could not collect instead of dying. See poo#204810.
+    my ($selinux, @logged);
+    unless (eval { $selinux = script_run('test -d /sys/fs/selinux'); 1 }) {
+        record_info('AVC', "Console did not answer, skipping the AVC check: $@", result => 'softfail');
+        return;
+    }
+    return if (!defined($selinux) || $selinux != 0);
+
+    unless (eval {
+            @logged = split(/\n/, script_output('ausearch -m avc,user_avc,selinux_err,user_selinux_err -r',
+                    timeout => 300, proceed_on_failure => 1));
+            1;
+    }) {
+        record_info('AVC', "'ausearch' did not answer, skipping the AVC check: $@", result => 'softfail');
+        return;
+    }
 
     if (scalar @logged <= $avc_record{start}) {
         record_info('AVC', 'No AVCs were recorded');


### PR DESCRIPTION
`Utils::Logging::record_avc_selinux_alerts()` runs from `consoletest::post_run_hook`, i.e. after the module body is done. Both `script_run()` and `script_output()` croak when the console does not answer within the timeout, so a console stall there turns a passing module red:

```
# Test died: command 'test -d /sys/fs/selinux' timed out at testapi.pm line 1011
        testapi::script_run("test -d /sys/fs/selinux") at lib/Utils/Logging.pm line 605
        Utils::Logging::record_avc_selinux_alerts(aa_status=...) at lib/consoletest.pm line 33
        consoletest::post_run_hook(aa_status=...) at basetest.pm line 326
```

Across the currently failing jobs of group 429 the probe is the reported cause of 14 module failures in 7 jobs.

Most of those are the 12-SP5 `mau-apparmor` ones, where the probe is only the messenger and the real cause is the prompt hook writing to a `/dev/ttyS0` that nothing holds open — that is fixed at the source in #26287, so this change is not what rescues them. What is left is the plain case: `setup_eal4_env` in `cc_ipsec_client` (https://openqa.suse.de/tests/23786635), where all four commands of the module body succeeded, the post-run probe then timed out, and because the module is fatal the remaining modules were skipped and the parallel `cc_ipsec_server` job went `parallel_failed` with it.

Either way the collection is a diagnostic and should never be the reason a module goes red. Gather the alerts opportunistically instead and record a soft failure naming what could not be collected, so the information is not silently lost.