### PR TITLE
Fix Virt MU snpguest package handling in 15-SP7

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2484,7 +2484,7 @@ sub set_mu_virt_vars {
     # If $_pkg contains none, it is for ease of functional testing when no incidents are coming.
     if ($_pkg =~ /none/) {
         $_update_package = '';
-    } elsif ($_pkg =~ /qemu|xen|virt-manager|libguestfs|open-vm-tools|dnsmasq|sevctl/) {
+    } elsif ($_pkg =~ /qemu|xen|virt-manager|libguestfs|open-vm-tools|dnsmasq|sevctl|snpguest|snphost/) {
         $_update_package = $_pkg;
     } elsif ($_pkg =~ /libvirt/) {
         $_update_package = 'libvirt-client';
@@ -2651,6 +2651,7 @@ sub set_sles16_mu_virt_vars {
 
 sub load_hypervisor_tests {
     return unless (get_var('HOST_HYPERVISOR') =~ /xen|kvm|qemu/);
+    die "SNP testing is supported only on SLE >= 15-SP7" if (get_var('UPDATE_PACKAGE') =~ /snphost|snpguest/ && is_sle('<15-SP7'));
 
     if (check_var('ENABLE_HOST_INSTALLATION', 1)) {
         if (get_var('AUTOYAST')) {
@@ -2676,7 +2677,7 @@ sub load_hypervisor_tests {
         }
         if (check_var('PATCH_WITH_ZYPPER', 1)) {
             loadtest "virtualization/universal/patch_and_reboot";
-            if (check_var('UPDATE_PACKAGE', 'kernel-default')) {
+            if (check_var('UPDATE_PACKAGE', 'kernel-default') || check_var("UPDATE_PACKAGE", "snpguest")) {
                 loadtest "virt_autotest/login_console";
                 loadtest "virtualization/universal/list_guests";
                 loadtest "virtualization/universal/patch_guests";
@@ -2685,7 +2686,7 @@ sub load_hypervisor_tests {
                 loadtest "virtualization/universal/list_guests" unless (check_var('VIRT_NEW_GUEST_MIGRATION_DST', '1'));
             }
         }
-        loadtest "virtualization/universal/kernel";
+        loadtest "virtualization/universal/kernel" unless (check_var("UPDATE_PACKAGE", "snpguest") || check_var("UPDATE_PACKAGE", "snphost"));
         loadtest "virtualization/universal/finish";
     }
 

--- a/tests/virt_autotest/sev_snp_validation.pm
+++ b/tests/virt_autotest/sev_snp_validation.pm
@@ -37,6 +37,7 @@ use virt_autotest::common;
 use virt_autotest::utils qw(guest_is_sle wait_guest_online is_guest_online execute_over_ssh upload_virt_logs);
 use version_utils qw(is_sle package_version_cmp);
 use Utils::Architectures;
+use utils qw(write_sut_file);
 use package_utils;
 use bootloader_setup qw(add_grub_cmdline_settings grub_mkconfig);
 use power_action_utils 'power_action';
@@ -44,7 +45,7 @@ use power_action_utils 'power_action';
 # Define constants for SNP verification
 use constant {
     # ucode-amd provides CPU microcode required by snphost ok verification
-    SNP_HOST_TOOLS => ['snphost', 'sevctl', 'snpguest', 'ucode-amd'],
+    SNP_HOST_TOOLS => ['snphost', 'sevctl', 'ucode-amd'],
     SNP_GUEST_TOOLS => ['snpguest'],
     SNP_MIN_KERNEL_VER => '5.19.0',
 
@@ -180,6 +181,8 @@ sub check_sev_snp_on_host {
         record_info('Installed SEV-SNP Packages', $installed_pkgs_info);
     }
 
+    validate_script_output("zypper if snphost", sub { m/(?=.*TEST_\d+)(?=.*up-to-date)/s }) if check_var("UPDATE_PACKAGE", "snphost");
+
     # Configure SEV-SNP kernel parameters (reboots if needed, also loads newly installed ucode-amd)
     $self->configure_sev_snp_kernel_parameters();
 
@@ -302,7 +305,7 @@ sub check_sev_snp_host_capability {
     # Store output for later reference (regardless of success or failure)
     my $output_file = LOG_DIR . "/${tool_name}_output.txt";
     script_run("mkdir -p " . LOG_DIR);
-    script_run("echo '$check_output' > $output_file");
+    write_sut_file($output_file, $check_output);
 
     # Just check if there are any FAIL entries in the output
     if ($check_output =~ /FAIL/) {
@@ -485,6 +488,8 @@ sub check_sev_snp_on_guest {
     } else {
         record_info('SEV-SNP Config', "Successfully configured SEV-SNP for guest $guest_name");
     }
+
+    wait_guest_online($guest_name, 50, 1);
 
     # Check if SEV-SNP is enabled in guest's dmesg
     record_info('Guest dmesg', "Checking for SEV-SNP features in guest $guest_name dmesg");
@@ -854,6 +859,8 @@ sub install_snp_packages_on_guest {
         timeout => 180    # Increased timeout for package installation
     );
     save_screenshot;
+
+    validate_script_output("ssh root\@$guest_name zypper if snpguest", sub { m/(?=.*TEST_\d+)(?=.*up-to-date)/s }) if check_var("UPDATE_PACKAGE", "snpguest");
 
     if ($install_result != 0) {
         record_info('Installation Failed', "Failed to install packages on guest $guest_name: $package_list", result => 'softfail');


### PR DESCRIPTION
- disable kernel test scheduling for `snpguest`, `snphost` and `ENABLE_SEV_SNP`
- gate `snpguest` and `snphost` support to `15-SP7` on `<16.0`
- patch guests when `UPDATE_PACKAGE=snpguest`
- skip host installation of `snpguest`
- add `15-SP7` `snpguest` and `snphost` parsing in `set_mu_virt_vars`
- verify `snpguest` or `snphost` comes from the TEST repo

---

- Related ticket: https://progress.opensuse.org/issues/205242
- Needles: N/A
- Verification run:
  - [ BUILD=':smelt:45772:snpguest'](https://openqa.suse.de/tests/23890111)
  - [BUILD=':git:1234:snphost'](https://openqa.suse.de/tests/23890112)
  - [BUILD=':git:1234:none'](https://openqa.suse.de/tests/23890113)