### PR TITLE
lib/x11utils.pm: Also handle "Dim automatically" on Plasma

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -412,10 +412,18 @@ Turns off the Plasma desktop screen energy saving.
 sub turn_off_plasma_screen_energysaver {
     my $kcmshell = is_plasma6 ? 'kcmshell6' : 'kcmshell5';
     x11_start_program("$kcmshell powerdevilprofilesconfig", target_match => [qw(kde-energysaver-enabled energysaver-disabled)]);
-    # Open dropdown menu if necessary
+    # Open dropdown menu if necessary ("Turn off screen")
     click_lastmatch if match_has_tag('kde-display-timeout-menu');
     assert_and_click 'kde-disable-energysaver' if match_has_tag('kde-energysaver-enabled');
     assert_screen 'kde-energysaver-disabled';
+    # Disable "Dim automatically" if necessary.
+    # That option is not available on X11, there 'kde-display-dim-disabled' should match absence of the option.
+    assert_screen [qw(kde-display-dim-enabled kde-display-dim-disabled)];
+    if (match_has_tag('kde-display-dim-enabled')) {
+        click_lastmatch;    # Open dropdown
+        assert_and_click 'kde-display-dim-disable';
+        assert_screen 'kde-display-dim-disabled';
+    }
     # Was 'alt-o' before, but does not work in Plasma 5.17 due to kde#411758
     send_key 'ctrl-ret';
     assert_screen 'generic-desktop';


### PR DESCRIPTION
That option needs to be handled in Wayland sessions as well.

- Almost failure: https://openqa.opensuse.org/tests/6148412#step/live_installation/32
- Needles: Created on o3
- Verification runs:
  * X11: [![opensuse-Tumbleweed-KDE-Live-x86_64-Build20260804-kde-live_installation@64bit-4G test result](https://openqa.opensuse.org/tests/6148427/badge)](https://openqa.opensuse.org/tests/6148427)
  * Wayland: [![opensuse-Tumbleweed-KDE-Live-x86_64-Build20260805-kde-live_installation@64bit-4G test result](https://openqa.opensuse.org/tests/6148426/badge)](https://openqa.opensuse.org/tests/6148426)