### PR TITLE
shells: mark non-fatal for coverage measurement compatibility

### DIFF
--- a/tests/console/shells.pm
+++ b/tests/console/shells.pm
@@ -71,4 +71,8 @@ sub tcsh_extra_tests {
     script_run 'userdel tcsh_user';
 }
 
+sub test_flags {
+    return {fatal => 0, no_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
When tcsh and zsh are shimmed by eBPF coverage tooling the extra startup overhead can cause occasional timeouts. The test only installs packages, creates a temporary user and cleans up at the end of run(), so no_rollback is safe.

Verification run: https://openqa.opensuse.org/tests/6165314