### PR TITLE
cleanup_known_coredumps: Restrict known-coredump entries to specific architectures

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -174,6 +174,11 @@ sub cleanup_known_coredumps {
         # cmdline is a literal string, not a regex, matching part of the command line.
         # signals is optional; all signals match if not specified.
         # architectures is optional; all architectures match if not specified.
+        'poo#200531' => {
+            cmdline => q(/usr/sbin/nscd),
+            signals => [qw(BUS)],
+            architectures => [qw(s390x)],
+        },
         'poo#198596' => {
             cmdline => q(openssl3-conf/base_only.cnf -p $'"hello"'),
             signals => [qw(ABRT)],

--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -173,6 +173,7 @@ sub cleanup_known_coredumps {
     my %known_coredumps = (
         # cmdline is a literal string, not a regex, matching part of the command line.
         # signals is optional; all signals match if not specified.
+        # architectures is optional; all architectures match if not specified.
         'poo#198596' => {
             cmdline => q(openssl3-conf/base_only.cnf -p $'"hello"'),
             signals => [qw(ABRT)],
@@ -190,6 +191,7 @@ sub cleanup_known_coredumps {
         },
     );
 
+    my $arch = get_var('ARCH');
     for my $pid (split(/\n/, script_output(q(coredumpctl -q --no-pager --no-legend | awk '$9 ~ /^(present|truncated)$/ { print $5 }'), proceed_on_failure => 1))) {
         my $coredump_info = script_output("time coredumpctl info --no-pager $pid", proceed_on_failure => 1);
         my ($cmdline) = $coredump_info =~ /^\s+Command Line: (.*)$/m;
@@ -200,6 +202,7 @@ sub cleanup_known_coredumps {
             my $entry = $known_coredumps{$known};
             next if index($cmdline, $entry->{cmdline}) < 0;
             next if $entry->{signals} && !grep { $_ eq $signal } @{$entry->{signals}};
+            next if $entry->{architectures} && !grep { $_ eq $arch } @{$entry->{architectures}};
             record_info('Known dump', $coredump_info);
             # Fetch path from a line like:
             #   Storage: /var/lib/systemd/coredump/core.binary.999.zst (present)


### PR DESCRIPTION
- Add an optional `architectures` field to entries in `cleanup_known_coredumps` so a known-coredump can be scoped to only the architecture(s) it's known to occur on, instead of matching everywhere.  
- Add a new entry for poo#200531 (`/usr/sbin/nscd` crashing with `SIGBUS`), restricted to `s390x`, as the first consumer of this new option.

Related ticket: https://progress.opensuse.org/issues/200531
Failed job: https://openqa.suse.de/tests/23841677#step/coredump_collect/11 (force-passed to unblock updates)
Verification run: https://openqa.suse.de/tests/23841887