### PR TITLE
Skip tianocore SecureBoot dance when firmware already disabled it

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -44,7 +44,7 @@ use bootloader_setup;
 use registration;
 use utils;
 use version_utils qw(is_jeos is_microos is_opensuse is_sle is_selfinstall is_sle_micro is_leap_micro is_bootloader_sdboot is_bootloader_grub2_bls is_transactional);
-use Utils::Backends qw(is_ipmi);
+use Utils::Backends qw(is_ipmi is_qemu);
 
 # hint: press shift-f10 trice for highest debug level
 sub run {
@@ -130,8 +130,9 @@ sub run {
         return;
     }
 
-    my $efi_vars_have_nosb = get_var('UEFI_PFLASH_VARS', '') =~ /nosb/i;
-    if (!$efi_vars_have_nosb && get_var('DISABLE_SECUREBOOT') && (get_var('BACKEND') eq 'qemu')) {
+    my $secure_boot_disabled = get_var('UEFI_PFLASH_VARS', '') =~ /nosb/i
+      || check_var('UEFI_PFLASH_SECURE_BOOT', '0');
+    if (!$secure_boot_disabled && get_var('DISABLE_SECUREBOOT') && is_qemu) {
         $self->tianocore_disable_secureboot;
     }
     if ((get_var("ZDUP") && !is_jeos) || (get_var('ONLINE_MIGRATION') && check_var('BOOTFROM', 'd'))) {


### PR DESCRIPTION
The nosb check relied on a vars filename that is going away. Using UEFI_PFLASH_SECURE_BOOT instead.

- Related ticket: https://progress.opensuse.org/issues/203517
- Verification runs: https://openqa.suse.de/tests/overview?build=poo203517-vr

### Notes

* [23855026](https://openqa.suse.de/tests/23855026) is incomplete with
  `asset failure: Failed to download SLES-16.0-Minimal-VM.aarch64-kvm-Build39.67.qcow2`.
  Group 703 last ran in June and its image has been garbage collected, there is no
  newer build to clone from. The anchor in `qr/16.0.yaml` is byte-identical to the
  one in `latest-16.yaml`, which is covered by 23855025.
* The aarch64 staging VR sets the firmware explicitly to stand in for the medium
  change, since a medium cannot be cloned. On x86_64 the medium needs no change,
  os-autoinst falls back to `ovmf-x86_64-ms-4m-code.bin` on its own. There is no
  such fallback for aarch64.
