### PR TITLE
lib/locale.pm: Check locale on tty3 instead of tty1 on 15 SP6 + SP7

### DIFF
--- a/lib/locale.pm
+++ b/lib/locale.pm
@@ -10,6 +10,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils qw(is_sle);
 use Utils::Backends 'has_ttys';
 use x11utils 'turn_off_gnome_suspend';
 
@@ -37,7 +38,15 @@ sub verify_default_keymap_textmode {
         select_console($tty{console});
     }
     else {
-        send_key('alt-f1');
+        if ((is_sle('=15-SP6') || is_sle('=15-SP7')) && check_var('DESKTOP', 'gnome')) {
+            # Switching to tty1 is broken, use tty3 as workaround
+            record_soft_failure 'bsc#1274029 - plymouth blocks switch to tty1';
+            send_key('alt-f3');
+        } else {
+            # Check tty1, which is the initial console set up by kernel and initrd
+            send_key('alt-f1');
+        }
+
         # remote backends can not provide a "not logged in console" so we use
         # a cleared remote terminal instead
         assert_screen(has_ttys() ? 'linux-login' : 'cleared-console');


### PR DESCRIPTION
Alt-F1 just hangs in that combination, use tty3 again as a workaround.

- Failure: https://openqa.suse.de/tests/23790480#step/keymap_or_locale/4
- Verification run: http://10.168.5.231/tests/2103