### PR TITLE
xfstests: Fix sysrq-t not work when test timeout

### DIFF
--- a/lib/xfstests_utils.pm
+++ b/lib/xfstests_utils.pm
@@ -639,6 +639,7 @@ Enable softlockup panic collection and could manually enable other setting by XF
 
 sub config_debug_option {
     my $debug_info = shift;
+    script_run('echo 1 > /proc/sys/kernel/sysrq');    # The default 184 will skip some sysrq key
     script_run('echo 1 > /proc/sys/kernel/softlockup_all_cpu_backtrace');    # on detection capture more debug information
     script_run('echo 1 > /proc/sys/kernel/softlockup_panic');    # panic when softlockup
     if ($debug_info) {

--- a/tests/xfstests/run_subtest.pm
+++ b/tests/xfstests/run_subtest.pm
@@ -468,8 +468,8 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = @_;
-
     $self->override_known_failures() if $self->{result} eq 'fail';
+    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
When using VIRTIO_CONSOLE=0, xfstests should get stack info by sysrq-t, but this part is not inside the run_subtests post_fail_hook part. Add it and give /proc/sys/kernel/sysrq enable to accept sysrq-t type

- Related ticket: https://progress.opensuse.org/issues/194266
- Verification run: https://openqa.suse.de/tests/23799081
- The call dump works https://openqa.suse.de/tests/23799081#step/generic-604/147