### PR TITLE
[Publiccloud] Remove SSH tunnel dependency in publiccloud/systemd_detect_virt.pm

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -67,6 +67,7 @@ sub load_maintenance_publiccloud_tests {
         loadtest "publiccloud/aws_enclave", run_args => $args;
     } else {
         loadtest("publiccloud/check_services", run_args => $args) if (get_var('PUBLIC_CLOUD_SMOKETEST'));
+        loadtest("publiccloud/systemd_detect_virt", run_args => $args) if (get_var('PUBLIC_CLOUD_SMOKETEST'));
         loadtest "publiccloud/ssh_interactive_start", run_args => $args;
         loadtest "publiccloud/instance_overview", run_args => $args;
         if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
@@ -86,7 +87,6 @@ sub load_maintenance_publiccloud_tests {
             # flavor_check is concentrated on checking things which make sense only for image which is registered
             # against internal Public Cloud infra, so whenever we using SUSEConnect whole module does not make much sense
             loadtest "publiccloud/flavor_check" if (is_ec2() && !check_var('PUBLIC_CLOUD_SCC_ENDPOINT', 'SUSEConnect'));
-            loadtest "publiccloud/systemd_detect_virt", run_args => $args;
             loadtest "publiccloud/sev" if (get_var('PUBLIC_CLOUD_CONFIDENTIAL_VM'));
             loadtest "publiccloud/xen" if (get_var('PUBLIC_CLOUD_XEN'));
             loadtest "publiccloud/hardened" if is_hardened;
@@ -159,6 +159,7 @@ sub load_latest_publiccloud_tests {
                 loadtest("publiccloud/bsc_1205002", run_args => $args);
             } else {    # All test cases below excluding check_service require tunelled environment
                 loadtest("publiccloud/check_services", run_args => $args) if (get_var('PUBLIC_CLOUD_SMOKETEST'));
+                loadtest("publiccloud/systemd_detect_virt", run_args => $args) if (get_var('PUBLIC_CLOUD_SMOKETEST'));
                 loadtest "publiccloud/ssh_interactive_start", run_args => $args;
                 loadtest "publiccloud/instance_overview", run_args => $args;
                 if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
@@ -178,7 +179,6 @@ sub load_latest_publiccloud_tests {
                     # flavor_check is concentrated on checking things which make sense only for image which is registered
                     # against internal Public Cloud infra, so whenever we using SUSEConnect whole module does not make much sense
                     loadtest "publiccloud/flavor_check", run_args => $args if (is_ec2() && !check_var('PUBLIC_CLOUD_SCC_ENDPOINT', 'SUSEConnect'));
-                    loadtest "publiccloud/systemd_detect_virt", run_args => $args;
                     loadtest "publiccloud/sev", run_args => $args if (get_var('PUBLIC_CLOUD_CONFIDENTIAL_VM'));
                     loadtest "publiccloud/xen", run_args => $args if (get_var('PUBLIC_CLOUD_XEN'));
                 } elsif (get_var('PUBLIC_CLOUD_XFS')) {

--- a/tests/publiccloud/systemd_detect_virt.pm
+++ b/tests/publiccloud/systemd_detect_virt.pm
@@ -8,7 +8,7 @@
 
 use Mojo::Base 'consoletest';
 use testapi;
-use serial_terminal 'select_serial_terminal';
+use publiccloud::ssh_interactive 'select_host_console';
 use publiccloud::utils;
 use version_utils;
 use utils;
@@ -88,14 +88,14 @@ sub assert_systemd_detect_virt_virtual {
 }
 
 sub assert_systemd_detect_virt {
-    my ($self) = @_;
+    my ($self, $instance) = @_;
 
-    my $rc = int(script_run('systemd-detect-virt'));
-    my $output = script_output('systemd-detect-virt', proceed_on_failure => 1);
+    my $rc = int($instance->ssh_script_run('systemd-detect-virt'));
+    my $output = $instance->ssh_script_output('systemd-detect-virt', proceed_on_failure => 1);
 
     record_info('systemd-detect-virt', "rc: $rc; output: $output");
 
-    my $systemd_version = script_output('rpm -q systemd');
+    my $systemd_version = $instance->ssh_script_output('rpm -q systemd');
 
     record_info('systemd version', $systemd_version);
 
@@ -109,9 +109,9 @@ sub assert_systemd_detect_virt {
 sub run {
     my ($self, $args) = @_;
 
-    select_serial_terminal;
+    select_host_console();
 
-    $self->assert_systemd_detect_virt;
+    $self->assert_systemd_detect_virt($args->{my_instance});
 }
 
 1;


### PR DESCRIPTION
Reworks `publiccloud/systemd_detect_virt.pm` to run its checks via `$instance->ssh_script_run`/`ssh_script_output` instead of `select_serial_terminal` + bare `script_run`/`script_output`, so it executes commands directly over SSH regardless of tunnel state.

Moves the `systemd_detect_virt` module before `ssh_interactive_start` in both `load_maintenance_publiccloud_tests` and `load_latest_publiccloud_tests`, next to `check_services`, guarded the same way.

* Related ticket: [poo#205173](https://progress.opensuse.org/issues/205173)
* Verification runs: In comment below
