### PR TITLE
Fix terraform: replace custom_data with user_data

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -158,10 +158,10 @@ resource "azurerm_image" "image" {
   count               = var.image_id != "" ? 1 : 0
 
   os_disk {
-    os_type  = "Linux"
-    os_state = "Generalized"
-    blob_uri = "https://${var.storage-account}.blob.core.windows.net/sle-images/${var.image_id}"
-    size_gb  = var.root-disk-size 
+    os_type      = "Linux"
+    os_state     = "Generalized"
+    blob_uri     = "https://${var.storage-account}.blob.core.windows.net/sle-images/${var.image_id}"
+    size_gb      = var.root-disk-size
     storage_type = "Standard_LRS"
   }
 
@@ -202,7 +202,7 @@ resource "azurerm_linux_virtual_machine" "openqa-vm" {
     storage_account_type = "Standard_LRS"
     # SLE images are 30G by default. Uncomment this line in case we need to increase the disk size
     # note: value can not be decreased because 30 GB is minimum allowed by Azure
-    disk_size_gb         = var.root-disk-size
+    disk_size_gb = var.root-disk-size
   }
 
   source_image_id = var.image_uri != "" ? var.image_uri : (var.image_id != "" ? azurerm_image.image[0].id : null)
@@ -225,7 +225,7 @@ resource "azurerm_linux_virtual_machine" "openqa-vm" {
     create = var.vm_create_timeout
   }
 
-  custom_data = var.cloud_init != "" ? filebase64(var.cloud_init) : null
+  user_data = var.cloud_init != "" ? filebase64(var.cloud_init) : null
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "default" {


### PR DESCRIPTION
When UDF filesystem support is unavailable, cloud-init fails to mount the Azure provisioning CD-ROM, logging "Unable to find provisioning media" and exiting in a `degraded` state.
While legacy `custom_data` can still execute by falling back to files written to disk by the Azure Linux Agent, switching to `user_data` is the best practice. It allows cloud-init to natively fetch the payload directly from the IMDS REST API, bypassing legacy OVF dependencies and providing a cleaner, more resilient boot process.

- Related ticket: https://progress.opensuse.org/issues/203505 and https://bugzilla.suse.com/show_bug.cgi?id=1266207 and needed by https://progress.opensuse.org/issues/204834 to re-enable cloud-init tests

# Verification run:
 - sle-15-SP7-Azure-Incidents-x86_64-Build:smelt:45685:grub2-publiccloud_smoketests_gen1 az_Standard_B2s -> http://openqa.suse.de/tests/23800993 :green_circle:  notice as `cloud-init status --long` no more show warnings https://openqa.suse.de/tests/23800993/logfile?filename=serial_terminal.txt#line-2388

Reference job without this PR and showing the warning https://openqa.suse.de/tests/23800988/logfile?filename=serial_terminal.txt#line-2522
