### PR TITLE
fix(consoletest): fix serial marker race in post_run_hook

### DIFF
--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -28,7 +28,7 @@ sub post_run_hook {
     my ($self) = @_;
 
     # start next test in home directory
-    enter_cmd "cd";
+    assert_script_run "cd";
 
     $self->record_avc_selinux_alerts();
     # clear screen to make screen content ready for next test


### PR DESCRIPTION
Motivation:
Using fire-and-forget enter_cmd for `cd` before script_run causes
script_run to match a stale shell prompt. This leads to the next command
being typed too early, which corrupts the terminal state and causes fake
timeouts (e.g., `test -d /sys/fs/selinux` failing).

Design Choices:
Convert `enter_cmd "cd"` to a synchronous `assert_script_run "cd"` so
that the terminal prompt is properly consumed and synchronized before the
subsequent `record_avc_selinux_alerts` runs.

Benefits:
Prevents random command timeouts during `post_run_hook` by ensuring the
serial buffer is clean before executing the SELinux checks.

Verification:
```
BADGE=1 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26312 https://openqa.suse.de/tests/23798295 EXIT_AFTER_MODULE=check_os_release _SKIP_POST_FAIL_HOOKS=1
```

* [![sle-15-SP4-SAP-DVD-Updates-x86_64-Build20260805-1-qam_sles4sap_hanasr_angi_wmp_supportserver@64bit](https://openqa.suse.de/tests/23802529/badge)](https://openqa.suse.de/tests/23802529)
* [![sle-15-SP4-SAP-DVD-Updates-x86_64-Build20260805-1-qam_sles4sap_hanasr_angi_wmp_hana_node01@64bit-sap-qam](https://openqa.suse.de/tests/23802530/badge)](https://openqa.suse.de/tests/23802530)

Related issue: https://progress.opensuse.org/issues/199934