### PR TITLE
fix(pubcloud): fix the supportconfig existence check

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -673,11 +673,11 @@ sub upload_supportconfig_log {
     # To remove exclusions, _EXCLUDE='-'
     $exclude = undef if ($exclude eq '-');
     $exclude = "-x " . $exclude if ($exclude);
-    my $res = $self->ssh_script_run("sudo which supportconfig", apply_graceful_timeout => 1);
+    my $res = $self->ssh_script_run("sudo -s command -v supportconfig", apply_graceful_timeout => 1);
     unless (isok($res)) {
         record_info('Fail supportconfig',
             ($res == 255) ? "ssh connectivity issues during remote supportconfig check"
-            : "supportconfig command not found",
+            : "supportconfig command not found. Exit: $res",
             result => 'fail');
         return;
     }


### PR DESCRIPTION
- check `supportconfig` existence with `command` being `which` missing in some cases
- print exit code too 

Sometime the publiccloud instance doesn't have the `which` command, to pre-check `supportconfig` existence as `root`, like this [case](https://openqa.suse.de/tests/23842458/#step/destroy/22): check changed to use `command`, POSIX standard.

