### PR TITLE
Adapt the schedule to the new eBPF tracer

### DIFF
--- a/schedule/coverage/clamav.yaml
+++ b/schedule/coverage/clamav.yaml
@@ -22,13 +22,11 @@ schedule:
     - console/clamav
     - coverage/coverage_report
 test_data:
-    # these packages are needed by the tests, we need to install them early to instrument them
-    extra_packages:
-        - clamav
-    # the following section is an array of binaries that we want to instrument
+    # package -> binary (or list of binaries) to instrument
     coverage_targets:
-        # - /usr/bin/freshclam # needs investigation, gives operation not permitted
-        - /usr/bin/clamdscan
-        - /usr/bin/clamscan
-        - /usr/bin/sigtool
-        - /usr/sbin/clamd
+        clamav:
+            # - /usr/bin/freshclam # needs investigation, gives operation not permitted
+            - /usr/bin/clamdscan
+            - /usr/bin/clamscan
+            - /usr/bin/sigtool
+            - /usr/sbin/clamd

--- a/schedule/coverage/squid_proxy.yaml
+++ b/schedule/coverage/squid_proxy.yaml
@@ -22,10 +22,9 @@ schedule:
   - fips/squid/squid_reverse_proxy
   - coverage/coverage_report
 test_data:
-  # these packages are needed by the tests, we need to install them early to instrument them
-  extra_packages:
-    - wget    # to download the test data
-    - squid
-  # the following section is an array of binaries that we want to instrument
+  # packages needed to make tests work, but NOT instrumented
+  helper_packages:
+    - wget    # to download test data
+  # package -> binary (or list of binaries) to instrument
   coverage_targets:
-    - /usr/sbin/squid
+    squid: /usr/sbin/squid

--- a/schedule/coverage/tw_textmode.yaml
+++ b/schedule/coverage/tw_textmode.yaml
@@ -2,6 +2,9 @@
 # when you add a test, you need to fill out the last
 # section about coverage targets as well
 
+# TODO figure out a better way to select the tuple : coverage targets, tests and packages
+
+
 name:  measure test coverage for selected text mode utils
 description: >
     Maintainer: amanzini
@@ -18,7 +21,7 @@ schedule:
   - console/system_prepare
   - coverage/coverage_setup
   - network/snmp
-  - console/dig
+#  - console/dig
   - console/cpio
   - console/curl_https
   - console/curl_ipv6
@@ -26,67 +29,47 @@ schedule:
   - console/lshw
   - console/nano
   - console/nftables
-  - console/run0
-  - console/tracepath
+#  - console/tracepath
   - console/traceroute
-  - console/nginx
-  - console/pciutils
-  - console/sysctl
+#  - console/nginx
+#  - console/pciutils
+#  - console/sysctl
   - console/tar
-  - console/tcpdump
   - console/unzip
   - console/vim
   - console/wavpack
   - coverage/coverage_report
 test_data:
-  # these packages are needed by the tests, we need to install them early to instrument them
-  extra_packages:
-    - bind-utils  # for dig test
-    - bzip2  # for tar test
-    - cpio
-    - curl
-    - cpupower
-    - gd
-    - iputils  # for ping and tracepath
-    - lshw
-    - nano
-    - nftables
-    - nginx
-    - procps
-    - powertop
-    - unzip
-    - net-snmp
-    - systemd  # for systemd-run (run0 test)
-    - tar
-    - tcpdump
-    - traceroute
-    - wavpack
-    - wget    # to download the test data
-    - vim
-  # the following section is an array of binaries that we want to instrument
+  # packages needed to make tests work, but NOT instrumented
+  helper_packages:
+    - gzip       # used by tar test
+    - iputils    # for ping
+    - systemd    # for systemd-run (run0 test)
+    - wget       # to download test data
+  # syntax: package -> binary (or list of binaries) to instrument
   coverage_targets:
-    - /usr/bin/cpio
-    - /usr/bin/cpupower
-    - /usr/bin/curl
-    - /usr/bin/dig
-    - /usr/bin/giftogd2
-    - /usr/bin/gd2togif
-    - /usr/bin/nano
-    - /usr/bin/run0
-    - /usr/bin/snmpget
-    - /usr/bin/snmpset
-    - /usr/bin/snmpusm
-    - /usr/bin/tar
-    - /usr/bin/tracepath
-    - /usr/bin/vim-nox11
-    - /usr/bin/vmstat
-    - /sbin/nginx
-    - /sbin/sysctl
-    - /usr/sbin/lshw
-    - /usr/sbin/nft
-    - /usr/sbin/powertop
-    - /usr/sbin/tcpdump
-    - /usr/sbin/traceroute
-    - /usr/bin/unzip
-    - /usr/bin/wavpack
-    - /usr/bin/wvunpack
+    bind-utils: /usr/bin/dig
+    bzip2: /usr/bin/bzip2
+    cpio: /usr/bin/cpio
+    curl: /usr/bin/curl
+    gd:
+      - /usr/bin/giftogd2
+      - /usr/bin/gd2togif
+    lshw: /usr/sbin/lshw
+    net-snmp:
+      - /usr/bin/snmpget
+      - /usr/bin/snmpset
+      - /usr/bin/snmpusm
+    nftables: /usr/sbin/nft
+    nano: /usr/bin/nano
+    procps:
+      - /usr/bin/vmstat
+      - /sbin/sysctl
+    tar: /usr/bin/tar
+    unzip: /usr/bin/unzip
+    vim: /usr/bin/vim-nox11
+    wavpack:
+      - /usr/bin/wavpack
+      - /usr/bin/wvunpack
+#    nginx: /sbin/nginx
+    traceroute: /usr/sbin/traceroute

--- a/tests/coverage/coverage_report.pm
+++ b/tests/coverage/coverage_report.pm
@@ -12,10 +12,26 @@ sub run {
     select_serial_terminal;
     assert_script_run 'mkdir -p /var/coverage/report';
     assert_script_run 'funkoverage report /var/coverage/data /var/coverage/report';
+    # Raw coverage data is large; only upload it when explicitly requested.
+    if (get_var('BINARY_COVERAGE_UPLOAD_DATA')) {
+        assert_script_run 'tar -czf /tmp/coverage_data.tar.gz -C /var/coverage data';
+        upload_logs('/tmp/coverage_data.tar.gz', failok => 1);
+    }
     # Upload the coverage report files
     my @files = split("\n", script_output 'ls -1 /var/coverage/report/*');
-    # parse the XML reports
-    parse_extra_log('XUnit', $_) for grep { /\.xml/ } @files;
+    # parse_extra_log() uploads the file first, then parses it via OpenQA::Parser
+    # (require'd internally); on a bare isotovideo worker without the full openQA
+    # install (e.g. run_this_in_openqa's container) that module doesn't exist, so
+    # it croaks — after the upload already happened. Installing OpenQA::Parser
+    # there isn't a lightweight fix: it comes from openQA-common, which pulls in
+    # ~140 packages (Mojolicious, DateTime, Selenium, even a different os-autoinst
+    # build) — the "openQA stack" a bare isotovideo worker deliberately doesn't
+    # have. So: try the structured parse, but don't let its absence fail this
+    # module — the raw (already uploaded) file is enough outside a full openQA install.
+    for (grep { /\.xml/ } @files) {
+        eval { parse_extra_log('XUnit', $_) };
+        record_info('XUnit parse skipped', $@) if $@;
+    }
     # upload the files except the XML reports
     upload_logs($_) for grep { $_ !~ /\.xml/ } @files;
 }

--- a/tests/coverage/coverage_setup.pm
+++ b/tests/coverage/coverage_setup.pm
@@ -4,13 +4,25 @@
 # Summary: setup coverage tooling
 # Maintainer: Andrea Manzini <andrea.manzini@suse.com>
 
-# test data section in the YAML schedule must contain an hash
-# of packages to install -> binary to instrument. For example
+# test_data in the YAML schedule must contain:
+#   coverage_targets: hash of package_name -> binary (scalar) or [list of binaries]
+#   helper_packages:  (optional) packages needed to make tests work, but NOT instrumented
 #
-# test_data:
-#   coverage_targets:
-#     unzip: /usr/bin/unzip
-#     nano: /usr/bin/nano
+# Example:
+#   test_data:
+#     helper_packages:
+#       - wget
+#     coverage_targets:
+#       curl: /usr/bin/curl
+#       net-snmp:
+#         - /usr/bin/snmpget
+#         - /usr/bin/snmpset
+#
+# BINARY_COVERAGE_GITREF: if set, build funkoverage from source on the SUT instead
+# of installing the packaged coverage-tools RPM. Value must be a full git clone URL
+# (any fork/branch works, e.g. a URL with a #branch suffix), not just a branch name.
+# Upstream reference: https://github.com/ilmanzo/BinaryCoverage
+# Example: BINARY_COVERAGE_GITREF=https://github.com/ilmanzo/BinaryCoverage#main
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
@@ -27,6 +39,7 @@ sub run {
 
     # TODO maybe not the best way, but it works
     my $test_data = get_test_suite_data();
+    my $gitref = get_var('BINARY_COVERAGE_GITREF');
 
     my %repositories;    # an hash of repositories to add
 
@@ -53,25 +66,56 @@ sub run {
             debug => 'http://download.opensuse.org/debug/tumbleweed/repo/oss/');
     }
     while (my ($name, $url) = each(%repositories)) {
-        assert_script_run "zypper ar -e -f $url $name";
+        # Priority 1: some HDD images already have a same-purpose debug repo (e.g. an
+        # openQA asset-mirror one) baked in at a lower priority (higher number) that
+        # only carries a curated package subset; ours must win so debuginfo actually
+        # resolves against a repo that has it, not just one that was registered first.
+        assert_script_run "zypper ar -e -f -p 1 $url $name";
     }
 
-    # install coverage tools and any extra packages + debug info
-    my @packages;
-    for (@{$test_data->{extra_packages}}) {
-        push @packages, $_;
-        push @packages, $_ . '-debuginfo';
+    # install coverage tools + debuginfo, and any helper packages
+    my (@packages, @binaries);
+    while (my ($pkg, $targets) = each(%{$test_data->{coverage_targets}})) {
+        push @packages, $pkg, $pkg . '-debuginfo';
+        my @pkg_bins = ref($targets) eq 'ARRAY' ? @$targets : ($targets);
+        push @binaries, @pkg_bins;
     }
-    push @packages, 'coverage-tools';
+    for (@{$test_data->{helper_packages} // []}) {
+        push @packages, $_;
+    }
+    push @packages, 'elfutils';
+    push @packages, 'coverage-tools' unless $gitref;
     zypper_call '--gpg-auto-import-keys in ' . join ' ', @packages;
 
-    assert_script_run 'mkdir -m 0777 -p /var/coverage/data';
+    # sets up the environment for coverage
+    my $log_dir = '/var/coverage/data';
 
-    # set up eBPF capabilities required by funkoverage
+    assert_script_run "mkdir -m 0777 -p $log_dir";
+
+    if ($gitref) {
+        # build funkoverage from source instead of using the packaged coverage-tools.
+        # $gitref is a full git URL (any fork), optionally with a '#branch' suffix.
+        zypper_call 'in go git';
+        my ($repo_url, $branch) = split /#/, $gitref, 2;
+        assert_script_run 'git clone --depth 1 ' . ($branch ? "--branch $branch " : '')
+          . "'$repo_url' /opt/BinaryCoverage", timeout => 300;
+        assert_script_run 'cd /opt/BinaryCoverage && ./build.sh', timeout => 600;
+        # build.sh's output path isn't pinned by contract; locate then install it.
+        # funkoverage-shim must sit alongside funkoverage: install runs 'funkoverage
+        # install' which shims target binaries and looks up the shim next to itself.
+        assert_script_run 'install -m 0755 '
+          . '"$(find /opt/BinaryCoverage -maxdepth 2 -type f -name funkoverage | head -1)" '
+          . '/usr/local/bin/funkoverage';
+        assert_script_run 'install -m 0755 '
+          . '"$(find /opt/BinaryCoverage -maxdepth 2 -type f -name funkoverage-shim | head -1)" '
+          . '/usr/local/bin/funkoverage-shim';
+    }
+
+    # set capabilities to run eBPF programs without root privileges
     assert_script_run 'funkoverage setup';
 
-    # install shims around the binaries to be instrumented for coverage
-    assert_script_run "funkoverage install " . join ' ', @{$test_data->{coverage_targets}};
+    # wrap the binaries that will be instrumented for 'coverage'
+    assert_script_run "funkoverage install " . join ' ', @binaries;
 }
 
 sub test_flags {


### PR DESCRIPTION
With the recent changes to https://github.com/ilmanzo/binarycoverage, refactor the `coverage_setup.pm` in order to be more flexible 

