### PR TITLE
ibtest: Remove hardcoded IPXE support server

### DIFF
--- a/schedule/kernel/ibtest-master-autoyast.yaml
+++ b/schedule/kernel/ibtest-master-autoyast.yaml
@@ -9,7 +9,6 @@ vars:
     IBTEST_ROLE: IBTEST_MASTER
     IPXE: 1
     IPXE_CONSOLE: ttyS1,115200
-    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
     SCC_ADDONS: sdk
     VIDEOMODE: ssh-x
 schedule:

--- a/schedule/kernel/ibtest-master-rdma-next.yaml
+++ b/schedule/kernel/ibtest-master-rdma-next.yaml
@@ -7,7 +7,6 @@ vars:
     IBTESTS: 1
     IBTEST_ROLE: IBTEST_MASTER
     IPXE: 1
-    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
     IPXE_CONSOLE: ttyS1,115200
     KERNEL_GIT_TREE: https://git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git
     KERNEL_GIT_BRANCH: for-next

--- a/schedule/kernel/ibtest-master.yaml
+++ b/schedule/kernel/ibtest-master.yaml
@@ -9,7 +9,6 @@ vars:
     IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_MASTER
     IPXE: 1
-    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
     IPXE_CONSOLE: ttyS1,115200
     PATTERNS: base,minimal
     SCC_ADDONS: sdk

--- a/schedule/kernel/ibtest-slave-autoyast.yaml
+++ b/schedule/kernel/ibtest-slave-autoyast.yaml
@@ -10,7 +10,6 @@ vars:
     IBTEST_ROLE: IBTEST_SLAVE
     IPXE: 1
     IPXE_CONSOLE: ttyS1,115200
-    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
     PARALLEL_WITH: ibtest-master
     SCC_ADDONS: sdk
 schedule:

--- a/schedule/kernel/ibtest-slave-rdma-next.yaml
+++ b/schedule/kernel/ibtest-slave-rdma-next.yaml
@@ -7,7 +7,6 @@ vars:
     IBTESTS: 1
     IBTEST_ROLE: IBTEST_SLAVE
     IPXE: 1
-    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
     IPXE_CONSOLE: ttyS1,115200
     KERNEL_GIT_TREE: https://git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git
     KERNEL_GIT_BRANCH: for-next

--- a/schedule/kernel/ibtest-slave.yaml
+++ b/schedule/kernel/ibtest-slave.yaml
@@ -9,7 +9,6 @@ vars:
     IBTEST_GITTREE: https://github.com/SUSE/hpc-testing.git
     IBTEST_ROLE: IBTEST_SLAVE
     IPXE: 1
-    IPXE_HTTPSERVER: http://baremetal-support.qa.suse.de
     IPXE_CONSOLE: ttyS1,115200
     PATTERNS: base,minimal
     SCC_ADDONS: sdk


### PR DESCRIPTION
Remove the `IPXE_HTTPSERVER` setting from ibtest YAML schedule. This variable should be set by the worker machine instead.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/23825724
