### PR TITLE
yast_lang: increase timeout for language set commands

### DIFF
--- a/tests/yast2_cmd/yast_lang.pm
+++ b/tests/yast2_cmd/yast_lang.pm
@@ -17,9 +17,9 @@ sub run {
     select_serial_terminal;
     zypper_call "in yast2-country";
     validate_script_output 'yast language list', sub { m/(.*)de_DE(.*)it_IT(.*)/s };
-    assert_script_run 'yast language set lang=de_DE languages=it_IT';
+    assert_script_run('yast language set lang=de_DE languages=it_IT', timeout => 300);
     validate_script_output 'yast language summary', sub { m/(.*)de_DE(.*)it_IT(.*)/s };
-    assert_script_run 'yast language set lang=en_US';
+    assert_script_run('yast language set lang=en_US', timeout => 300);
 }
 
 1;


### PR DESCRIPTION
'yast language set' downloads and installs language packages internally via zypper. This regularly exceeds the default 90s timeout on constrained VMs. Increase to 300s.

Verification run: https://openqa.opensuse.org/tests/6164489