### PR TITLE
fix(bci): avoid clear command

### DIFF
--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -162,6 +162,8 @@ sub run {
     die("$error_count tests failed.") if ($error_count > 0);
 }
 
+sub post_run_hook { }
+
 sub test_flags {
     return {fatal => 0, no_rollback => 1};
 }


### PR DESCRIPTION
Avoid running `clear` command in bci test runner module as openQA does not wait for clear command to return

Error in https://openqa.suse.de/tests/23857558#step/bci_logs/2

```
cat > /tmp/scriptUt0xG.sh << 'EOT_Ut0xG'; echo Ut0xG-$?-
find /root/BCI-tests -maxdepth 2 -type f -name "junit_*.xml"
```