### PR TITLE
snapper_create: increase delete --sync timeout from 240s to 600s

### DIFF
--- a/tests/console/snapper_create.pm
+++ b/tests/console/snapper_create.pm
@@ -52,7 +52,7 @@ sub run {
     }
     assert_script_run("snapper list");
     # Delete all those snapshots we just created so other tests are not confused
-    assert_script_run("snapper delete --sync $first_snap_to_delete-" . $self->get_last_snap_number(), timeout => 240);
+    assert_script_run("snapper delete --sync $first_snap_to_delete-" . $self->get_last_snap_number(), timeout => 600);
     assert_script_run("snapper list");
     # check whether average system load is below treshold
     # wait until the load gets below 0.2


### PR DESCRIPTION
When many snapshots have accumulated (e.g. 60+ from repeated zypper installs), `snapper delete --sync` of 15 snapshots can exceed 240s on busy workers or under eBPF instrumentation. The btrfs subvolume deletion with `--sync` waits for each removal to complete, and the cost grows with the amount of accumulated metadata.

Increase to 600s.

Validation (60 packages installed to generate snapshots before the test): https://openqa.opensuse.org/tests/6159830