### PR TITLE
Allow controlling custom_data vs user_data in Azure Terraform

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -71,6 +71,10 @@ variable "cloud_init" {
   default = ""
 }
 
+variable "use_user_data" {
+  default = true
+}
+
 variable "storage-account" {
   # Note: Don't delete the default value!!!
   # Not all of our `terraform destroy` calls pass this variable and neither is it necessary.
@@ -225,7 +229,8 @@ resource "azurerm_linux_virtual_machine" "openqa-vm" {
     create = var.vm_create_timeout
   }
 
-  user_data = var.cloud_init != "" ? filebase64(var.cloud_init) : null
+  custom_data = (!var.use_user_data && var.cloud_init != "") ? filebase64(var.cloud_init) : null
+  user_data   = (var.use_user_data && var.cloud_init != "") ? filebase64(var.cloud_init) : null
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "default" {

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -554,7 +554,10 @@ sub terraform_apply {
     $vars{type} = $instance_type;
     $vars{name} = $self->resource_name;
     $vars{project} = $args{project} if ($args{project});
-    $vars{cloud_init} = TERRAFORM_DIR . "/cloud-init.yaml" if (get_var('PUBLIC_CLOUD_CLOUD_INIT'));
+    if (get_var('PUBLIC_CLOUD_CLOUD_INIT')) {
+        $vars{cloud_init} = TERRAFORM_DIR . "/cloud-init.yaml";
+        $vars{use_user_data} = get_var('PUBLIC_CLOUD_USER_DATA') if defined get_var('PUBLIC_CLOUD_USER_DATA');
+    }
     $vars{vm_create_timeout} = $terraform_vm_create_timeout;
     my $root_size = get_var('PUBLIC_CLOUD_ROOT_DISK_SIZE');
     $vars{'root-disk-size'} = $root_size if ($root_size);
@@ -706,7 +709,10 @@ sub terraform_destroy {
     record_info('INFO', 'Removing terraform plan...');
     # Add region variable also to `terraform destroy` (poo#63604) -- needed by AWS.
     $vars{region} = $self->provider_client->region;
-    $vars{cloud_init} = TERRAFORM_DIR . '/cloud-init.yaml' if (get_var('PUBLIC_CLOUD_CLOUD_INIT'));
+    if (get_var('PUBLIC_CLOUD_CLOUD_INIT')) {
+        $vars{cloud_init} = TERRAFORM_DIR . '/cloud-init.yaml';
+        $vars{use_user_data} = get_var('PUBLIC_CLOUD_USER_DATA') if defined get_var('PUBLIC_CLOUD_USER_DATA');
+    }
     $vars{ssh_public_key} = $self->ssh_key . '.pub';
 
     # Add image_id, offer and sku on Azure runs, if defined.

--- a/variables.md
+++ b/variables.md
@@ -414,6 +414,7 @@ PUBLIC_CLOUD_TOOLS_REPO | string | false | The URL to the cloud:tools repo (opti
 PUBLIC_CLOUD_TTL_OFFSET | integer | 300 | This number + MAX_JOB_TIME equals the TTL of created VM.
 PUBLIC_CLOUD_UPLOAD_IMG | boolean | false | If set, `publiccloud/upload_image` test module is added to the job.
 PUBLIC_CLOUD_USER | string | "" | The public cloud instance system user.
+PUBLIC_CLOUD_USER_DATA | boolean | true | Specific to Azure, about the API used in the azure.tf file to inject the cloud-init profile. 1:user_data, 0:custom_data.
 PUBLIC_CLOUD_XEN | boolean | false | Indicates if this is a Xen test run.
 SCC_REGISTRY | string | "" | Registry which requires SCC login
 SCC_PROXY_USERNAME | string | "" | Credentials username for registry which requires SCC login


### PR DESCRIPTION
Recent change replaced `custom_data` with `user_data` in Azure Terraform to fetch cloud-init configurations directly via IMDS instead of OVF.

However, older distributions like SLES 12 SP5 carry `cloud-init 20.2`, which only supports reading `custom_data` via OVF CD-ROM (`/dev/sr0`). When `user_data` is used, cloud-init on SLES 12 SP5 receives an empty 0-byte configuration payload and skips user-data execution.

This change introduces the `use_user_data` variable (default `true`) to `azure.tf`, allowing openQA jobs to select between `user_data` (IMDS) and legacy `custom_data` (OVF) via `PUBLIC_CLOUD_TERRAFORM_USER_DATA`. By default, `user_data` remains enabled for all modern distributions.

Fix a regression introduced by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26304


- Related ticket: https://progress.opensuse.org/issues/204834

# Verifications

## 15
sle-15-SP7-Azure-BYOS-Hardened-Incidents-x86_64-Build:smelt:45831:kernel-azure-publiccloud_smoketests_gen1 az_Standard_B2s -
- http://openqa.suse.de/tests/23868423 terraform is using `user_data` https://openqa.suse.de/tests/23868423/logfile?filename=serial_terminal.txt#line-2208
-  http://openqa.suse.de/tests/23869485 terraform is using `user_data` https://openqa.suse.de/tests/23869485/logfile?filename=serial_terminal.txt#line-2208

## 12sp5
- sle-12-SP5-Azure-BYOS-Incidents-x86_64-Build:smelt:45872:kernel-ec2-publiccloud_smoketests_gen1 az_Standard_B2s 
- http://openqa.suse.de/tests/23868410 without PUBLIC_CLOUD_USER_DATA is expected to fail
- http://openqa.suse.de/tests/23868789 with PUBLIC_CLOUD_USER_DATA=1
-  http://openqa.suse.de/tests/23873641 with PUBLIC_CLOUD_USER_DATA=0 terraform use the legacy `custom_data` https://openqa.suse.de/tests/23873641/logfile?filename=serial_terminal.txt#line-1773 failure is https://openqa.suse.de/tests/23873641#step/check_services/4 poo#175024
-  http://openqa.suse.de/tests/23874043 with PUBLIC_CLOUD_USER_DATA=0 and PUBLIC_CLOUD_CLOUD_INIT=1
- http://openqa.suse.de/tests/23874068 with PUBLIC_CLOUD_USER_DATA=0 and PUBLIC_CLOUD_CLOUD_INIT=1
