### PR TITLE
openssl_nodejs: Exclude PQC tests

### DIFF
--- a/data/console/test_openssl_nodejs.sh
+++ b/data/console/test_openssl_nodejs.sh
@@ -70,7 +70,7 @@ test_node_version(){
       ACTUAL_DIR=$(cd /usr/src/packages/SOURCES/ && find . -maxdepth 1 -type d -name "nodejs*" -print -quit)
       if [ "$OS_VERSION" = "SLE_16.0" ]; then
         pushd "$ACTUAL_DIR/$SOURCE_DIR"
-      else 
+      else
         pushd "$SOURCE_DIR"
       fi
       quilt push -a
@@ -86,7 +86,7 @@ test_node_version(){
 
   # Cleanup sources
   rm -rf /usr/src/packages/SOURCES/*
-  rm -rf /usr/src/packages/SPECS/* 
+  rm -rf /usr/src/packages/SPECS/*
 }
 
 main(){
@@ -115,7 +115,7 @@ main(){
   for v in $NODE_VERSIONS; do
     echo "Found node version: $v"
   done
-  echo "Will test only latest version: $NODE_LATEST_VERSION" 
+  echo "Will test only latest version: $NODE_LATEST_VERSION"
 
   # Install latest nodejs version and sources
   zypper -n in --no-recommends "nodejs$NODE_LATEST_VERSION"
@@ -176,6 +176,19 @@ skip_test=(
   ["10.22.1-1.27.1 test/parallel/test-crypto-dh.js SLE_15_SP1"]="skip"
   ["10.24.1-1.36.1 test/parallel/test-tls-passphrase.js SLE_15"]="skip"
   ["10.24.1-1.36.1 test/parallel/test-tls-passphrase.js SLE_15_SP1"]="skip"
+  # https://bugzilla.suse.com/show_bug.cgi?id=1272321
+  ["24.18.1-150700.15.16.1 test/parallel/test-crypto-encap-decap.js SLE_15_SP7"]="skip"
+  ["24.18.1-150700.15.16.1 test/parallel/test-crypto-key-objects-raw.js SLE_15_SP7"]="skip"
+  ["24.18.1-150700.15.16.1 test/parallel/test-crypto-key-objects-to-crypto-key.js SLE_15_SP7"]="skip"
+  ["24.18.1-150700.15.16.1 test/parallel/test-crypto-keygen-raw.js SLE_15_SP7"]="skip"
+  ["24.18.1-150700.15.16.1 test/parallel/test-crypto-pqc-encrypted-pkcs8.js SLE_15_SP7"]="skip"
+  ["24.18.1-150700.15.16.1 test/parallel/test-crypto-pqc-key-objects-ml-dsa.js SLE_15_SP7"]="skip"
+  ["24.18.1-150700.15.16.1 test/parallel/test-crypto-pqc-key-objects-ml-kem.js SLE_15_SP7"]="skip"
+  ["24.18.1-150700.15.16.1 test/parallel/test-crypto-pqc-key-objects-slh-dsa.js SLE_15_SP7"]="skip"
+  ["24.18.1-150700.15.16.1 test/parallel/test-crypto-pqc-keygen-ml-dsa.js SLE_15_SP7"]="skip"
+  ["24.18.1-150700.15.16.1 test/parallel/test-crypto-pqc-keygen-ml-kem.js SLE_15_SP7"]="skip"
+  ["24.18.1-150700.15.16.1 test/parallel/test-crypto-pqc-keygen-slh-dsa.js SLE_15_SP7"]="skip"
+  ["24.18.1-150700.15.16.1 test/parallel/test-crypto-pqc-sign-verify-ml-dsa.js SLE_15_SP7"]="skip"
 )
 
 # Common flags to use on each test


### PR DESCRIPTION
Also remove spaces at the end of lines

This error occurs because the dynamic OpenSSL library (libcrypto.so) linked to Node.js lacks support for the ML-DSA-44 algorithm (NIST FIPS 204), causing Node's C++ bindings to reject 'ml-dsa-44' as an invalid key type.

Why This Happens

- Shared System OpenSSL Limitations Node.js v24 includes native support for Post-Quantum Cryptography (PQC) standards (ML-DSA, ML-KEM, SLH-DSA). When Node is built with --shared-openssl (standard for Linux distribution packaging like SUSE/openSUSE under /usr/src/packages/SOURCES/), it relies on the system's installed OpenSSL library. System versions prior to OpenSSL 3.5 do not include native ML-DSA key managers (EVP_PKEY_ML_DSA_44).

- Test Suite Execution vs. Runtime Support Mismatch The test runner checks header flags or version macros during compilation to determine whether to run PQC tests. If header checks pass but the runtime libcrypto.so lacks the ML-DSA implementation,
crypto.generateKeyPairSync('ml-dsa-44') fails at runtime with ERR_INVALID_ARG_VALUE.

Older OpenSSL 3.x releases (OpenSSL 3.0 through 3.4) do not include native key managers for these standards.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1272321
- Verification run: https://openqa.suse.de/tests/23854414
https://openqa.suse.de/tests/23855005
https://openqa.suse.de/tests/23855006