### PR TITLE
fix(bci): avoid clear in host config

### DIFF
--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -122,6 +122,8 @@ sub run {
     record_info("podman info", script_output("podman info")) if ($engine =~ 'podman');
 }
 
+sub post_run_hook { }
+
 sub test_flags {
     return {fatal => 1, milestone => 1};
 }


### PR DESCRIPTION
The same as other previous PRs. Command clear can break stuff due to a race condition
