### PR TITLE
use rm -rf src && mkdir src to handle pre-existing dir in get_cac_code

### DIFF
--- a/lib/oscap_tests.pm
+++ b/lib/oscap_tests.pm
@@ -748,8 +748,7 @@ sub get_cac_code {
     if (is_sle) {
         zypper_call("in git-core");
     }
-    assert_script_run("mkdir src");
-    assert_script_run("rm -r $cac_dir", quiet => 1) if (-e "$cac_dir");
+    assert_script_run("rm -rf src && mkdir src");
     assert_script_run('git config --global http.sslVerify false', quiet => 1);
     assert_script_run("set -o pipefail ; $git_clone_cmd", timeout => 600, quiet => 1);
 


### PR DESCRIPTION
The test fails because the 'src' directory is already there from a previous run.
Add a condition or make the previous test cleanup upon exit.

- Related ticket: https://progress.opensuse.org/issues/204819
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: 

https://openqa.suse.de/tests/23886221
