### PR TITLE
irqbalance: skip gracefully on single-cpu systems instead of dying

### DIFF
--- a/tests/console/irqbalance.pm
+++ b/tests/console/irqbalance.pm
@@ -15,9 +15,12 @@ use utils qw(systemctl zypper_call clear_console);
 sub run {
     select_serial_terminal;
 
-    # Return when balancing is ineffective on system with a single cpu
+    # Skip when balancing is ineffective on system with a single cpu
     my $nproc = script_output('cat /proc/cpuinfo | grep processor | wc -l');
-    die("Balancing is ineffective on systems with a single cpu (nproc=$nproc)") unless ($nproc > 1);
+    unless ($nproc > 1) {
+        record_info('SKIP', "Balancing is ineffective on systems with a single cpu (nproc=$nproc)");
+        return;
+    }
 
     zypper_call("in irqbalance");
     systemctl('enable --now irqbalance.service');


### PR DESCRIPTION
On single-cpu systems irqbalance cannot balance anything. The current `die()` triggers post_fail_hook and on setups with snapshots causes a rollback. Use `record_info` + `return` instead so the module passes cleanly and does not disrupt the rest of the schedule.

- Verification run (1-cpu worker, should skip cleanly): https://openqa.opensuse.org/tests/6154327