### PR TITLE
Move img_proof to a dedicated library

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -15,6 +15,7 @@ use testapi qw(is_serial_terminal :DEFAULT);
 use mmapi 'get_current_job_id';
 use utils qw(script_retry script_output_retry);
 use publiccloud::azure_client;
+use publiccloud::img_proof qw(run_img_proof);
 use publiccloud::ssh_interactive 'select_host_console';
 use Data::Dumper;
 
@@ -496,7 +497,7 @@ sub img_proof {
         $args{running_instance_id} = $parsed_id->{vm_name};
     }
 
-    return $self->run_img_proof(%args);
+    return run_img_proof($self, %args);
 }
 
 sub terraform_apply {

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -17,6 +17,7 @@ use Utils::Architectures qw(is_aarch64);
 use publiccloud::utils qw(is_byos pc_data_url);
 use publiccloud::zypper qw(pc_zypper_call pc_transactional_call);
 use publiccloud::aws_client;
+use publiccloud::img_proof qw(run_img_proof);
 use publiccloud::ssh_interactive 'select_host_console';
 
 has ssh_key_pair => undef;
@@ -215,7 +216,7 @@ sub img_proof {
     $args{ssh_private_key_file} //= SSH_KEY_PEM;
     $args{key_name} //= $self->ssh_key;
 
-    return $self->run_img_proof(%args);
+    return run_img_proof($self, %args);
 }
 
 sub teardown {
@@ -444,6 +445,42 @@ sub _install_dmesg_capture_to_log
     );
 }
 
+# Deploy CloudWatch agent configuration and start the service.
+# Returns "" on success, or a descriptive error string on failure.
+sub _configure_and_start_cloudwatch_agent {
+    my ($self, $instance) = @_;
+
+    my $cfg_file = 'cloudwatch_config.json';
+    my $cfg_target = '/opt/aws/amazon-cloudwatch-agent/etc/' . $cfg_file;
+
+    my $rc = $instance->ssh_script_run("sudo mkdir -p /opt/aws/amazon-cloudwatch-agent/etc");
+    return "mkdir for config dir failed (rc=$rc)" if $rc;
+
+    $rc = $instance->ssh_script_run("sudo $curl_cmd $cfg_target " . pc_data_url("publiccloud/$cfg_file"));
+    return "config download failed (rc=$rc)" if $rc;
+
+    $rc = $instance->ssh_script_run(
+        "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl " .
+          "-a fetch-config " .
+          "-m ec2 " .
+          "-c file:$cfg_target " .
+          "-s"
+    );
+    return "agent-ctl fetch-config failed (rc=$rc)" if $rc;
+
+    $rc = $instance->ssh_script_run("sudo systemctl enable --now amazon-cloudwatch-agent");
+    return "systemctl enable --now failed (rc=$rc)" if $rc;
+
+    $rc = $instance->ssh_script_retry("sudo systemctl is-active amazon-cloudwatch-agent",
+        die => 0, retry => 3, delay => 5);
+    return "agent not active after start (rc=$rc)" if $rc;
+
+    return "";
+}
+
+# Install the CloudWatch agent RPM and start the service.
+# Uses non-fatal APIs internally — never dies.
+# Returns "" on success, or a descriptive error string on failure.
 sub _install_ec2_cloudwatch_agent
 {
     my ($self, $instance) = @_;
@@ -457,54 +494,88 @@ sub _install_ec2_cloudwatch_agent
 
     my $download_directory = "/root";
 
-    $instance->ssh_assert_script_run("sudo $curl_cmd $download_directory/$gpg_file https://amazoncloudwatch-agent.s3.amazonaws.com/assets/amazon-cloudwatch-agent.gpg");
+    # Pre-check: skip download+install if already present
+    if ($instance->ssh_script_run("rpm -q amazon-cloudwatch-agent") == 0) {
+        record_info('CW agent', 'Already installed, skipping RPM installation');
+        return $self->_configure_and_start_cloudwatch_agent($instance);
+    }
 
-    $instance->ssh_assert_script_run("sudo gpg --batch --status-fd=1 --import $download_directory/$gpg_file 2>&1");
-
-    $instance->ssh_assert_script_run("sudo $curl_cmd $download_directory/$rpm_file.sig https://amazoncloudwatch-agent.s3.amazonaws.com/suse/$arch/latest/amazon-cloudwatch-agent.rpm.sig");
-    $instance->ssh_assert_script_run("sudo $curl_cmd $download_directory/$rpm_file https://amazoncloudwatch-agent.s3.amazonaws.com/suse/$arch/latest/amazon-cloudwatch-agent.rpm");
-    $instance->ssh_assert_script_run(
-        "sudo gpg --verify $download_directory/$rpm_file.sig $download_directory/$rpm_file 2>&1 | grep 'Good signature'",
-        fail_message => "GPG signature verification failed for the downloaded RPM package."
+    # Download GPG key
+    my $rc = $instance->ssh_script_run(
+        "sudo $curl_cmd $download_directory/$gpg_file " .
+          "https://amazoncloudwatch-agent.s3.amazonaws.com/assets/amazon-cloudwatch-agent.gpg"
     );
+    return "GPG key download failed (rc=$rc)" if $rc;
 
+    # Import GPG key
+    $rc = $instance->ssh_script_run(
+        "sudo gpg --batch --status-fd=1 --import $download_directory/$gpg_file 2>&1"
+    );
+    return "GPG key import failed (rc=$rc)" if $rc;
+
+    # Download RPM signature
+    $rc = $instance->ssh_script_run(
+        "sudo $curl_cmd $download_directory/$rpm_file.sig " .
+          "https://amazoncloudwatch-agent.s3.amazonaws.com/suse/$arch/latest/amazon-cloudwatch-agent.rpm.sig"
+    );
+    return "RPM signature download failed (rc=$rc)" if $rc;
+
+    # Download RPM
+    $rc = $instance->ssh_script_run(
+        "sudo $curl_cmd $download_directory/$rpm_file " .
+          "https://amazoncloudwatch-agent.s3.amazonaws.com/suse/$arch/latest/amazon-cloudwatch-agent.rpm"
+    );
+    return "RPM download failed (rc=$rc)" if $rc;
+
+    # Verify GPG signature
+    $rc = $instance->ssh_script_run(
+        "sudo gpg --verify $download_directory/$rpm_file.sig $download_directory/$rpm_file 2>&1 | " .
+          "grep 'Good signature'"
+    );
+    return "GPG signature verification failed (rc=$rc)" if $rc;
+
+    # Install the RPM
     if (is_transactional) {
-        pc_transactional_call(
+        $rc = pc_transactional_call(
             $instance,
             "run sh -c 'rpm -Uvh --noscripts $download_directory/$rpm_file'",
-            timeout => 300, exitcode => [0], no_reboot => 1
+            timeout => 300, exitcode => [0], no_reboot => 1,
+            proceed_on_failure => 1
         );
-        $instance->softreboot();
+        return "transactional-update install failed (rc=$rc)" if $rc;
+
+        eval { $instance->softreboot() };
+        return "softreboot after transactional-update failed: $@" if $@;
     } else {
         if (is_sle(">12-SP5")) {
-            pc_zypper_call($instance, "install --no-recommends --allow-unsigned-rpm $download_directory/$rpm_file", retry => 3);
+            $rc = pc_zypper_call(
+                $instance,
+                "install --no-recommends --allow-unsigned-rpm $download_directory/$rpm_file",
+                retry => 3, proceed_on_failure => 1
+            );
+            return "zypper install failed (rc=$rc)" if $rc;
         } else {
-            $instance->ssh_assert_script_run("sudo rpm -Uvh $download_directory/$rpm_file");
+            $rc = $instance->ssh_script_run("sudo rpm -Uvh $download_directory/$rpm_file");
+            return "rpm install failed (rc=$rc)" if $rc;
         }
     }
 
-    $instance->ssh_assert_script_run("sudo rm -f $download_directory/$rpm_file $download_directory/$rpm_file.sig $download_directory/$gpg_file");
-
-    my $cfg_file = 'cloudwatch_config.json';
-    my $cfg_target = '/opt/aws/amazon-cloudwatch-agent/etc/' . $cfg_file;
-    $instance->ssh_assert_script_run("sudo mkdir -p /opt/aws/amazon-cloudwatch-agent/etc");
-    $instance->ssh_assert_script_run("sudo $curl_cmd $cfg_target " . pc_data_url("publiccloud/$cfg_file"));
-    $instance->ssh_assert_script_run(
-        "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl " .
-          "-a fetch-config " .
-          "-m ec2 " .
-          "-c file:$cfg_target " .
-          "-s"
+    # Cleanup downloads (non-critical, don't fail on error)
+    $instance->ssh_script_run(
+        "sudo rm -f $download_directory/$rpm_file $download_directory/$rpm_file.sig $download_directory/$gpg_file"
     );
-    $instance->ssh_assert_script_run("sudo systemctl enable --now amazon-cloudwatch-agent");
-    $instance->ssh_script_retry("sudo systemctl is-active amazon-cloudwatch-agent");
+
+    return $self->_configure_and_start_cloudwatch_agent($instance);
 }
 
 sub initialize_logging {
     my ($self, $instance) = @_;
     $self->upload_boot_diagnostics(log_name => "console-beginning");
     record_info('Logging', 'Initializing logging for EC2 instance');
-    $self->_install_ec2_cloudwatch_agent($instance);
+    my $err = $self->_install_ec2_cloudwatch_agent($instance);
+    if ($err) {
+        record_soft_failure("poo#205539 - CloudWatch agent setup failed: $err");
+    }
 }
 
 sub finalize_logging {

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -13,6 +13,7 @@ use Mojo::Util qw(trim);
 use Mojo::JSON 'decode_json';
 use testapi;
 use utils;
+use publiccloud::img_proof qw(run_img_proof);
 use publiccloud::ssh_interactive 'select_host_console';
 
 sub init {
@@ -197,7 +198,7 @@ sub img_proof {
     $args{user} //= $self->provider_client->username;
     $args{provider} //= 'gce';
 
-    return $self->run_img_proof(%args);
+    return run_img_proof($self, %args);
 }
 
 sub terraform_apply {

--- a/lib/publiccloud/img_proof.pm
+++ b/lib/publiccloud/img_proof.pm
@@ -1,0 +1,203 @@
+# SUSE's openQA tests
+#
+# Copyright 2018 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Helper routines for running img-proof framework
+#
+# Maintainer: QE-C team <qa-c@suse.de>
+
+package publiccloud::img_proof;
+
+use strict;
+use warnings;
+use Exporter qw(import);
+
+use testapi;
+use Data::Dumper;
+use Carp qw(croak);
+use publiccloud::utils qw(is_gce is_ec2 is_hardened);
+
+our @EXPORT_OK = qw(
+  run_img_proof
+);
+
+=encoding UTF-8
+
+=head1 NAME
+
+publiccloud::img_proof - Routines to run img-proof and parse its output
+
+=head1 SYNOPSIS
+
+    use publiccloud::img_proof qw(run_img_proof);
+
+    my $results = run_img_proof($provider, instance => $instance, tests => $tests);
+
+=head1 DESCRIPTION
+
+Helper module for interacting with the C<img-proof> tool during public cloud image testing.
+=cut
+
+# Internal helper function to parse img-proof CLI output
+sub parse_img_proof_output {
+    my ($output) = @_;
+    croak('Output parameter is undefined') unless defined $output;
+    my $ret = {};
+
+    for my $line (split(/\r?\n/, $output)) {
+        if ($line =~ m/^ID of instance: (\S+)$/) {
+            $ret->{instance_id} = $1;
+        }
+        elsif ($line =~ m/^Terminating instance (\S+)$/) {
+            $ret->{instance_id} = $1;
+        }
+        elsif ($line =~ m/^IP of instance: (\S+)$/) {
+            $ret->{ip} = $1;
+        }
+        elsif ($line =~ m/^Created log file (\S+)$/) {
+            $ret->{logfile} = $1;
+        }
+        elsif ($line =~ m/^Created results file (\S+)$/) {
+            $ret->{results} = $1;
+        }
+        elsif ($line =~ m/tests=(\d+)\|pass=(\d+)\|skip=(\d+)\|fail=(\d+)\|error=(\d+)/) {
+            $ret->{tests} = $1;
+            $ret->{pass} = $2;
+            $ret->{skip} = $3;
+            $ret->{fail} = $4;
+            $ret->{error} = $5;
+        }
+        $ret->{output} .= $line . "\n";
+    }
+
+    for my $k (qw(ip logfile results tests pass skip fail error)) {
+        return unless (exists($ret->{$k}));
+    }
+    return $ret;
+}
+
+=head2 run_img_proof
+
+    run_img_proof(
+        $provider,
+        instance => $instance,
+        [provider => 'ec2',]
+        [tests => 'test_security',]
+        [distro => 'sles',]
+        [timeout => 7200,]
+        [results_dir => 'img_proof_results',]
+        [user => 'ec2-user',]
+        [key_name => 'my_key',]
+        [credentials_file => 'aws_creds.json',]
+        [running_instance_id => 'i-12345',]
+        [exclude => 'test_a, test_b',]
+        [beta => 0]
+    );
+
+Calls the C<img-proof> CLI tool and retrieves a hash reference containing the test results.
+
+Updates C<$instance->public_ip> with the instance IP extracted from the command output.
+Returns a hash reference containing the parsed results
+(with C<instance_id> and C<ip> deleted from the returned hash).
+
+=over
+
+=item B<provider> - Public cloud provider instance object (first positional parameter)
+
+=item B<instance> - Mandatory public cloud instance object
+
+=item B<provider> - Cloud provider name string (e.g., 'azure', 'ec2', 'gce')
+
+=item B<tests> - Comma-separated or space-separated list of test cases to run (default: '')
+
+=item B<distro> - Target Linux distribution name passed to C<--distro> (default: 'sles')
+
+=item B<timeout> - Execution timeout in seconds (default: 7200)
+
+=item B<results_dir> - Directory path for img-proof test results passed to C<--results-dir> (default: 'img_proof_results')
+
+=item B<user> - SSH username used for accessing the target instance (C<-u>)
+
+=item B<key_name> - Name or file path of the SSH key passed to C<--ssh-key-name>
+
+=item B<credentials_file> - Path to service account or cloud credentials file passed to C<--service-account-file>
+
+=item B<running_instance_id> - Override instance ID if different from C<$instance->instance_id>
+
+=item B<exclude> - Comma-separated list of test cases to exclude from execution (C<--exclude>)
+
+=item B<beta> - Enable beta features flag in img-proof (default: 0)
+
+=back
+
+=cut
+
+sub run_img_proof {
+    my $provider = shift;
+    my %args = @_;
+    die('Must provide an instance object') if (!$args{instance});
+
+    $args{tests} //= '';
+    $args{timeout} //= 60 * 120;
+    $args{results_dir} //= 'img_proof_results';
+    $args{distro} //= 'sles';
+    $args{tests} =~ s/,/ /g;
+
+    my $exclude = $args{exclude} // '';
+    my $beta = $args{beta} // 0;
+
+    my $version = script_output('img-proof --version', 300);
+    record_info("img-proof version", $version);
+
+    my $cmd = 'img-proof --no-color test ' . $args{provider};
+    $cmd .= ' --debug ';
+    $cmd .= "--distro " . $args{distro} . " ";
+    if (is_gce()) {
+        $cmd .= '--region "' . $provider->provider_client->region . '-' . $provider->provider_client->availability_zone . '" ';
+    }
+    else {
+        $cmd .= '--region "' . $provider->provider_client->region . '" ';
+    }
+    $cmd .= '--results-dir "' . $args{results_dir} . '" ';
+    $cmd .= '--no-cleanup ';
+    $cmd .= '--collect-vm-info ';
+    $cmd .= '--service-account-file "' . $args{credentials_file} . '" ' if ($args{credentials_file});
+    #TODO: this if is just dirty hack which needs to be replaced with something more sane ASAP.
+    $cmd .= '--access-key-id $AWS_ACCESS_KEY_ID --secret-access-key $AWS_SECRET_ACCESS_KEY ' if (is_ec2());
+    $cmd .= '--ssh-key-name $(realpath ' . $args{key_name} . ') ' if ($args{key_name});
+    $cmd .= '-u ' . $args{user} . ' ' if ($args{user});
+    $cmd .= '--ssh-private-key-file $(realpath ' . $provider->ssh_key . ') ';
+    $cmd .= '--running-instance-id "' . ($args{running_instance_id} // $args{instance}->instance_id) . '" ';
+    $cmd .= "--beta " if ($beta);
+    if ($exclude) {
+        # Split exclusion tests by command and add them individually
+        for my $excl (split ',', $exclude) {
+            $excl =~ s/^\s+|\s+$//g;    # trim spaces
+            $cmd .= "--exclude $excl ";
+        }
+    }
+
+    # Tell img-proof to generate SCAP report on hardened images
+    if (is_hardened) {
+        my $scap_report = get_var("SCAP_REPORT", "skip");
+        $cmd = "SCAP_REPORT=$scap_report " . $cmd;
+    }
+
+    $cmd .= $args{tests};
+    record_info("img-proof cmd", $cmd);
+
+    my $output = script_output($cmd . ' 2>&1', $args{timeout}, proceed_on_failure => 1);
+    record_info("img-proof output", $output);
+    my $img_proof = parse_img_proof_output($output);
+    record_info("img-proof results", Dumper($img_proof));
+    die($output) unless (defined($img_proof));
+
+    $args{instance}->public_ip($img_proof->{ip});
+    delete($img_proof->{instance_id});
+    delete($img_proof->{ip});
+
+    return $img_proof;
+}
+
+1;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -126,50 +126,6 @@ sub img_proof {
     die('img_proof() isn\'t implemented');
 }
 
-=head2 parse_img_proof_output
-
-Parse the output from img-proof command and retrieves instance-id, ip and logfile names.
-
-=cut
-
-sub parse_img_proof_output {
-    my ($self, $output) = @_;
-    my $ret = {};
-    my $instance_id;
-    my $ip;
-
-    for my $line (split(/\r?\n/, $output)) {
-        if ($line =~ m/^ID of instance: (\S+)$/) {
-            $ret->{instance_id} = $1;
-        }
-        elsif ($line =~ m/^Terminating instance (\S+)$/) {
-            $ret->{instance_id} = $1;
-        }
-        elsif ($line =~ m/^IP of instance: (\S+)$/) {
-            $ret->{ip} = $1;
-        }
-        elsif ($line =~ m/^Created log file (\S+)$/) {
-            $ret->{logfile} = $1;
-        }
-        elsif ($line =~ m/^Created results file (\S+)$/) {
-            $ret->{results} = $1;
-        }
-        elsif ($line =~ m/tests=(\d+)\|pass=(\d+)\|skip=(\d+)\|fail=(\d+)\|error=(\d+)/) {
-            $ret->{tests} = $1;
-            $ret->{pass} = $2;
-            $ret->{skip} = $3;
-            $ret->{fail} = $4;
-            $ret->{error} = $5;
-        }
-        $ret->{output} .= $line . "\n";
-    }
-
-    for my $k (qw(ip logfile results tests pass skip fail error)) {
-        return unless (exists($ret->{$k}));
-    }
-    return $ret;
-}
-
 =head2 create_ssh_key
 
 Creates an ssh keypair in a given file path by $args{ssh_private_key_file}
@@ -202,78 +158,6 @@ sub place_ssh_config {
     my $ssh_config_url = data_url(get_var('PUBLIC_CLOUD_SSH_CONFIG', 'publiccloud/ssh_config'));
     assert_script_run("curl $ssh_config_url -o ~/.ssh/config");
     file_content_replace("~/.ssh/config", "%SSH_KEY%" => get_ssh_private_key_path());
-}
-
-=head2 run_img_proof
-
-called by childs within img-proof function
-
-=cut
-
-sub run_img_proof {
-    my ($self, %args) = @_;
-    die('Must provide an instance object') if (!$args{instance});
-
-    $args{tests} //= '';
-    $args{timeout} //= 60 * 120;
-    $args{results_dir} //= 'img_proof_results';
-    $args{distro} //= 'sles';
-    $args{tests} =~ s/,/ /g;
-
-    my $exclude = $args{exclude} // '';
-    my $beta = $args{beta} // 0;
-
-    my $version = script_output('img-proof --version', 300);
-    record_info("img-proof version", $version);
-
-    my $cmd = 'img-proof --no-color test ' . $args{provider};
-    $cmd .= ' --debug ';
-    $cmd .= "--distro " . $args{distro} . " ";
-    if (is_gce()) {
-        $cmd .= '--region "' . $self->provider_client->region . '-' . $self->provider_client->availability_zone . '" ';
-    }
-    else {
-        $cmd .= '--region "' . $self->provider_client->region . '" ';
-    }
-    $cmd .= '--results-dir "' . $args{results_dir} . '" ';
-    $cmd .= '--no-cleanup ';
-    $cmd .= '--collect-vm-info ';
-    $cmd .= '--service-account-file "' . $args{credentials_file} . '" ' if ($args{credentials_file});
-    #TODO: this if is just dirty hack which needs to be replaced with something more sane ASAP.
-    $cmd .= '--access-key-id $AWS_ACCESS_KEY_ID --secret-access-key $AWS_SECRET_ACCESS_KEY ' if (is_ec2());
-    $cmd .= '--ssh-key-name $(realpath ' . $args{key_name} . ') ' if ($args{key_name});
-    $cmd .= '-u ' . $args{user} . ' ' if ($args{user});
-    $cmd .= '--ssh-private-key-file $(realpath ' . $self->ssh_key . ') ';
-    $cmd .= '--running-instance-id "' . ($args{running_instance_id} // $args{instance}->instance_id) . '" ';
-    $cmd .= "--beta " if ($beta);
-    if ($exclude) {
-        # Split exclusion tests by command and add them individually
-        for my $excl (split ',', $exclude) {
-            $excl =~ s/^\s+|\s+$//g;    # trim spaces
-            $cmd .= "--exclude $excl ";
-        }
-    }
-
-    # Tell img-proof to generate SCAP report on hardened images
-    if (is_hardened) {
-        my $scap_report = get_var("SCAP_REPORT", "skip");
-        $cmd = "SCAP_REPORT=$scap_report " . $cmd;
-    }
-
-    $cmd .= $args{tests};
-    record_info("img-proof cmd", $cmd);
-
-    my $output = script_output($cmd . ' 2>&1', $args{timeout}, proceed_on_failure => 1);
-    record_info("img-proof output", $output);
-    my $img_proof = $self->parse_img_proof_output($output);
-    record_info("img-proof results", Dumper($img_proof));
-    die($output) unless (defined($img_proof));
-
-    $args{instance}->public_ip($img_proof->{ip});
-    delete($img_proof->{instance_id});
-    delete($img_proof->{ip});
-
-    return $img_proof;
 }
 
 =head2 get_image_id

--- a/t/51_publiccloud_img_proof.t
+++ b/t/51_publiccloud_img_proof.t
@@ -1,0 +1,271 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Unit tests for publiccloud::img_proof helper functions
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockObject;
+use Test::MockModule;
+use Test::Exception;
+use Test::Warnings;
+use testapi 'set_var';
+
+use publiccloud::img_proof qw(run_img_proof);
+
+sub _unset { for my $k (@_) { set_var($k, undef) } }
+
+sub mock_script_output {
+    my ($mock, %args) = @_;
+    my $eol = $args{eol} // "\n";
+    my $calls = $args{calls};
+    my @lines = $args{lines} ? @{$args{lines}} : (
+        $args{instance_hdr} // 'ID of instance: i-0123456789abcdef0',
+        'IP of instance: 192.168.1.100',
+        'Created log file /tmp/img_proof.log',
+        'Created results file /tmp/results.json',
+        'tests=10|pass=8|skip=1|fail=1|error=0',
+    );
+
+    if (defined $args{num_lines}) {
+        @lines = @lines[0 .. ($args{num_lines} - 1)];
+    }
+
+    $mock->redefine(script_output => sub {
+            push @$calls, $_[0] if $calls;
+            if ($_[0] =~ /img-proof --version/) {
+                return $args{version} // 'img-proof 1.0';
+            }
+            return join($eol, @lines) . $eol;
+    });
+}
+
+subtest '[run_img_proof] missing instance argument' => sub {
+    my $dummy_provider = Test::MockObject->new();
+    dies_ok { run_img_proof($dummy_provider, provider => 'azure') } 'dies when instance argument is missing';
+};
+
+subtest '[run_img_proof] parses valid output with LF and CRLF line endings' => sub {
+    my @calls;
+    for my $eol_test ("\n", "\r\n") {
+        @calls = ();
+        my $mock = Test::MockModule->new('publiccloud::img_proof', no_auto => 1);
+        mock_script_output($mock, calls => \@calls, eol => $eol_test);
+        $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+        $mock->redefine(is_ec2 => sub { 0 });
+        $mock->redefine(is_gce => sub { 0 });
+        $mock->redefine(is_hardened => sub { 0 });
+
+        my $assigned_ip;
+        my $instance = Test::MockObject->new();
+        $instance->mock('instance_id', sub { 'i-0123456789abcdef0' });
+        $instance->mock('public_ip', sub { $assigned_ip = $_[1] if @_ > 1; return $assigned_ip; });
+
+        my $provider_client = Test::MockObject->new();
+        $provider_client->mock('region', sub { 'valhalla' });
+
+        my $provider = Test::MockObject->new();
+        $provider->mock('provider_client', sub { $provider_client });
+        $provider->mock('ssh_key', sub { '/path/to/key' });
+
+        my $res = run_img_proof(
+            $provider,
+            provider => 'azure',
+            instance => $instance,
+        );
+
+        note("\n  -->  " . join("\n  -->  ", @calls));
+        my $label = ($eol_test eq "\r\n") ? 'CRLF' : 'LF';
+        is($assigned_ip, '192.168.1.100', "[$label] assigned instance public IP");
+        is($res->{logfile}, '/tmp/img_proof.log', "[$label] parsed logfile path");
+        is($res->{results}, '/tmp/results.json', "[$label] parsed results path");
+        is($res->{tests}, 10, "[$label] parsed test count");
+        is($res->{pass}, 8, "[$label] parsed pass count");
+        is($res->{skip}, 1, "[$label] parsed skip count");
+        is($res->{fail}, 1, "[$label] parsed fail count");
+        is($res->{error}, 0, "[$label] parsed error count");
+        ok(!exists $res->{instance_id}, "[$label] instance_id deleted from return hash");
+        ok(!exists $res->{ip}, "[$label] ip deleted from return hash");
+    }
+};
+
+subtest '[run_img_proof] parses alternative Terminating instance output line' => sub {
+    my @calls;
+    my $mock = Test::MockModule->new('publiccloud::img_proof', no_auto => 1);
+    mock_script_output($mock, calls => \@calls, instance_hdr => 'Terminating instance i-99999999');
+    $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $mock->redefine(is_ec2 => sub { 0 });
+    $mock->redefine(is_gce => sub { 0 });
+    $mock->redefine(is_hardened => sub { 0 });
+
+    my $assigned_ip;
+    my $instance = Test::MockObject->new();
+    $instance->mock('instance_id', sub { 'i-99999999' });
+    $instance->mock('public_ip', sub { $assigned_ip = $_[1] if @_ > 1; return $assigned_ip; });
+
+    my $provider_client = Test::MockObject->new();
+    $provider_client->mock('region', sub { 'eu-central-1' });
+
+    my $provider = Test::MockObject->new();
+    $provider->mock('provider_client', sub { $provider_client });
+    $provider->mock('ssh_key', sub { '/path/to/key' });
+
+    my $res = run_img_proof(
+        $provider,
+        provider => 'azure',
+        instance => $instance,
+    );
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    is($assigned_ip, '192.168.1.100', 'assigned instance public IP');
+    is($res->{pass}, 8, 'parsed pass count');
+};
+
+subtest '[run_img_proof] dies on incomplete / unparseable output' => sub {
+    my @calls;
+    my $mock = Test::MockModule->new('publiccloud::img_proof', no_auto => 1);
+    mock_script_output($mock, calls => \@calls, num_lines => 3);
+    $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $mock->redefine(is_ec2 => sub { 0 });
+    $mock->redefine(is_gce => sub { 0 });
+    $mock->redefine(is_hardened => sub { 0 });
+
+    my $instance = Test::MockObject->new();
+    $instance->mock('instance_id', sub { 'i-123' });
+
+    my $provider_client = Test::MockObject->new();
+    $provider_client->mock('region', sub { 'region1' });
+
+    my $provider = Test::MockObject->new();
+    $provider->mock('provider_client', sub { $provider_client });
+    $provider->mock('ssh_key', sub { '/path/key' });
+
+    dies_ok {
+        run_img_proof(
+            $provider,
+            provider => 'azure',
+            instance => $instance,
+        );
+    } 'dies when output is missing required parsed fields';
+};
+
+subtest '[run_img_proof] EC2 provider command structure & flags' => sub {
+    my @calls;
+    my $mock = Test::MockModule->new('publiccloud::img_proof', no_auto => 1);
+    mock_script_output($mock, calls => \@calls);
+    $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $mock->redefine(is_ec2 => sub { 1 });
+    $mock->redefine(is_gce => sub { 0 });
+    $mock->redefine(is_hardened => sub { 0 });
+
+    my $assigned_ip;
+    my $instance = Test::MockObject->new();
+    $instance->mock('instance_id', sub { 'i-ec2-123' });
+    $instance->mock('public_ip', sub { $assigned_ip = $_[1] if @_ > 1; return $assigned_ip; });
+
+    my $provider_client = Test::MockObject->new();
+    $provider_client->mock('region', sub { 'us-east-1' });
+
+    my $provider = Test::MockObject->new();
+    $provider->mock('provider_client', sub { $provider_client });
+    $provider->mock('ssh_key', sub { '/path/to/key.pem' });
+
+    my $res = run_img_proof(
+        $provider,
+        provider => 'ec2',
+        instance => $instance,
+        credentials_file => 'aws_creds.json',
+        key_name => 'my_key',
+        user => 'ec2-user',
+        exclude => 'test_a, test_b',
+        beta => 1,
+        tests => 'test_security',
+    );
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    is($assigned_ip, '192.168.1.100', 'instance public_ip assigned');
+    is($res->{pass}, 8, 'result pass count');
+
+    my $cmd = (grep { /img-proof --no-color test ec2/ } @calls)[0];
+    ok($cmd, 'img-proof command found');
+    ok($cmd =~ /--access-key-id \$AWS_ACCESS_KEY_ID --secret-access-key \$AWS_SECRET_ACCESS_KEY/, 'contains AWS credentials');
+    ok($cmd =~ /--service-account-file "aws_creds.json"/, 'contains credentials_file');
+    ok($cmd =~ /--ssh-key-name \$\(realpath my_key\)/, 'contains ssh key name');
+    ok($cmd =~ /-u ec2-user/, 'contains user');
+    ok($cmd =~ /--beta/, 'contains beta flag');
+    ok($cmd =~ /--exclude test_a --exclude test_b/, 'contains exclusions');
+    ok($cmd =~ /test_security/, 'contains test target');
+};
+
+subtest '[run_img_proof] GCE provider region formatting' => sub {
+    my @calls;
+    my $mock = Test::MockModule->new('publiccloud::img_proof', no_auto => 1);
+    mock_script_output($mock, calls => \@calls);
+    $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $mock->redefine(is_ec2 => sub { 0 });
+    $mock->redefine(is_gce => sub { 1 });
+    $mock->redefine(is_hardened => sub { 0 });
+
+    my $instance = Test::MockObject->new();
+    $instance->mock('instance_id', sub { 'gce-inst' });
+    $instance->mock('public_ip', sub { });
+
+    my $provider_client = Test::MockObject->new();
+    $provider_client->mock('region', sub { 'us-central1' });
+    $provider_client->mock('availability_zone', sub { 'a' });
+
+    my $provider = Test::MockObject->new();
+    $provider->mock('provider_client', sub { $provider_client });
+    $provider->mock('ssh_key', sub { '/path/to/key' });
+
+    run_img_proof(
+        $provider,
+        provider => 'gce',
+        instance => $instance,
+    );
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    my $cmd = (grep { /img-proof --no-color test gce/ } @calls)[0];
+    ok($cmd =~ /--region "us-central1-a"/, 'GCE region includes availability zone');
+};
+
+subtest '[run_img_proof] hardened image SCAP_REPORT' => sub {
+    my @calls;
+    my $mock = Test::MockModule->new('publiccloud::img_proof', no_auto => 1);
+    mock_script_output($mock, calls => \@calls);
+    $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $mock->redefine(is_ec2 => sub { 0 });
+    $mock->redefine(is_gce => sub { 0 });
+    $mock->redefine(is_hardened => sub { 1 });
+
+    set_var('SCAP_REPORT', 'full');
+
+    my $instance = Test::MockObject->new();
+    $instance->mock('instance_id', sub { 'hard-inst' });
+    $instance->mock('public_ip', sub { });
+
+    my $provider_client = Test::MockObject->new();
+    $provider_client->mock('region', sub { 'westeurope' });
+
+    my $provider = Test::MockObject->new();
+    $provider->mock('provider_client', sub { $provider_client });
+    $provider->mock('ssh_key', sub { '/path/to/key' });
+
+    run_img_proof(
+        $provider,
+        provider => 'azure',
+        instance => $instance,
+    );
+
+    note("\n  -->  " . join("\n  -->  ", @calls));
+    my $cmd = (grep { /img-proof --no-color test azure/ } @calls)[0];
+    ok($cmd =~ /^SCAP_REPORT=full img-proof/, 'hardened image prefixes command with SCAP_REPORT');
+
+    _unset('SCAP_REPORT');
+};
+
+done_testing;


### PR DESCRIPTION
Move the code related to img_proof out from the provider library to a dedicated library file, keep the changes in the code to be minimal and only focus on moving code.
Create a dedicated unit test file.

- Related ticket: https://progress.opensuse.org/issues/203700

# Verification run:
sle-15-SP4-Azure-BYOS-Updates-x86_64-Build20260813-1-publiccloud_img_proof az_Standard_B2s
 -  http://openqa.suse.de/tests/23902314
 -  http://openqa.suse.de/tests/23903772

sle-15-SP5-EC2-BYOS-Updates-aarch64-Build20260813-1-publiccloud_img_proof ec2_c6g.large 
 - http://openqa.suse.de/tests/23902378

sle-15-SP5-GCE-BYOS-Updates-x86_64-Build20260813-1-publiccloud_img_proof gce_n1_standard_2
 - http://openqa.suse.de/tests/23903811