### PR TITLE
Add bootloader_zkvm for usb_virt_test on s390x

### DIFF
--- a/schedule/kernel/usb_virt.yaml
+++ b/schedule/kernel/usb_virt.yaml
@@ -11,6 +11,13 @@ vars:
     QEMU_DISABLE_SNAPSHOTS: '1'
     QEMU_APPEND: "device qemu-xhci,id=usb-bus0 -netdev user,id=unstack -device usb-net,netdev=unstack,bus=usb-bus0.0,id=nic0"
 schedule:
+- '{{boot}}'
 - boot/boot_to_desktop
 - kernel/usb_drive
 - kernel/usb_nic
+
+conditional_schedule:
+    boot:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm


### PR DESCRIPTION
s390x runs need installation/bootloader_zkvm before boot_to_desktop, matching the pattern already used in kdump.yaml and io_uring.yaml.

- Related ticket: N/A
- Verification run: s390: https://openqa.suse.de/tests/23853827

