### PR TITLE
coverage_report: handle large target sets

### DIFF
--- a/tests/coverage/coverage_report.pm
+++ b/tests/coverage/coverage_report.pm
@@ -11,29 +11,31 @@ use serial_terminal 'select_serial_terminal';
 sub run {
     select_serial_terminal;
     assert_script_run 'mkdir -p /var/coverage/report';
-    assert_script_run 'funkoverage report /var/coverage/data /var/coverage/report';
+    # Redirect funkoverage output to a log file. With 50+ targets the
+    # report progress output can fill the serial buffer and break
+    # subsequent serial commands.
+    assert_script_run 'funkoverage report /var/coverage/data /var/coverage/report >/tmp/fv_report.log 2>&1', timeout => 600;
     # Raw coverage data is large; only upload it when explicitly requested.
     if (get_var('BINARY_COVERAGE_UPLOAD_DATA')) {
         assert_script_run 'tar -czf /tmp/coverage_data.tar.gz -C /var/coverage data';
         upload_logs('/tmp/coverage_data.tar.gz', failok => 1);
     }
-    # Upload the coverage report files
-    my @files = split("\n", script_output 'ls -1 /var/coverage/report/*');
+    # List report files via a file to avoid serial buffer issues with large listings.
+    assert_script_run 'ls /var/coverage/report/ > /tmp/rpt_files.txt';
+    my @files = map { "/var/coverage/report/$_" }
+      split(/\n/, script_output('cat /tmp/rpt_files.txt'));
     # parse_extra_log() uploads the file first, then parses it via OpenQA::Parser
     # (require'd internally); on a bare isotovideo worker without the full openQA
     # install (e.g. run_this_in_openqa's container) that module doesn't exist, so
-    # it croaks — after the upload already happened. Installing OpenQA::Parser
-    # there isn't a lightweight fix: it comes from openQA-common, which pulls in
-    # ~140 packages (Mojolicious, DateTime, Selenium, even a different os-autoinst
-    # build) — the "openQA stack" a bare isotovideo worker deliberately doesn't
-    # have. So: try the structured parse, but don't let its absence fail this
-    # module — the raw (already uploaded) file is enough outside a full openQA install.
+    # it croaks — after the upload already happened. So: try the structured parse,
+    # but don't let its absence fail this module.
     for (grep { /\.xml/ } @files) {
         eval { parse_extra_log('XUnit', $_) };
         record_info('XUnit parse skipped', $@) if $@;
     }
-    # upload the files except the XML reports
-    upload_logs($_) for grep { $_ !~ /\.xml/ } @files;
+    # Upload HTML reports, skipping shared library reports (lib*.html) which
+    # can number 200+ with large target sets and cause upload timeouts.
+    upload_logs($_) for grep { /\.html$/ && !/\/lib/i } @files;
 }
 
 1;


### PR DESCRIPTION
With 50+ coverage targets, funkoverage report output and the file listing can fill the serial buffer. Redirect report output to a log file, list files via a temp file, and skip lib*.html uploads (200+ shared library reports cause upload timeouts).

All existing features preserved (BINARY_COVERAGE_UPLOAD_DATA, XUnit eval guard).

Discussed with @ilmanzo.