### PR TITLE
Remove file_content_replace from sles4sap

### DIFF
--- a/lib/sles4sap/publiccloud.pm
+++ b/lib/sles4sap/publiccloud.pm
@@ -22,7 +22,6 @@ use List::MoreUtils qw(uniq);
 use Carp qw(croak);
 use YAML::PP;
 use testapi;
-use utils qw(file_content_replace);
 use serial_terminal qw(serial_term_prompt);
 use version_utils qw(check_version is_sle);
 use hacluster;

--- a/tests/sles4sap/ensa/ensa_filesystems.pm
+++ b/tests/sles4sap/ensa/ensa_filesystems.pm
@@ -10,7 +10,7 @@
 use Mojo::Base 'sles4sap';
 use testapi;
 use serial_terminal qw(select_serial_terminal);
-use utils qw(systemctl file_content_replace script_retry);
+use utils qw(systemctl script_retry);
 use hacluster;
 use lockapi;
 

--- a/tests/sles4sap/wmp_check_process.pm
+++ b/tests/sles4sap/wmp_check_process.pm
@@ -9,7 +9,7 @@
 use Mojo::Base 'sles4sap';
 use testapi;
 use File::Basename qw(basename);
-use utils qw(zypper_call file_content_replace script_output_retry);
+use utils qw(zypper_call script_output_retry);
 use version_utils qw(is_sle);
 
 sub run {


### PR DESCRIPTION
Remove importing this function when the file does not use it.

- Verification run: I think the PR github workflow is enough
