### PR TITLE
fix: Add softfailure for bsc#1264275

### DIFF
--- a/tests/publiccloud/check_services.pm
+++ b/tests/publiccloud/check_services.pm
@@ -24,6 +24,7 @@ sub run {
         'systemd-vconsole-setup' => 'bsc#1249902 - systemd-vconsole-setup.service failed to load',
         augenrules => 'bsc#1250320 - augenrules.service fails at startup on Hardened Images',
         cleanoldsepoldir => 'bsc#1271814 - snapper is intentionally not installed on Public Cloud images',
+        guestregister => 'bsc#1264275 - guestregister.service fails to register the instance against the update infrastructure',
     );
     $known_failing_services{guestregister} = 'Custom ignore of guestregister via openQA variable' if (get_var('PUBLIC_CLOUD_IGNORE_UNREGISTERED'));
     my $failed_services_output = $instance->ssh_script_output(


### PR DESCRIPTION
Add a softfailure for the failing guestregister.service due to [bsc#1264275](https://bugzilla.suse.com/show_bug.cgi?id=1264275)

- Related ticket: https://progress.opensuse.org/issues/205326
- Verification run: https://openqa.suse.de/tests/23802493
