### PR TITLE
gdb: mark non-fatal for coverage measurement compatibility

### DIFF
--- a/tests/console/gdb.pm
+++ b/tests/console/gdb.pm
@@ -114,4 +114,8 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
 }
 
+sub test_flags {
+    return {fatal => 0, no_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
When gdb is traced with eBPF coverage tooling (funkoverage) the shim adds startup latency that can cause breakpoint timeouts. Mark the test non-fatal so a timeout does not abort the schedule or trigger snapshot rollback, which would discard collected coverage data.

Verification run: https://openqa.opensuse.org/tests/6164489