### PR TITLE
Extend rabbitmq test to run with multiple versions

### DIFF
--- a/tests/console/rabbitmq.pm
+++ b/tests/console/rabbitmq.pm
@@ -17,6 +17,7 @@ use serial_terminal qw(select_serial_terminal);
 sub run {
     select_serial_terminal;
     install_package('rabbitmq-server go curl', trup_reboot => 1);
+    record_info('rabbitmq-server&erlang versions: ', script_output('rpm -qa | grep -E "rabbitmq-server|erlang"'));
     systemctl 'start rabbitmq-server';
     systemctl 'status rabbitmq-server';
     my $curl_opts = "--retry 1 --retry-max-time 60 -D - -O";
@@ -55,6 +56,7 @@ EOF
         script_run('rm -rf /usr/lib{.64}/rabbitmq');
 
         zypper_call 'in rabbitmq-server31*';
+        record_info('rabbitmq-server&erlang versions: ', script_output('rpm -qa | grep -E "rabbitmq-server|erlang"'));
         systemctl 'start rabbitmq-server';
         systemctl 'status rabbitmq-server';
         enter_cmd 'go run send.go';


### PR DESCRIPTION
https://progress.opensuse.org/issues/205698

On sle16.0+, the default version is 3.13+, so we only need to cover sle15sp6/sp7

- Verification run: https://openqa.suse.de/tests/23917131