### PR TITLE
Sync terminal session in hana_install, hana_cluster and WMP tests

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -2185,9 +2185,15 @@ sub check_crm_nonroot {
 
     my $orig_prompt = serial_term_prompt() // '# ';
 
+    # The nested 'su -' shell has not PROMPT_COMMAND hook, so pretty
+    # serial markers would never be emited there. See poo#204471
+    # This command disables the pretty serial markers within the scope
+    # of this function
+    my $marker_guard = $testapi::distri->pretty_serial_marker_guard(0);
+
     # Login as non-root user
     enter_cmd "su - $user";
-    wait_serial '> ', no_regex => 1, timeout => 2;
+    wait_serial '> ', no_regex => 1;
     set_serial_prompt '> ';
 
     # Unset all related PATH which belong to non-root user.
@@ -2203,7 +2209,7 @@ sub check_crm_nonroot {
     enter_cmd 'exit';
 
     $testapi::distri->{serial_term_prompt} = $orig_prompt;
-    wait_serial $orig_prompt, no_regex => 1, timeout => 2;
+    wait_serial $orig_prompt, no_regex => 1;
 
     select_serial_terminal();
 }

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -443,6 +443,7 @@ sub prepare_profile {
 
     if ($has_saptune) {
         assert_script_run 'saptune service takeover';
+        wait_serial($testapi::distri->{serial_term_prompt}, no_regex => 1, quiet => 1) if testapi::is_serial_terminal;
         enter_cmd "saptune solution verify $profile; echo DONE-$\? > /dev/$serialdev";
         my $ret = wait_serial qr/DONE-\d/, timeout => 30;
         if (!defined $ret) {

--- a/tests/sles4sap/wmp_check_process.pm
+++ b/tests/sles4sap/wmp_check_process.pm
@@ -42,7 +42,7 @@ sub run {
     # Run script
     my $current_test = get_var('WMP_PHASE', $testphases[0]);
     $current_test = $testphases[0] unless (grep /^$current_test$/, @testphases);
-    enter_cmd "cd /root/$testname";
+    assert_script_run "cd /root/$testname";
     my $out = script_output_retry("python3 check_process.py -o $logdir -n $current_test 2>&1", retry => 3, timeout => 30, delay => 10);
     die "$testname failed with error [$out]" if ($out =~ /ERROR:/);
     my ($index) = grep { $testphases[$_] eq $current_test } (0 .. $#testphases);


### PR DESCRIPTION
This commit includes 3 changes:

1. It ensures there is a prompt before running `saptune solution verify` in `lib/sles4sap` by adding a `wait_serial()` call for the serial prompt right before the call to the saptune command. Goal is to ensure the terminal session is ready to receive the command and avoid possible timeouts later.

2. Disable serial markers in `lib/hacluster::check_crm_nonroot()` as the function includes a call to switch user.

3. Additionally, the `sles4sap/wmp_check_process` has also been modified to use `assert_script_run` instead of `enter_cmd` when changing directories. As `assert_script_run` will wait for the retval of the command it will allow the terminal session more time to be ready before running the next command (`python3 check_process.py`).

- Related Ticket: https://jira.suse.com/browse/TEAM-11462
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/23822928 :green_circle: , https://openqa.suse.de/tests/overview?version=15-SP5&build=pr26235&distri=sle :green_circle: , https://openqa.suse.de/tests/overview?distri=sle&build=pr26235ha&version=15-SP5 :green_circle: 
