### PR TITLE
publiccloud: gate check_services on boot completion

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -350,8 +350,8 @@ sub load_slem_on_pc_tests {
         loadtest("publiccloud/prepare_instance", run_args => $args);
         loadtest("publiccloud/registration", run_args => $args) unless (check_var('PUBLIC_CLOUD_IGNORE_UNREGISTERED', 1));
         loadtest("publiccloud/network_test", run_args => $args);
-        loadtest("publiccloud/kdump", run_args => $args);
         loadtest("publiccloud/check_boottime", run_args => $args);
+        loadtest("publiccloud/kdump", run_args => $args);
         loadtest("publiccloud/check_cloudinit", run_args => $args);
         # 2 next modules of pubcloud needed for sle-micro incidents/repos verification
         if (get_var('PUBLIC_CLOUD_QAM', 0)) {

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -25,9 +25,9 @@ sub load_maintenance_publiccloud_tests {
     loadtest "publiccloud/download_repos" unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
     loadtest "publiccloud/prepare_instance", run_args => $args;
     loadtest "publiccloud/network_test", run_args => $args;
+    loadtest "publiccloud/check_boottime", run_args => $args;
     loadtest "publiccloud/check_services", run_args => $args;
     loadtest "publiccloud/kdump", run_args => $args;
-    loadtest "publiccloud/check_boottime", run_args => $args;
     loadtest "publiccloud/check_cloudinit", run_args => $args;
     if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
         loadtest("publiccloud/registration_lifecycle", run_args => $args);
@@ -36,6 +36,7 @@ sub load_maintenance_publiccloud_tests {
     }
     loadtest "publiccloud/transfer_repos", run_args => $args unless (check_var('PUBLIC_CLOUD_SKIP_MU', 1));
     loadtest "publiccloud/patch_and_reboot", run_args => $args;
+    loadtest "publiccloud/check_boottime", run_args => $args;
     loadtest "publiccloud/check_cloudinit", run_args => $args;
     if (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
         loadtest "publiccloud/check_services", run_args => $args;
@@ -133,8 +134,8 @@ sub load_latest_publiccloud_tests {
         loadtest "publiccloud/prepare_instance", run_args => $args;
         loadtest "publiccloud/registration", run_args => $args;
         loadtest "publiccloud/network_test", run_args => $args;
-        loadtest "publiccloud/kdump", run_args => $args;
         loadtest "publiccloud/check_boottime", run_args => $args;
+        loadtest "publiccloud/kdump", run_args => $args;
         loadtest "publiccloud/check_cloudinit", run_args => $args;
         loadtest 'publiccloud/run_ltp', run_args => $args;
     }
@@ -147,8 +148,8 @@ sub load_latest_publiccloud_tests {
     } else {    # All test cases below require prepare_instance
         loadtest "publiccloud/prepare_instance", run_args => $args;
         loadtest "publiccloud/network_test", run_args => $args;
-        loadtest "publiccloud/kdump", run_args => $args;
         loadtest "publiccloud/check_boottime", run_args => $args;
+        loadtest "publiccloud/kdump", run_args => $args;
         loadtest "publiccloud/check_cloudinit", run_args => $args;
         if (get_var('PUBLIC_CLOUD_REGISTRATION_TESTS')) {
             loadtest "publiccloud/registration_lifecycle", run_args => $args;
@@ -241,8 +242,8 @@ sub load_publiccloud_appimg_tests {
     loadtest "publiccloud/prepare_instance", run_args => $args;
     loadtest "publiccloud/registration", run_args => $args;
     loadtest "publiccloud/network_test", run_args => $args;
-    loadtest "publiccloud/kdump", run_args => $args;
     loadtest "publiccloud/check_boottime", run_args => $args;
+    loadtest "publiccloud/kdump", run_args => $args;
     loadtest "publiccloud/check_cloudinit", run_args => $args;
     loadtest "publiccloud/instance_overview", run_args => $args;
 

--- a/tests/publiccloud/check_boottime.pm
+++ b/tests/publiccloud/check_boottime.pm
@@ -103,22 +103,38 @@ sub do_systemd_analyze_time {
     return @ret;
 }
 
+=head2 is_first_boot
+
+    is_first_boot($instance);
+
+Return true the first time this is called for a given instance, tracked via a marker file left on the instance (the journal is volatile on public cloud images, so C<journalctl --list-boots> cannot be used to detect earlier boots).
+
+=cut
+
+sub is_first_boot {
+    my ($instance) = @_;
+    my $marker = '/root/openqa_boottime_seen';
+    return 0 if ($instance->ssh_script_run(cmd => "sudo test -e $marker", proceed_on_failure => 1) == 0);
+    $instance->ssh_script_run(cmd => "sudo touch $marker", proceed_on_failure => 1);
+    return 1;
+}
+
 =head2 check_system_boottime
 
     check_system_boottime($instance);
 
-Check the system boot time, measured by C<systemd-analyze>, to be under a threshold.
-Assign the threshold in seconds to PUBLIC_CLOUD_BOOTTIME_MAX in test settings.
-The boot time is saved in a local json structure, then printed in the test's logs:
-when the threshold is exceeded the job is stopped.
-The routine is skipped when the threshold is undefined or zero.
+Wait for the instance to finish booting (via C<systemd-analyze time>) and
+record the timing, acting as a readiness gate for whatever runs after this
+module (poo#203817, poo#204852, poo#205311). When C<PUBLIC_CLOUD_BOOTTIME_MAX>
+is set, also fail the job if the measured boot time exceeds it. Diagnostic
+logs are collected only on the first boot.
 
 =cut
 
 sub check_system_boottime {
     my ($instance, %args) = @_;
     my $max_boot_time = get_var('PUBLIC_CLOUD_BOOTTIME_MAX');
-    return unless ($max_boot_time);
+    my $first_boot = is_first_boot($instance);
 
     my $ret = {
         kernel_release => undef,
@@ -143,11 +159,14 @@ sub check_system_boottime {
 
     $Data::Dumper::Sortkeys = 1;
     record_info("RESULTS", Dumper($ret));
-    my $dir = "/var/log";
-    my @logs = qw(cloudregister cloud-init.log cloud-init-output.log messages NetworkManager);
-    $instance->upload_check_logs_tar(map { "$dir/$_" } @logs);
+    if ($first_boot) {
+        my $dir = "/var/log";
+        my @logs = qw(cloudregister cloud-init.log cloud-init-output.log messages NetworkManager);
+        $instance->upload_check_logs_tar(map { "$dir/$_" } @logs);
+    }
 
-    # Boot time overall limit check
+    # Boot time overall limit check, only when a threshold is configured
+    return unless ($max_boot_time);
     if ($boottime > $max_boot_time) {
         if (is_azure()) {
             # Unreliable userspace boot time in Azure.

--- a/tests/publiccloud/check_services.pm
+++ b/tests/publiccloud/check_services.pm
@@ -6,6 +6,8 @@
 # Summary: Check public cloud specific services
 # Maintainer: QE-C team <qa-c@suse.de>
 
+# Requires publiccloud/check_boottime to run first (poo#205311): waagent.service starts only after guestregister.service finishes, so a not-yet-booted instance reports it as inactive.
+
 use Mojo::Base 'publiccloud::basetest';
 use serial_terminal 'select_serial_terminal';
 use registration;


### PR DESCRIPTION
Makes `publiccloud/check_boottime` always wait for boot completion, instead of only running when `PUBLIC_CLOUD_BOOTTIME_MAX` is set (unset on Azure, where the waagent race happens; EC2/GCE templates do set it). Schedules it before `check_services` and `kdump` in every publiccloud flow, so services aren't probed before boot-time units like `guestregister`/`waagent` have started. Diagnostic logs are now uploaded only once per instance, tracked via a marker file (the journal is volatile on these images, so `journalctl --list-boots` can't be used).

* Related ticket: [poo#205311](https://progress.opensuse.org/issues/205311)
* Related failure: [openqa.suse.de/t23799155](https://openqa.suse.de/tests/23799155)
* Verification runs: In comment below
