### PR TITLE
docker_compose: Add xfails for gh#docker/compose#14005

### DIFF
--- a/tests/containers/docker_compose.pm
+++ b/tests/containers/docker_compose.pm
@@ -66,6 +66,11 @@ sub test ($target) {
         "github.com/docker/compose/$v/pkg/e2e::TestWatch",
         "github.com/docker/compose/$v/pkg/e2e::TestWatch/debian",
     );
+    push @xfails, (
+        # These fail due to https://github.com/docker/compose/issues/14005
+        "github.com/docker/compose/v5/pkg/e2e::TestImageVolume",
+        "github.com/docker/compose/v5/pkg/e2e::TestImageVolumeRecreateOnRebuild",
+    ) if (is_tumbleweed);
 
     run_timeout_command "$env make $target &> $target.txt", no_assert => 1, timeout => 3600;
     upload_logs "$target.txt", failok => 1;


### PR DESCRIPTION
Add xfails for https://github.com/docker/compose/issues/14005

Failed job: https://openqa.opensuse.org/tests/6146470 (soft-failed to unblock Tumbleweed release).