### PR TITLE
cryptsetup: increase luksFormat timeout to 300s

### DIFF
--- a/tests/console/cryptsetup.pm
+++ b/tests/console/cryptsetup.pm
@@ -34,7 +34,7 @@ sub run {
     wait_still_screen;
 
     # Use cryptsetup to luksFormat and luksOpen volume
-    assert_script_run("echo -e $cryptpasswd | cryptsetup -q luksFormat /test.dm");
+    assert_script_run("echo -e $cryptpasswd | cryptsetup -q luksFormat /test.dm", timeout => 300);
     assert_script_run("echo -e $cryptpasswd | cryptsetup -q luksOpen /test.dm dmtest");
 
     # Format the dmtest and mount it with /test


### PR DESCRIPTION
`cryptsetup luksFormat` runs Argon2id key derivation which is CPU-intensive by design. The default 90s `assert_script_run` timeout is not enough on slow VMs, single-core workers, or when the binary is instrumented with eBPF tracing.

Increase to 300s. No impact on fast systems - `assert_script_run` returns as soon as the command finishes.

Validation: https://openqa.opensuse.org/tests/6158721