### PR TITLE
Fix haproxy "Failed to start Cluster Controlled haproxy"

### DIFF
--- a/tests/ha/haproxy.pm
+++ b/tests/ha/haproxy.pm
@@ -93,8 +93,8 @@ sub run {
         # Do a check of the cluster with a screenshot
         save_state;
 
-        # Check service is started
-        systemctl 'status haproxy';
+        # Check haproxy
+        assert_script_run 'crm resource status haproxy';
     }
 
     if (is_node(2)) {


### PR DESCRIPTION
Fix haproxy "Failed to start Cluster Controlled haproxy"

- Related ticket: 
[TEAM-11467](https://jira.suse.com/browse/TEAM-11467) - [qam][ha] qam_2nodes and qam_3nodes cases failed on "Failed to start Cluster Controlled haproxy"

- Verification run:
15sp6 2nodes: https://openqa.suse.de/tests/23839045 (passed)
15sp7 2nodes: https://openqa.suse.de/tests/23840541 (passed)
12sp5 2 nodes: https://openqa.suse.de/tests/23841463 (passed)