### PR TITLE
yast_timezone: increase timeout for timezone set commands

### DIFF
--- a/tests/yast2_cmd/yast_timezone.pm
+++ b/tests/yast2_cmd/yast_timezone.pm
@@ -24,8 +24,8 @@ sub run {
     my $timezone = script_output 'yast timezone summary 2>&1 | grep "Current Time Zone" | cut -d: -f2';
     record_info 'default timezone', $timezone;
     validate_script_output 'yast timezone list 2>&1', sub { m#Africa/Cairo# };
-    assert_script_run 'yast timezone set timezone=Africa/Cairo';
+    assert_script_run('yast timezone set timezone=Africa/Cairo', timeout => 300);
     validate_script_output 'yast timezone summary 2>&1', sub { m#Africa/Cairo# };
-    assert_script_run "yast timezone set timezone=$timezone";
+    assert_script_run("yast timezone set timezone=$timezone", timeout => 300);
 }
 1;


### PR DESCRIPTION
'yast timezone set' can exceed the default 90s timeout on constrained VMs. Increase to 300s, matching the yast_lang fix.

Verification run: https://openqa.opensuse.org/tests/6164489