### PR TITLE
perf: mark non-fatal for coverage measurement compatibility

### DIFF
--- a/tests/console/perf.pm
+++ b/tests/console/perf.pm
@@ -88,4 +88,8 @@ sub run {
     assert_script_run('timeout 5 perf --no-pager list');
 }
 
+sub test_flags {
+    return {fatal => 0, no_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
When perf is shimmed by eBPF coverage tooling (funkoverage) the uprobe attachment can cause probe timeouts. Mark the test non-fatal so it does not abort the schedule or trigger snapshot rollback.

Verification run: https://openqa.opensuse.org/tests/6164489