### PR TITLE
fix(graphicsmagick/test.sh) Force the PNG encoder to fix image

### DIFF
--- a/data/graphicsmagick/test.sh
+++ b/data/graphicsmagick/test.sh
@@ -10,6 +10,23 @@
 #
 # Usage; test.sh path_of_resources
 
+function exit_handler {
+  local exit_code=$?
+  echo "OK: $count_ok, ERRORS: $count_ko, TOTAL: ${#tests[*]}"
+  case $exit_code in
+    0)
+      echo "All tests passed"
+      ;;
+    *)
+      echo "KO:" >&2
+      printf '%s\n' "${ko_list[@]}" >&2
+    ;;
+    esac
+  exit $exit_code;
+}
+
+trap exit_handler EXIT
+
 #####################
 # Download resorces
 #####################
@@ -82,7 +99,7 @@ gm convert white.png frame4.gif
 
 ## Check if the first version is equal or greater than the required version
 # e.g version_or_higher "1.3.33" "1.3.28" returns true
-function version_or_higher() {
+function version_or_higher {
   local version="${1:-0}"
   local required="${2:-0}"
 
@@ -454,7 +471,7 @@ if ! version_or_higher "$(rpm -q GraphicsMagick --qf '%{VERSION}')" "1.3.47"; th
   )
 fi
 
-function special(){
+function special {
   case $1 in
     0) gm convert -resize 500x250! -fill red -draw 'rectangle 250,0 500,250' blue.png $2 && compare PAE $2 quadrants_up_500x250.png 0;;
     1) gm convert -fill red -draw 'circle 125,125 125,0' white.png $2 && compare PAE $2 red_circle.png 0;;
@@ -497,8 +514,8 @@ do
 
       res=$($cmd)
       if [ $? -ne 0 ]; then
-        res="KO"
-        break;
+        res=$cmd
+        break
       fi
     done
 
@@ -506,13 +523,11 @@ do
       ok_list[$count_ok]=$index
       count_ok=$(( count_ok + 1 ))
     else
-      ko_list[$count_ko]=$index
+      ko_list[$count_ko]="test $index => $res"
       count_ko=$(( count_ko + 1 ))
     fi
 
     echo "$index - $res - $original_command"
 done
-
-echo "OK: $count_ok , ERRORS: $count_ko"
 
 exit $count_ko

--- a/data/graphicsmagick/test.sh
+++ b/data/graphicsmagick/test.sh
@@ -397,7 +397,7 @@ tests=(
   # Test 8. Composite images
 
   # a. Composite an image from two images
-  "gm composite blue.png quadrants500x500_transparent_blue.png __1.png;compare PAE __1.png quadrants500x500.png 0"
+  "gm composite blue.png quadrants500x500_transparent_blue.png PNG32:__1.png; compare PAE __1.png quadrants500x500.png 0"
 
   # b. Compute the difference between images:
   "gm composite -compose difference red.png blue.png __1.png;compare PAE __1.png magenta.png 0"

--- a/tests/x11/graphicsMagick.pm
+++ b/tests/x11/graphicsMagick.pm
@@ -9,8 +9,11 @@
 
 use Mojo::Base 'x11test';
 use testapi;
+use serial_terminal qw(select_serial_terminal);
 use utils 'zypper_call';
 use x11utils qw(default_gui_terminal close_gui_terminal);
+
+my $workdir;
 
 sub run {
     my $self = shift;
@@ -22,13 +25,14 @@ sub run {
     select_console "x11";
     x11_start_program(default_gui_terminal);
 
-    my $tmp = script_output 'mktemp -d';
-    assert_script_run("pushd $tmp");
+    $workdir = script_output 'mktemp -d';
+    assert_script_run("pushd $workdir");
 
     record_info("INFO", "Step 1. Runs command line tests");
     assert_script_run "wget --quiet " . data_url('graphicsmagick/test.sh') . " -O test.sh";
     assert_script_run "chmod +x test.sh";
-    assert_script_run("./test.sh " . data_url('graphicsmagick'), 3 * 60);
+    my $command = "./test.sh " . data_url('graphicsmagick') . " |& tee run.log";
+    assert_script_run("$command", 3 * 60);
 
     record_info("INFO", "Step 2. Runs visual tests");
 
@@ -53,11 +57,18 @@ sub run {
     enter_cmd "gm convert noise_blur_10.png HISTOGRAM:- | gm display -";
     assert_screen('open_an_image_histogram', 90);
     send_key 'alt-f4';
-
+    upload_logs("run.log");
     assert_script_run("popd");
-    assert_script_run("rm -rf $tmp");
+    assert_script_run("rm -rf $workdir");
 
     close_gui_terminal;
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    select_serial_terminal;
+    upload_logs("${workdir}/run.log");
+    $self->SUPER::post_fail_hook();
 }
 
 1;


### PR DESCRIPTION
Seems that the original file (quadrants500x500) was not properly created and
this was causing the composite image being garbage due to handling of PNG
images being reworked in GraphicsMagick 1.48

This PR focuses on making the test pass, I'll handle asset generation as part of https://progress.opensuse.org/issues/205077 since regenerating them causes more failures.

openqa: clone https://openqa.opensuse.org/tests/6157798

Does not run on SLE


#### Results from cloned jobs:
- [![https://openqa.opensuse.org/tests/6158329](https://openqa.opensuse.org/tests/6158329/badge)](https://openqa.opensuse.org/tests/6158329)

<sub>The above list is generated with a script with information from the "clone_mentioned_job" workflow.</sub>
