### PR TITLE
Check the result of the pre-attach detach in hotplugging_HDD

### DIFF
--- a/lib/virt_feature_test_base.pm
+++ b/lib/virt_feature_test_base.pm
@@ -62,7 +62,7 @@ sub prepare_run_test {
     select_console 'sol', await_console => 0;
     use_ssh_serial_console;
     reconnect_if_problematic;
-    assert_script_run("> ~/.bash_history");
+    #assert_script_run("> ~/.bash_history");
 
     check_host_health;
 

--- a/tests/virtualization/universal/hotplugging_HDD.pm
+++ b/tests/virtualization/universal/hotplugging_HDD.pm
@@ -28,17 +28,29 @@ sub test_add_virtual_disk {
     assert_script_run("rm -f $disk_image");
     # Set disk size=9.5G to make it to be found more easily within the guest
     assert_script_run "qemu-img create -f $disk_format $disk_image 9.5G";
-    my $domblk_target = 'vdz';
-    $domblk_target = 'xvdz' if (is_xen_host);
-    script_run("virsh detach-disk $guest ${domblk_target}", 240);
-    if (try_attach("virsh attach-disk --domain $_ --source $disk_image --target ${domblk_target}")) {
+    my $domblk_target = is_xen_host ? 'xvdz' : 'vdz';
+    # Detach unconditionally (bsc#1272852: libvirt must reject a missing disk gracefully).
+    # script_output captures the console output (incl. the crash msg); the 'if' guard
+    # keeps bash -e from aborting so we still read the real rc.
+    my $detach_cmd = "( virsh detach-disk $guest ${domblk_target} )";
+    my $detach_out = script_output(
+        "if $detach_cmd 2>&1; then rc=0; else rc=\$?; fi; echo \"detach_rc=\$rc\"",
+        proceed_on_failure => 1);
+    my $detach_rc = $detach_out =~ /detach_rc=(\d+)/ ? $1 : -1;
+    # rc >= 128 => killed by a signal (crash); the output regex catches a lost
+    # libvirtd connection, where virsh exits with a small rc but prints these errors.
+    my $detach_crashed = $detach_rc >= 128
+      || $detach_out =~ m/End of file|Cannot recv data|failed to connect/i;
+    record_info("Detach ${domblk_target}", $detach_out,
+        result => $detach_crashed ? 'fail' : 'ok');
+    if (try_attach("virsh attach-disk --domain $guest --source $disk_image --target ${domblk_target}")) {
         assert_script_run "virsh domblklist $guest | grep ${domblk_target}";
         assert_script_run("ssh root\@$guest lsblk");
         # Attach disk check
-        assert_script_run("ssh root\@$guest lsblk | grep -iE '[x]?vd[a-z] +.*9.5G'", timeout => 60, fail_message => "Failed to attach disk for guest $guest");
-        assert_script_run("virsh detach-disk $guest ${domblk_target}", 240);
-        # Detach disk check
-        assert_script_run("! ssh root\@$guest lsblk | grep -iE '[x]?vd[b-z]'", timeout => 60, fail_message => "Failed to detach disk for guest $guest");
+        script_retry("ssh root\@$guest lsblk | grep -iE '[x]?vd[a-z] +.*9.5G'", delay => 5, retry => 12, fail_message => "Failed to attach disk for guest $guest");
+        assert_script_run($detach_cmd, 240);
+        # Detach disk check, the unplug is asynchronous so the guest needs time to process it
+        script_retry("! ssh root\@$guest lsblk | grep -iE '[x]?vd[b-z]'", delay => 5, retry => 12, fail_message => "Failed to detach disk for guest $guest");
     }
     assert_script_run("rm -f $disk_image");
 }

--- a/tests/virtualization/universal/hotplugging_HDD.pm
+++ b/tests/virtualization/universal/hotplugging_HDD.pm
@@ -28,17 +28,24 @@ sub test_add_virtual_disk {
     assert_script_run("rm -f $disk_image");
     # Set disk size=9.5G to make it to be found more easily within the guest
     assert_script_run "qemu-img create -f $disk_format $disk_image 9.5G";
-    my $domblk_target = 'vdz';
-    $domblk_target = 'xvdz' if (is_xen_host);
-    script_run("virsh detach-disk $guest ${domblk_target}", 240);
-    if (try_attach("virsh attach-disk --domain $_ --source $disk_image --target ${domblk_target}")) {
+    my $domblk_target = is_xen_host ? 'xvdz' : 'vdz';
+    # Detach unconditionally: bsc#1272852 - libvirt must reject a missing disk gracefully.
+    my $detach_cmd = "virsh detach-disk $guest ${domblk_target}";
+    # The crash msg is on the shell's stderr, not virsh's, so capture that in a file.
+    my $detach_out = script_output(
+        "bash -c '$detach_cmd; echo \"detach_rc=\$?\"' >/tmp/detach.log 2>&1; cat /tmp/detach.log",
+        proceed_on_failure => 1);
+    my $detach_rc = $detach_out =~ /detach_rc=(\d+)/ ? $1 : -1;
+    record_info("Detach ${domblk_target}", $detach_out,
+        result => $detach_rc == 0 ? 'ok' : 'fail');
+    if (try_attach("virsh attach-disk --domain $guest --source $disk_image --target ${domblk_target}")) {
         assert_script_run "virsh domblklist $guest | grep ${domblk_target}";
         assert_script_run("ssh root\@$guest lsblk");
         # Attach disk check
-        assert_script_run("ssh root\@$guest lsblk | grep -iE '[x]?vd[a-z] +.*9.5G'", timeout => 60, fail_message => "Failed to attach disk for guest $guest");
-        assert_script_run("virsh detach-disk $guest ${domblk_target}", 240);
-        # Detach disk check
-        assert_script_run("! ssh root\@$guest lsblk | grep -iE '[x]?vd[b-z]'", timeout => 60, fail_message => "Failed to detach disk for guest $guest");
+        script_retry("ssh root\@$guest lsblk | grep -iE '[x]?vd[a-z] +.*9.5G'", delay => 5, retry => 12, fail_message => "Failed to attach disk for guest $guest");
+        assert_script_run($detach_cmd, 240);
+        # Detach disk check, the unplug is asynchronous so the guest needs time to process it
+        script_retry("! ssh root\@$guest lsblk | grep -iE '[x]?vd[b-z]'", delay => 5, retry => 12, fail_message => "Failed to detach disk for guest $guest");
     }
     assert_script_run("rm -f $disk_image");
 }


### PR DESCRIPTION
The result of `virsh detach-disk $guest vdz` was thrown away. On a clean guest **vdz** does not exist and **libvirt** has crashed on that (bsc#1272852) without the test noticing.
    
Keep the detach unconditional, that path is worth exercising, but capture the output and flag a crash or a lost **libvirtd** connection in a `red` box.
    
Also use `script_retry` for the guest side checks, the unplug is async, and pass `$guest` to the attach command instead of the global `$_`.

- Related ticket: https://progress.opensuse.org/issues/204786
- Verification run:
SLE16.1 DEV
[uefi-gi-online-guest_developing-on-host_developing-kvm](http://openqa.suse.de/tests/23887004#) 
SLE16 MU
[uefi-gi-online-guest_developing-on-host_developing-kvm](http://openqa.suse.de/tests/23887005#)