### PR TITLE
lsof: match process name 'nc' in addition to 'netcat'

### DIFF
--- a/tests/console/lsof.pm
+++ b/tests/console/lsof.pm
@@ -60,17 +60,20 @@ sub run {
     assert_script_run('exec 4>&-');
     assert_script_run('lsof -a -p $$ -d 4 | grep testoutput || test $? -eq 1');
 
+    # netcat-openbsd installs /usr/bin/netcat as a symlink to /usr/bin/nc,
+    # so the process name in lsof may appear as either 'nc' or 'netcat'
+    # depending on how the binary was invoked.
     assert_script_run('(netcat -l 5555 &)');
     assert_script_run('for i in $(seq 1 10); do lsof -i :5555 >/dev/null 2>&1 && break; sleep 0.5; done');
-    validate_script_output("lsof -i :5555 |grep netcat", sub { m/TCP/ });
-    assert_script_run("killall netcat");
-    assert_script_run('lsof -i :5555|grep netcat || test $? -eq 1');
+    validate_script_output("lsof -i :5555 |grep -E 'nc|netcat'", sub { m/TCP/ });
+    assert_script_run("killall nc || killall netcat");
+    assert_script_run('lsof -i :5555|grep -E "nc|netcat" || test $? -eq 1');
 
     assert_script_run('(netcat -ul 5555 &)');
     assert_script_run('for i in $(seq 1 10); do lsof -i UDP:5555 >/dev/null 2>&1 && break; sleep 0.5; done');
-    validate_script_output("lsof -i UDP:5555 |grep netcat", sub { m/UDP/ });
-    assert_script_run("killall netcat");
-    assert_script_run('lsof -i UDP:5555|grep netcat || test $? -eq 1');
+    validate_script_output("lsof -i UDP:5555 |grep -E 'nc|netcat'", sub { m/UDP/ });
+    assert_script_run("killall nc || killall netcat");
+    assert_script_run('lsof -i UDP:5555|grep -E "nc|netcat" || test $? -eq 1');
 
 }
 


### PR DESCRIPTION
netcat-openbsd provides /usr/bin/netcat as a symlink to /usr/bin/nc.
Depending on how the binary is invoked the lsof COMMAND column may
show 'nc' instead of 'netcat'. Use 'grep nc' which matches both.
Also fix killall to try both names.

Verification run: https://openqa.opensuse.org/tests/6164489