### PR TITLE
consoletest: prevent post_fail_hook cascade on console switch failure

### DIFF
--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -50,7 +50,11 @@ sub post_fail_hook {
     return if is_public_cloud();
     # Remaining log functions are executed in Utils::Logging::export_logs()
     # called in opensusebasetest::post_fail_hook()
-    select_console('log-console');
+    eval { select_console('log-console') };
+    if ($@) {
+        record_info('console error', "Could not switch to log-console: $@", result => 'fail');
+        return;
+    }
     show_oom_info;
     show_tasks_in_blocked_state;
 }


### PR DESCRIPTION
When a module fails and leaves the terminal in a broken state (e.g. interactive gdb session, mid-VNC-switch), `select_console('log-console')` in post_fail_hook dies and cascades into skipping all subsequent modules.

Wrap the console switch in eval so the failure is recorded but does not abort the schedule.

poo#205416

- Verification run: [Tumbleweed](https://openqa.opensuse.org/tests/6153524) | [15-SP7](https://openqa.suse.de/tests/23834847) | [16.0](https://openqa.suse.de/tests/23834848)