### PR TITLE
fix(helm): use absolute path to custom chart values

### DIFF
--- a/lib/containers/helm.pm
+++ b/lib/containers/helm.pm
@@ -61,7 +61,7 @@ sub helm_configure_values {
     my ($helm_values, %args) = @_;
 
     # Pull helm values file if defined
-    assert_script_run("curl -sSL --retry 3 --retry-delay 30 -o myvalue.yaml $helm_values") if ($helm_values);
+    assert_script_run("curl -sSL --retry 3 --retry-delay 30 -o /root/myvalue.yaml $helm_values") if ($helm_values);
 
     # Configure Registry, Image repository and Image tag
     my $full_registry_path = get_var('HELM_FULL_REGISTRY_PATH');
@@ -95,7 +95,7 @@ sub helm_configure_values {
     my $helm_options = "--debug";
 
     # Use the provided helm values if defined
-    $helm_options = "-f myvalue.yaml $helm_options" if ($helm_values);
+    $helm_options = "-f /root/myvalue.yaml $helm_options" if ($helm_values);
     return ($set_options, $helm_options);
 }
 


### PR DESCRIPTION
Failure: https://openqa.suse.de/tests/23886256#step/rmt/11
```
Error: INSTALLATION FAILED: open myvalue.yaml: no such file or directory
```

VR: https://babu-frik.qe.prg2.suse.org/tests/159#step/rmt/30

#### Verification runs

 - sle-15-SP7-BCI-App-x86_64-Build73.11_pulseaudio-image-SLES-16-0-podman@64bit -> https://openqa.suse.de/tests/23887171
 - sle-15-SP7-BCI-App-x86_64-Build83.11_xorg-image-SLES-16-0-podman@64bit -> https://openqa.suse.de/tests/23887172
 - sle-15-SP7-BCI-App-x86_64-Build88.7_rmt-server-image-SLES-16-0-podman@64bit -> https://openqa.suse.de/tests/23887173
