### PR TITLE
Fix SSH console failure by clearing bash history file directly

### DIFF
--- a/lib/virt_feature_test_base.pm
+++ b/lib/virt_feature_test_base.pm
@@ -62,7 +62,7 @@ sub prepare_run_test {
     select_console 'sol', await_console => 0;
     use_ssh_serial_console;
     reconnect_if_problematic;
-    assert_script_run("history -c");
+    assert_script_run("> ~/.bash_history");
 
     check_host_health;
 


### PR DESCRIPTION
openQA's assert_script_run fails on 'history -c' over SSH serial consoles because clearing the in-memory history buffer breaks the framework's internal shell prompt and exit-status detection hooks.

Truncate ~/.bash_history directly instead of wiping session memory so that past command artifacts are removed without corrupting openQA's serial state tracking.

- Related ticket: https://progress.opensuse.org/issues/205671
- Verification run: 
[uefi-gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23899135)    //running
[tdx-gi-full-developing-guest_on-host_sle16-full-kvm](https://openqa.suse.de/tests/23899137)
[uefi-gi-guest_developing-on-host_sles16dot0-kvm on arm](https://openqa.suse.de/tests/23899332)     //running
[sev-snp-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/23899360)     //running

