### PR TITLE
irqbalance: mark non-fatal for coverage measurement compatibility

### DIFF
--- a/tests/console/irqbalance.pm
+++ b/tests/console/irqbalance.pm
@@ -46,4 +46,8 @@ sub run {
     clear_console if !is_serial_terminal;
 }
 
+sub test_flags {
+    return {fatal => 0, no_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
The test skips on single-CPU VMs and can time out when the binary is shimmed by eBPF coverage tooling. It only installs a package and starts a benign service, so no_rollback is safe.


Verification run: https://openqa.opensuse.org/tests/6165314