### PR TITLE
publiccloud: Change ownership of cloud-init logs before upload

### DIFF
--- a/tests/publiccloud/check_cloudinit.pm
+++ b/tests/publiccloud/check_cloudinit.pm
@@ -34,6 +34,7 @@ sub check_cloudinit {
 
     # cloud-init collect-logs
     $instance->ssh_assert_script_run('sudo cloud-init collect-logs');
+    $instance->ssh_script_run('sudo chown $(id -un) ~/cloud-init.tar.gz');
     $instance->upload_log('~/cloud-init.tar.gz', failok => 1);
 
     if (get_var('PUBLIC_CLOUD_CLOUD_INIT')) {


### PR DESCRIPTION
When running `sudo cloud-init collect-logs`, the resulting archive is created under the user's home directory ('~/cloud-init.tar.gz') but is owned by root. Since the 'upload_log' helper retrieves the file using the non-root SSH user session, it cannot access or upload the archive due to permission restrictions.

This change uses `sudo chown $(id -un) ~/cloud-init.tar.gz` to transfer ownership of the archive to the current SSH user right before upload. An additional `sudo ls -l` call is added to print permissions for easier debugging in test logs.

- Related ticket: https://progress.opensuse.org/issues/204834

# Verification run:

## PUBLIC_CLOUD_CLOUD_INIT="1"
 - sle-15-SP7-Azure-BYOS-Hardened-Incidents-x86_64-Build:smelt:45685:grub2-publiccloud_smoketests_gen1 az_Standard_B2s -> http://openqa.suse.de/tests/23803848 :green_circle: 

 - sle-15-SP7-Azure-Incidents-x86_64-Build:smelt:45831:kernel-azure-publiccloud_smoketests_gen1 az_Standard_B2s -> http://openqa.suse.de/tests/23804224 :green_circle: 

## PUBLIC_CLOUD_CLOUD_INIT="install"
 sle-15-SP7-Azure-BYOS-Hardened-Incidents-x86_64-Build:smelt:45685:grub2-publiccloud_smoketests_gen1 az_Standard_B2s 
 - http://openqa.suse.de/tests/23800988
 - http://openqa.suse.de/tests/23803764 after rebase to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26304

 - sle-15-SP7-Azure-Incidents-x86_64-Build:smelt:45831:kernel-azure-publiccloud_smoketests_gen2 az_Standard_B2s -> http://openqa.suse.de/tests/23804234 :green_circle: 