### PR TITLE
Fix SSH console test timeout by removing leading space before exclamation mark

### DIFF
--- a/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
+++ b/tests/virt_autotest/sriov_network_card_pci_passthrough.pm
@@ -408,7 +408,7 @@ sub unplug_vf_from_vm {
     assert_script_run("virsh detach-device $vm $vf_xml_file --persistent", 60);
 
     #check if the nic is removed from vm
-    assert_script_run(" ! ssh root\@$vm \"ip l show $vf->{vm_nic}\"", fail_message => "ERROR: vf is unplugged from vm, but nic still exists!");
+    assert_script_run("! ssh root\@$vm \"ip l show $vf->{vm_nic}\"", fail_message => "ERROR: vf is unplugged from vm, but nic still exists!");
 }
 
 #print logs for debugging


### PR DESCRIPTION
openQA's assert_script_run failed with a serial timeout when checking unplugged network interfaces because the leading space in the command corrupted the framework's internal regex pattern generation for exit-status matching.

Remove the leading space before the shell negation operator so openQA can properly parse the command and match the serial console prompt upon completion.

- Related ticket: https://progress.opensuse.org/issues/205773
- Verification run: 
[MU sriov on sle16](https://openqa.suse.de/tests/23920280) 
[sle16.1 sriov](https://openqa.suse.de/tests/23920824) 
