### PR TITLE
ping: add no_rollback to test_flags

### DIFF
--- a/tests/console/ping.pm
+++ b/tests/console/ping.pm
@@ -129,7 +129,7 @@ sub run {
 }
 
 sub test_flags {
-    return {fatal => 0};
+    return {fatal => 0, no_rollback => 1};
 }
 
 1;


### PR DESCRIPTION
ping already has fatal => 0 but without no_rollback a failure still reverts to the last snapshot, wiping accumulated test data.

- Verification (full schedule, ping fails at position 33 but no rollback, schedule continues): https://openqa.opensuse.org/tests/6160422