### PR TITLE
sudo: mark as non-fatal

### DIFF
--- a/tests/console/sudo.pm
+++ b/tests/console/sudo.pm
@@ -146,6 +146,10 @@ sub post_run_hook {
     assert_script_run 'userdel -r sudo_test && groupdel sudo_group';
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 sub post_fail_hook {
     script_run('tar -cf /var/tmp/sudoers.tmp /etc/sudoers');
     upload_logs('/var/tmp/sudoers.tmp');


### PR DESCRIPTION
Without `fatal => 0`, a sudo failure aborts the entire schedule when snapshots are disabled. This is a validation test, not a setup step. Same pattern as `console/ping.pm`.

- Verification run: [Tumbleweed](https://openqa.opensuse.org/tests/6158028) | [15-SP7](https://openqa.suse.de/tests/23865030) | [16.0](https://openqa.suse.de/tests/23865031)