### PR TITLE
workaround: Wait for shell consoletest etc. on aarch64

### DIFF
--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -11,6 +11,7 @@ use known_bugs;
 use version_utils qw(is_public_cloud);
 use Utils::Logging qw(export_logs_basic export_logs_desktop record_avc_selinux_alerts);
 use utils;
+use Utils::Architectures qw(is_aarch64);
 
 =head1 consoletest
 
@@ -27,11 +28,14 @@ Method executed when run() finishes.
 sub post_run_hook {
     my ($self) = @_;
 
+    # https://progress.opensuse.org/issues/183761#note-45
+    wait_serial($testapi::distri->{serial_term_prompt}, timeout => 5, quiet => 1) if is_aarch64;
     # start next test in home directory
     assert_script_run "cd";
 
     $self->record_avc_selinux_alerts();
     # clear screen to make screen content ready for next test
+    wait_serial($testapi::distri->{serial_term_prompt}, timeout => 5, quiet => 1) if is_aarch64;
     $self->clear_and_verify_console;
 }
 

--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -133,7 +133,7 @@ sub configure_static_dns {
         $nm_id = script_output("nmcli -t -f NAME c | grep -v '^lo' | head -n 1") unless ($nm_id);
         assert_script_run "nmcli connection modify '$nm_id' ipv4.dns '$servers'";
     } else {
-        assert_script_run("sync", timeout => 600) if is_aarch64;    # workaround for slow virtual disk device
+        assert_script_run("time sync", timeout => 1000) if is_aarch64;    # workaround for slow virtual disk device
         assert_script_run "sed -i -e 's|^NETCONFIG_DNS_STATIC_SERVERS=.*|NETCONFIG_DNS_STATIC_SERVERS=\"$servers\"|' /etc/sysconfig/network/config";
         assert_script_run "netconfig -f update";
     }

--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -110,6 +110,8 @@ sub run {
     push @hashes, 'md5' unless check_var('FIPS_ENABLED', '1');
     for my $alg (@hashes) {
         assert_script_run "sigtool --$alg /usr/local/bin/maybeavirus > test.hdb";
+        # https://progress.opensuse.org/issues/183761#note-45
+        wait_serial($testapi::distri->{serial_term_prompt}, timeout => 5, quiet => 1) if is_aarch64;
         enter_cmd "clamscan -d test.hdb  /usr/local/bin/maybeavirus | tee /dev/$serialdev";
         die "Virus scan result was not expected" unless (wait_serial qr/maybeavirus\.UNOFFICIAL FOUND.*Known viruses: 1/ms);
     }

--- a/tests/console/gdb.pm
+++ b/tests/console/gdb.pm
@@ -20,6 +20,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use package_utils 'install_package';
 use version_utils qw(is_leap is_sle);
+use Utils::Architectures qw(is_aarch64);
 
 sub wait_serial_or_die {
     my ($feedback, %args) = @_;
@@ -53,6 +54,8 @@ sub run {
     #Test Case 1
     assert_script_run("curl -O " . data_url('gdb/test1.c'));
     assert_script_run("gcc -g -std=c99 test1.c -o test1");
+    # https://progress.opensuse.org/issues/183761#note-45
+    wait_serial($testapi::distri->{serial_term_prompt}, timeout => 5, quiet => 1) if is_aarch64;
     enter_cmd("gdb test1 | tee /dev/$serialdev");
     wait_serial_or_die('GNU gdb');
     #Needed because colour codes mess up the output on $serialdev


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/205107 https://progress.opensuse.org/issues/183761#note-45
- Verification run:
https://openqa.suse.de/tests/23840131
https://openqa.suse.de/tests/23840132