### PR TITLE
cryptsetup: increase luksOpen timeout to 300s

### DIFF
--- a/tests/console/cryptsetup.pm
+++ b/tests/console/cryptsetup.pm
@@ -35,7 +35,7 @@ sub run {
 
     # Use cryptsetup to luksFormat and luksOpen volume
     assert_script_run("echo -e $cryptpasswd | cryptsetup -q luksFormat /test.dm", timeout => 300);
-    assert_script_run("echo -e $cryptpasswd | cryptsetup -q luksOpen /test.dm dmtest");
+    assert_script_run("echo -e $cryptpasswd | cryptsetup -q luksOpen /test.dm dmtest", timeout => 300);
 
     # Format the dmtest and mount it with /test
     assert_script_run('mkfs.ext4 /dev/mapper/dmtest');


### PR DESCRIPTION
luksOpen performs key derivation (Argon2id) which can exceed the default 90s on constrained VMs. luksFormat already has timeout => 300, apply the same to luksOpen.

Verification run: https://openqa.opensuse.org/tests/6164489