### PR TITLE
[CLONE] Enhance logs collecting functionality in virt_logs_collector.sh

### DIFF
--- a/data/virt_autotest/fetch_logs_from_guest.sh
+++ b/data/virt_autotest/fetch_logs_from_guest.sh
@@ -1,6 +1,11 @@
 #!/bin/bash -x
 
-#Setup libguestfs environmen for non-x86_64 machine
+# Setup libguestfs environmen for non-x86_64 machine
+#
+# Arguments explanation:
+# - host_arch: Host hardware architecture.
+#
+# Please also refer to script help_usage().
 function setup_libguestfs_env() {
         local host_arch=`uname -p`
         if [[ ${host_arch} != "x86_64" ]];then
@@ -15,7 +20,16 @@ function setup_libguestfs_env() {
         return 0
 }
 
-#Find the correct disk device that holds the specific folder which contains log filesystem
+# Find the correct disk device that holds the specific folder which contains log
+# filesystem.
+#
+# Arguments explanation:
+# - guest_domain: Guest name can be used with libvirt or libguestfs.
+# - guest_filesystem: Absolute filesystem path to logs_folder on guest from which
+#   the storage device hosting it can be found, because libguestfs tool only works
+#   with specified storage device.
+#
+# Please also refer to script help_usage().
 function find_disk_hosts_filesystem() { 
         local guest_domain=$1
         local guest_filesystem=$2
@@ -42,13 +56,24 @@ function find_disk_hosts_filesystem() {
         fi
 }
 
-#Fetach logs from virtual machine to local host via ssh
+# Fetach logs from virtual machine to local host via ssh.
+#
+# Arguments explanation:
+# - guest_domain: Guest name can be used with libvirt or libguestfs.
+# - guest_ipaddr: Guest IP address to which ssh connection can be established.
+# - guest_password: Guest password with which ssh connection can be established.
+# - logs_folder: The folder hosts all logs on guest from which to be fetched. It
+#   is the top logs residence to which all logs are stored by the logs collecting
+#   script virt_logs_collector.sh.
+#
+# Please also refer to script help_usage().
 function fetch_logs_from_guest_via_ssh() {
         local guest_domain=$1
         local guest_ipaddr=$2
-        local logs_folder=$3
+        local guest_password=$3
+        local logs_folder=$4
         local guest_user="root"
-        local guest_pass="novell"
+        local guest_pass=${guest_password}
         local sshpass_scp_cmd="sshpass -p ${guest_pass} scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -r ${guest_user}@${guest_ipaddr}"
         local sshpass_ssh_cmd="sshpass -p ${guest_pass} ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${guest_user}@${guest_ipaddr}"
         local guest_transformed=${guest_domain//./_}
@@ -76,11 +101,25 @@ function fetch_logs_from_guest_via_ssh() {
 	return ${ret_result}
 }
 
-#Fetch logs from virtual machine to local host by using libguestfs tools
+# Fetch logs from virtual machine to local host by using libguestfs tools.
+#
+# Arguments explanatiion:
+# - guest_domain: Guest name can be used with libvirt or libguestfs.
+# - guest_password: Guest password with which ssh connection can be established.
+# - logs_fetched: Each folder or file to be fetached from logs_folder on guest
+#   which is the same as logs_folder via ssh and is sub-folder or sub-file in
+#   logs_folder via libguestfs tool because libguestfs can not fetch a whole
+#   folder all at once.  
+# - logs_folder: The folder hosts all logs on guest from which to be fetched. It
+#   is the top logs residence to which all logs are stored by the logs collecting
+#   script virt_logs_collector.sh.
+#
+# Please also refer to script help_usage().
 function fetch_logs_from_guest_via_libguestfs() {
         local guest_domain=$1
-        local logs_fetched=$2
-        local logs_folder=$3
+        local guest_password=$2
+        local logs_fetched=$3
+        local logs_folder=$4
 
         setup_libguestfs_env
         virt-filesystems -d ${guest_domain} &> /dev/null
@@ -111,10 +150,21 @@ function fetch_logs_from_guest_via_libguestfs() {
         fi
 }
 
-#Power off virtual machine if necessary and remove logs folder in it by using libguestfs
+# Power off virtual machine if necessary and remove logs folder in it by using
+# libguestfs.
+#
+# Arguments explanation:
+# - guest_domain: Guest name can be used with libvirt or libguestfs.
+# - guest_password: Guest password with which ssh connection can be established.
+# - logs_folder: The folder hosts all logs on guest from which to be fetched. It
+#   is the top logs residence to which all logs are stored by the logs collecting
+#   script virt_logs_collector.sh.
+#
+# Please also refer to script help_usage().
 function remove_logs_folder_from_guest_via_libguestfs() {
         local guest_domain=$1
-        local logs_folder=$2
+        local guest_password=$2
+        local logs_folder=$3
         local ret_result=0
 
         echo -e "Going to remove ${logs_folder} from ${guest_domain} via libguestfs"
@@ -140,24 +190,40 @@ function remove_logs_folder_from_guest_via_libguestfs() {
         return ${ret_result}
 }
 
-#Fetch logs from virtual machine to local host via ssh firstly. Will resort to libguestfs tools if ssh connection is broken
+# Fetch logs from virtual machine to local host via ssh firstly. Will resort to
+# libguestfs tools if ssh connection is broken
+#
+# Arguments explanation:
+# - guest_domain: Guest name can be used with libvirt or libguestfs.
+# - guest_ipaddr: Guest IP address to which ssh connection can be established.
+# - guest_password: Guest password with which ssh connection can be established
+# - logs_folder: The folder hosts all logs on guest from which to be fetched. It
+#   is the top logs residence to which all logs are stored by the logs collecting
+#   script virt_logs_collector.sh.
+# - extra_logs: Extra logs to fetched from guest via libguestfs tool because they
+#   might not be able to be collected successfully into logs_folder via ssh in the
+#   virt_logs_collector.sh. So they are only fetched again one by ne if logs_folder
+#   is not fetched successfully.  
+#
+# Please also refer to script help_usage().
 function fetch_logs_from_guest() {
 	local guest_domain=$1
 	local guest_ipaddr=$2
-	local logs_folder=$3
+	local guest_password=$3
+	local logs_folder=$4
 	shift
 	shift
 	shift
 	local extra_logs=($@)
 
 	local ret1=0
-	fetch_logs_from_guest_via_ssh ${guest_domain} ${guest_ipaddr} ${logs_folder}
+	fetch_logs_from_guest_via_ssh ${guest_domain} ${guest_ipaddr} ${guest_password} ${logs_folder}
 	if [[ $? -ne 0 ]];then
 	   echo -e "Try to use libguestfs tools to fetch ${logs_folder} from ${guest_domain}."
-	   fetch_logs_from_guest_via_libguestfs ${guest_domain} ${logs_folder} ${logs_folder}
+	   fetch_logs_from_guest_via_libguestfs ${guest_domain} ${guest_password} ${logs_folder} ${logs_folder}
 	   ret1=$?
 	   if [[ ${ret1} -eq 0 ]];then
-	      remove_logs_folder_from_guest_via_libguestfs ${guest_domain} ${logs_folder}	
+	      remove_logs_folder_from_guest_via_libguestfs ${guest_domain} ${guest_password} ${logs_folder}	
 	      if [[ $? -eq 0 ]];then
 	         echo -e "Successfully removed ${logs_folder} from ${guest_domain} via libguestfs."
 	      else
@@ -171,7 +237,7 @@ function fetch_logs_from_guest() {
 	   echo -e "Try to use libguestfs tools to fetch ${extra_logs[@]} from ${guest_domain}."
 	   local eachlog=""
 	   for eachlog in ${extra_logs[@]};do
-	       fetch_logs_from_guest_via_libguestfs ${guest_domain} ${eachlog} ${logs_folder}
+	       fetch_logs_from_guest_via_libguestfs ${guest_domain} ${guest_password} ${eachlog} ${logs_folder}
 	       ret2=$(( ${ret2} | $? ))
 	   done           
 	   if [[ ${ret2} -eq 0 ]];then
@@ -189,7 +255,14 @@ function fetch_logs_from_guest() {
 	fi
 }
 
-#Compress logs folder on local host which contains all logs from host and guest
+# Compress logs folder on local host which contains all logs from host and guest.
+#
+# Arguments explanation:
+# - logs_folder: The folder hosts all logs on guest from which to be fetched. It
+#   is the top logs residence to which all logs are stored by the logs collecting
+#   script virt_logs_collector.sh.
+#
+# Please also refer to script help_usage().
 function compress_virt_logs_folder() {
 	local logs_folder=$1
 	local logs_root=${logs_folder/\//}
@@ -214,12 +287,14 @@ function compress_virt_logs_folder() {
 help_usage(){
 	echo "script usage: $(basename $0) [-f \"Logs folder which contains logs collected(Can be omitted/Default to /tmp/virt_logs_residence)\"] \
 [-g \"guests to be involved, for example, \"guest1 guest2 guest3\" or all or none(Can be omitted/Default to all)\"] \
+[-p \"Root password to access all guests\"] \
 [-e \"Extra folders or files to be fetched from guest, for example, \"log_file1 log_file2 log_folder1\"(Can be omitted/Default to nothing)\"] \
 [-h help]"
 }
 
 fetch_logs_from_guest_log="/var/log/fetch_logs_from_guest.log"
 virt_guests_wanted=""
+virt_guests_password=""
 virt_logs_folder=""
 virt_extra_logs_guest=""
 fetch_logs_from_guest_log_result=0
@@ -227,7 +302,7 @@ rm -f -r ${fetch_logs_from_guest_log}
 
 #Parse input arguments, all options are optional
 #Any log paremter passed in should take absolute path form
-while getopts 'l:g:e:h' OPTION; do
+while getopts 'l:g:p:e:h' OPTION; do
    case "$OPTION" in
       f)
         virt_logs_folder="$OPTARG"
@@ -236,6 +311,10 @@ while getopts 'l:g:e:h' OPTION; do
       g)
         virt_guests_wanted="$OPTARG"
         echo "The guests involved are ${virt_guests_wanted}" | tee -a ${fetch_logs_from_guest_log}
+        ;;
+      p)
+        virt_guests_password="$OPTARG"
+        echo "Root password to access all guests [redacted]" | tee -a ${virt_logs_collecor_log}
         ;;
       e)
         virt_extra_logs_guest="$OPTARG"
@@ -252,12 +331,17 @@ while getopts 'l:g:e:h' OPTION; do
         ;;
    esac
 done
+
 shift "$(($OPTIND -1))"
 if [[ ${virt_logs_folder} == "" ]];then
    virt_logs_folder="/tmp/virt_logs_residence"
 fi
 if [[ ${virt_guests_wanted} == "" ]];then
    virt_guests_wanted="all"
+fi
+if [[ ${virt_guests_password} == "" ]];then
+   echo -e "Error: The virt_guests_password argument is mandatory." | tee -a ${fetch_logs_from_guest_log}
+   exit 1
 fi
 
 unset guest_hash_ipaddr
@@ -324,8 +408,8 @@ else
           if [[ ${guests_inactive_array[@]} == .*${guest_current}.* ]];then
              echo -e "Virtual machine ${guest_current} in shutdown state. Skip fetching logs from it." | tee -a ${fetch_logs_from_guest_log}
           else
-             echo -e "fetch_logs_from_guest ${guest_current} ${virt_logs_folder}" | tee -a ${fetch_logs_from_guest_log}
-             fetch_logs_from_guest ${guest_current} ${guest_hash_ipaddr[${guest_hash_index}]} ${virt_logs_folder} ${virt_extra_logs_guest[@]} | tee -a ${fetch_logs_from_guest_log}
+             echo -e "fetch_logs_from_guest ${guest_current} ${guest_hash_ipaddr[${guest_hash_index}]} ${virt_guests_password} ${virt_logs_folder} ${virt_extra_logs_guest[@]}" | tee -a ${fetch_logs_from_guest_log}
+             fetch_logs_from_guest ${guest_current} ${guest_hash_ipaddr[${guest_hash_index}]} ${virt_guests_password} ${virt_logs_folder} ${virt_extra_logs_guest[@]} | tee -a ${fetch_logs_from_guest_log}
              fetch_logs_from_guest_log_result=$(( ${fetch_logs_from_guest_log_result} | $? ))
           fi
        else

--- a/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
+++ b/data/virt_autotest/host_unattended_installation_files/agama/sle16.jsonnet
@@ -77,7 +77,7 @@ local agama_product_mode = if transactional == '1' then 'immutable' else 'standa
         content: |||
           #!/usr/bin/env bash
           sshd_config_file="/etc/ssh/sshd_config.d/01-virt-test.conf"
-          echo -e "TCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 60" > $sshd_config_file
+          echo -e "TCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 720" > $sshd_config_file
         |||
       },
       {

--- a/data/virt_autotest/virt_logs_collector.sh
+++ b/data/virt_autotest/virt_logs_collector.sh
@@ -5,6 +5,9 @@ shopt -s nocasematch
 # Get Product name
 # Product name are "SLES", "openSUSE Tumbleweed", "openSUSE Leap"
 # TBD: ALP, ...
+#
+# Arguments explanation:
+# - version_file: File from which release info is obtained.
 function get_product_name() {
 	local version_file=$1
 	if [[ -z ${version_file} ]];then
@@ -14,7 +17,11 @@ function get_product_name() {
 	echo $product_name
 }
 
-#Obtain SLES release version and service pack level
+# Obtain SLES release version and service pack level.
+#
+# Arguments explanation:
+# - query_type: major release or minor service pack.
+# - version_file: File from which release info is obtained.
 function get_sles_release() {
         local query_type=$1
         local version_file=$2
@@ -36,7 +43,7 @@ function get_sles_release() {
         fi
 }
 
-#Get host hypervisor type
+# Get host hypervisor type
 function get_sles_hypervisor() {
         (lsmod | grep -i kvm || dmesg | grep -i kvm) &> /dev/null
         if [[ $? -eq 0 ]];then
@@ -46,7 +53,14 @@ function get_sles_hypervisor() {
         fi
 }
 
-#Setup folder on host to be used as logs warehouse which will hold all host and guest logs at the last
+# Setup folder on host to be used as logs warehouse which will hold all host and
+# guest logs at the last.
+#
+# Arguments explanatiion:
+# - logs_folder: The folder hosts all logs collected from host or guest. It is
+#   the top logs residence to/from which all logs are stored/fetched.
+#
+# Please also refer to script help_usage().
 function setup_common_logs_folder() {
         local logs_folder=$1
         mkdir -p ${logs_folder}
@@ -54,13 +68,42 @@ function setup_common_logs_folder() {
         return $?
 }
 
-#Collect any desired logs from virtual machine by using virsh console and expect script
+# Collect any desired logs from virtual machine by using virsh console and expect
+# script.
+#
+# Arguments explanatiion:
+# - guest_domain: Guest name can be used with libvirt or libguestfs.
+# - guest_password: Guest password with which ssh connection can be established.
+# - logs_folder: The folder hosts all logs collected from host or guest. It is
+#   the top logs residence to/from which all logs are stored/fetched.
+# - extra_logs: Extra logs, supportconfig or sosreport log to be collected on guest
+#   because this function is called in collect_supportconfig_via_guest_console,
+#   collect_sosreport_via_guest_console and collect_extra_logs_via_guest_console
+#   to collect logs in the same manner.
+# - full_supportconfig: Whether run supportconfig command with -A (Activates all
+#   supportconfig functions with additional logging and full rpm verification).
+# - excluded_supportconfig_features_ref: Pointer to list of features to be excluded
+#   from being collected via supportconfig.
+#
+# Please also refer to script help_usage().
 function collect_logs_via_guest_console() {
         local guest_domain=$1
-        local logs_folder=$2
-        shift
-        shift
-        local extra_logs=$@
+        local guest_password=$2
+        local logs_folder=$3
+        if [[ $4 == "supportconfig" ]] || [[ $4 == "sosreport" ]];then
+            local extra_logs=$4
+        else 
+            local -n extra_logs_ref=$4
+            local extra_logs="${extra_logs_ref[@]}"
+        fi
+        if [[ $4 == "supportconfig" ]];then
+            local full_supportconfig=${5:-true}
+            local -n excluded_supportconfig_features_ref=$6
+            local excluded_supportconfig_features="${excluded_supportconfig_features_ref[@]}"
+        else 
+            local full_supportconfig="void"
+            local excluded_supportconfig_features="void"
+        fi
         local expfile="${logs_folder}/collect_logs_via_guest_console.exp"
         local guest_transformed=${guest_domain//./_}
         touch ${expfile}
@@ -71,13 +114,15 @@ cat <<EOF > ${expfile}
 set hypervisor [lindex \$argv 0]
 set guest_domain [lindex \$argv 1]
 set guest_transformed [lindex \$argv 2]
-set logs_folder [lindex \$argv 3]
-set extra_logs [lindex \$argv 4]
+set guest_password [lindex \$argv 3]
+set logs_folder [lindex \$argv 4]
+set extra_logs [lindex \$argv 5]
+set full_supportconfig [lindex \$argv 6]
+set excluded_supportconfig_features [lindex \$argv 7]
 set retry_times 2
 set ret_result 1
 set fail_string sad_to_fail
 set pass_string glad_go_pass
-set supportconfig_excluded_features "aFSLIST AUDIT SELINUX"
 
 while { \${retry_times} > 0 } {
       if { \${hypervisor} == {KVM} } {
@@ -95,7 +140,7 @@ while { \${retry_times} > 0 } {
       }
       expect {
          -nocase "login: $"  {send "root\r"; set ret_result 0; exp_continue -continue_timer}
-         -nocase "password:" {send "novell\rcd ~\r"; exp_continue -continue_timer}
+         -nocase "password:" {send "\${guest_password}\rcd ~\r"; exp_continue -continue_timer}
          -nocase "mistake|wrong|fault|error|fail|exception|not*found|timed*out" {puts "Can not login virsh console to \${guest_domain}\r"; set ret_result 1}
       }
 
@@ -104,19 +149,39 @@ while { \${retry_times} > 0 } {
          expect -re "~( |\\\])#"
          send "mkdir -p \${logs_folder};export time_stamp=\`date \'+%Y%m%d%H%M%S\'\`\r"
          expect -re "~( |\\\])#"
-         if { \${extra_logs} == {support_config} } {
+         if { \${extra_logs} == {supportconfig} } {
             send "rm -f -r \${logs_folder}/*supportconfig*\r"
-            send "export excluded_features=\"\""
-            send "for feature in \${supportconfig_excluded_features};do if supportconfig -F | grep -i \$feature &> /dev/null;then excluded_features=\"\${excluded_features},\$feature\";fi;done"
-            send "excluded_features=\${excluded_features#,}"
-            send "supportconfig -y -A -x \${excluded_features} -t \${logs_folder} -B guest_\${guest_transformed}_supportconfig_\\\${time_stamp}\r"
+            send "export excluded_features=\"\"\r"
+            send "for feature in \${excluded_supportconfig_features};do if supportconfig -F | grep -i \\\$feature &> /dev/null;then excluded_features=\"\\\${excluded_features},\\\$feature\";fi;done\r"
+            send "excluded_features=\\\${excluded_features#,}\r"
+            send "echo GRAB_THIS:\\\${excluded_features}\r"
+            expect -re "GRAB_THIS:(.*)\r" {
+                set excluded_features \$expect_out(1,string)
+                set excluded_features [string trim \$excluded_features "\r\n"]
+            }
+            send "echo \\\${excluded_features}\r"
+            send "export supportconfig_cmd=\"supportconfig -y\"\r"
+            if { \${excluded_features} != "" } {
+                send "supportconfig_cmd=\"\\\${supportconfig_cmd} -x \${excluded_features}\"\r"
+            }
+            send "supportconfig_cmd=\"\\\${supportconfig_cmd} -t \${logs_folder} -B guest_\${guest_transformed}_supportconfig_\\\${time_stamp}\"\r"
+            if { \${full_supportconfig} == {true} } {
+                send "echo \"\\\${supportconfig_cmd} -A\"\r"
+                send "\\\${supportconfig_cmd} -A\r"
+            }
+            if { \${full_supportconfig} == {false} } {
+                send "echo \"\\\${supportconfig_cmd}\"\r"
+                send "\\\${supportconfig_cmd}\r"
+            }
          }
-         if { \${extra_logs} == {sos_report} } {
+         if { \${extra_logs} == {sosreport} } {
             send "rm -f -r \${logs_folder}/*sosreport*\r"
+            send "echo \"sosreport --batch --debug -v --alloptions --all-logs -z xz --tmp-dir \${logs_folder}\"\r"
             send "sosreport --batch --debug -v --alloptions --all-logs -z xz --tmp-dir \${logs_folder}\r"
          }
-         if { \${extra_logs} != {support_config} && \${extra_logs} != {sos_report} && \${extra_logs} != "" } {
+         if { \${extra_logs} != {supportconfig} && \${extra_logs} != {sosreport} && \${extra_logs} != "" } {
             send "rm -f -r \${logs_folder}/*extra_logs*\r"
+            send "echo \"mkdir -p \${logs_folder}/guest_\${guest_transformed}_extra_logs;cp --parent -r -f \${extra_logs} \${logs_folder}/guest_\${guest_transformed}_extra_logs\"\r"
             send "mkdir -p \${logs_folder}/guest_\${guest_transformed}_extra_logs;cp --parent -r -f \${extra_logs} \${logs_folder}/guest_\${guest_transformed}_extra_logs\r"
          }
          expect {
@@ -152,8 +217,8 @@ EOF
 	for procid in `ps aux | grep -iE "${expfile}|virsh console" | grep -v "grep" | awk '{print $2}'`;do
 	    kill -9 ${procid}
 	done
-	echo -e "expect ${expfile} "${hypervisor}" "${guest_domain}" "${guest_transformed}" "${logs_folder}" "${extra_logs}""
-	expect ${expfile} "${hypervisor}" "${guest_domain}" "${guest_transformed}" "${logs_folder}" "${extra_logs}"
+	echo -e "expect ${expfile} "${hypervisor}" "${guest_domain}" "${guest_transformed}" "${guest_password}" "${logs_folder}" "${extra_logs}" "${full_supportconfig}" "${excluded_supportconfig_features}""
+	expect ${expfile} "${hypervisor}" "${guest_domain}" "${guest_transformed}" "${guest_password}" "${logs_folder}" "${extra_logs}" "${full_supportconfig}" "${excluded_supportconfig_features}"
 	if [[ $? == 0 ]];then
 	   echo -e "${expfile} returned with success. Successfully collected ${extra_logs} via ${guest_domain} console."
 	   rm -f ${expfile}
@@ -165,21 +230,43 @@ EOF
 	fi
 }
 
-#This function supports collecting supportconfig or sosreport from both host and guest. The argument target_type will be given 'host' or 'guest'
-#Will resort to guest virsh console if collecting from guest ssh failed. Collecting logs from host only supports local host
-#Typical usage: collect_system_log_and_diagnosis logs_folder host or collect_system_log_and_diagnosis logs_folder guest guest_ip guest_domain_name
+# This function supports collecting supportconfig or sosreport from both host and
+# guest. The argument target_type will be given 'host' or 'guest'.  Will resort
+# to guest virsh console if collecting from guest ssh failed. Collecting logs from
+# host only supports local host. Typical usage: collect_system_log_and_diagnosis
+# logs_folder host or collect_system_log_and_diagnosis logs_folder guest guest_ip
+# guest_domain_name. Collect any desired logs from virtual machine by using virsh
+# console and expect script
+#
+# Arguments explanatiion:
+# - logs_folder: The folder hosts all logs collected from host or guest. It is
+#   the top logs residence to/from which all logs are stored/fetched.
+# - target_type: host or guest
+# - target_ipaddr: Target ip address to which ssh connection can be established. 
+# - target_domain: Target domain name which is mainly used with guest libvirt or
+#   libguestfs.  
+# - target_password: Target password to be used with ssh or console connection. 
+#   full_supportconfig: Whether run supportconfig command with -A (Activates all
+#   supportconfig functions with additional logging and full rpm verification).
+# - excluded_supportconfig_features_ref: Pointer to list of features to be excluded
+#   from being collected via supportconfig.
+#
+# Please also refer to script help_usage().
 function collect_system_log_and_diagnosis() {
 	local logs_folder=$1
 	local target_type=$2
 	local target_ipaddr=$3
 	local target_domain=$4
+	local target_password=$5
+	local full_supportconfig=${6:-true}
+	local -n excluded_supportconfig_features=$7
 	local target_user=""
 	local target_pass=""
 	local sshpass_ssh_cmd=""
 
 	if [[ ${target_type} == "guest" ]];then
 	   target_user="root"
-	   target_pass="novell"
+	   target_pass=${target_password}
 	   sshpass_ssh_cmd="sshpass -p ${target_pass} ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${target_user}@${target_ipaddr}"
 	fi	
 
@@ -203,12 +290,21 @@ function collect_system_log_and_diagnosis() {
 	   else	   
     	      local time_stamp=`date '+%Y%m%d%H%M%S'`
 	      ${sshpass_ssh_cmd} rm -f -r ${logs_folder}/*supportconfig*
-	      local supportconfig_excluded_features="aFSLIST AUDIT SELINUX"
 	      local excluded_features=""
-	      for feature in ${supportconfig_excluded_features};do if supportconfig -F | grep -i $feature &> /dev/null;then excluded_features="${excluded_features},$feature";fi;done
+	      for feature in ${excluded_supportconfig_features[@]};do if supportconfig -F | grep -i $feature &> /dev/null;then excluded_features="${excluded_features},$feature";fi;done
 	      excluded_features=${excluded_features#,}
-	      echo -e "${sshpass_ssh_cmd} supportconfig -y -A -x ${excluded_features} -t ${logs_folder} -B ${target_type}_${target_transformed}_supportconfig_${time_stamp}"
-	      ${sshpass_ssh_cmd} supportconfig -y -A -x ${excluded_features} -t ${logs_folder} -B ${target_type}_${target_transformed}_supportconfig_${time_stamp}
+	      supportconfig_cmd="${sshpass_ssh_cmd} supportconfig -y"
+	      if [[ ${excluded_features} != "" ]];then
+	          supportconfig_cmd="${supportconfig_cmd} -x ${excluded_features}"
+	      fi
+	      supportconfig_cmd="${supportconfig_cmd} -t ${logs_folder} -B ${target_type}_${target_transformed}_supportconfig_${time_stamp}"
+	      if [[ ${full_supportconfig} == "true" ]];then
+	          echo -e "${supportconfig_cmd} -A"
+	          ${supportconfig_cmd} -A
+	      else
+	          echo -e "${supportconfig_cmd}"
+	          ${supportconfig_cmd}
+	      fi
 	   fi
 	   ret_result=$?
 	   if [[ ${ret_result} -eq 0 ]];then
@@ -221,11 +317,11 @@ function collect_system_log_and_diagnosis() {
 	if [[ ${target_type} == "guest" ]] && [[ ${ret_result} -ne 0 ]];then
 	   echo -e "Can not collect supportconfig or sosreport from ${target_type} ${target_domain} via ssh. Try to use guest virsh console."
 	   if [[ ${target_domain} =~ oracle|rhel|fedora ]];then
-	      echo -e "collect_sosreport_via_guest_console ${target_domain} ${logs_folder}"
-	      collect_sosreport_via_guest_console ${target_domain} ${logs_folder}
+	      echo -e "collect_sosreport_via_guest_console ${target_domain} ${target_password} ${logs_folder}"
+	      collect_sosreport_via_guest_console ${target_domain} ${target_password} ${logs_folder}
 	   else 
-	      echo -e "collect_supportconfig_via_guest_console ${target_domain} ${logs_folder}"
-	      collect_supportconfig_via_guest_console ${target_domain} ${logs_folder}
+	      echo -e "collect_supportconfig_via_guest_console ${target_domain} ${target_password} ${logs_folder} ${full_supportconfig} ${excluded_supportconfig_features[*]}"
+	      collect_supportconfig_via_guest_console ${target_domain} ${target_password} ${logs_folder} ${full_supportconfig} excluded_supportconfig_features
 	   fi
 	   if [[ $? -eq 0 ]];then
 	      return 0
@@ -240,10 +336,26 @@ function collect_system_log_and_diagnosis() {
 	return 0
 }
 
+# This function supports collecting supportconfig from guest console.
+#
+# Arguments explanatiion:
+# - guest_domain: Guest name can be used with libvirt or libguestfs.
+# - guest_password: Guest password to be used with ssh or console connection.
+# - logs_folder: The folder hosts all logs collected from host or guest. It is
+#   the top logs residence to/from which all logs are stored/fetched.
+# - full_supportconfig: Whether run supportconfig command with -A (Activates all
+#   supportconfig functions with additional logging and full rpm verification).
+# - excluded_supportconfig_features_ref: Pointer to list of features to be excluded
+#   from being collected via supportconfig.
+#
+# Please also refer to script help_usage().
 function collect_supportconfig_via_guest_console() {
         local guest_domain=$1
-        local logs_folder=$2
-        collect_logs_via_guest_console ${guest_domain} ${logs_folder} support_config
+        local guest_password=$2
+        local logs_folder=$3
+        local full_supportconfig=${4:-true}
+        local -n excluded_supportconfig_features_via_guest_console=$5
+        collect_logs_via_guest_console ${guest_domain} ${guest_password} ${logs_folder} supportconfig ${full_supportconfig} excluded_supportconfig_features_via_guest_console
         if [[ $? -eq 0 ]];then
            return 0
         else
@@ -251,10 +363,20 @@ function collect_supportconfig_via_guest_console() {
         fi
 }
 
+# This function supports collecting sosreport from guest console.
+#
+# Arguments explanatiion:
+# - guest_domain: Guest name can be used with libvirt or libguestfs.
+# - guest_password: Guest password to be used with ssh or console connection.
+# - logs_folder: The folder hosts all logs collected from host or guest. It is
+#   the top logs residence to/from which all logs are stored/fetched.
+#
+# Please also refer to script help_usage().
 function collect_sosreport_via_guest_console() {
         local guest_domain=$1
-        local logs_folder=$2
-        collect_logs_via_guest_console ${guest_domain} ${logs_folder} sos_report
+        local guest_password=$2
+        local logs_folder=$3
+        collect_logs_via_guest_console ${guest_domain} ${guest_password} ${logs_folder} sosreport
         if [[ $? -eq 0 ]];then
            return 0
         else
@@ -262,13 +384,23 @@ function collect_sosreport_via_guest_console() {
         fi
 }
 
+# This function supports collecting extra logs from guest console.
+#
+# Arguments explanatiion:
+# - guest_domain: Guest name can be used with libvirt or libguestfs.
+# - guest_password: Guest password to be used with ssh or console connection.
+# - logs_folder: The folder hosts all logs collected from host or guest. It is
+#   the top logs residence to/from which all logs are stored/fetched.
+# - extra_logs_via_guest_console: Pointer to list of extra logs to collected on
+#   guest. 
+#
+# Please also refer to script help_usage().
 function collect_extra_logs_via_guest_console() {
         local guest_domain=$1
-        local logs_folder=$2
-        shift
-        shift
-        local extra_logs=$@
-        collect_logs_via_guest_console ${guest_domain} ${logs_folder} ${extra_logs}
+        local guest_password=$2
+        local logs_folder=$3
+        local -n extra_logs_via_guest_console=$4
+        collect_logs_via_guest_console ${guest_domain} ${guest_password} ${logs_folder} extra_logs_via_guest_console
         if [[ $? -eq 0 ]];then
            return 0
         else
@@ -276,19 +408,28 @@ function collect_extra_logs_via_guest_console() {
         fi
 }
 
-#Collect any extra logs wanted from guest. Will resort to guest virsh console if collecting from ssh failed.
+# Collect any extra logs wanted from guest. Will resort to guest virsh console
+# if collecting from ssh failed.
+#
+# Arguments explanatiion:
+# - logs_folder: The folder hosts all logs collected from host or guest. It is
+#   the top logs residence to/from which all logs are stored/fetched.
+# - guest_ipaddr: Guest IP address to which ssh connection can be established.
+# - guest_domain: Guest name can be used with libvirt or libguestfs.
+# - guest_password: Guest password to be used with ssh or console connection.
+# - extra_logs: Pointer to list of extra logs to collected on guest. 
+#
+# Please also refer to script help_usage().
 function collect_extra_logs_from_guest() {
         local logs_folder=$1
         local guest_ipaddr=$2
         local guest_domain=$3
-        shift
-        shift
-        shift
-        local extra_logs=$@
+        local guest_password=$4
+        local -n extra_logs=$5
       
-        if [[ ${extra_logs} != "" ]];then
+        if [[ "${extra_logs[*]}" != "" ]];then
            local guest_user="root"
-           local guest_pass="novell"
+           local guest_pass=${guest_password}
            local sshpass_ssh_cmd="sshpass -p ${guest_pass} ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${guest_user}@${guest_ipaddr}"
            local guest_transformed=${guest_domain//./_}
            local ret_result=128
@@ -297,19 +438,19 @@ function collect_extra_logs_from_guest() {
            do
                  ${sshpass_ssh_cmd} rm -f -r ${logs_folder}/guest_${guest_transformed}_extra_logs
                  ${sshpass_ssh_cmd} mkdir -p ${logs_folder}/guest_${guest_transformed}_extra_logs
-                 echo -e "${sshpass_ssh_cmd} cp --parent -r -f ${extra_logs} ${logs_folder}/guest_${guest_transformed}_extra_logs"
-                 ${sshpass_ssh_cmd} cp --parent -r -f ${extra_logs} ${logs_folder}/guest_${guest_transformed}_extra_logs
+                 echo -e "${sshpass_ssh_cmd} cp --parent -r -f ${extra_logs[*]} ${logs_folder}/guest_${guest_transformed}_extra_logs"
+                 ${sshpass_ssh_cmd} cp --parent -r -f ${extra_logs[*]} ${logs_folder}/guest_${guest_transformed}_extra_logs
                  ret_result=$?
                  if [[ ${ret_result} -eq 0 ]];then
-                    echo -e "Successfully collected ${extra_logs} from guest ${guest_domain} via ssh."
+                    echo -e "Successfully collected ${extra_logs[*]} from guest ${guest_domain} via ssh."
                     break
                  fi
                  retry_times=$((${retry_times}+1))
            done
            if [[ ${ret_result} -ne 0 ]];then
-              echo -e "Can not collect ${extra_logs} from guest ${guest_domain} via ssh. Try to use guest virsh console"
-              echo -e "collect_extra_logs_via_guest_console ${guest_domain} ${logs_folder} ${extra_logs}"
-              collect_extra_logs_via_guest_console ${guest_domain} ${logs_folder} ${extra_logs}
+              echo -e "Can not collect ${extra_logs[*]} from guest ${guest_domain} via ssh. Try to use guest virsh console"
+              echo -e "collect_extra_logs_via_guest_console ${guest_domain} ${guest_password} ${logs_folder} ${extra_logs[*]}"
+              collect_extra_logs_via_guest_console ${guest_domain} ${guest_password} ${logs_folder} extra_logs
               if [[ $? -eq 0 ]];then
                  return 0
               else
@@ -324,7 +465,16 @@ function collect_extra_logs_from_guest() {
         fi
 }
 
-#Collect any extra wanted logs from host. And provide more complete virtualization logs for SLE-11-SP4 ,SLE-12 and SLE-15 hosts.
+# Collect any extra wanted logs from host. And provide more complete virtualization
+# logs for SLE-11-SP4 ,SLE-12 and SLE-15 hosts.
+#
+# Arguments explanatiion:
+# - logs_folder: The folder hosts all logs collected from host or guest. It is
+#   the top logs residence to/from which all logs are stored/fetched.
+# - target_domain: Host domain name to help form sub-folder to host extra logs. 
+# - extra_logs: Pointer to list of extra logs to collected on host. 
+#
+# Please also refer to script help_usage().
 function collect_extra_logs_from_host() {
 	local logs_folder=$1
 	local target_domain=$2
@@ -408,7 +558,10 @@ help_usage(){
 	echo "script usage: $(basename $0) [-f \"Folder to be used as logs residence(Can be omitted/Default to /tmp/virt_logs_residence)\"] \
 [-l \"Extra folders or files to be collected as host logs,for example,\"log_file_1 log_file_2 log_folder_1\"(Can be omitted/Default to nothing)\"] \
 [-g \"guests to be involved or none,for example,\"guest1 guest2 guest3\"(Can be omitted/Default to all)\"] \
+[-p \"Root password to access all guests\"] \
 [-e \"Extra folders or files to be collected as guest logs, for example, \"log_file_1 log_file_2 log_folder_1\"(Can be omitted/Default to nothing)\"] \
+[-a \"Activating all supportconfig functions or not, for example, \"true\" or \"false\"(Can be omitted/Default to true)\"] \
+[-x \"Features to be excluded from supportconfig log, for example, \"aFSLIST AUDIT SELINUX\" or \"\"(Can be omitted/Default to \"aFSLIST AUDIT SELINUX\")\"] \
 [-h help]"
 }
 
@@ -417,12 +570,15 @@ virt_logs_folder=""
 virt_extra_logs_host=""
 virt_extra_logs_guest=""
 virt_guests_wanted=""
+virt_guests_password=""
 virt_logs_collector_result=0
+full_supportconfig="true"
+excluded_supportconfig_features="aFSLIST AUDIT SELINUX"
 rm -f ${virt_logs_collecor_log}
 
 #Parse input arguments, all options are optional
 #Any log paremter passed in should take absolute path form
-while getopts 'f:l:g:e:h' OPTION; do
+while getopts 'f:l:g:p:e:a:x:h' OPTION; do
    case "$OPTION" in
       f)
         virt_logs_folder="$OPTARG"
@@ -439,9 +595,21 @@ while getopts 'f:l:g:e:h' OPTION; do
         fi
         echo "The guests involved are ${virt_guests_wanted}" | tee -a ${virt_logs_collecor_log}
         ;;
+      p)
+        virt_guests_password="$OPTARG"
+        echo "Root password to access all guests [redacted]" | tee -a ${virt_logs_collecor_log}
+        ;;
       e)
         virt_extra_logs_guest="$OPTARG"
         echo "The extra guest logs wanted are ${virt_extra_logs_guest}" | tee -a ${virt_logs_collecor_log}
+        ;;
+      a)
+        full_supportconfig="$OPTARG"
+        echo "Activating all supportconfig functions is ${full_supportconfig}" | tee -a ${virt_logs_collecor_log}
+        ;;
+      x)
+        excluded_supportconfig_features="$OPTARG"
+        echo "Features to be excluded from supportconfig log are ${excluded_supportconfig_features}" | tee -a ${virt_logs_collecor_log}
         ;;
       h)
         help_usage | tee -a ${virt_logs_collecor_log}
@@ -453,6 +621,7 @@ while getopts 'f:l:g:e:h' OPTION; do
         ;;
    esac
 done
+
 shift "$(($OPTIND -1))"
 if [[ ${virt_logs_folder} == "" ]];then
    virt_logs_folder="/tmp/virt_logs_residence"
@@ -460,7 +629,13 @@ fi
 if [[ ${virt_guests_wanted} == "" ]];then
    virt_guests_wanted="all"
 fi
+if [[ ${virt_guests_password} == "" ]];then
+   echo -e "Error: The virt_guests_password argument is mandatory." | tee -a ${virt_logs_collecor_log}
+   exit 1
+fi
 
+declare -a virt_extra_logs_guest=($virt_extra_logs_guest)
+declare -a excluded_supportconfig_features=($excluded_supportconfig_features)
 unset guest_hash_ipaddr
 declare -a guest_hash_ipaddr=""
 guest_domain_types="sles|opensuse|tumbleweed|leap|oracle|alp"
@@ -517,8 +692,8 @@ done
 
 #Start collecing logs from host and virtual machine
 setup_common_logs_folder ${virt_logs_folder}	
-echo -e "collect_system_log_and_diagnosis ${virt_logs_folder} host" | tee -a ${virt_logs_collecor_log}
-collect_system_log_and_diagnosis ${virt_logs_folder} host | tee -a ${virt_logs_collecor_log}
+echo -e "collect_system_log_and_diagnosis ${virt_logs_folder} host n/a n/a n/a ${full_supportconfig} ${excluded_supportconfig_features[*]}"  | tee -a ${virt_logs_collecor_log}
+collect_system_log_and_diagnosis ${virt_logs_folder} host "" "" "" ${full_supportconfig} excluded_supportconfig_features | tee -a ${virt_logs_collecor_log}
 virt_logs_collector_result=$(( ${virt_logs_collector_result} | $? ))
 echo -e "collect_extra_logs_from_host ${virt_logs_folder} ${virt_extra_logs_host}" | tee -a ${virt_logs_collecor_log}
 collect_extra_logs_from_host ${virt_logs_folder} "" ${virt_extra_logs_host} | tee -a ${virt_logs_collecor_log}
@@ -532,11 +707,11 @@ else
           if [[ ${guests_inactive_array[@]} =~ .*${guest_current}.* ]];then 
              echo -e "Virtual machine ${guest_current} in shutdown state. Skip collecting logs from it." | tee -a ${virt_logs_collecor_log}
           else
-             echo -e "collect_system_log_and_diagnosis ${virt_logs_folder} guest ${guest_hash_ipaddr[${guest_hash_index}]} ${guest_current}" | tee -a ${virt_logs_collecor_log}
-             collect_system_log_and_diagnosis ${virt_logs_folder} guest ${guest_hash_ipaddr[${guest_hash_index}]} ${guest_current} | tee -a ${virt_logs_collecor_log}
+             echo -e "collect_system_log_and_diagnosis ${virt_logs_folder} guest ${guest_hash_ipaddr[${guest_hash_index}]} ${guest_current} ${virt_guests_password} ${full_supportconfig} ${excluded_supportconfig_features[*]}" | tee -a ${virt_logs_collecor_log}
+             collect_system_log_and_diagnosis ${virt_logs_folder} guest ${guest_hash_ipaddr[${guest_hash_index}]} ${guest_current} ${virt_guests_password} ${full_supportconfig} excluded_supportconfig_features | tee -a ${virt_logs_collecor_log}
              virt_logs_collector_result=$(( ${virt_logs_collector_result} | $? ))
-             echo -e "collect_extra_logs_from_guest ${virt_logs_folder} ${guest_hash_ipaddr[${guest_hash_index}]} ${guest_current}  ${virt_extra_logs_guest}" | tee -a ${virt_logs_collecor_log}
-             collect_extra_logs_from_guest ${virt_logs_folder} ${guest_hash_ipaddr[${guest_hash_index}]} ${guest_current} ${virt_extra_logs_guest} | tee -a ${virt_logs_collecor_log}
+             echo -e "collect_extra_logs_from_guest ${virt_logs_folder} ${guest_hash_ipaddr[${guest_hash_index}]} ${guest_current} ${virt_guests_password} ${virt_extra_logs_guest[*]}" | tee -a ${virt_logs_collecor_log}
+             collect_extra_logs_from_guest ${virt_logs_folder} ${guest_hash_ipaddr[${guest_hash_index}]} ${guest_current} ${virt_guests_password} virt_extra_logs_guest | tee -a ${virt_logs_collecor_log}
              virt_logs_collector_result=$(( ${virt_logs_collector_result} | $? ))
           fi
        else

--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -2931,7 +2931,8 @@ sub check_guest_installation_result_via_ssh {
                 virt_autotest::utils::add_alias_in_ssh_config('/root/.ssh/config', $_guest_transient_hostname_via_ipaddr, $self->{guest_domain_name}, $self->{guest_name});
             }
             save_screenshot;
-            $_ret = script_run("timeout 30 " . $_host_params{ssh_command} . "\@$self->{guest_name} hostname", timeout => 60);
+            $_ret = 255;
+            # $_ret = script_run("timeout 30 " . $_host_params{ssh_command} . "\@$self->{guest_name} hostname", timeout => 60);
             $_guest_transient_hostname_via_name = script_output("timeout 30 " . $_host_params{ssh_command} . "\@$self->{guest_name} hostname", proceed_on_failure => 1);
             save_screenshot;
             if ($_guest_transient_hostname_via_name ne '' and $_ret == 0) {
@@ -2942,12 +2943,14 @@ sub check_guest_installation_result_via_ssh {
                 if ($self->{guest_network_type} eq 'bridge' and $self->{guest_network_mode} eq 'host') {
                     virt_autotest::utils::add_guest_to_hosts("$_guest_transient_hostname_via_ipaddr", $self->{guest_ipaddr});
                     virt_autotest::utils::add_guest_to_hosts("$_guest_transient_hostname_via_ipaddr.$self->{guest_domain_name}", $self->{guest_ipaddr});
-                    $_ret = script_run("timeout 30 " . $_host_params{ssh_command} . "\@$_guest_transient_hostname_via_ipaddr.$self->{guest_domain_name} hostname", timeout => 60);
+                    $_ret = 255;
+# $_ret = script_run("timeout 30 " . $_host_params{ssh_command} . "\@$_guest_transient_hostname_via_ipaddr.$self->{guest_domain_name} hostname", timeout => 60);
                     $_guest_transient_hostname_via_name = script_output("timeout 30 " . $_host_params{ssh_command} . "\@$_guest_transient_hostname_via_ipaddr.$self->{guest_domain_name} hostname", proceed_on_failure => 1);
                 }
                 else {
                     virt_autotest::utils::add_guest_to_hosts($self->{guest_name}, $self->{guest_ipaddr});
-                    $_ret = script_run("timeout 30 " . $_host_params{ssh_command} . "\@$self->{guest_name} hostname", timeout => 60);
+                    $_ret = 255;
+                    # $_ret = script_run("timeout 30 " . $_host_params{ssh_command} . "\@$self->{guest_name} hostname", timeout => 60);
                     $_guest_transient_hostname_via_name = script_output("timeout 30 " . $_host_params{ssh_command} . "\@$self->{guest_name} hostname", proceed_on_failure => 1);
                 }
                 if ($_guest_transient_hostname_via_name ne '' and $_ret == 0) {
@@ -3488,7 +3491,13 @@ sub post_fail_hook {
     $self->reveal_myself;
     $self->upload_guest_installation_logs;
     save_screenshot;
-    virt_utils::collect_host_and_guest_logs("", "/var/log", "/root /var/log /emergency_mode /agama_installation_logs", "_guest_installation");
+    virt_utils::collect_host_and_guest_logs(
+        extra_host_log => get_var('EXTRA_HOST_LOG', '/var/log'),
+        extra_guest_log => get_var('EXTRA_GUEST_LOG', '/root /var/log /emergency_mode /agama_installation_logs'),
+        full_supportconfig => get_var('FULL_SUPPORTCONFIG', 1),
+        excluded_supportconfig_features => get_var('EXCLUDED_SUPPORTCONFIG_FEATURES', 'aFSLIST AUDIT SELINUX'),
+        token => '_guest_installation'
+    );
     save_screenshot;
     upload_coredumps;
     save_screenshot;

--- a/lib/parallel_guest_migration_base.pm
+++ b/lib/parallel_guest_migration_base.pm
@@ -1855,7 +1855,11 @@ sub post_fail_hook {
 
     $self->{"stop_run"} = time();
     $self->create_junit_log;
-    collect_host_and_guest_logs('', '/var/log', '/var/log', "_post_fail_hook");
+    collect_host_and_guest_logs(
+        full_supportconfig => get_var('FULL_SUPPORTCONFIG', 1),
+        excluded_supportconfig_features => get_var('EXCLUDED_SUPPORTCONFIG_FEATURES', 'aFSLIST AUDIT SELINUX'),
+        token => '_post_fail_hook'
+    );
 }
 
 1;

--- a/lib/virt_feature_test_base.pm
+++ b/lib/virt_feature_test_base.pm
@@ -192,7 +192,11 @@ sub post_fail_hook {
     # virt logs are included in next step "virt_utils::collect_host_and_guest_logs"
     collect_virt_system_logs() unless get_var("VIRT_AUTOTEST");
 
-    virt_utils::collect_host_and_guest_logs('', '', '', "_" . caller 0);
+    virt_utils::collect_host_and_guest_logs(
+        full_supportconfig => get_var('FULL_SUPPORTCONFIG', 1),
+        excluded_supportconfig_features => get_var('EXCLUDED_SUPPORTCONFIG_FEATURES', 'aFSLIST AUDIT SELINUX'),
+        token => "_" . caller 0
+    );
     upload_logs("/var/log/clean_up_virt_logs.log");
     save_screenshot;
     upload_logs("/var/log/guest_console_monitor.log");

--- a/tests/virt_autotest/parallel_guest_migration_destination.pm
+++ b/tests/virt_autotest/parallel_guest_migration_destination.pm
@@ -169,7 +169,12 @@ sub guest_migration_test {
             if ($ret == 0) {
                 $ret = $self->test_after_migration(guest => $guest, virttool => $virttool, persistent => $persistent, offline => $offline);
                 $ret |= $self->do_guest_migration(guest => $guest, test => $test, command => $command, offline => $offline, cando => (($migration == 0) ? 1 : 0));
-                collect_host_and_guest_logs($guest, '/var/log', '/var/log', "_$guest" . "_$test") if ($ret != 0 and get_var('INTERVAL_LOG', ''));
+                collect_host_and_guest_logs(
+                    guest => $guest,
+                    full_supportconfig => get_var('FULL_SUPPORTCONFIG', 1),
+                    excluded_supportconfig_features => get_var('EXCLUDED_SUPPORTCONFIG_FEATURES', 'aFSLIST AUDIT SELINUX'),
+                    token => "_$guest" . "_$test"
+                ) if ($ret != 0 and get_var('INTERVAL_LOG', ''));
             }
             $test_stop_time = time();
             $parallel_guest_migration_base::_test_result{$guest}{$command}{test_time} = strftime("\%H:\%M:\%S", gmtime($test_stop_time - $test_start_time));

--- a/tests/virt_autotest/parallel_guest_migration_source.pm
+++ b/tests/virt_autotest/parallel_guest_migration_source.pm
@@ -192,7 +192,12 @@ sub guest_migration_test {
             my $test_stop_time = $test_start_time;
             $self->pre_guest_migration(guest => $guest, virttool => $virttool, first => (($testindex == 0) ? 1 : 0));
             $ret = $self->do_guest_migration(guest => $guest, test => $test, command => $command, offline => $offline);
-            collect_host_and_guest_logs($guest, '/var/log', '/var/log', "_$guest" . "_$test") if ($ret != 0 and get_var('INTERVAL_LOG', ''));
+            collect_host_and_guest_logs(
+                guest => $guest,
+                full_supportconfig => get_var('FULL_SUPPORTCONFIG', 1),
+                excluded_supportconfig_features => get_var('EXCLUDED_SUPPORTCONFIG_FEATURES', 'aFSLIST AUDIT SELINUX'),
+                token => "_$guest" . "_$test"
+            ) if ($ret != 0 and get_var('INTERVAL_LOG', ''));
 
             barrier_wait("DO_GUEST_MIGRATION_DONE_$counter");
 

--- a/tests/virt_autotest/prepare_non_transactional_server.pm
+++ b/tests/virt_autotest/prepare_non_transactional_server.pm
@@ -60,6 +60,7 @@ sub prepare_ground {
 sub prepare_console {
     my $self = shift;
 
+    select_backend_console(console => 'root-ssh-virt', init => 0);
     select_backend_console(init => 0);
 }
 

--- a/tests/virt_autotest/validate_system_health.pm
+++ b/tests/virt_autotest/validate_system_health.pm
@@ -40,10 +40,20 @@ sub run {
     # Upload logs on x86_64
     if (get_var('FORCE_UPLOAD_LOGS') || @unhealthy_list != 0) {
         if (get_var('FORCE_UPLOAD_LOGS')) {
-            collect_host_and_guest_logs(join(' ', grep { $_ ne 'host' } keys %health_status), '', '', '_validate_system_health');
+            collect_host_and_guest_logs(
+                guest => join(' ', grep { $_ ne 'host' } keys %health_status),
+                full_supportconfig => get_var('FULL_SUPPORTCONFIG', 1),
+                excluded_supportconfig_features => get_var('EXCLUDED_SUPPORTCONFIG_FEATURES', 'aFSLIST AUDIT SELINUX'),
+                token => '_validate_system_health'
+            );
         }
         else {
-            collect_host_and_guest_logs(join(' ', grep { $_ ne 'host' } @unhealthy_list), '', '', '_validate_system_health');
+            collect_host_and_guest_logs(
+                guest => join(' ', grep { $_ ne 'host' } @unhealthy_list),
+                full_supportconfig => get_var('FULL_SUPPORTCONFIG', 1),
+                excluded_supportconfig_features => get_var('EXCLUDED_SUPPORTCONFIG_FEATURES', 'aFSLIST AUDIT SELINUX'),
+                token => '_validate_system_health'
+            );
         }
         $self->upload_coredumps;
         save_screenshot;

--- a/tests/virt_autotest/verify_virtualization.pm
+++ b/tests/virt_autotest/verify_virtualization.pm
@@ -251,7 +251,12 @@ sub post_fail_hook {
     script_run("cp -r /etc/sysconfig/network/scripts > /var/log/etc_sysconfig_network_scripts");
     script_run("cp -r /etc/NetworkManager/system-connections > /var/log/etc_networkmanager_system_connections");
     script_run("iptables -L -n -v > /var/log/iptables_rules");
-    virt_utils::collect_host_and_guest_logs("", "/var/log", "/root /var/log", "_verify_virtualization");
+    virt_utils::collect_host_and_guest_logs(
+        extra_guest_log => get_var('EXTRA_GUEST_LOG', '/root /var/log'),
+        full_supportconfig => get_var('FULL_SUPPORTCONFIG', 1),
+        excluded_supportconfig_features => get_var('EXCLUDED_SUPPORTCONFIG_FEATURES', 'aFSLIST AUDIT SELINUX'),
+        token => '_verify_virtualization'
+    );
     save_screenshot;
     upload_coredumps;
     save_screenshot;

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -282,10 +282,17 @@ sub post_fail_hook {
     check_host_health;
 
     if (get_var("VIRT_PRJ2_HOST_UPGRADE")) {
-        virt_utils::collect_host_and_guest_logs('', '/root/autoupg.xml', '');
+        virt_utils::collect_host_and_guest_logs(
+            extra_host_log => get_var('EXTRA_HOST_LOG', '/root/autoupg.xml'),
+            full_supportconfig => get_var('FULL_SUPPORTCONFIG', 1),
+            excluded_supportconfig_features => get_var('EXCLUDED_SUPPORTCONFIG_FEATURES', 'aFSLIST AUDIT SELINUX')
+        );
     }
     else {
-        virt_utils::collect_host_and_guest_logs;
+        virt_utils::collect_host_and_guest_logs(
+            full_supportconfig => get_var('FULL_SUPPORTCONFIG', 1),
+            excluded_supportconfig_features => get_var('EXCLUDED_SUPPORTCONFIG_FEATURES', 'aFSLIST AUDIT SELINUX')
+        );
     }
     save_screenshot;
 

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -697,34 +697,60 @@ sub perform_guest_restart {
     }
 }
 
-#This subroutine collects desired logs from host and guest, and place them into folder /tmp/virt_logs_residence on host then compress it to /tmp/virt_logs_all.tar.gz
-#Please refer to virt_logs_collector.sh and fetch_logs_from_guest.sh in data/virt_autotest for their detailed functionality, implementation and usage
+# This subroutine collects desired logs from host and guest, and place them into
+# folder /tmp/virt_logs_residence on host then compress it to /tmp/virt_logs_all.tar.gz
+# Please refer to virt_logs_collector.sh and fetch_logs_from_guest.sh in data/virt_autotest
+# for their detailed functionality, implementation and usage.
+# Arguments explanation:
+# guest: only collect and fetch logs from specified guests which are separated
+# by space.
+# guest_password: password to establish ssh or console connection to guest.
+# extra_host_log: extra logs to be collected from host separated by space.
+# extra_guest_log: extra logs to be collected from guest separated by space.
+# full_supportconfig: whether use supportconfig with -A option to activate all
+# features (1 or 0).
+# excluded_supportconfig_features: features to be excluded from supportconfig
+# separated by space.
+# token: label to appended at the end to form the final uploaded log name.
+# keep: whether remove uploaded logs at the last (true or false).
+# timeout: time out value for logs collecting and fetching. Default to 3600.
 sub collect_host_and_guest_logs {
-    my ($guest_wanted, $host_extra_logs, $guest_extra_logs, $log_token) = @_;
-    $guest_wanted //= '';
-    $host_extra_logs //= '';
-    $guest_extra_logs //= '';
-    $log_token //= '';
+    my %args = @_;
+    $args{guest} //= '';
+    $args{guest_password} = '';
+    $args{extra_host_log} //= get_var('EXTRA_HOST_LOG', '/var/log');
+    $args{extra_guest_log} //= get_var('EXTRA_GUEST_LOG', '/var/log');
+    $args{full_supportconfig} //= get_var('FULL_SUPPORTCONFIG', 1);
+    $args{excluded_supportconfig_features} //= get_var('EXCLUDED_SUPPORTCONFIG_FEATURES', 'aFSLIST AUDIT SELINUX');
+    $args{token} //= '';
+    $args{keep} //= 'false';
+    $args{timeout} //= 3600;
 
+    $args{full_supportconfig} = ($args{full_supportconfig} ? 'true' : 'false');
     my $logs_collector_script_url = data_url("virt_autotest/virt_logs_collector.sh");
-    script_output("curl -s -o ~/virt_logs_collector.sh $logs_collector_script_url", 180, type_command => 0, proceed_on_failure => 0);
+    script_output("curl -s -o ~/virt_logs_collector.sh $logs_collector_script_url", timeout => 180, type_command => 0, proceed_on_failure => 0);
     save_screenshot;
-    script_output("chmod +x ~/virt_logs_collector.sh && ~/virt_logs_collector.sh -l \"$host_extra_logs\" -g \"$guest_wanted\" -e \"$guest_extra_logs\"", 3600 / get_var('TIMEOUT_SCALE', 1), type_command => 1, proceed_on_failure => 1);
+    script_output(
+"chmod +x ~/virt_logs_collector.sh && ~/virt_logs_collector.sh -l \"$args{extra_host_log}\" -g \"$args{guest}\" -p \"$args{guest_password}\" -e \"$args{extra_guest_log}\" -a \"$args{full_supportconfig}\" -x \"$args{excluded_supportconfig_features}\"",
+        timeout => $args{timeout},
+        type_command => 1,
+        proceed_on_failure => 1
+    );
     save_screenshot;
 
     send_key("ret");
     my $logs_fetching_script_url = data_url("virt_autotest/fetch_logs_from_guest.sh");
     script_output("curl -s -o ~/fetch_logs_from_guest.sh $logs_fetching_script_url", 180, type_command => 0, proceed_on_failure => 0);
     save_screenshot;
-    script_output("chmod +x ~/fetch_logs_from_guest.sh && ~/fetch_logs_from_guest.sh -g \"$guest_wanted\" -e \"$guest_extra_logs\"", 1800, type_command => 1, proceed_on_failure => 1);
+    script_output("chmod +x ~/fetch_logs_from_guest.sh && ~/fetch_logs_from_guest.sh -g \"$args{guest}\" -p \"$args{guest_password}\" -e \"$args{extra_guest_log}\"", timeout => $args{timeout}, type_command => 1, proceed_on_failure => 1);
     save_screenshot;
 
     send_key("ret");
-    upload_logs("/tmp/virt_logs_all.tar.gz", log_name => "virt_logs_all$log_token.tar.gz", timeout => 600);
-    upload_logs("/var/log/virt_logs_collector.log", log_name => "virt_logs_collector$log_token.log");
-    upload_logs("/var/log/fetch_logs_from_guest.log", log_name => "fetch_logs_from_guest$log_token.log");
+    upload_logs("/tmp/virt_logs_all.tar.gz", log_name => "virt_logs_all$args{token}.tar.gz", timeout => 600);
+    upload_logs("/var/log/virt_logs_collector.log", log_name => "virt_logs_collector$args{token}.log");
+    upload_logs("/var/log/fetch_logs_from_guest.log", log_name => "fetch_logs_from_guest$args{token}.log");
     save_screenshot;
-    script_run("rm -f -r /tmp/virt_logs_all.tar.gz /var/log/virt_logs_collector.log /var/log/fetch_logs_from_guest.log");
+    script_run("rm -f -r /tmp/virt_logs_all.tar.gz /var/log/virt_logs_collector.log /var/log/fetch_logs_from_guest.log") if ($args{keep} eq 'false');
     save_screenshot;
 }
 


### PR DESCRIPTION
1.Enhance subroutine collect_host_and_guest_logs in test module tests/virt_autotest/virt_utils.pm use named arguments to have more flexibility especially when introducing the new arguments guest_password,full_supportconfig ,excluded_supportconfig_features and keep:
a).The new argument guest_password stores the root password to access all guests on logs collecting.
b).The new argument full_supportconfig indicates whether activating all supportconfig functions, namely the -A options, with supportconfig command run. Default to true. This can help accelerate logs collecting on demand and solve logs collecting freeze issue if necessary. Default to 1. c).The new argument excluded_supportconfig_features specifies features to be excluded from collecting with supportconfig command. They are passed in as string with space as the separator. This can help accelerate logs collecting on demand and solve logs collecting freeze issue if necessary. Default to 'aFSLIST AUDIT SELINUX' which can basically eliminates all logs collecting issue I have ever encountered and, at the same time, collecting extra log /var/log/xxx or /var/log can help compensate.
d).The new argument keep indicates whether uploaded logs will be deleted locally. Default to false.
e).User can use test suite setting _SECRET_GUEST_PASSWORD to specify guest password, FULL_SUPPORTCONFIG to do toggling, EXTRA_HOST_LOG and EXTRA_GUEST_LOG to specify extra logs to be collected from host and guest, and EXCLUDED_SUPPORTCONFIG_FEATURES to exclude unwanted supportconfig features. This increases flexibility significantly instead all fixed options. f).Also added arguments explanation and formatted subroutine description better. 2.The new argument guest_password leads to changes to scripts data/virt_autotest/virt_logs_collector.sh and
data/virt_autotest/fetch_logs_from_guest.sh:
a).New argument virt_guests_password as passed-in script argument. b).New argument guest_password to functions:
collect_logs_via_guest_console
collect_supportconfig_via_guest_console
collect_sosreport_via_guest_console
collect_extra_logs_via_guest_console
collect_extra_logs_from_guest
collect_system_log_and_diagnosis
fetch_logs_from_guest_via_ssh
fetch_logs_from_guest_via_libguestfs
remove_logs_folder_from_guest_via_libguestfs
fetch_logs_from_guest
3.The new argument full_supportconfig leads to changes to script data/virt_autotest/virt_logs_collector.sh:
a).New argument full_supportconfig as passed-in script argument. b).New argument full_supportconfig to functions:
collect_logs_via_guest_console
collect_system_log_and_diagnosis
collect_supportconfig_via_guest_console
4.The new argument excluded_supportconfig_features leads to changes to script data/virt_autotest/virt_logs_collector.sh:
a).New argument excluded_supportconfig_features as passed-in script argument. b).New argument excluded_supportconfig_features_ref to functions: collect_logs_via_guest_console
c).New argument excluded_supportconfig_features to functions: collect_logs_via_guest_console
collect_system_log_and_diagnosis
5.Update collect_host_and_guest_logs calling in modules: guest_installation_and_configuration_base.pm
parallel_guest_migration_base.pm
parallel_guest_migration_destination.pm
parallel_guest_migration_destination.pm
validate_system_health.pm
verify_virtualization.pm
virt_autotest_base.pm
virt_feature_test_base.pm
validate_system_health.pm
7.Also added function arguments explanation and formatted descriptions better for functions in scripts data/virt_autotest/virt_logs_collector.sh and data/virt_autotest/fetch_logs_from_guest.sh.

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
