### PR TITLE
BCI remove milestone flag, avoid execution of clear

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -154,7 +154,7 @@ sub run {
 sub post_run_hook { }
 
 sub test_flags {
-    return {fatal => 1, milestone => 1};
+    return {fatal => 1, milestone => 0};
 }
 
 1;

--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -151,6 +151,8 @@ sub run {
     my $host_version = get_var("HOST_VERSION", get_required_var("VERSION"));    # VERSION is the version of the container, not the host.
 }
 
+sub post_run_hook { }
+
 sub test_flags {
     return {fatal => 1, milestone => 1};
 }

--- a/tests/containers/bci_version_check.pm
+++ b/tests/containers/bci_version_check.pm
@@ -59,6 +59,8 @@ sub run {
     }
 }
 
+sub post_run_hook { }
+
 sub test_flags {
     return {fatal => 1, milestone => 1};
 }

--- a/tests/containers/bci_version_check.pm
+++ b/tests/containers/bci_version_check.pm
@@ -62,7 +62,7 @@ sub run {
 sub post_run_hook { }
 
 sub test_flags {
-    return {fatal => 1, milestone => 1};
+    return {fatal => 1, milestone => 0};
 }
 
 1;


### PR DESCRIPTION
1. BCI testing does not require SUT snapshots.

2. avoid clear
`consoletests::post_run_hook::$self->clear_and_verify_console;` injects
`clear` in serial terminal, that tend to break the next command
execution as the bash prompt is not ready, but the test is already
typing the command. openQA does not wait for `clear` to finnish it's
execution.

It would be better to use `printf '\033[2J\033[H'` instead of clear

https://openqa.suse.de/tests/23856674
https://openqa.suse.de/tests/23856623
https://openqa.suse.de/tests/23856624
