### PR TITLE
fix(hpc): guard unsupported nested user switches in switch_user

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -140,6 +140,11 @@ sub get_slurm_logs {
 
 sub switch_user {
     my ($self, $username) = @_;
+
+    # poo#183761 nested user switches are not supported by the pretty_serial feature.
+    # We use pretty_serial_marker_guard(0) to temporarily fall back to classic markers,
+    # ensuring terminal synchronization remains reliable during the user transition.
+    my $marker_guard = $testapi::distri->pretty_serial_marker_guard(0);
     enter_cmd("su - $username");
     type_string(qq/PS1="# "\n/);
     wait_serial(qr/PS1="# "/);


### PR DESCRIPTION
[fix(hpc): guard unsupported nested user switches in switch_user

- Related ticket: https://progress.opensuse.org/issues/205227
- Verification run: https://openqa.suse.de/tests/23798136#
