### PR TITLE
lsof: detect listening port instead of hardcoding :22

### DIFF
--- a/tests/console/lsof.pm
+++ b/tests/console/lsof.pm
@@ -7,7 +7,7 @@
 # - Run lsof alone
 # - Run lsof selecting root files
 # - Run lsof selecting all networks
-# - Run lsof selecting applications listening on port 22
+# - Run lsof selecting applications listening on a discovered port
 # - Run lsof listing all files owned by root
 # - Run "exec 3>testoutput && echo 'random words' >&3"
 # - Run lsof and search all open instances with "testoutput"
@@ -35,7 +35,18 @@ sub run {
     assert_script_run("lsof");
     assert_script_run("lsof -u root");
     assert_script_run("lsof -i");
-    assert_script_run("lsof -i :22");
+
+    # Find any listening TCP port instead of assuming sshd on :22.
+    # If nothing is listening, skip — lsof -i :PORT is already covered
+    # by the netcat sections below.
+    my $port = script_output('ss -tlnp | awk \'NR>1 {split($4,a,":"); print a[length(a)]; exit}\'', proceed_on_failure => 1);
+    if ($port && $port =~ /^\d+$/) {
+        record_info('lsof -i :PORT', "Using port $port");
+        assert_script_run("lsof -i :$port");
+    } else {
+        record_info('No listeners', 'No TCP listeners found, skipping — covered by netcat tests below');
+    }
+
     assert_script_run("lsof -p 1");
 
     assert_script_run("exec 3>testoutput && echo 'random words' >&3");

--- a/tests/console/lsof.pm
+++ b/tests/console/lsof.pm
@@ -44,7 +44,7 @@ sub run {
         record_info('lsof -i :PORT', "Using port $port");
         assert_script_run("lsof -i :$port");
     } else {
-        record_info('No listeners', 'No TCP listeners found, skipping — covered by netcat tests below');
+        record_info('No listeners', 'No TCP listeners found, skipping - covered by netcat tests below');
     }
 
     assert_script_run("lsof -p 1");

--- a/tests/console/lsof.pm
+++ b/tests/console/lsof.pm
@@ -39,7 +39,7 @@ sub run {
     # Find any listening TCP port instead of assuming sshd on :22.
     # If nothing is listening, skip — lsof -i :PORT is already covered
     # by the netcat sections below.
-    my $port = script_output('ss -tlnp | awk \'NR>1 {split($4,a,":"); print a[length(a)]; exit}\'', proceed_on_failure => 1);
+    my $port = script_output(q{ss -tlnp | awk 'NR>1 {split($4,a,":"); print a[length(a)]; exit}'}, proceed_on_failure => 1);
     if ($port && $port =~ /^\d+$/) {
         record_info('lsof -i :PORT', "Using port $port");
         assert_script_run("lsof -i :$port");


### PR DESCRIPTION
This test is about lsof, not sshd. The hardcoded `lsof -i :22` fails on any system where sshd is not running (e.g. minimal AutoYaST installs).

Instead, discover an actual listening TCP port via `ss`. If no TCP listeners exist, skip the check - the same `lsof -i :PORT` functionality is already tested by the netcat sections later in the module.

Validation: https://openqa.opensuse.org/tests/6158703