### PR TITLE
Don't let publiccloud destroy.pm's log upload skip teardown

### DIFF
--- a/tests/publiccloud/destroy.pm
+++ b/tests/publiccloud/destroy.pm
@@ -20,14 +20,19 @@ sub run {
     select_host_console(force => 1);
 
     if ($instance) {
-        upload_final_logs($instance);
-        $provider->finalize_logging($instance);
+        eval {
+            upload_final_logs($instance);
+            $provider->finalize_logging($instance);
+        };
+        record_info('log upload failed', $@, result => 'fail') if $@;
     } else {
         record_info('Undef instance', 'The $instance object is not available. The logs will not be uploaded.');
     }
 
     if ($provider) {
-        $provider->upload_boot_diagnostics();
+        # Keep teardown() reachable even if boot diagnostics upload fails, to avoid leaking cloud resources.
+        eval { $provider->upload_boot_diagnostics() };
+        record_info('boot diagnostics failed', $@, result => 'fail') if $@;
         $provider->teardown();
     } else {
         die('The $provider object is not available. We are not able to destroy the testing infrastructure.');
@@ -38,7 +43,8 @@ sub upload_final_logs {
     my ($instance) = shift;
 
     my $ssh_sut_log = '/var/tmp/ssh_sut.log';
-    assert_script_run("sudo chmod a+r " . $ssh_sut_log);
+    # script_run, not assert_script_run: the file may not exist if the instance never became SSH-reachable (poo#205743).
+    script_run("sudo chmod a+r " . $ssh_sut_log);
     upload_logs($ssh_sut_log, failok => 1, log_name => 'ssh_sut.txt');
 
     my @instance_logs = ('/var/log/cloudregister', '/etc/hosts', '/var/log/zypper.log', '/etc/zypp/credentials.d/SCCcredentials');


### PR DESCRIPTION
Makes `destroy.pm`'s log upload tolerant of a missing `/var/tmp/ssh_sut.log` (only created once an ssh command actually runs against the instance) and wraps the log-upload/boot-diagnostics steps in `eval` so `teardown()` always runs, avoiding a leaked cloud resource and a silently skipped console log upload when the instance never became SSH-reachable.

* Related ticket: [poo#205743](https://progress.opensuse.org/issues/205743)
* Related failure: [openqa.suse.de/t23899012](https://openqa.suse.de/tests/23899012)
* Verification runs: In comment below
