### PR TITLE
Run publiccloud/smoketest.pm over ssh instead of the tunnel

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -66,8 +66,14 @@ sub load_maintenance_publiccloud_tests {
     } elsif (get_var('PUBLIC_CLOUD_EC2_ENCLAVE_TESTS')) {
         loadtest "publiccloud/aws_enclave", run_args => $args;
     } else {
+        my $smoketest = get_var('PUBLIC_CLOUD_SMOKETEST')
+          && !get_var('PUBLIC_CLOUD_CONSOLE_TESTS')
+          && !get_var('PUBLIC_CLOUD_BTRFS')
+          && !get_var('PUBLIC_CLOUD_CONTAINERS')
+          && !get_var('PUBLIC_CLOUD_XFS');
         loadtest("publiccloud/check_services", run_args => $args) if (get_var('PUBLIC_CLOUD_SMOKETEST'));
         loadtest("publiccloud/systemd_detect_virt", run_args => $args) if (get_var('PUBLIC_CLOUD_SMOKETEST'));
+        loadtest("publiccloud/smoketest", run_args => $args) if ($smoketest);
         loadtest "publiccloud/ssh_interactive_start", run_args => $args;
         loadtest "publiccloud/instance_overview", run_args => $args;
         if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
@@ -82,8 +88,7 @@ sub load_maintenance_publiccloud_tests {
             loadtest "publiccloud/xfsprepare", run_args => $args;
             loadtest "xfstests/run", run_args => $args;
             return;
-        } elsif (get_var('PUBLIC_CLOUD_SMOKETEST')) {
-            loadtest "publiccloud/smoketest";
+        } elsif ($smoketest) {
             # flavor_check is concentrated on checking things which make sense only for image which is registered
             # against internal Public Cloud infra, so whenever we using SUSEConnect whole module does not make much sense
             loadtest "publiccloud/flavor_check" if (is_ec2() && !check_var('PUBLIC_CLOUD_SCC_ENDPOINT', 'SUSEConnect'));
@@ -158,8 +163,14 @@ sub load_latest_publiccloud_tests {
             } elsif (get_var('PUBLIC_CLOUD_NEW_INSTANCE_TYPE')) {
                 loadtest("publiccloud/bsc_1205002", run_args => $args);
             } else {    # All test cases below excluding check_service require tunelled environment
+                my $smoketest = get_var('PUBLIC_CLOUD_SMOKETEST')
+                  && !get_var('PUBLIC_CLOUD_CONSOLE_TESTS')
+                  && !get_var('PUBLIC_CLOUD_BTRFS')
+                  && !check_var('PUBLIC_CLOUD_NVIDIA', 1)
+                  && !get_var('PUBLIC_CLOUD_CONTAINERS');
                 loadtest("publiccloud/check_services", run_args => $args) if (get_var('PUBLIC_CLOUD_SMOKETEST'));
                 loadtest("publiccloud/systemd_detect_virt", run_args => $args) if (get_var('PUBLIC_CLOUD_SMOKETEST'));
+                loadtest("publiccloud/smoketest", run_args => $args) if ($smoketest);
                 loadtest "publiccloud/ssh_interactive_start", run_args => $args;
                 loadtest "publiccloud/instance_overview", run_args => $args;
                 if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
@@ -174,8 +185,7 @@ sub load_latest_publiccloud_tests {
                 }
                 elsif (get_var('PUBLIC_CLOUD_CONTAINERS')) {
                     load_container_tests();
-                } elsif (get_var('PUBLIC_CLOUD_SMOKETEST')) {
-                    loadtest "publiccloud/smoketest", run_args => $args;
+                } elsif ($smoketest) {
                     # flavor_check is concentrated on checking things which make sense only for image which is registered
                     # against internal Public Cloud infra, so whenever we using SUSEConnect whole module does not make much sense
                     loadtest "publiccloud/flavor_check", run_args => $args if (is_ec2() && !check_var('PUBLIC_CLOUD_SCC_ENDPOINT', 'SUSEConnect'));

--- a/tests/publiccloud/smoketest.pm
+++ b/tests/publiccloud/smoketest.pm
@@ -6,19 +6,21 @@
 # Summary: Run basic smoketest on publiccloud test instance
 # Maintainer: QE-C team <qa-c@suse.de>
 
-use Mojo::Base 'consoletest';
-use testapi;
-use serial_terminal 'select_serial_terminal';
-use utils;
+use Mojo::Base 'publiccloud::basetest';
+use publiccloud::ssh_interactive 'select_host_console';
 
 sub run {
-    select_serial_terminal;
+    my ($self, $args) = @_;
+    select_host_console();
+
+    my $instance = $args->{my_instance};
 
     # Check if systemd completed sucessfully
-    assert_script_run 'journalctl -b | grep "Reached target Basic System"';
+    $instance->ssh_assert_script_run('sudo journalctl -b | grep "Reached target Basic System"');
     # Additional basic commands to verify the instance is healthy
-    validate_script_output('echo "ping"', sub { m/ping/ });
-    assert_script_run 'uname -a';
+    my $output = $instance->ssh_script_output('echo "ping"');
+    die("Unexpected output of 'echo ping': $output") unless ($output =~ m/ping/);
+    $instance->ssh_assert_script_run('uname -a');
 }
 
 1;


### PR DESCRIPTION
### Problem

`publiccloud/smoketest.pm` ran its checks as plain `assert_script_run` over the serial console. That only reaches the cloud instance because `publiccloud/ssh_interactive_start` had already redirected `$serialdev` through the SSH tunnel — an unnecessary coupling to the tunnel, which poo#202752 tracks removing across several modules (siblings: poo#205170 `instance_overview.pm`, poo#205173 `systemd_detect_virt.pm`).

### Fix

- `tests/publiccloud/smoketest.pm`: switched from `consoletest` + `select_serial_terminal` to `publiccloud::basetest` + `select_host_console()`, running all commands via `$args->{my_instance}->ssh_*` — the same tunnel-free pattern already used in `check_services.pm`. `journalctl -b` now runs under `sudo` since it executes as the cloud user rather than root.
- `lib/main_publiccloud.pm`: in both `load_latest_publiccloud_tests` and `load_maintenance_publiccloud_tests`, hoisted the `smoketest` `loadtest` call above `ssh_interactive_start` (adding `run_args => $args` where it was missing), guarded by a single `$smoketest` lexical shared with the existing `elsif` branch so the set of variable combinations that schedule `smoketest` is unchanged from `master`.

### Testing

- `perl -c`, `perltidy`, `perlcritic` clean on both changed files
- `check_metadata`, `check_invalid_syntax`, `check_pod_errors`, `check_code_style` pass
- Full `prove -l t/` run: no regressions (979/980 pass; the one pre-existing failure reproduces identically on `master` and is unrelated — a macOS-local environment gap, not present in CI)

### Verification runs

Clones of existing OSD jobs with CASEDIR pointed at this PR's branch (via `openqa-clone-custom-git-refspec`), covering both changed scheduling paths and providers:

- GCE, `load_latest_publiccloud_tests` path: https://openqa.suse.de/tests/23918643
- Azure, `load_latest_publiccloud_tests` path: https://openqa.suse.de/tests/23918644
- EC2, `load_maintenance_publiccloud_tests` path: https://openqa.suse.de/tests/23918646

Fixes poo#205176
