### PR TITLE
Added post_run_hook to failed steps

### DIFF
--- a/tests/yam/validate/validate_first_user.pm
+++ b/tests/yam/validate/validate_first_user.pm
@@ -13,4 +13,13 @@ sub run {
     select_console 'user-console';
 }
 
+# Overwrite post_run_hook due to no permissions from first user to go home on TTYS0
+sub post_run_hook {
+    my ($self) = @_;
+
+    $self->record_avc_selinux_alerts();
+    # clear screen to make screen content ready for next test
+    $self->clear_and_verify_console;
+}
+
 1;

--- a/tests/yam/validate/validate_rescue_system.pm
+++ b/tests/yam/validate/validate_rescue_system.pm
@@ -25,4 +25,13 @@ sub run {
     }
 }
 
+# Overwrite post_run_hook due to no HOME defined in root TTY
+sub post_run_hook {
+    my ($self) = @_;
+
+    $self->record_avc_selinux_alerts();
+    # clear screen to make screen content ready for next test
+    $self->clear_and_verify_console;
+}
+
 1;

--- a/tests/yam/validate/validate_self_update.pm
+++ b/tests/yam/validate/validate_self_update.pm
@@ -30,4 +30,13 @@ sub run {
     }
 }
 
+# Overwrite post_run_hook due to no HOME defined in root TTY
+sub post_run_hook {
+    my ($self) = @_;
+
+    $self->record_avc_selinux_alerts();
+    # clear screen to make screen content ready for next test
+    $self->clear_and_verify_console;
+}
+
 1;


### PR DESCRIPTION
We have overwrite post_run_hook on `validate_first_user`, `validate_self_update` and on `validate_rescue_system` this will solve the error of `cd` after test.

- Related ticket: N/A
- Needles: N/A
- Verification run:
  - validate_first_user: https://openqa.suse.de/tests/23840494#
  - validate_rescue_system: https://openqa.suse.de/tests/23840337
  - validate_self_update: https://openqa.suse.de/tests/23840730
