### PR TITLE
Keep using /dev/sshserial for secondary connection

### DIFF
--- a/lib/parallel_guest_migration_base.pm
+++ b/lib/parallel_guest_migration_base.pm
@@ -664,7 +664,7 @@ sub config_host_security {
         assert_script_run("sed -i -r \'s/^SELINUX=enforcing\$/SELINUX=permissive/g\' /etc/selinux/config");
     }
 
-    script_run("iptables -P INPUT ACCEPT;
+    enter_cmd("iptables -P INPUT ACCEPT;
 iptables -P FORWARD ACCEPT;
 iptables -P OUTPUT ACCEPT;
 iptables -t nat -F;
@@ -673,6 +673,8 @@ sysctl -w net.ipv4.ip_forward=1;
 sysctl -w net.ipv4.conf.all.forwarding=1"
     );
     save_screenshot;
+    reset_consoles;
+    select_console("root-ssh");
     setup_common_ssh_config(ssh_id_file => $args{_keyfile});
 }
 
@@ -1628,7 +1630,6 @@ sub virsh_migrate_manual_postcopy {
     enter_cmd("sleep 120 && $_command[0]");
     save_screenshot;
     select_console("root-ssh-virt");
-    $testapi::serialdev = "virtsshserial";
     enter_cmd("clear");
     $_ret = script_run("(set -x;unset migrate_postcopy;export migrate_postcopy=1; for i in `seq 87000`;do $_command[1];migrate_postcopy=\$?; if [ \$migrate_postcopy -eq 0 ];then set +x;break;fi; done; if [ \$migrate_postcopy -eq 0 ];then echo -e \"Migrate Postcopy Succeeded! \\n\";else command-not-found;fi)", timeout => 300);
     wait_still_screen(30);

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -517,8 +517,8 @@ sub init_consoles {
                 hostname => get_required_var('SUT_IP'),
                 password => $testapi::password,
                 username => 'root',
-                serial => 'rm -f /dev/virtsshserial; mkfifo /dev/virtsshserial; chmod 666 /dev/virtsshserial; while true; do cat /dev/virtsshserial; done',
-                gui => 1
+                serial => 'rm -f /dev/sshserial; mkfifo /dev/sshserial; chmod 666 /dev/sshserial; while true; do cat /dev/sshserial; done',
+                gui => 0
             }) if (get_var('VIRT_AUTOTEST', '') or get_var('REGRESSION', ''));
     }
 


### PR DESCRIPTION
* **Console** ```root-ssh-virt``` serial device ```/dev/virtsshserial``` causes issue which hangs all ssh connection regardless of the way in which user connects, for example, [this one](https://openqa.suse.de/tests/23768355#step/parallel_guest_migration_source/783), root prompt never appears and ssh login never completes.

* **Change** to use original ```/dev/sshserial``` can solve the above issue. And guest migration test needs two such consoles, otherwise test run will fail.

* **Enabling** IP traffic forwarding may cause temporary interrupted network connection which leads to time out, for example, [this one](https://openqa.suse.de/tests/23886907#step/parallel_guest_migration_destination/140).

* **Change** to execute command and reconnect console to ensure stable test run.

* **By** the way, ```PRETTY_SERIAL_MARKER=0``` does not solve the issue.

* **Verification Runs:**
  * [sle-16.1-Online-x86_64-Build62.2-virt-guest-migration-developing-from-developing-to-developing-kvm-src](https://openqa.suse.de/tests/23886881) [-dst](https://openqa.suse.de/tests/23886882)
  * [sle-16.1-Online-x86_64-Build63.1-virt-guest-migration-sle16-from-sle16-to-developing-kvm-src](https://openqa.suse.de/tests/23898648) [-dst](https://openqa.suse.de/tests/23898647)
  * [sle-16.1-Online-x86_64-Build63.1-virt-guest-migration-developing-from-developing-to-developing-kvm-src](https://openqa.suse.de/tests/23898822) [-dst](https://openqa.suse.de/tests/23898821)
  * [sle-15-SP7-Server-DVD-Incidents-VIRT-Core-x86_64-Build:smelt:45775:qemu-qam-kvm-migration-src](https://openqa.suse.de/tests/23898953) [-dst](https://openqa.suse.de/tests/23898954)