### PR TITLE
fix: remove obsolete device.map from log tarball

### DIFF
--- a/tests/autoyast/logs.pm
+++ b/tests/autoyast/logs.pm
@@ -17,7 +17,7 @@ sub run {
     # save all logs that might be useful
 
     script_run "systemctl status > /var/log/systemctl_status ||:";
-    script_run "tar cjf /tmp/logs.tar.bz2 --exclude=/etc/{brltty,udev/hwdb.bin} --exclude=/var/log/{YaST2,zypp,{pbl,zypper}.log} /var/{log,adm/autoinstall} /run/systemd/system/ /usr/lib/systemd/system/ /boot/grub2/{device.map,grub{.cfg,env}} /etc/ ||:", timeout => 300;
+    script_run "tar cjf /tmp/logs.tar.bz2 --exclude=/etc/{brltty,udev/hwdb.bin} --exclude=/var/log/{YaST2,zypp,{pbl,zypper}.log} /var/{log,adm/autoinstall} /run/systemd/system/ /usr/lib/systemd/system/ /boot/grub2/grub{.cfg,env} /etc/ ||:", timeout => 300;
     upload_logs "/tmp/logs.tar.bz2";
     enter_cmd "echo UPLOADFINISH >/dev/$serialdev";
     wait_serial("UPLOADFINISH", 200);


### PR DESCRIPTION
Motivation:
Under GRUB 2, /boot/grub2/device.map is deprecated and absent by default. The
tar command failed when attempting to archive this non-existent file.

Design Choices:
Removed the reference to /boot/grub2/device.map in the tar command arguments.

Verification:
```
BADGE=1 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26324 https://openqa.suse.de/tests/23804429 EXIT_AFTER_MODULE=logs
```

* [![sle-15-SP4-Container-Host-s390x-BuildGM-create_hdd_autoyast_containers@s390x-kvm](https://openqa.suse.de/tests/23823058/badge)](https://openqa.suse.de/tests/23823058)

Benefits:
Fixes the test suite crash caused by tar returning a non-zero exit code.