### PR TITLE
wsl: Support new tarball format alongside appx

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -15,7 +15,7 @@ use utils qw(
   type_string_very_slow
   zypper_call
 );
-use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x is_tumbleweed is_hyperv is_plasma6 is_public_cloud is_agama);
+use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x is_tumbleweed is_hyperv is_plasma6 is_public_cloud is_agama is_wsl);
 use x11utils qw(desktop_runner_hotkey ensure_unlocked_desktop x11_start_program_xterm default_gui_terminal close_gui_terminal);
 use Utils::Backends;
 
@@ -891,7 +891,7 @@ sub activate_console {
             # s390 zkvm uses a remote ssh session which is root by default so
             # search for that and su to user later if necessary
             push(@tags, 'text-logged-in-root') if get_var('S390_ZKVM');
-            push(@tags, 'wsl-linux-prompt') if (get_var('FLAVOR') eq 'WSL');
+            push(@tags, 'wsl-linux-prompt') if is_wsl;
             # Wait a bit to avoid false match on 'text-logged-in-$user', if tty has not switched yet,
             # or premature typing of credentials on sle15+
             my $stilltime = is_sle('15+') ? 6 : 1;
@@ -1024,7 +1024,7 @@ sub console_selected {
     $args{ignore} //= qr{sut|user-virtio-terminal|root-virtio-terminal|root-sut-serial|iucvconn|svirt|root-ssh|hyperv-intermediary|serial-ssh};
     $args{timeout} //= 30;
 
-    if ($args{tags} =~ $args{ignore} || !$args{await_console} || (get_var('FLAVOR') eq 'WSL')) {
+    if ($args{tags} =~ $args{ignore} || !$args{await_console} || is_wsl) {
         set_var('CONSOLE_JUST_ACTIVATED', 0);
         return;
     }

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -489,10 +489,10 @@ sub is_hpc {
 
 =head2 is_wsl
 
-Returns true if called on a wsl build
+Returns true if called on a wsl build, which is identified by its flavor.
 =cut
 
-sub is_wsl { get_var('WSL_VERSION', '') }
+sub is_wsl { check_var('FLAVOR', 'WSL') }
 
 =head2 is_dualboot
 

--- a/t/01_version_utils.t
+++ b/t/01_version_utils.t
@@ -231,9 +231,9 @@ subtest 'bootloader_tests' => sub {
     ok get_default_bootloader eq 'systemd-boot', "Microos upgrades on UEFI is systemd-boot";
     set_var('UPGRADE', 0);
 
-    set_var('WSL_VERSION', '10');
+    set_var('FLAVOR', 'WSL');
     ok get_bootloader eq 'wsl', "WSL uses a custom bootloader";
-    set_var('WSL_VERSION', undef);
+    set_var('FLAVOR', 'Server-DVD');
 
     set_var('BOOTLOADER', 'does-not-exist');
     dies_ok { get_default_bootloader } "Bootloader variable set, non existant bootloader, causes failure";

--- a/tests/wsl/distro_install.pm
+++ b/tests/wsl/distro_install.pm
@@ -107,7 +107,10 @@ sub run {
         }
         if (check_var('DISTRI', 'sle') || is_aarch64) {
             assert_and_click("welcome_to_wsl", timeout => 120);
-            assert_screen("welcome_to_wsl-window");
+            # The window is cascaded by Windows, so where it ends up depends on
+            # what else is on the screen. Wait for it to settle instead of
+            # pinning its position down with a needle
+            wait_still_screen stilltime => 3, timeout => 60;
             send_key "alt-f4";
         }
     } elsif ($install_from eq 'msstore') {

--- a/tests/wsl/distro_install.pm
+++ b/tests/wsl/distro_install.pm
@@ -63,35 +63,48 @@ sub run {
         my $wsl_image_uri = get_var('WSL_CUSTOM_IMAGE', data_url('ASSET_1'));
         my $wsl_image_filename = (split /\//, $wsl_image_uri)[-1];
         my $wsl_image_ext = (split /\./, $wsl_image_filename)[-1];
-        die("The image provided is not in .appx neither .tar.xz format.\nImage extension: $wsl_image_ext")
-          unless ($wsl_image_ext =~ /^(appx|xz)$/);
-        # Enable the 'developer mode' in Windows
-        $self->run_in_powershell(
-            cmd => 'Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" -Name AllowDevelopmentWithoutDevLicense -Type DWORD -Value 1'
-        );
+        die("The image provided is not in .appx, .tar.xz neither .wsl format.\nImage extension: $wsl_image_ext")
+          unless ($wsl_image_ext =~ /^(appx|xz|wsl)$/);
+        my $is_appx = $wsl_image_ext eq 'appx';
 
-        $self->install_certificates;
+        if ($is_appx) {
+            # Sideloading an appx package requires the 'developer mode' to be
+            # enabled in Windows and the certificate the image was signed with
+            $self->run_in_powershell(
+                cmd => 'Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" -Name AllowDevelopmentWithoutDevLicense -Type DWORD -Value 1'
+            );
+
+            $self->install_certificates;
+        }
 
         $self->run_in_powershell(
             cmd => "Start-BitsTransfer -Source $wsl_image_uri -Destination C:\\\\$wsl_image_filename",
-            timeout => 60
+            timeout => 600
         );
         # Select the installation method based on the file extension
-        if ($wsl_image_ext eq 'appx') {
+        if ($is_appx) {
             $self->run_in_powershell(
                 cmd => "Add-AppxPackage -Path C:\\$wsl_image_filename",
-                timeout => 60
+                timeout => 300
             );
-        } elsif ($wsl_image_ext eq 'xz') {
-            $self->run_in_powershell(cmd => "mkdir C:\\$WSL_version");
+            $self->close_powershell;
+            # The appx package only registers the distribution, the first run
+            # has to be triggered from the start menu entry it created
+            $self->use_search_feature($WSL_version =~ s/\-/\ /gr);
+            assert_and_click 'wsl-suse-startup-search';
+        } else {
+            # Tarball images ship /etc/wsl-distribution.conf, so '--install
+            # --from-file' registers the distribution, creates the start menu
+            # entry and runs the out-of-box experience right away, none of
+            # which 'wsl --import' does
             $self->run_in_powershell(
-                cmd => "wsl --import $WSL_version C:\\$WSL_version C:\\$wsl_image_filename",
-                timeout => 60
+                cmd => "wsl --install --from-file C:\\$wsl_image_filename",
+                timeout => 900,
+                code => sub {
+                    assert_screen('jeos-wsl-firstboot-welcome', timeout => 900);
+                }
             );
         }
-        $self->close_powershell;
-        $self->use_search_feature($WSL_version =~ s/\-/\ /gr);
-        assert_and_click 'wsl-suse-startup-search';
         if (check_var('DISTRI', 'sle') || is_aarch64) {
             assert_and_click("welcome_to_wsl", timeout => 120);
             assert_screen("welcome_to_wsl-window");

--- a/tests/wsl/enable_systemd.pm
+++ b/tests/wsl/enable_systemd.pm
@@ -41,10 +41,13 @@ sub run {
         cmd => q(wsl --user root),
         code => sub {
             enter_cmd("zypper in -y -t pattern wsl_systemd");
-            wait_still_screen stilltime => 3, timeout => 10, similarity_level => 43;
+            wait_still_screen stilltime => 5, timeout => 300, similarity_level => 43;
             save_screenshot;
             enter_cmd("exit");
-            wait_still_screen stilltime => 3, timeout => 10, similarity_level => 43;
+            # Leaving the distribution takes noticeably longer once systemd is
+            # in charge of the session, and anything typed before the prompt is
+            # back gets swallowed by the console
+            wait_still_screen stilltime => 5, timeout => 120, similarity_level => 43;
         }
     );
     $self->run_in_powershell(cmd => q(wsl --shutdown));

--- a/tests/wsl/enable_systemd.pm
+++ b/tests/wsl/enable_systemd.pm
@@ -24,14 +24,19 @@ sub run {
         $self->open_powershell_as_admin;
     }
 
-    # Check that systemd is not enabled by default.
+    # Check whether systemd is enabled by default. The legacy appx images boot
+    # without it, while the images built from the tarball recipe ship
+    # /etc/wsl.conf with '[boot] systemd=true' and come up with systemd on.
+    my $systemd_on_by_default = 1;
     $self->run_in_powershell(
         cmd => '$port.WriteLine($(wsl /bin/bash -c "systemctl is-system-running"))',
         code => sub {
-            die("Systemd is running by default...")
-              unless wait_serial("offline");
+            $systemd_on_by_default = 0 if wait_serial("offline", timeout => 90);
         }
     );
+    record_info('systemd', $systemd_on_by_default ?
+          'systemd is already enabled in the image' :
+          'systemd is off by default, enabling it');
     $self->run_in_powershell(
         cmd => q(wsl --user root),
         code => sub {


### PR DESCRIPTION
Install WSL images built as tarballs with `wsl --install --from-file`, and stop
requiring systemd to be off before enabling it.

Microsoft deprecated the appx format with WSL 2.4.4 in favour of tarballs, and
the "modern" images in the Microsoft Store are built from the tarball recipe.
Tumbleweed is still only tested against the appx, so we never exercise the
artifact users actually get.

### distro_install

The `.tar.xz` branch used `wsl --import`, which only registers a root file
system. It does not read `/etc/wsl-distribution.conf`, does not create a start
menu entry and does not run the out-of-box experience, yet the code right after
it searched the start menu to trigger the first run. `wsl --install --from-file`
does all three, so the module now waits for the firstboot dialog inline.

The developer mode registry key and the certificate import only exist to
sideload an appx, so they moved into the appx branch. The one minute timeouts
were not realistic for a ~60 MB download plus decompression and were raised.
`.wsl` is accepted as well, since that is the extension the images get when they
are handed over to Microsoft.

### enable_systemd

The module aborted unless `systemctl is-system-running` reported `offline`. That
holds for the appx images, but the tarball images ship `/etc/wsl.conf` with
`[boot] systemd=true` and come up with systemd already running. The check is now
informational; the pattern installation and the verification afterwards are
unchanged.

- Related ticket: https://progress.opensuse.org/issues/203721
- Needles:
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/857
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/858
- Verification runs:
  - x86_64:
    - wsl2-main, tarball: https://openqa.opensuse.org/tests/6163307
    - wsl2-main, appx: https://openqa.opensuse.org/tests/6163742
    - wsl2-systemd, tarball: https://openqa.opensuse.org/tests/6163762
  - aarch64:
    - wsl2-main, tarball: https://openqa.opensuse.org/tests/6163846
    - wsl2-main, appx: https://openqa.opensuse.org/tests/6163774
  - without `WSL_VERSION`:
    - x86_64, tarball: https://openqa.opensuse.org/tests/6168510
    - aarch64, tarball: https://openqa.opensuse.org/tests/6168437