### PR TITLE
Kernel::utils: add get_kernel_config

### DIFF
--- a/lib/Kernel/utils.pm
+++ b/lib/Kernel/utils.pm
@@ -18,6 +18,7 @@ use utils 'systemctl';
 our @EXPORT_OK = qw(
   is_debugfs_mounted
   enable_debugfs
+  get_kernel_config
 );
 
 =head2 is_debugfs_mounted
@@ -45,6 +46,35 @@ disabled by default per PED-8812).
 sub enable_debugfs {
     record_info('debugfs', 'debugfs not mounted, enabling sys-kernel-debug.mount');
     systemctl('enable --now sys-kernel-debug.mount');
+}
+
+=head2 get_kernel_config
+
+ get_kernel_config();
+
+Locates the running kernel's config file (C</boot/config-$(uname -r)>,
+falling back to C</usr/lib/modules/$(uname -r)/config> and then
+C</proc/config.gz>) and records its full contents via C<record_info()>,
+prefixed with a comment naming the source file (as done in
+C<LTP::utils::log_versions>).
+
+=cut
+
+sub get_kernel_config {
+    my $config = script_output(
+        'ls -U "/boot/config-$(uname -r)" "/usr/lib/modules/$(uname -r)/config" /proc/config.gz 2>/dev/null | head -n 1',
+        proceed_on_failure => 1
+    );
+
+    unless ($config) {
+        record_info('kernel config', 'No kernel config file found');
+        return;
+    }
+
+    upload_logs($config, failok => 1);
+
+    my $cmd = "echo '# $config'; echo; " . ($config =~ /\.gz$/ ? "zcat $config" : "cat $config");
+    record_info('kernel config', script_output($cmd));
 }
 
 1;

--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -17,7 +17,7 @@ use LTP::utils 'prepare_whitelist_environment';
 use package_utils 'install_package';
 use Utils::Logging qw(export_logs_basic save_and_upload_log);
 use Kernel::block_dev qw(is_block_device record_storage_info);
-use Kernel::utils qw(is_debugfs_mounted enable_debugfs);
+use Kernel::utils qw(is_debugfs_mounted enable_debugfs get_kernel_config);
 
 sub prepare_blktests_config {
     my ($devices, $test_case_dev_array) = @_;
@@ -50,6 +50,7 @@ sub run {
 
     record_info('KERNEL', script_output('(rpm -qi kernel-default; uname -a)'));
     save_and_upload_log('(rpm -qi kernel-default; uname -a)', 'kernel_bug_report.txt');
+    get_kernel_config();
 
     enable_debugfs() unless is_debugfs_mounted();
 


### PR DESCRIPTION
Locates the running kernel's config file, uploads it as a log artifact, and records its full contents via record_info, for use by kernel test modules.

- Related ticket: https://progress.opensuse.org/issues/205248
- Verification run: https://openqa.suse.de/tests/23870187#step/blktests/16