### PR TITLE
usb_drive.pm: apply lklfuse install immediately on transactional systems

### DIFF
--- a/tests/kernel/usb_drive.pm
+++ b/tests/kernel/usb_drive.pm
@@ -66,7 +66,7 @@ sub run {
 
 
     if (@{zypper_search('lklfuse')}) {
-        install_package 'lklfuse';
+        install_package('lklfuse', trup_apply => 1);
         assert_script_run "usermod -a -G disk bernhard";
 
         select_user_serial_terminal;


### PR DESCRIPTION
- Related ticket:  https://progress.opensuse.org/issues/205464
- Verification run: https://openqa.suse.de/tests/23841881
- regression check for regular system: https://openqa.suse.de/tests/23841882
