### PR TITLE
fix(autoyast): fix serial marker race before upload

### DIFF
--- a/tests/autoyast/logs.pm
+++ b/tests/autoyast/logs.pm
@@ -16,8 +16,8 @@ sub run {
 
     # save all logs that might be useful
 
-    enter_cmd "systemctl status > /var/log/systemctl_status";
-    enter_cmd "tar cjf /tmp/logs.tar.bz2 --exclude=/etc/{brltty,udev/hwdb.bin} --exclude=/var/log/{YaST2,zypp,{pbl,zypper}.log} /var/{log,adm/autoinstall} /run/systemd/system/ /usr/lib/systemd/system/ /boot/grub2/{device.map,grub{.cfg,env}} /etc/";
+    script_run "systemctl status > /var/log/systemctl_status ||:";
+    script_run "tar cjf /tmp/logs.tar.bz2 --exclude=/etc/{brltty,udev/hwdb.bin} --exclude=/var/log/{YaST2,zypp,{pbl,zypper}.log} /var/{log,adm/autoinstall} /run/systemd/system/ /usr/lib/systemd/system/ /boot/grub2/{device.map,grub{.cfg,env}} /etc/ ||:", timeout => 300;
     upload_logs "/tmp/logs.tar.bz2";
     enter_cmd "echo UPLOADFINISH >/dev/$serialdev";
     wait_serial("UPLOADFINISH", 200);

--- a/tests/autoyast/wicked.pm
+++ b/tests/autoyast/wicked.pm
@@ -40,26 +40,26 @@ sub run {
         $up = 0 if !wait_serial("up", 10);
     }
     if (!$up) {
-        enter_cmd "mkdir /tmp/wicked";
+        assert_script_run "mkdir /tmp/wicked";
         # enable debugging
-        enter_cmd "perl -i -lpe 's{^(WICKED_DEBUG)=.*}{\$1=\"all\"};s{^(WICKED_LOG_LEVEL)=.*}{\$1=\"debug\"}' /etc/sysconfig/network/config";
-        enter_cmd "grep -E \"WICKED_DEBUG|WICKED_LOG_LEVEL\" /etc/sysconfig/network/config";
+        assert_script_run "perl -i -lpe 's{^(WICKED_DEBUG)=.*}{\$1=\"all\"};s{^(WICKED_LOG_LEVEL)=.*}{\$1=\"debug\"}' /etc/sysconfig/network/config";
+        script_run "grep -E \"WICKED_DEBUG|WICKED_LOG_LEVEL\" /etc/sysconfig/network/config ||:";
         # restart the daemons
-        enter_cmd "systemctl restart wickedd";
+        script_run "systemctl restart wickedd ||:";
         save_screenshot;
         # reapply the config
-        enter_cmd "wicked --debug all ifup all";
+        script_run "wicked --debug all ifup all ||:";
         save_screenshot;
         # collect the configuration
-        enter_cmd "wicked show-config > /tmp/wicked/config-dump.log";
+        script_run "wicked show-config > /tmp/wicked/config-dump.log ||:";
         # collect the status
-        enter_cmd "wicked ifstatus --verbose all > /tmp/wicked/status.log";
-        enter_cmd "journalctl -b -o short-precise > /tmp/wicked/wicked.log";
-        enter_cmd "ip addr show > /tmp/wicked/ip_addr.log";
-        enter_cmd "ip route show table all > /tmp/wicked/routes.log";
+        script_run "wicked ifstatus --verbose all > /tmp/wicked/status.log ||:";
+        script_run "journalctl -b -o short-precise > /tmp/wicked/wicked.log ||:";
+        script_run "ip addr show > /tmp/wicked/ip_addr.log ||:";
+        script_run "ip route show table all > /tmp/wicked/routes.log ||:";
         # collect network information
-        enter_cmd "hwinfo --netcard > /tmp/wicked/hwinfo-netcard.log";
-        enter_cmd "tar -czf /tmp/wicked_logs.tgz /etc/sysconfig/network /tmp/wicked";
+        script_run "hwinfo --netcard > /tmp/wicked/hwinfo-netcard.log ||:";
+        script_run "tar -czf /tmp/wicked_logs.tgz /etc/sysconfig/network /tmp/wicked ||:", timeout => 300;
         upload_logs "/tmp/wicked_logs.tgz";
         save_screenshot;
     }


### PR DESCRIPTION
Motivation:
With PRETTY_SERIAL_MARKER enabled, using fire-and-forget enter_cmd to create
archives leaves a stale marker in the serial buffer, causing fake test
failures.

Design Choices:
Convert asynchronous command sequences to synchronous script_run or
assert_script_run calls. Use script_run with "||:" to ignore benign non-zero
exit codes without claiming to assert successful command execution.

Benefits:
Prevents false-positive test failures by ensuring all markers are consumed
synchronously before log uploading begins.

Manual verification:
* [![sle-15-SP5-Server-DVD-Incidents-Kernel-KOTD-x86_64-Build5.14.21-150500.282.1.g0e5db07-qam-gfxdrivers@64bit-i915](https://openqa.suse.de/tests/23815898/badge)](https://openqa.suse.de/tests/23815898)

Related issue: https://progress.opensuse.org/issues/199934