### PR TITLE
libaom: fix timeouts for ffmpeg build on small VMs

### DIFF
--- a/tests/console/libaom.pm
+++ b/tests/console/libaom.pm
@@ -27,7 +27,7 @@ sub run {
     assert_script_run 'wget --quiet ' . data_url('libaom/ffmpeg-snapshot.tar.bz2');
     assert_script_run 'tar xjvf ffmpeg-snapshot.tar.bz2';
     assert_script_run 'cd ffmpeg';
-    assert_script_run "PATH=\"\$HOME/bin:\$PATH\" PKG_CONFIG_PATH=\"\$HOME/ffmpeg_build/lib/pkgconfig\" ./configure --prefix=\"\$HOME/ffmpeg_build\" --pkg-config-flags=\"--static\" --extra-cflags=\"-I\$HOME/ffmpeg_build/include\" --extra-ldflags=\"-L\$HOME/ffmpeg_build/lib\" --extra-libs=-lpthread --extra-libs=-lm --bindir=\"\$HOME/bin\" --enable-libaom";
+    assert_script_run("PATH=\"\$HOME/bin:\$PATH\" PKG_CONFIG_PATH=\"\$HOME/ffmpeg_build/lib/pkgconfig\" ./configure --prefix=\"\$HOME/ffmpeg_build\" --pkg-config-flags=\"--static\" --extra-cflags=\"-I\$HOME/ffmpeg_build/include\" --extra-ldflags=\"-L\$HOME/ffmpeg_build/lib\" --extra-libs=-lpthread --extra-libs=-lm --bindir=\"\$HOME/bin\" --enable-libaom", timeout => 600);
 
     my $make_cmd;
     my $time_out = 1200;
@@ -38,8 +38,8 @@ sub run {
         $make_cmd = "make -j$jobs";
     }
     else {
-        $make_cmd = "make";
-        $time_out = 1500;
+        $make_cmd = "make -j$num_cpus";
+        $time_out = 2400;
     }
     assert_script_run($make_cmd, timeout => $time_out);
     assert_script_run "$make_cmd install";


### PR DESCRIPTION
The ffmpeg ./configure can take over 90s on a 2-CPU VM, add explicit 600s timeout.

With 1-2 CPUs the test was running plain 'make' (no parallelism) with a 1500s timeout. A single-threaded ffmpeg build cannot finish in that time. Use make -j$nproc and increase the timeout to 2400s.

Verification run: https://openqa.opensuse.org/tests/6164489