### PR TITLE
php_postgresql: Reinstall serial marker hook

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -285,6 +285,10 @@ sub test_pgsql {
     assert_script_run 'sudo chsh postgres -s /bin/bash';
     enter_cmd "su - postgres", wait_still_screen => 1;
     enter_cmd "PS1='# '", wait_still_screen => 1;
+    # The login shell of $user does not have the openQA prompt hook for
+    # PRETTY_SERIAL_MARKER in its ~/.bashrc yet, so force a re-install on the
+    # next command, same as become_root does. poo#205122
+    $testapi::distri->invalidate_serial_marker_hook();
     # upgrade db from oldest version to latest version
     if (script_run('test $(sudo update-alternatives --list postgresql|wc -l) -gt 1') == 0) {
         assert_script_run 'for v in $(sudo update-alternatives --list postgresql); do rpm -q ${v##*/};done';


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/183761 https://progress.opensuse.org/issues/205107
- Verification run: https://openqa.suse.de/tests/23853161#step/php_postgresql/50
