### PR TITLE
Fix iptables setup with classic serial markers

### DIFF
--- a/lib/parallel_guest_migration_base.pm
+++ b/lib/parallel_guest_migration_base.pm
@@ -664,17 +664,21 @@ sub config_host_security {
         assert_script_run("sed -i -r \'s/^SELINUX=enforcing\$/SELINUX=permissive/g\' /etc/selinux/config");
     }
 
-    enter_cmd("iptables -P INPUT ACCEPT;
+    # Use scoped classic serial markers for iptables network configuration
+    {
+        my $marker_guard = $testapi::distri->pretty_serial_marker_guard(0);
+
+        script_run("iptables -P INPUT ACCEPT;
 iptables -P FORWARD ACCEPT;
 iptables -P OUTPUT ACCEPT;
 iptables -t nat -F;
 iptables -F;
 sysctl -w net.ipv4.ip_forward=1;
 sysctl -w net.ipv4.conf.all.forwarding=1"
-    );
+        );
+    }
+
     save_screenshot;
-    reset_consoles;
-    select_console("root-ssh");
     setup_common_ssh_config(ssh_id_file => $args{_keyfile});
 }
 


### PR DESCRIPTION
Temporarily disable pretty serial markers while configuring iptables in parallel_guest_migration_base.

Scope pretty_serial_marker_guard(0) to the network configuration block so the previous serial marker behavior is restored immediately afterward.

This follows the scoped guard approach from
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26276

- Related ticket: https://progress.opensuse.org/issues/205164
- Verification run:
  - https://openqa.suse.de/tests/23919660
  - https://openqa.suse.de/tests/23919659
