### PR TITLE
xfstests: collect .mountfail file

### DIFF
--- a/lib/xfstests_utils.pm
+++ b/lib/xfstests_utils.pm
@@ -552,6 +552,7 @@ sub copy_all_log {
     copy_log($category, $num, 'out.bad');
     copy_log($category, $num, 'full');
     copy_log($category, $num, 'dmesg');
+    copy_log($category, $num, 'mountfail');
     copy_fsxops($category, $num);
     if (script_run("ls /opt/xfstests/results/$category/$num.*.md* 1> /dev/null 2>&1") == 0) {
         script_run("tar -cf $LOG_DIR/$num.dump.tar /opt/xfstests/results/$category/$num.*.md*");

--- a/tests/xfstests/run_subtest.pm
+++ b/tests/xfstests/run_subtest.pm
@@ -102,6 +102,7 @@ sub override_known_failures {
     $self->record_resultfile('out.bad', "$targs->{outbad}", %args) if defined($targs->{outbad});
     $self->record_resultfile('full', "$targs->{fullog}", %args) if defined($targs->{fullog});
     $self->record_resultfile('dmesg', "$targs->{dmesg}", %args) if defined($targs->{dmesg});
+    $self->record_resultfile('mountfail', "$targs->{mountfail}", %args) if defined($targs->{mountfail});
 
     if ($targs->{status} =~ /SOFTFAILED/) {
         $self->record_soft_failure_result($targs->{failinfo}, force_status => 1, %args) if defined($targs->{failinfo});
@@ -430,6 +431,7 @@ sub run {
         $targs{outbad} = script_output("if [ -f $test_path.out.bad ]; then tail -n 200 $test_path.out.bad | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176'; else echo '$test_path.out.bad not exist';fi", 600, type_command => 1, proceed_on_failure => 1);
         $targs{fullog} = script_output("if [ -f $test_path.full ]; then tail -n 200 $test_path.full | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176'; else echo '$test_path.full not exist'; fi", 600, type_command => 1, proceed_on_failure => 1);
         $targs{dmesg} = script_output("if [ -f $test_path.dmesg ]; then tail -n 200 $test_path.dmesg | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176'; fi", 600, type_command => 1, proceed_on_failure => 1);
+        $targs{mountfail} = script_output("if [ -f $test_path.mountfail ]; then tail -n 200 $test_path.mountfail | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176'; fi", 600, type_command => 1, proceed_on_failure => 1);
         $targs{status} = 'SOFTFAILED' if $status =~ /SOFTFAILED/;
 
         if (exists($softfail_list{$generate_name})) {


### PR DESCRIPTION
xfstests will leave a .mountfail file if test fails with a mount failure. So we should keep this log for debugging.


- Related ticket: https://progress.opensuse.org/issues/204567
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/23824534#step/overlay-083/68
