### PR TITLE
sysstat: accept 6 or 7 mpstat 'all' lines

### DIFF
--- a/tests/console/sysstat.pm
+++ b/tests/console/sysstat.pm
@@ -62,7 +62,9 @@ sub run {
     validate_script_output "iostat 2 5 |grep Device |wc -l", sub { /5/ };
 
     #mpstat 5 mpstat device iterations, we confirm success couting the summary 'all' column spawns
-    validate_script_output "mpstat -P ALL 2 5 |grep all |wc -l", sub { /6/ };
+    # 5 intervals + 1 average = 6 "all" lines, but some sysstat versions
+    # also print an initial snapshot, producing 7.
+    validate_script_output "mpstat -P ALL 2 5 |grep all |wc -l", sub { /^[67]$/ };
 
     #header integrity checks:
     if (is_sle('>=12-SP2') || is_opensuse) {


### PR DESCRIPTION
mpstat -P ALL 2 5 produces 5 interval reports plus 1 average, each with an 'all' line. sysstat 12.7.9+ also prints an initial snapshot before the first interval, giving 7 lines instead of 6.

Verification run: https://openqa.opensuse.org/tests/6166336