### PR TITLE
Remove extra file_content_replace includes

### DIFF
--- a/lib/containers/docker.pm
+++ b/lib/containers/docker.pm
@@ -13,7 +13,7 @@ use Mojo::Base 'containers::engine';
 use testapi;
 use containers::utils qw(registry_url);
 use containers::common qw(install_docker_when_needed);
-use utils qw(systemctl file_content_replace);
+use utils qw(systemctl);
 has runtime => 'docker';
 
 sub init {

--- a/lib/containers/engine.pm
+++ b/lib/containers/engine.pm
@@ -13,7 +13,7 @@ use Mojo::Base -base;
 use testapi;
 use Carp 'croak';
 use Test::Assert 'assert_equals';
-use utils qw(systemctl file_content_replace script_retry);
+use utils qw(systemctl script_retry);
 use version_utils qw(package_version_cmp);
 use overload
   '""' => sub { return shift->runtime },

--- a/lib/containers/podman.pm
+++ b/lib/containers/podman.pm
@@ -13,7 +13,6 @@ use Mojo::Base 'containers::engine';
 use testapi;
 use containers::utils qw(registry_url);
 use containers::common qw(install_podman_when_needed);
-use utils qw(file_content_replace);
 has runtime => "podman";
 
 sub init {


### PR DESCRIPTION
Remove all the includes of file_content_replace that are not needed

Progress: https://progress.opensuse.org/issues/205377

- Verification run:

sle-15-SP4-Container-Host-x86_64-BuildGM-create_hdd_autoyast_containers 
 - http://openqa.suse.de/tests/24042177

sle-15-SP5-Container-Host-s390x-BuildGM-create_hdd_fips_autoyast_containers s390x-kvm
- http://openqa.suse.de/tests/24042178

sle-16.0-Container-Host-x86_64-BuildGM-create_hdd_fips_containers 64bit
- http://openqa.suse.de/tests/24042179