### PR TITLE
fix(publiccloud): gate prepare_instance on passwordless sudo

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -533,6 +533,32 @@ sub wait_for_ssh_login {
     $self->ssh_script_retry("true", ssh_opts => $ssh_opts, retry => $retry, delay => $delay, fail_message => "ssh connection failed ($retry attempts in $timeout seconds)");
 }
 
+=head2 wait_for_sudo
+
+    wait_for_sudo([timeout => 180] [, delay => 10]);
+
+Wait until the ssh user can run C<sudo> without a password, polling
+C<sudo -n true> every C<delay> seconds for at most C<timeout> seconds,
+and die if it never succeeds.
+
+Meant to be used right after C<wait_for_ssh>: sshd can already be reachable
+while first-boot provisioning is still granting the user its sudo rights.
+
+=cut
+
+sub wait_for_sudo {
+    my ($self, %args) = @_;
+    my $timeout = $args{timeout} // 180;
+    my $delay = $args{delay} // 10;
+    my $retry = $timeout / $delay;
+
+    ## ControlPath=none is required: the public cloud ssh config keeps a persistent ControlMaster and
+    ## group membership is resolved at login, so a master opened before the sudoers group was added
+    ## would never see it
+    my $ssh_opts = $self->ssh_opts() . ' -o ControlPath=none';
+    $self->ssh_script_retry('sudo -n true', ssh_opts => $ssh_opts, retry => $retry, delay => $delay, fail_message => "sudo still requires a password after $timeout seconds");
+}
+
 =head2 isok
 
     isok($exit_code);

--- a/t/44_publiccloud_instance.t
+++ b/t/44_publiccloud_instance.t
@@ -313,6 +313,19 @@ subtest '[wait_for_ssh_login] timeout/delay/retry argument propagation' => sub {
     set_var('PUBLIC_CLOUD_SSH_TIMEOUT', undef);
 };
 
+subtest '[wait_for_sudo] probes sudo over a non-multiplexed connection' => sub {
+    my $instmod = Test::MockModule->new('publiccloud::instance', no_auto => 1);
+    my ($cmd, %args);
+    $instmod->redefine(ssh_script_retry => sub { (my $self, $cmd, %args) = @_; return 0; });
+    my $inst = publiccloud::instance->new(public_ip => '10.0.0.1', username => 'u', provider => Test::MockObject->new);
+
+    $inst->wait_for_sudo();
+    is($cmd, 'sudo -n true', 'probes passwordless sudo non-interactively');
+    # group membership is resolved at login, so a ControlMaster opened before
+    # the sudoers group was added would never see it
+    like($args{ssh_opts}, qr/ControlPath=none/, 'does not reuse an existing ssh master connection');
+};
+
 $autotest::current_test = {name => 'wait_for_guestregister_test'};
 
 subtest '[wait_for_guestregister] failed records a soft failure (bsc#1264275)' => sub {

--- a/tests/publiccloud/prepare_instance.pm
+++ b/tests/publiccloud/prepare_instance.pm
@@ -43,6 +43,9 @@ sub run {
     my $instance = $args->{my_instance};
     $instance->wait_for_ssh(scan_ssh_host_key => 1);
 
+    # sshd can be reachable before first-boot provisioning granted the user sudo
+    $instance->wait_for_sudo();
+
     $provider->initialize_logging($instance);
     # Add additional authorized_keys for human users
     add_additional_authorized_keys($instance);


### PR DESCRIPTION
sshd on a public cloud instance can become reachable before first-boot
provisioning has granted the ssh user passwordless sudo. On GCE (no
cloud-init) google-guest-agent creates the user, its google-sudoers group
and the `/etc/sudoers.d` entry asynchronously from sshd starting, so the
first sudo in prepare_instance (in TUNNELED runs: `prepare_ssh_tunnel`'s
`useradd`) can transiently fail with `sudo: a password is required`.

Add `publiccloud::instance::wait_for_sudo()`, polling `sudo -n true` for up
to 180s, called from prepare_instance right after `wait_for_ssh`. The probe
uses `-o ControlPath=none`: the public cloud ssh config keeps a persistent
ControlMaster and group membership is resolved at login, so a master
opened before the sudoers group was added would never see it.

- Related ticket: https://progress.opensuse.org/issues/205479
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/23853497#step/prepare_instance/72