### PR TITLE
coverage: raise guest memlock for funkoverage

### DIFF
--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -54,7 +54,11 @@ sub post_fail_hook {
     return if is_public_cloud();
     # Remaining log functions are executed in Utils::Logging::export_logs()
     # called in opensusebasetest::post_fail_hook()
-    select_console('log-console');
+    eval { select_console('log-console') };
+    if ($@) {
+        record_info('console error', "Could not switch to log-console: $@", result => 'fail');
+        return;
+    }
     show_oom_info;
     show_tasks_in_blocked_state;
 }

--- a/schedule/coverage/bisect_15.yaml
+++ b/schedule/coverage/bisect_15.yaml
@@ -1,0 +1,51 @@
+name: coverage - bisect 15 binaries
+description: Binary search for uprobe limit. Testing 15 (~10K probes).
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_uefi
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - coverage/coverage_setup
+  - console/tar
+  - console/curl_https
+  - console/kmod
+  - console/cpio
+  - console/unzip
+  - console/nano
+  - console/gpg
+  - console/nginx
+  - console/dig
+  - console/shells
+  - console/sqlite3
+  - console/wget_https
+  - console/openssl_alpn
+  - console/dnsmasq
+  - coverage/coverage_report
+test_data:
+  helper_packages:
+    - gzip
+    - iputils
+    - systemd
+    - wget
+  coverage_targets:
+    tar: /usr/bin/tar
+    curl: /usr/bin/curl
+    kmod: /usr/bin/kmod
+    cpio: /usr/bin/cpio
+    unzip: /usr/bin/unzip
+    nano: /usr/bin/nano
+    gpg2: /usr/bin/gpg
+    nginx: /usr/sbin/nginx
+    bind-utils: /usr/bin/dig
+    tcsh: /usr/bin/tcsh
+    zsh: /usr/bin/zsh
+    sqlite3: /usr/bin/sqlite3
+    wget: /usr/bin/wget
+    openssl-3: /usr/bin/openssl
+    dnsmasq: /usr/sbin/dnsmasq

--- a/schedule/coverage/bisect_20.yaml
+++ b/schedule/coverage/bisect_20.yaml
@@ -1,0 +1,62 @@
+name: coverage - bisect 20 binaries
+description: Binary search for uprobe limit. 11 works, 35 fails. Testing 20.
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_uefi
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - coverage/coverage_setup
+  - console/tar
+  - console/curl_https
+  - console/kmod
+  - console/cpio
+  - console/unzip
+  - console/nano
+  - console/gpg
+  - console/nginx
+  - console/dig
+  - console/shells
+  - console/sqlite3
+  - console/vim
+  - console/wget_https
+  - console/openssl_alpn
+  - console/dnsmasq
+  - console/chrony
+  - console/cron
+  - console/quota
+  - console/arping
+  - console/tracepath
+  - coverage/coverage_report
+test_data:
+  helper_packages:
+    - gzip
+    - iputils
+    - systemd
+    - wget
+  coverage_targets:
+    tar: /usr/bin/tar
+    curl: /usr/bin/curl
+    kmod: /usr/bin/kmod
+    cpio: /usr/bin/cpio
+    unzip: /usr/bin/unzip
+    nano: /usr/bin/nano
+    gpg2: /usr/bin/gpg
+    nginx: /usr/sbin/nginx
+    bind-utils: /usr/bin/dig
+    tcsh: /usr/bin/tcsh
+    zsh: /usr/bin/zsh
+    sqlite3: /usr/bin/sqlite3
+    vim: /usr/bin/vim-nox11
+    wget: /usr/bin/wget
+    openssl-3: /usr/bin/openssl
+    dnsmasq: /usr/sbin/dnsmasq
+    chrony: /usr/bin/chronyc
+    cronie: /usr/sbin/cron
+    quota: /usr/bin/quota
+    iputils: /usr/bin/arping

--- a/schedule/coverage/bisect_22.yaml
+++ b/schedule/coverage/bisect_22.yaml
@@ -1,0 +1,65 @@
+name: coverage - bisect 22 binaries
+description: Bisect between 20 (works) and 25 (fails). Testing 22.
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_uefi
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - coverage/coverage_setup
+  - console/tar
+  - console/curl_https
+  - console/kmod
+  - console/cpio
+  - console/unzip
+  - console/nano
+  - console/gpg
+  - console/nginx
+  - console/dig
+  - console/shells
+  - console/sqlite3
+  - console/vim
+  - console/wget_https
+  - console/openssl_alpn
+  - console/dnsmasq
+  - console/chrony
+  - console/cron
+  - console/quota
+  - console/arping
+  - console/tracepath
+  - console/shar
+  - coverage/coverage_report
+test_data:
+  helper_packages:
+    - gzip
+    - iputils
+    - systemd
+    - wget
+  coverage_targets:
+    tar: /usr/bin/tar
+    curl: /usr/bin/curl
+    kmod: /usr/bin/kmod
+    cpio: /usr/bin/cpio
+    unzip: /usr/bin/unzip
+    nano: /usr/bin/nano
+    gpg2: /usr/bin/gpg
+    nginx: /usr/sbin/nginx
+    bind-utils: /usr/bin/dig
+    tcsh: /usr/bin/tcsh
+    zsh: /usr/bin/zsh
+    sqlite3: /usr/bin/sqlite3
+    vim: /usr/bin/vim-nox11
+    wget: /usr/bin/wget
+    openssl-3: /usr/bin/openssl
+    dnsmasq: /usr/sbin/dnsmasq
+    chrony: /usr/bin/chronyc
+    cronie: /usr/sbin/cron
+    quota: /usr/bin/quota
+    iputils: /usr/bin/arping
+    traceroute: /usr/sbin/traceroute
+    sharutils: /usr/bin/shar

--- a/schedule/coverage/bisect_23.yaml
+++ b/schedule/coverage/bisect_23.yaml
@@ -1,0 +1,67 @@
+name: coverage - bisect 23 binaries
+description: Bisect between 22 (works) and 25 (fails). Testing 23.
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_uefi
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - coverage/coverage_setup
+  - console/tar
+  - console/curl_https
+  - console/kmod
+  - console/cpio
+  - console/unzip
+  - console/nano
+  - console/gpg
+  - console/nginx
+  - console/dig
+  - console/shells
+  - console/sqlite3
+  - console/vim
+  - console/wget_https
+  - console/openssl_alpn
+  - console/dnsmasq
+  - console/chrony
+  - console/cron
+  - console/quota
+  - console/arping
+  - console/tracepath
+  - console/shar
+  - console/procps
+  - coverage/coverage_report
+test_data:
+  helper_packages:
+    - gzip
+    - iputils
+    - systemd
+    - wget
+  coverage_targets:
+    tar: /usr/bin/tar
+    curl: /usr/bin/curl
+    kmod: /usr/bin/kmod
+    cpio: /usr/bin/cpio
+    unzip: /usr/bin/unzip
+    nano: /usr/bin/nano
+    gpg2: /usr/bin/gpg
+    nginx: /usr/sbin/nginx
+    bind-utils: /usr/bin/dig
+    tcsh: /usr/bin/tcsh
+    zsh: /usr/bin/zsh
+    sqlite3: /usr/bin/sqlite3
+    vim: /usr/bin/vim-nox11
+    wget: /usr/bin/wget
+    openssl-3: /usr/bin/openssl
+    dnsmasq: /usr/sbin/dnsmasq
+    chrony: /usr/bin/chronyc
+    cronie: /usr/sbin/cron
+    quota: /usr/bin/quota
+    iputils: /usr/bin/arping
+    traceroute: /usr/sbin/traceroute
+    sharutils: /usr/bin/shar
+    procps: /usr/bin/free

--- a/schedule/coverage/bisect_24.yaml
+++ b/schedule/coverage/bisect_24.yaml
@@ -1,0 +1,69 @@
+name: coverage - bisect 24 binaries
+description: Bisect between 22 (works) and 25 (fails). Testing 24.
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_uefi
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - coverage/coverage_setup
+  - console/tar
+  - console/curl_https
+  - console/kmod
+  - console/cpio
+  - console/unzip
+  - console/nano
+  - console/gpg
+  - console/nginx
+  - console/dig
+  - console/shells
+  - console/sqlite3
+  - console/vim
+  - console/wget_https
+  - console/openssl_alpn
+  - console/dnsmasq
+  - console/chrony
+  - console/cron
+  - console/quota
+  - console/arping
+  - console/tracepath
+  - console/shar
+  - console/procps
+  - console/man_pages
+  - coverage/coverage_report
+test_data:
+  helper_packages:
+    - gzip
+    - iputils
+    - systemd
+    - wget
+  coverage_targets:
+    tar: /usr/bin/tar
+    curl: /usr/bin/curl
+    kmod: /usr/bin/kmod
+    cpio: /usr/bin/cpio
+    unzip: /usr/bin/unzip
+    nano: /usr/bin/nano
+    gpg2: /usr/bin/gpg
+    nginx: /usr/sbin/nginx
+    bind-utils: /usr/bin/dig
+    tcsh: /usr/bin/tcsh
+    zsh: /usr/bin/zsh
+    sqlite3: /usr/bin/sqlite3
+    vim: /usr/bin/vim-nox11
+    wget: /usr/bin/wget
+    openssl-3: /usr/bin/openssl
+    dnsmasq: /usr/sbin/dnsmasq
+    chrony: /usr/bin/chronyc
+    cronie: /usr/sbin/cron
+    quota: /usr/bin/quota
+    iputils: /usr/bin/arping
+    traceroute: /usr/sbin/traceroute
+    sharutils: /usr/bin/shar
+    procps: /usr/bin/free
+    man: /usr/bin/man

--- a/schedule/coverage/bisect_25.yaml
+++ b/schedule/coverage/bisect_25.yaml
@@ -1,0 +1,72 @@
+name: coverage - bisect 25 single-path binaries
+description: 25 single-path shims. Bisect between 20 (works) and 35 (fails).
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_uefi
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - coverage/coverage_setup
+  - console/tar
+  - console/curl_https
+  - console/kmod
+  - console/cpio
+  - console/unzip
+  - console/nano
+  - console/gpg
+  - console/nginx
+  - console/dig
+  - console/shells
+  - console/sqlite3
+  - console/vim
+  - console/wget_https
+  - console/openssl_alpn
+  - console/dnsmasq
+  - console/chrony
+  - console/cron
+  - console/quota
+  - console/arping
+  - console/tracepath
+  - console/procps
+  - console/man_pages
+  - console/irqbalance
+  - console/shar
+  - console/run0
+  - coverage/coverage_report
+test_data:
+  helper_packages:
+    - gzip
+    - iputils
+    - systemd
+    - wget
+  coverage_targets:
+    tar: /usr/bin/tar
+    curl: /usr/bin/curl
+    kmod: /usr/bin/kmod
+    cpio: /usr/bin/cpio
+    unzip: /usr/bin/unzip
+    nano: /usr/bin/nano
+    gpg2: /usr/bin/gpg
+    nginx: /usr/sbin/nginx
+    bind-utils: /usr/bin/dig
+    tcsh: /usr/bin/tcsh
+    zsh: /usr/bin/zsh
+    sqlite3: /usr/bin/sqlite3
+    vim: /usr/bin/vim-nox11
+    wget: /usr/bin/wget
+    openssl-3: /usr/bin/openssl
+    dnsmasq: /usr/sbin/dnsmasq
+    chrony: /usr/bin/chronyc
+    cronie: /usr/sbin/cron
+    quota: /usr/bin/quota
+    iputils: /usr/bin/arping
+    traceroute: /usr/sbin/traceroute
+    procps: /usr/bin/free
+    man: /usr/bin/man
+    irqbalance: /usr/sbin/irqbalance
+    sharutils: /usr/bin/shar

--- a/schedule/coverage/diag_validate.yaml
+++ b/schedule/coverage/diag_validate.yaml
@@ -1,0 +1,45 @@
+name: coverage - diagnostic (10 binaries + kernel limits)
+description: >
+    Test 10 binaries to find the uprobe scaling boundary.
+    Also dumps kernel eBPF limits for diagnosis.
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_uefi
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - coverage/coverage_setup
+  - console/tar
+  - console/curl_https
+  - console/kmod
+  - console/cpio
+  - console/unzip
+  - console/nano
+  - console/gpg
+  - console/nginx
+  - console/dig
+  - console/shells
+  - coverage/coverage_report
+test_data:
+  helper_packages:
+    - gzip
+    - iputils
+    - systemd
+    - wget
+  coverage_targets:
+    tar: /usr/bin/tar
+    curl: /usr/bin/curl
+    kmod: /usr/bin/kmod
+    cpio: /usr/bin/cpio
+    unzip: /usr/bin/unzip
+    nano: /usr/bin/nano
+    gpg2: /usr/bin/gpg
+    nginx: /usr/sbin/nginx
+    bind-utils: /usr/bin/dig
+    tcsh: /usr/bin/tcsh
+    zsh: /usr/bin/zsh

--- a/schedule/coverage/medium_no_irqbalance.yaml
+++ b/schedule/coverage/medium_no_irqbalance.yaml
@@ -1,0 +1,89 @@
+name: coverage - medium 35 paths without irqbalance
+description: >
+    Same as medium_validate but without irqbalance.
+    Testing if irqbalance is the trigger for the 25-shim limit.
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_uefi
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - coverage/coverage_setup
+  - console/tar
+  - console/curl_https
+  - console/kmod
+  - console/cpio
+  - console/unzip
+  - console/nano
+  - console/vim
+  - console/sqlite3
+  - console/wget_https
+  - console/gpg
+  - console/openssl_alpn
+  - console/nginx
+  - console/dnsmasq
+  - console/chrony
+  - console/cron
+  - console/quota
+  - console/arping
+  - console/tracepath
+  - console/dig
+  - console/shells
+  - console/procps
+  - console/man_pages
+  - console/shar
+  - console/run0
+  - coverage/coverage_report
+test_data:
+  helper_packages:
+    - gzip
+    - iputils
+    - systemd
+    - wget
+  coverage_targets:
+    tar: /usr/bin/tar
+    curl: /usr/bin/curl
+    kmod: /usr/bin/kmod
+    cpio: /usr/bin/cpio
+    unzip: /usr/bin/unzip
+    nano: /usr/bin/nano
+    vim: /usr/bin/vim-nox11
+    sqlite3: /usr/bin/sqlite3
+    wget: /usr/bin/wget
+    gpg2:
+      - /usr/bin/gpg
+      - /usr/bin/gpgconf
+    openssl-3: /usr/bin/openssl
+    nginx: /usr/sbin/nginx
+    dnsmasq: /usr/sbin/dnsmasq
+    chrony: /usr/bin/chronyc
+    cronie:
+      - /usr/sbin/cron
+      - /usr/bin/crontab
+    quota:
+      - /usr/bin/quota
+      - /usr/sbin/quotacheck
+      - /usr/sbin/quotaon
+    iputils:
+      - /usr/bin/arping
+      - /usr/bin/tracepath
+    bind-utils:
+      - /usr/bin/dig
+      - /usr/bin/host
+    tcsh: /usr/bin/tcsh
+    zsh: /usr/bin/zsh
+    procps:
+      - /usr/bin/free
+      - /usr/bin/top
+      - /usr/bin/ps
+      - /usr/bin/vmstat
+    man: /usr/bin/man
+    sharutils:
+      - /usr/bin/shar
+      - /usr/bin/unshar
+    systemd: /usr/bin/run0

--- a/schedule/coverage/medium_validate.yaml
+++ b/schedule/coverage/medium_validate.yaml
@@ -1,0 +1,91 @@
+name: coverage - medium o3 validation (25 test modules)
+description: >
+    Medium validation to verify coverage across 25 test modules on o3.
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_uefi
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - coverage/coverage_setup
+  # --- 25 test modules ---
+  - console/tar
+  - console/curl_https
+  - console/kmod
+  - console/cpio
+  - console/unzip
+  - console/nano
+  - console/vim
+  - console/sqlite3
+  - console/wget_https
+  - console/gpg
+  - console/openssl_alpn
+  - console/nginx
+  - console/dnsmasq
+  - console/chrony
+  - console/cron
+  - console/quota
+  - console/arping
+  - console/tracepath
+  - console/dig
+  - console/shells
+  - console/procps
+  - console/man_pages
+  - console/irqbalance
+  - console/shar
+  - console/run0
+  - coverage/coverage_report
+test_data:
+  helper_packages:
+    - gzip
+    - iputils
+    - systemd
+    - wget
+  coverage_targets:
+    tar: /usr/bin/tar
+    curl: /usr/bin/curl
+    kmod: /usr/bin/kmod
+    cpio: /usr/bin/cpio
+    unzip: /usr/bin/unzip
+    nano: /usr/bin/nano
+    vim: /usr/bin/vim-nox11
+    sqlite3: /usr/bin/sqlite3
+    wget: /usr/bin/wget
+    gpg2:
+      - /usr/bin/gpg
+      - /usr/bin/gpgconf
+    openssl-3: /usr/bin/openssl
+    nginx: /usr/sbin/nginx
+    dnsmasq: /usr/sbin/dnsmasq
+    chrony: /usr/bin/chronyc
+    cronie:
+      - /usr/sbin/cron
+      - /usr/bin/crontab
+    quota:
+      - /usr/bin/quota
+      - /usr/sbin/quotacheck
+      - /usr/sbin/quotaon
+    iputils:
+      - /usr/bin/arping
+      - /usr/bin/tracepath
+    bind-utils:
+      - /usr/bin/dig
+      - /usr/bin/host
+    tcsh: /usr/bin/tcsh
+    zsh: /usr/bin/zsh
+    procps:
+      - /usr/bin/free
+      - /usr/bin/top
+      - /usr/bin/ps
+      - /usr/bin/vmstat
+    man: /usr/bin/man
+    irqbalance: /usr/sbin/irqbalance
+    sharutils:
+      - /usr/bin/shar
+      - /usr/bin/unshar
+    systemd: /usr/bin/run0

--- a/schedule/coverage/quick_validate.yaml
+++ b/schedule/coverage/quick_validate.yaml
@@ -1,0 +1,30 @@
+name: coverage - quick o3 validation
+description: >
+    Minimal schedule to verify funkoverage shims produce coverage
+    on o3. Compare tar, curl, kmod numbers with local results.
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_uefi
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - coverage/coverage_setup
+  - console/tar
+  - console/curl_https
+  - console/kmod
+  - coverage/coverage_report
+test_data:
+  helper_packages:
+    - gzip
+    - iputils
+    - systemd
+    - wget
+  coverage_targets:
+    tar: /usr/bin/tar
+    curl: /usr/bin/curl
+    kmod: /usr/bin/kmod

--- a/schedule/coverage/tw_confirmed.yaml
+++ b/schedule/coverage/tw_confirmed.yaml
@@ -1,0 +1,336 @@
+name: coverage - confirmed binaries (production schedule)
+description: >
+    Clean list of binaries confirmed compatible with funkoverage eBPF coverage
+    measurement. Every binary here has been validated in a local podman+QEMU job
+    and produces non-zero coverage data. This is the production schedule.
+    Only stock test modules from os-autoinst-distri-opensuse are used.
+    Maintainer: amanzini / balogh
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_uefi
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - coverage/coverage_setup
+  # --- confirmed: original batch ---
+  - network/snmp
+  - console/cpio
+  - console/curl_https
+  - console/gd
+  - console/kmod
+  - console/lshw
+  - console/nano
+  - console/nftables
+  - console/rpm
+  - console/sqlite3
+  - console/tar
+  - console/unzip
+  - console/vim
+  - console/wavpack
+  - console/wget_https
+  - console/zbar
+  # --- confirmed: job 52 additions ---
+  - console/chrony
+  - console/dnsmasq
+  - console/gpg
+  - console/mta
+  - console/quota
+  # --- confirmed: batch 1 ---
+  - console/arping
+  - console/ping          # softfail: cap check; coverage ok
+  - console/tracepath
+  - console/openssl_alpn
+  - console/cron
+  - console/syslog
+  - console/timezone
+  - console/nginx
+  - console/libvorbis
+  - console/libxslt
+  - console/valkey
+  - console/ruby
+  - console/gdb            # softfail: breakpoint timeout under shim
+  - console/journald_fss
+  - console/vhostmd
+  - console/clamav         # softfail: OOM on virus DB; coverage ok
+  - console/pkcon
+  - console/redis          # softfail: OOM; coverage ok
+  - console/shells
+  - console/sudo           # softfail: capabilities check; coverage ok
+  - console/valgrind
+  - console/zziplib
+  # --- confirmed: tier 1 ---
+  - console/dig
+  - console/lsof           # softfail: no sshd on :22; coverage ok
+  - console/perf           # softfail: probe timeout under shim; coverage ok
+  # --- confirmed: tier 2 (job 85) ---
+  - console/procps
+  - console/osinfo_db
+  - console/gcc
+  - console/cryptsetup
+  - console/vsftpd
+  - console/fwupd
+  - security/audit/auditctl
+  - security/audit/auditd
+  - security/audit/autrace
+  # --- confirmed: apparmor (no coverage targets — aa-* are scripts; AppArmor inactive) ---
+  - security/apparmor/aa_status
+  - security/apparmor/aa_enforce
+  - security/apparmor/aa_complain
+  - security/apparmor/aa_disable
+  - security/apparmor/aa_autodep
+  - security/apparmor/aa_notify
+  - security/apparmor/aa_easyprof
+  # --- confirmed: batch 3 (jobs 87+89) — stock modules only ---
+  - console/pciutils
+  - security/lynis/lynis_setup
+  - security/usbguard/usbguard
+  - hpc/cpuid
+  - security/pam/pam_config
+  # --- batch from job 106 ---
+  - console/mariadb_srv
+  - console/udisks2
+  # --- batch from job 107 ---
+  - console/mariadb_odbc
+  # --- batch from job 110 ---
+  - console/systemd_resolved
+  - console/check_default_network_manager
+  - console/libgpiod
+#  - console/libjpeg_turbo  # removed: consistently fails in full run
+#  - console/openvswitch  # removed: consistently fails in full run
+  - console/libaom
+  - console/btrfs_check
+  - console/snapper_create
+  - console/suse_module_tools
+  # --- batch from job 118 ---
+#  - console/apache  # removed: fails in full run
+#  - console/ovn  # removed: fails in full run
+  - console/btrfsmaintenance
+  - console/snapper_cleanup
+  - console/snapper_used_space
+  # --- batch from job 119 ---
+  - console/irqbalance
+  - console/man_pages
+  - console/dns_srv
+  - console/textinfo
+  # --- batch from job 121 ---
+#  - security/libserf/libserf  # removed: fails in full run
+  - security/pam/pam_u2f
+  - console/ca_certificates_mozilla
+  - security/pam/pam_basic_function
+  - security/crypto_policies/crypto_policies_setup
+  - security/selinux/sestatus
+  - security/selinux/selinuxexeccon
+  # --- batch from job 123 ---
+#  - console/fs_stress  # removed: consistently fails in full run
+  - yast2_cmd/yast_lang
+  - yast2_cmd/yast_timezone
+#  - yast2_cmd/yast_storage  # removed: yast2-storage package not found
+  # --- batch from job 124 ---
+  - security/openscap/oscap_setup
+  - security/openscap/oscap_info
+  - security/openscap/oscap_oval_scanning
+  # --- batch from job 139 (deep repo scan August 8, 2026) ---
+  - security/selinux/semodule
+  # --- batch from job 146 (PR verification August 8, 2026) ---
+  - console/shar
+  - console/run0
+  - coverage/coverage_report
+test_data:
+  helper_packages:
+    - gzip
+    - iputils
+    - systemd
+    - wget
+  coverage_targets:
+    # --- original ---
+    bzip2: /usr/bin/bzip2
+    cpio: /usr/bin/cpio
+    curl: /usr/bin/curl
+    gd:
+      - /usr/bin/giftogd2
+      - /usr/bin/gd2togif
+      - /usr/bin/gd2topng             # job 147
+      - /usr/bin/gdcmpgif             # job 147
+      - /usr/bin/pngtogd              # job 147
+      - /usr/bin/gdtopng              # job 147
+      - /usr/bin/webpng               # job 147
+    lshw: /usr/sbin/lshw
+    nano: /usr/bin/nano
+    net-snmp:
+      - /usr/bin/snmpget
+      - /usr/bin/snmpset
+      - /usr/bin/snmpusm
+    nftables: /usr/sbin/nft
+    tar: /usr/bin/tar
+    traceroute: /usr/sbin/traceroute
+    unzip: /usr/bin/unzip
+    vim: /usr/bin/vim-nox11
+    wavpack:
+      - /usr/bin/wavpack
+      - /usr/bin/wvunpack
+      - /usr/bin/wvgain               # job 147
+    kmod: /usr/bin/kmod
+    rpm: /usr/bin/rpm
+    sqlite3: /usr/bin/sqlite3
+    wget: /usr/bin/wget
+    zbar: /usr/bin/zbarimg
+    # --- job 52 additions ---
+    chrony: /usr/bin/chronyc
+    dnsmasq: /usr/sbin/dnsmasq
+    gpg2:
+      - /usr/bin/gpg
+      - /usr/bin/gpgconf              # job 147
+    postfix: /usr/sbin/postfix
+    quota:
+      - /usr/bin/quota
+      - /usr/sbin/quotacheck
+      - /usr/sbin/quotaon             # job 147
+    # --- batch 1 ---
+    iputils:
+      - /usr/bin/arping
+      - /usr/bin/ping
+      - /usr/bin/tracepath
+    openssl-3: /usr/bin/openssl
+    cronie:
+      - /usr/sbin/cron
+      - /usr/bin/crontab
+    util-linux-systemd: /usr/bin/logger
+    timezone:
+      - /usr/sbin/zdump
+      - /usr/sbin/zic                 # job 147
+    nginx: /usr/sbin/nginx
+    vorbis-tools:
+      - /usr/bin/ogg123
+      - /usr/bin/ogginfo
+    libxslt-tools: /usr/bin/xsltproc
+    valkey:
+      - /usr/bin/valkey-server
+      - /usr/bin/valkey-cli           # job 147
+    gdb: /usr/bin/gdb
+    clamav:
+      - /usr/bin/clamscan
+      - /usr/bin/clamdscan
+      - /usr/sbin/clamd
+    vhostmd: /usr/sbin/vhostmd
+    # --- batch 2 ---
+    sudo: /usr/bin/sudo
+    tcsh: /usr/bin/tcsh
+    zsh: /usr/bin/zsh
+    redis:
+      - /usr/sbin/redis-server
+      - /usr/bin/redis-cli            # job 147
+    valgrind: /usr/bin/valgrind
+    PackageKit:
+      - /usr/bin/pkcon
+      - /usr/libexec/packagekitd
+    # --- tier 1 ---
+    bind-utils:
+      - /usr/bin/dig
+      - /usr/bin/host                 # job 147
+    lsof: /usr/bin/lsof
+    perf: /usr/bin/perf
+    netcat-openbsd: /usr/bin/netcat
+    psmisc: /usr/bin/killall
+    zziplib-devel:
+      - /usr/bin/unzzip
+      - /usr/bin/unzip-mem
+    # --- tier 2: confirmed job 85 ---
+    procps:
+      - /usr/bin/free
+      - /usr/bin/pgrep
+      - /usr/bin/pmap
+      - /usr/bin/pwdx
+      - /usr/bin/top
+      - /usr/bin/ps
+      - /usr/bin/w
+      - /usr/bin/pidof
+      - /usr/bin/vmstat
+      - /sbin/sysctl
+    gcc16: /usr/bin/gcc
+    cryptsetup: /usr/sbin/cryptsetup
+    vsftpd: /usr/sbin/vsftpd
+    lftp: /usr/bin/lftp
+    fwupd: /usr/bin/fwupdmgr
+    audit:
+      - /usr/sbin/auditd
+      - /usr/sbin/aureport
+      - /usr/sbin/ausearch
+    # --- batch 3: confirmed jobs 87+89 ---
+    pciutils: /usr/sbin/lspci
+    cpupower: /usr/bin/cpupower
+    powertop: /usr/sbin/powertop
+    util-linux:
+      - /usr/bin/lscpu
+      - /usr/bin/uuidgen
+      - /usr/bin/dmesg
+      - /usr/sbin/sfdisk
+      - /usr/sbin/blkid
+      - /usr/bin/lsmem
+      - /usr/bin/chrt
+    glibc: /usr/bin/getent
+    gawk: /usr/bin/gawk
+    xmlstarlet: /usr/bin/xmlstarlet
+    dmidecode: /usr/sbin/dmidecode
+    cpuid: /usr/bin/cpuid
+    pam-config: /usr/sbin/pam-config
+    # --- job 106 additions ---
+    mariadb-client:
+      - /usr/bin/mariadb              # 12.4%
+      - /usr/bin/mariadb-admin        # job 147
+    udisks2: /usr/bin/udisksctl          # 43.8%
+    systemd-container: /usr/bin/systemd-nspawn  # 19.9%
+    # --- job 107 additions ---
+    unixODBC:
+      - /usr/bin/isql              # 38.5%
+      - /usr/bin/odbcinst          # 66.7%
+    socat: /usr/bin/socat          # shows as socat1 in report, 16.5%
+    # --- job 110 additions ---
+    # resolvectl, networkctl already in systemd package
+    libgpiod-utils:
+      - /usr/bin/gpiodetect
+      - /usr/bin/gpioinfo
+      - /usr/bin/gpioset
+      - /usr/bin/gpioget
+    libjpeg-turbo: /usr/bin/jpegtran
+    ImageMagick: /usr/bin/identify
+    openvswitch:
+      - /usr/bin/ovs-vsctl
+      - /usr/bin/ovs-ofctl
+    mokutil:
+      - /usr/bin/modhash
+      - /usr/bin/modsign-verify
+    # systemd-cat already in systemd package; 100% coverage
+
+    # --- job 118 additions ---
+    ovn:
+      - /usr/bin/ovn-nbctl            # 8.9%
+      - /usr/bin/ovn-sbctl            # 29.2%
+    # --- job 119 additions ---
+    irqbalance: /usr/sbin/irqbalance  # 73.9%
+    man: /usr/bin/man                  # 60.9%
+    aide: /usr/bin/aide                # 14.5% (test softfails, coverage ok)
+    openslp-server: /usr/sbin/slpd     # 32.9% (test softfails, coverage ok)
+    openslp: /usr/bin/slptool          # 25.0%
+    # --- job 124 additions ---
+    openscap-utils: /usr/bin/oscap     # 18.75%
+    # --- job 139 additions (deep repo scan August 8, 2026) ---
+    snapper: /usr/bin/snapper          # 275 funcs; exercised by snapper_create/cleanup/used_space
+    dirmngr:
+      - /usr/bin/dirmngr              # 455 funcs; exercised indirectly by gpg
+      - /usr/bin/dirmngr-client       # 105 funcs
+    policycoreutils:
+      - /usr/sbin/setfiles            # 47 funcs; restorecon is symlink to this
+      - /usr/sbin/semodule            # 63 funcs; exercised by security/selinux/semodule
+      - /usr/sbin/setsebool           # 41 funcs; exercised by SELinux setup
+      - /usr/bin/sestatus             # 47 funcs; exercised by security/selinux/sestatus
+    # run0 is a symlink to systemd-run; this gets systemd-debuginfo installed
+    systemd: /usr/bin/run0             # 193 funcs; shimmed as run0 -> systemd-run
+    # --- job 146 additions (PR verification August 8, 2026) ---
+    sharutils:
+      - /usr/bin/shar                  # verified in job #146
+      - /usr/bin/unshar

--- a/schedule/coverage/tw_confirmed.yaml
+++ b/schedule/coverage/tw_confirmed.yaml
@@ -59,7 +59,6 @@ schedule:
   - console/pkcon
   - console/redis          # softfail: OOM; coverage ok
   - console/shells
-  - console/sudo           # softfail: capabilities check; coverage ok
   - console/valgrind
   - console/zziplib
   # --- confirmed: tier 1 ---
@@ -139,8 +138,12 @@ schedule:
   - console/shar
   - console/run0
   - coverage/coverage_report
-  # --- after report: modules that may crash the console on o3 ---
-  - console/gdb            # post_fail_hook breaks console on o3; coverage data already collected
+  # --- after report: modules whose post_fail_hook crashes the console on o3 ---
+  # These use VNC console switching or interactive terminal sessions.
+  # Their coverage data is NOT in the report (shim data written after report).
+  # See: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26330
+  - console/gdb
+  - console/sudo
 test_data:
   helper_packages:
     - gzip

--- a/schedule/coverage/tw_confirmed.yaml
+++ b/schedule/coverage/tw_confirmed.yaml
@@ -53,7 +53,6 @@ schedule:
   - console/libxslt
   - console/valkey
   - console/ruby
-  - console/gdb            # softfail: breakpoint timeout under shim
   - console/journald_fss
   - console/vhostmd
   - console/clamav         # softfail: OOM on virus DB; coverage ok
@@ -140,6 +139,8 @@ schedule:
   - console/shar
   - console/run0
   - coverage/coverage_report
+  # --- after report: modules that may crash the console on o3 ---
+  - console/gdb            # post_fail_hook breaks console on o3; coverage data already collected
 test_data:
   helper_packages:
     - gzip

--- a/schedule/coverage/tw_confirmed.yaml
+++ b/schedule/coverage/tw_confirmed.yaml
@@ -53,12 +53,14 @@ schedule:
   - console/libxslt
   - console/valkey
   - console/ruby
+  - console/gdb            # softfail: breakpoint timeout under shim
   - console/journald_fss
   - console/vhostmd
   - console/clamav         # softfail: OOM on virus DB; coverage ok
   - console/pkcon
   - console/redis          # softfail: OOM; coverage ok
   - console/shells
+  - console/sudo           # softfail: capabilities check; coverage ok
   - console/valgrind
   - console/zziplib
   # --- confirmed: tier 1 ---
@@ -138,12 +140,6 @@ schedule:
   - console/shar
   - console/run0
   - coverage/coverage_report
-  # --- after report: modules whose post_fail_hook crashes the console on o3 ---
-  # These use VNC console switching or interactive terminal sessions.
-  # Their coverage data is NOT in the report (shim data written after report).
-  # See: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26330
-  - console/gdb
-  - console/sudo
 test_data:
   helper_packages:
     - gzip

--- a/tests/console/gdb.pm
+++ b/tests/console/gdb.pm
@@ -106,4 +106,15 @@ sub run {
     assert_script_run("pkill -9 test3");
 }
 
+sub post_fail_hook {
+    my ($self) = @_;
+    # gdb may still be running interactively on the serial terminal.
+    # Exit it before the base class tries to switch consoles.
+    type_string("quit\n");
+    type_string("y\n");
+    sleep 1;
+    script_run('pkill -9 gdb', timeout => 5);
+    $self->SUPER::post_fail_hook;
+}
+
 1;

--- a/tests/console/run0.pm
+++ b/tests/console/run0.pm
@@ -8,7 +8,7 @@
 use Mojo::Base 'consoletest';
 use testapi;
 use serial_terminal qw(select_serial_terminal);
-use utils qw(systemctl zypper_call);
+use utils qw(systemctl zypper_call write_sut_file);
 
 sub run {
     select_serial_terminal;
@@ -47,14 +47,13 @@ sub run {
     # Privilege escalation
     zypper_call 'in sudo expect';
     my $polkit_config_path = '/etc/polkit-1/rules.d/90-run0-auth.rules';
-    my $polkit_config = <<'EOF';
-polkit.addRule(function(action, subject) {
+    my $polkit_config = 'polkit.addRule(function(action, subject) {
     if (action.id == "org.freedesktop.systemd1.manage-units") {
         return polkit.Result.AUTH_ADMIN_KEEP;
     }
 });
-EOF
-    assert_script_run("echo '$polkit_config' > $polkit_config_path");
+';
+    write_sut_file($polkit_config_path, $polkit_config);
     systemctl('restart polkit');
     select_console('user-console');
     validate_script_output(qq{expect -c 'spawn "run0 echo I_Am_Groot"; expect "Password:" {send "$testapi::password\\r"}; interact'}, sub { $_ =~ m/I_Am_Groot/ }, proceed_on_failure => 1);

--- a/tests/console/shar.pm
+++ b/tests/console/shar.pm
@@ -25,7 +25,8 @@ sub run {
     }
 
     select_console 'user-console';
-    assert_script_run('sh ~/data/shar_testdata.sh');
+    assert_script_run('curl -o /tmp/shar_testdata.sh ' . data_url('shar_testdata.sh'));
+    assert_script_run('sh /tmp/shar_testdata.sh');
     assert_script_run('file shar_testdata/suse.png | grep "600 x 550"');
     assert_script_run('head -1 shar_testdata/hallo.txt | grep "Hallo Welt"');
     assert_script_run('shar shar_testdata > a.sh');

--- a/tests/console/tcpdump.pm
+++ b/tests/console/tcpdump.pm
@@ -21,11 +21,16 @@ sub run {
     select_serial_terminal;
 
     install_package("tcpdump", trup_reboot => 1);
-    # Start tcpdump to sniff only icmp loclhost packets in background and do ping
-    script_run("tcpdump -i lo icmp and src localhost -vv > $tcpdump_log_file 2>&1 & echo \$! > $pid_file & sleep 4");
-    assert_script_run("ping -c4 localhost -4 & sleep 4");
+    # Start tcpdump in the background sniffing ICMP on loopback
+    script_run("tcpdump -i lo icmp -vv > $tcpdump_log_file 2>&1 & echo \$! > $pid_file");
+    # Wait until tcpdump is ready before sending traffic
+    script_retry("grep -q 'listening on' $tcpdump_log_file", delay => 1, retry => 10);
+    sleep 2;
+    assert_script_run("ping -c10 -i0.2 localhost -4");
 
     assert_script_run("kill \$(cat $pid_file)");
+    # Wait for tcpdump to exit and flush its summary
+    script_retry("! kill -0 \$(cat $pid_file) 2>/dev/null", delay => 1, retry => 5);
     record_info("TEST LOG", script_output("cat $tcpdump_log_file"));
     validate_script_output("cat $tcpdump_log_file", sub { m/0 packets dropped by kernel/ });
 }

--- a/tests/coverage/coverage_report.pm
+++ b/tests/coverage/coverage_report.pm
@@ -11,13 +11,18 @@ use serial_terminal 'select_serial_terminal';
 sub run {
     select_serial_terminal;
     assert_script_run 'mkdir -p /var/coverage/report';
-    assert_script_run 'funkoverage report /var/coverage/data /var/coverage/report';
-    # Upload the coverage report files
-    my @files = split("\n", script_output 'ls -1 /var/coverage/report/*');
-    # parse the XML reports
-    parse_extra_log('XUnit', $_) for grep { /\.xml/ } @files;
-    # upload the files except the XML reports
-    upload_logs($_) for grep { $_ !~ /\.xml/ } @files;
+    # Redirect funkoverage output to a log file to prevent serial console flooding.
+    # With 50+ targets the report progress output fills the terminal buffer and
+    # leaves the serial console in a degraded state for subsequent commands.
+    assert_script_run 'funkoverage report /var/coverage/data /var/coverage/report >/tmp/fv_report.log 2>&1', timeout => 600;
+    # Now the serial console is clean; ls redirect works reliably.
+    assert_script_run 'ls /var/coverage/report/ > /tmp/rpt_files.txt', timeout => 120;
+    my @files = split /\n/, script_output('cat /tmp/rpt_files.txt', timeout => 120);
+    my @xmlfiles  = map { "/var/coverage/report/$_" } grep { /\.xml$/  } @files;
+    my @htmlfiles = map { "/var/coverage/report/$_" }
+                    grep { /\.html$/ && !/^lib/i } @files;  # skip lib*.html (220+ shared lib reports)
+    parse_extra_log('XUnit', $_) for @xmlfiles;
+    upload_logs($_)              for @htmlfiles;
 }
 
 1;

--- a/tests/coverage/coverage_report.pm
+++ b/tests/coverage/coverage_report.pm
@@ -23,6 +23,8 @@ sub run {
                     grep { /\.html$/ && !/^lib/i } @files;  # skip lib*.html (220+ shared lib reports)
     parse_extra_log('XUnit', $_) for @xmlfiles;
     upload_logs($_)              for @htmlfiles;
+    # Print XML coverage summaries to serial console for ease of diagnostics (poo#205467)
+    assert_script_run 'grep -h "<testsuite" /var/coverage/report/*.xml || true';
 }
 
 1;

--- a/tests/coverage/coverage_setup.pm
+++ b/tests/coverage/coverage_setup.pm
@@ -75,6 +75,9 @@ sub run {
     my $log_dir = '/var/coverage/data';
     assert_script_run "mkdir -m 0777 -p $log_dir";
 
+    # Dump kernel eBPF/uprobe limits for diagnostics
+    script_run 'echo "=== eBPF diagnostics ===" && cat /proc/sys/kernel/perf_event_paranoid && echo "perf_event_paranoid" && ulimit -l && echo "memlock limit (kB)" && cat /proc/sys/kernel/perf_event_max_sample_rate 2>/dev/null && echo "max_sample_rate" && ls /sys/kernel/debug/tracing/uprobe_events 2>/dev/null && echo "uprobe_events accessible" || echo "uprobe_events NOT accessible"';
+
     assert_script_run 'funkoverage setup';
 
     # funkoverage install soft-fails per binary and exits non-zero if any fail.

--- a/tests/coverage/coverage_setup.pm
+++ b/tests/coverage/coverage_setup.pm
@@ -78,6 +78,14 @@ sub run {
     # Dump kernel eBPF/uprobe limits for diagnostics
     script_run 'echo "=== eBPF diagnostics ===" && cat /proc/sys/kernel/perf_event_paranoid && echo "perf_event_paranoid" && ulimit -l && echo "memlock limit (kB)" && cat /proc/sys/kernel/perf_event_max_sample_rate 2>/dev/null && echo "max_sample_rate" && ls /sys/kernel/debug/tracing/uprobe_events 2>/dev/null && echo "uprobe_events accessible" || echo "uprobe_events NOT accessible"';
 
+    # Raise memlock limits to unlimited to prevent uprobe resource exhaustion (poo#205467)
+    assert_script_run 'ulimit -l unlimited';
+    assert_script_run 'mkdir -p /etc/systemd/system.conf.d /etc/security/limits.d';
+    assert_script_run 'printf "[Manager]\nDefaultLimitMEMLOCK=infinity\n" > /etc/systemd/system.conf.d/memlock.conf';
+    assert_script_run 'systemctl daemon-reexec';
+    assert_script_run 'printf "* - memlock unlimited\n" > /etc/security/limits.d/99-memlock.conf';
+    assert_script_run 'ulimit -l';
+
     assert_script_run 'funkoverage setup';
 
     # funkoverage install soft-fails per binary and exits non-zero if any fail.

--- a/tests/coverage/coverage_setup.pm
+++ b/tests/coverage/coverage_setup.pm
@@ -74,7 +74,7 @@ sub run {
 
     my $log_dir = '/var/coverage/data';
     assert_script_run "mkdir -m 0777 -p $log_dir";
-    assert_script_run 'find /lib* /usr/lib* -type f -executable -exec chmod +x {} +';
+
     assert_script_run 'funkoverage setup';
 
     # funkoverage install soft-fails per binary and exits non-zero if any fail.

--- a/tests/coverage/coverage_setup.pm
+++ b/tests/coverage/coverage_setup.pm
@@ -4,14 +4,6 @@
 # Summary: setup coverage tooling
 # Maintainer: Andrea Manzini <andrea.manzini@suse.com>
 
-# test data section in the YAML schedule must contain an hash
-# of packages to install -> binary to instrument. For example
-#
-# test_data:
-#   coverage_targets:
-#     unzip: /usr/bin/unzip
-#     nano: /usr/bin/nano
-
 use Mojo::Base 'opensusebasetest';
 use testapi;
 use utils;
@@ -22,60 +14,79 @@ use repo_tools 'add_qa_head_repo';
 
 sub run {
     select_serial_terminal;
-    # enable debug repos
-    # on Tumbleweed does not have debuginfo in to-be-tested snapshots, except for selected package
-
-    # TODO maybe not the best way, but it works
     my $test_data = get_test_suite_data();
-
-    my %repositories;    # an hash of repositories to add
+    my %repositories;
 
     if (is_sle '>=15-SP4') {
         add_qa_head_repo;
-        # enable debug repos
         assert_script_run q(zypper mr -e $(zypper lr | awk '/Debug/ {print $1}'));
         my $version = get_required_var('VERSION');
         my $baseurl = 'http://download.suse.de/ibs/SUSE/Products';
         my $debug_suffix = 'x86_64/product_debug/';
         %repositories = (
             basesystem_debug => "$baseurl/SLE-Module-Basesystem/$version/$debug_suffix",
-            serverapp_debug => "$baseurl/SLE-Module-Server-Applications/$version/$debug_suffix",
-            legacy_debug => "$baseurl/SLE-Module-Legacy/$version/$debug_suffix",
-            scripting_debug => "$baseurl/SLE-Module-Web-Scripting/$version/$debug_suffix",
+            serverapp_debug  => "$baseurl/SLE-Module-Server-Applications/$version/$debug_suffix",
+            legacy_debug     => "$baseurl/SLE-Module-Legacy/$version/$debug_suffix",
+            scripting_debug  => "$baseurl/SLE-Module-Web-Scripting/$version/$debug_suffix",
         );
     } else {
-        # set SELinux to permissive, as it is not supported by coverage tools
         assert_script_run 'setenforce 0' if has_selinux;
         %repositories = (
             devtools => 'http://download.opensuse.org/repositories/devel:/tools/openSUSE_Tumbleweed',
-            main => 'http://download.opensuse.org/tumbleweed/repo/oss/',
-            update => 'http://download.opensuse.org/update/tumbleweed/',
-            debug => 'http://download.opensuse.org/debug/tumbleweed/repo/oss/');
+            main     => 'http://download.opensuse.org/tumbleweed/repo/oss/',
+            # update repo skipped - causes zypper ref failures when snapshot changes
+            debug    => 'http://download.opensuse.org/debug/tumbleweed/repo/oss/');
     }
     while (my ($name, $url) = each(%repositories)) {
         assert_script_run "zypper ar -e -f $url $name";
+        # Append type=rpm-md to prevent zypper probing for media.1/media
+        # (absent on HTTP repos; CDN returns 404 causing fatal zypper error)
+        assert_script_run "echo type=rpm-md >> /etc/zypp/repos.d/$name.repo";
     }
 
-    # install coverage tools and any extra packages + debug info
-    my @packages;
-    for (@{$test_data->{extra_packages}}) {
+    # Force refresh all repos to pick up latest metadata
+    # (needed when TW publishes a new snapshot while we use an older ISO)
+    # Retry zypper ref up to 3 times - SLIRP DNS may not be ready immediately
+    for my $attempt (1..3) {
+        last if script_run(q{zypper --gpg-auto-import-keys ref --force 2>&1 | tail -5}, timeout => 300) == 0;
+        record_info("zypper ref retry", "Attempt $attempt failed, retrying in 30s");
+        sleep 30;
+    }
+
+    my (@packages, @binaries);
+    while (my ($pkg, $targets) = each(%{$test_data->{coverage_targets}})) {
+        push @packages, $pkg, $pkg . '-debuginfo';
+        my @pkg_bins = ref($targets) eq 'ARRAY' ? @$targets : ($targets);
+        push @binaries, @pkg_bins;
+    }
+    for (@{$test_data->{helper_packages} // []}) {
         push @packages, $_;
-        push @packages, $_ . '-debuginfo';
     }
-    push @packages, 'coverage-tools';
-    zypper_call '--gpg-auto-import-keys in ' . join ' ', @packages;
+    push @packages, 'coverage-tools', 'elfutils';
 
-    assert_script_run 'mkdir -m 0777 -p /var/coverage/data';
+    # Split packages into batches of 20 to avoid serial console input buffer overflow
+    # on very large coverage target lists (100+ packages = 3000+ char command line)
+    my @pkg_chunks;
+    while (@packages) { push @pkg_chunks, [splice(@packages, 0, 20)] }
+    for my $chunk (@pkg_chunks) {
+        zypper_call q{--gpg-auto-import-keys in } . join(q{ }, @{$chunk});
+    }
 
-    # set up eBPF capabilities required by funkoverage
+    my $log_dir = '/var/coverage/data';
+    assert_script_run "mkdir -m 0777 -p $log_dir";
+    assert_script_run 'find /lib* /usr/lib* -type f -executable -exec chmod +x {} +';
     assert_script_run 'funkoverage setup';
 
-    # install shims around the binaries to be instrumented for coverage
-    assert_script_run "funkoverage install " . join ' ', @{$test_data->{coverage_targets}};
+    # funkoverage install soft-fails per binary and exits non-zero if any fail.
+    # Split binaries into batches of 15 to avoid serial console input buffer overflow.
+    assert_script_run 'true > /tmp/fv_install.log';
+    my @bin_chunks;
+    while (@binaries) { push @bin_chunks, [splice(@binaries, 0, 15)] }
+    for my $bchunk (@bin_chunks) {
+        script_run(q{funkoverage install } . join(q{ }, @{$bchunk}) . q{ 2>&1 >> /tmp/fv_install.log}, timeout => 300);
+    }
+    assert_script_run 'cat /tmp/fv_install.log';
 }
 
-sub test_flags {
-    return {fatal => 1, milestone => 1};
-}
-
+sub test_flags { return {fatal => 1, milestone => 1} }
 1;


### PR DESCRIPTION
Motivation:
Funkoverage drops to near-zero coverage when more than 24 binaries are shimmed
on openQA workers due to default 8 MB guest RLIMIT_MEMLOCK limit exhaustion.

Design Choices:
Raise guest memlock limits to unlimited for the shell, system-wide systemd
services, and user sessions. Print XML testsuite summaries to the console for
easy, direct visibility in the main test log.

Benefits:
Allows shimming of unlimited target binaries without silent coverage loss and
makes any future coverage failures loud and easily diagnosable.

Related issue: https://progress.opensuse.org/issues/205467