### PR TITLE
Ensure there is a prompt before initializing cluster

### DIFF
--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -28,6 +28,7 @@ sub type_qnetd_pwd {
 sub cluster_init {
     my ($init_method, $fencing_opt, $unicast_opt, $qdevice_opt) = @_;
 
+    wait_serial($testapi::distri->{serial_term_prompt}, no_regex => 1, quiet => 1);
     record_info 'cluster_init', "Initializing cluster with: -y $fencing_opt $unicast_opt $qdevice_opt";
     if ($init_method eq 'crm-cluster-init') {
         enter_cmd "crm cluster init -y $fencing_opt $unicast_opt $qdevice_opt ; echo cluster-init-finished-\$?";

--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -50,6 +50,7 @@ sub run {
 
     # Try to join the HA cluster through first node
     assert_script_run "ping -c1 $node_to_join";
+    wait_serial($testapi::distri->{serial_term_prompt}, no_regex => 1, quiet => 1);
     record_info 'cluster_join', "Joining $node_to_join";
     enter_cmd "crm cluster join -yc $node_to_join ; echo cluster-join-finished-\$?";
     wait_for_password_prompt(timeout => $join_timeout);


### PR DESCRIPTION
This commit introduces a `wait_serial()` call searching for the serial terminal prompt right before calls to `crm cluster init` and `crm cluster join` in the corresponding modules (`ha/ha_cluster_init` and `ha/ha_cluster_join` respectively). Idea is to ensure the prompt has been printed in the terminal session before initializing the cluster to prevent the `wait_serial()` call that waits for the password prompt from wrongly waiting before the command is actually running.

- Related ticket: https://jira.suse.com/browse/TEAM-11462
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?version=15-SP5&build=team11462&distri=sle&flavor=Server-DVD-SAP-Incidents (50 clusters) - No failures in `ha_cluster_join`, 8 failures in `check_os_release` which should be covered by #26312 
