### PR TITLE
Extend timeout for ansible-galaxy install

### DIFF
--- a/tests/console/ansible.pm
+++ b/tests/console/ansible.pm
@@ -124,7 +124,7 @@ sub run {
 
     # Install config_manager role from ansible-network
     # https://galaxy.ansible.com/ansible-network/config_manager
-    assert_script_run 'ansible-galaxy install ansible-network.config_manager', timeout => 300;
+    assert_script_run 'ansible-galaxy install ansible-network.config_manager', timeout => 700;
 
     # Verify that the config_manager is installed
     my $galaxy_installed = script_output 'ansible-galaxy list';


### PR DESCRIPTION
Extend timeout for ansible-galaxy install

- Related ticket: https://progress.opensuse.org/issues/205506
- Verification run: https://openqa.suse.de/tests/overview?build=tinawang123%2Fos-autoinst-distri-opensuse%23ansible
