### PR TITLE
Ensure the locale package is installed

### DIFF
--- a/schedule/yam/agama_change_localization_unattended.yaml
+++ b/schedule/yam/agama_change_localization_unattended.yaml
@@ -8,3 +8,4 @@ schedule:
   - installation/grub_test
   - installation/first_boot
   - locale/keymap_or_locale
+  - yam/validate/validate_localization

--- a/tests/yam/validate/validate_localization.pm
+++ b/tests/yam/validate/validate_localization.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Verify the CZ keyboard layout and locale configuration
+# Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
+
+use Mojo::Base 'basetest';
+use testapi;
+
+sub run {
+    # Clear leftover characters from the previous test module
+    send_key 'ctrl-u';
+
+    enter_cmd 'root';
+    assert_screen 'password-prompt', 10;
+
+    enter_cmd 'nots#cr#t';
+    assert_screen 'root-console-prompt', 15;
+
+    # Switch keyboard layout to US
+    # Note: 'y' and 'z' are swapped on CZ layout, so we send 'loadkezs us'
+    enter_cmd 'loadkezs us';
+
+    enter_cmd 'rpm -q glibc-locale';
+    assert_screen 'glibc-locale-installed', 15;
+
+    enter_cmd 'cat /etc/locale.conf';
+    assert_screen 'locale-configuration-cz', 15;
+
+    enter_cmd 'rpm -qa --provides | grep "locale\(.*:cs\)" | xargs -n1 rpm -q --whatprovides | sort -u';
+    assert_screen 'lang-package', 15;
+}
+
+sub post_fail_hook {
+    save_screenshot;
+}
+
+1;


### PR DESCRIPTION
Ensure locale package is installed, and check the CZ keyboard output by running commands.

- Related ticket: https://progress.opensuse.org/issues/200913
- Verification run: [vr_link](https://openqa.suse.de/tests/overview?test=sles_change_localization_unattended_test&groupid=576&version=16.1&distri=sle&build=63.1)