### PR TITLE
gdb: clean up interactive session in post_fail_hook

### DIFF
--- a/tests/console/gdb.pm
+++ b/tests/console/gdb.pm
@@ -103,4 +103,12 @@ sub run {
     assert_script_run("pkill -9 test3");
 }
 
+sub post_fail_hook {
+    my ($self) = @_;
+    # gdb may still be running interactively on the serial terminal.
+    # Kill it before the base class tries to switch consoles.
+    script_run('pkill gdb');
+    $self->SUPER::post_fail_hook;
+}
+
 1;


### PR DESCRIPTION
When gdb dies mid-session, the interactive process is still running on the serial terminal. The base class post_fail_hook tries to switch consoles and fails, cascading into skipping all subsequent modules.

Exit gdb and kill it before handing off to the base class.

- Verification run: [Tumbleweed](https://openqa.opensuse.org/tests/6153359) | [15-SP7](https://openqa.suse.de/tests/23834639) | [16.0](https://openqa.suse.de/tests/23834640)