### PR TITLE
Enable sles_extended in s390x

### DIFF
--- a/schedule/yam/agama_extended_s390x.yaml
+++ b/schedule/yam/agama_extended_s390x.yaml
@@ -1,0 +1,18 @@
+---
+name: agama_extended
+description: >
+  Perform interactive installation with the following additional test:
+    - Set static hostname via UI.
+    - Install packages gvim,rpm-build via profile.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/import_agama_profile
+  - yam/agama/patch_agama_tests
+  - yam/validate/validate_self_update
+  - yam/agama/agama
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - yam/validate/validate_hostname
+  - yam/validate/validate_connectivity
+  - yam/validate/validate_bootloader_timeout
+  - yam/validate/validate_ntp

--- a/test_data/yam/agama_sle_extended_s390x.yaml
+++ b/test_data/yam/agama_sle_extended_s390x.yaml
@@ -1,0 +1,17 @@
+---
+hostname: suselinux
+files:
+  - path: '/usr/local/share/dummy.xml'
+    mode: '644'
+    owner: 'root'
+    sha256sum: '5f925f748a27b757853767477ec0e0e6f04b1727f3607c7f622a2a1e4bd2a0e5'
+repos:
+  - name: science
+    alias: science
+    uri: https://download.opensuse.org/repositories/science/16.0/
+    enabled: 'Yes'
+    filter: name
+bootloader_timeout: '30'
+self_update_enabled: 1
+ntp_servers:
+  - 3.suse.pool.ntp.org

--- a/tests/yam/validate/validate_hostname.pm
+++ b/tests/yam/validate/validate_hostname.pm
@@ -17,22 +17,27 @@ use Utils::Backends qw(is_svirt);
 
 sub run {
     select_console 'root-console';
-    my @s390x_resolvers = (
-        {
-            match => sub { is_s390x && is_zvm },
-            resolve => sub { get_required_var('ZVM_GUEST') },
-        },
-        {
-            match => sub { is_s390x && is_svirt },
-            resolve => sub { (split(/\./, get_required_var('SUT_IP')))[0] },
-        },
-    );
 
-    my ($active_rule) = grep { $_->{match}->() } @s390x_resolvers;
-
-    my $expected_install_hostname = $active_rule
-      ? $active_rule->{resolve}->()
-      : (get_test_suite_data()->{hostname} // 'localhost');
+    my $expected_install_hostname;
+    if (my $hostname = get_test_suite_data()->{hostname}) {
+        $expected_install_hostname = $hostname;
+    } elsif (is_s390x) {
+        my @s390x_resolvers = (
+            {
+                match => sub { is_zvm },
+                resolve => sub { get_required_var('ZVM_GUEST') },
+            },
+            {
+                match => sub { is_svirt },
+                resolve => sub { (split(/\./, get_required_var('SUT_IP')))[0] },
+            },
+        );
+        my ($active_rule) = grep { $_->{match}->() } @s390x_resolvers
+          or die "Unable to determine expected install hostname for s390x: neither zVM nor sVirt matched";
+        $expected_install_hostname = $active_rule->{resolve}->();
+    } else {
+        $expected_install_hostname = 'localhost';
+    }
 
     my $hostname = script_output('hostnamectl hostname');
     assert_str_equals($expected_install_hostname, $hostname, "Wrong hostname. Expected: '$expected_install_hostname', got '$hostname'");


### PR DESCRIPTION
Added the required schedule and modifications to enable sles_extended on s390x-kvm

- Related ticket: https://progress.opensuse.org/issues/203805
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/879
- Needles: N/A
- Verification run:
    - s390x: https://openqa.suse.de/tests/23927452
    - x86_64: https://openqa.suse.de/tests/23927453
    - cli installation (Validate hostname without test_data): https://openqa.suse.de/tests/23927454
