### PR TITLE
shar: fetch test data via data_url instead of ~/data

### DIFF
--- a/tests/console/shar.pm
+++ b/tests/console/shar.pm
@@ -25,7 +25,8 @@ sub run {
     }
 
     select_console 'user-console';
-    assert_script_run('sh ~/data/shar_testdata.sh');
+    assert_script_run('curl -o /tmp/shar_testdata.sh ' . data_url('shar_testdata.sh'));
+    assert_script_run('sh /tmp/shar_testdata.sh');
     assert_script_run('file shar_testdata/suse.png | grep "600 x 550"');
     assert_script_run('head -1 shar_testdata/hallo.txt | grep "Hallo Welt"');
     assert_script_run('shar shar_testdata > a.sh');


### PR DESCRIPTION
~/data relies on 9p virtfs sharing which is not available in all setups (e.g. minimal or coverage schedules). Fetch the test archive from the openQA server via data_url() instead, matching the pattern used by other modules like console/gd.

- Verification runs:
  - https://openqa.suse.de/tests/23834456
  - https://openqa.suse.de/tests/23834457
  - https://openqa.suse.de/tests/23834458
  - https://openqa.suse.de/tests/23834459