### PR TITLE
publiccloud: soft-fail wait_for_guestregister on bsc#1264275

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -363,7 +363,8 @@ sub wait_for_guestregister {
             # ( e.g. when we testing images not published on Market hence w/o product codes)
             return 1 if (get_var('PUBLIC_CLOUD_IGNORE_UNREGISTERED'));
             $self->_upload_guestregister_diagnostics($log, $name);
-            die('guestregister failed');
+            record_soft_failure('bsc#1264275 - guestregister.service fails to register the instance against the update infrastructure');
+            return 1;
         }
         elsif ($out =~ m/active$/) {
             diag("guestregister active");

--- a/t/44_publiccloud_instance.t
+++ b/t/44_publiccloud_instance.t
@@ -315,21 +315,24 @@ subtest '[wait_for_ssh_login] timeout/delay/retry argument propagation' => sub {
 
 $autotest::current_test = {name => 'wait_for_guestregister_test'};
 
-subtest '[wait_for_guestregister] failed captures diagnostics before dying' => sub {
-    # wait_for_guestregister -- diagnostics (log + full journal) must be captured before every die on the failure paths (poo#204360)
+subtest '[wait_for_guestregister] failed records a soft failure (bsc#1264275)' => sub {
+    # wait_for_guestregister -- diagnostics (log + full journal) must be captured on every failure path (poo#204360)
     my $instmod = Test::MockModule->new('publiccloud::instance', no_auto => 1);
-    my (@uploads, @calls);
+    my (@uploads, @calls, @softfails);
     $instmod->redefine(ssh_script_run => sub { my ($self, %args) = @_; push @calls, $args{cmd}; return 0 });
     $instmod->redefine(ssh_script_output => sub { my ($self, %args) = @_; push @calls, $args{cmd}; return 'guestregister.service - failed' });
     $instmod->redefine(upload_log => sub { my ($self, $log, %args) = @_; push @uploads, [$log, \%args] });
     $instmod->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)) });
+    $instmod->redefine(record_soft_failure => sub { push @softfails, $_[0] });
 
     my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u');
-    throws_ok { $inst->wait_for_guestregister() } qr/guestregister failed/, 'dies with guestregister failed';
+    is($inst->wait_for_guestregister(), 1, 'returns 1 instead of dying');
     note("\n  C-->  " . join("\n  C-->  ", @calls));
     is(scalar @uploads, 2, 'upload_log called for the cloudregister log and the guestregister journal');
     is($uploads[0][0], '/var/log/cloudregister', 'uploads /var/log/cloudregister');
     ok((any { /journalctl -u guestregister\.service/ } @calls), 'journal command targets guestregister.service');
+    is(scalar @softfails, 1, 'records exactly one soft failure');
+    like($softfails[0], qr/bsc#1264275/, 'soft failure references bsc#1264275');
 };
 
 subtest '[wait_for_guestregister] failed + PUBLIC_CLOUD_IGNORE_UNREGISTERED skips diagnostics' => sub {


### PR DESCRIPTION
Records a soft failure and returns instead of dying in `wait_for_guestregister()` when `guestregister.service` fails, matching what `check_services.pm` already does for the same issue (PR #26308) but on the `registration.pm` path, which runs first and was still hard-failing the job before that soft-fail could ever apply.

* Related ticket: [poo#205326](https://progress.opensuse.org/issues/205326)
* Related failure: [openqa.suse.de/t23819160](https://openqa.suse.de/tests/23819160)
* Related merge requests: #26308
* Verification runs:
