### PR TITLE
Use new testapi function 'become_user'

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -283,12 +283,7 @@ sub test_pgsql {
     assert_script_run 'echo "postgres ALL=(root) NOPASSWD: ALL" >/etc/sudoers.d/postgres';
     assert_script_run "gpasswd -a postgres \$(stat -c %G /dev/$serialdev)";
     assert_script_run 'sudo chsh postgres -s /bin/bash';
-    enter_cmd "su - postgres", wait_still_screen => 1;
-    enter_cmd "PS1='# '", wait_still_screen => 1;
-    # The login shell of $user does not have the openQA prompt hook for
-    # PRETTY_SERIAL_MARKER in its ~/.bashrc yet, so force a re-install on the
-    # next command, same as become_root does. poo#205122
-    $testapi::distri->invalidate_serial_marker_hook();
+    become_user('postgres');
     # upgrade db from oldest version to latest version
     if (script_run('test $(sudo update-alternatives --list postgresql|wc -l) -gt 1') == 0) {
         assert_script_run 'for v in $(sudo update-alternatives --list postgresql); do rpm -q ${v##*/};done';

--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -140,15 +140,7 @@ sub get_slurm_logs {
 
 sub switch_user {
     my ($self, $username) = @_;
-
-    # poo#183761 nested user switches are not supported by the pretty_serial feature.
-    # We use pretty_serial_marker_guard(0) to temporarily fall back to classic markers,
-    # ensuring terminal synchronization remains reliable during the user transition.
-    my $marker_guard = $testapi::distri->pretty_serial_marker_guard(0);
-    enter_cmd("su - $username");
-    type_string(qq/PS1="# "\n/);
-    wait_serial(qr/PS1="# "/);
-    assert_script_run("whoami|grep $username");
+    become_user($username);
 }
 
 =head2 master_node_names

--- a/tests/jeos/glibc_locale.pm
+++ b/tests/jeos/glibc_locale.pm
@@ -38,10 +38,7 @@ my %test_data_lang = (
 );
 
 sub switch_user {
-    # In aarch64 the user change takes some time, causing the next command to get
-    # lost
-    enter_cmd("su - $testapi::username", wait_still_screen => 10);
-    validate_script_output('whoami', sub { m/$testapi::username/ });
+    become_user($testapi::username);
 }
 
 sub change_locale {

--- a/tests/security/vsftpd/vsftpd.pm
+++ b/tests/security/vsftpd/vsftpd.pm
@@ -23,11 +23,7 @@ sub run {
         assert_script_run("restorecon -R $ftp_users_path");
     }
 
-    enter_cmd("su - $user");
-    # The login shell of $user does not have the openQA prompt hook for
-    # PRETTY_SERIAL_MARKER in its ~/.bashrc yet, so force a re-install on the
-    # next command, same as become_root does. poo#205122
-    $testapi::distri->invalidate_serial_marker_hook();
+    become_user($user);
 
     # Download/upload file using atomatic SSL method selection
     assert_script_run("curl -v -k --ssl ftp://$user:$pwd\@localhost/served/f1.txt -o $ftp_users_path/$user/$ftp_received_dir/f1.txt");


### PR DESCRIPTION
* jeos: Use become_user helper in glibc_locale
* hpcbase: Use become_user helper for user switching
* apachetest: Use become_user helper for switching to postgres
* vsftpd: Use become_user helper for user switching
* Merge pull request #26416 from rfan1/rabbitmq_multi_versions
* Keep using /dev/sshserial for secondary connection
* Move img_proof to a dedicated library (#26402)
* Extend rabbitmq test to run with multiple versions
* Merge pull request #26415 from pdostal/publiccloud-destroy-log-upload-safety
* Merge pull request #26400 from Julie-CAO/julie/history
* Fix SSH console failure by clearing bash history file directly
* fix(publiccloud): Don't let destroy.pm's log upload skip teardown
* Merge pull request #26319 from volodymyrkatkalov/virt_mu_snpguest_update_package_fix
* Redirect Google CLI install log to file
* Merge pull request #26385 from bzoltan1/cryptsetup-luksformat-timeout
* Merge pull request #26288 from pdostal/sshd-force-ipv4-debug-log
* Merge pull request #26401 from tjyrinki/poo-205689
* fips_strongswan_server: avoid leading-space assert_script_run commands
* Merge pull request #26339 from pablo-herranz/poo203517_replace-UEFI_PFLASH-vars
* Merge pull request #26396 from ilmanzo/funkoverage_miss_dependencies
* Merge pull request #26399 from tinawang123/ansible
* Skip tianocore SecureBoot dance when firmware already disabled it
* Install packages for coverage when built from source
* Allow controlling custom_data vs user_data in Azure Terraform (#26367)
* Fix Virt MU snpguest package handling in 15-SP7
* fix(sshd): Wrap interactive ssh login in script(1) for a real pty
* Merge pull request #26393 from bzoltan1/fix-ping-no-rollback
* Merge pull request #26394 from mloviska/helm_abspath
* fix(helm): use absolute path to custom chart values
* Merge pull request #26362 from bzoltan1/coverage-chunking-and-chmod-removal
* Merge pull request #26364 from bzoltan1/coverage-report-large-targets
* ping: add no_rollback to prevent snapshot revert on failure
* Merge pull request #26384 from bzoltan1/lsof-poll-netcat-listen
* lsof: poll for netcat listen state instead of sleep
* Merge pull request #26389 from dzedro/rabbitmq
* Extend timeout
* fix(sshd): Drive the interactive login with script_start_io
* fix(sshd): Make interactive SSH login deterministic
* Merge pull request #26381 from m-dati/pc_cons_test_upd
* rabbitmq: Upload rabbitmq logs
* Merge pull request #26387 from rfan1/firefox_pdf
* Fix firefox pdf url
* Merge pull request #26379 from dzedro/cmd
* cryptsetup: increase luksFormat timeout to 300s
* Merge pull request #26383 from bzoltan1/perf-probe-timeout
* Merge pull request #26380 from Avinesh/blktests-record-version
* Revert "setup_multimachine: Wait longer for sync on aarch64"
* mm_network: Wait for shell before enter_cmd on aarch64
* perf: increase timeout for probe fallback without debuginfod
* Merge pull request #26382 from bzoltan1/lsof-dynamic-port-detection
* Update tests/console/lsof.pm
* Merge pull request #26376 from foursixnine/graphicsmagick-issue
* lsof: fix wide character in record_info (em dash -> ASCII)
* refact(pubcloud):p.c. console tests refactoring and reduction proposal
* Merge pull request #26378 from schlad/config_kernel
* lsof: detect listening port instead of hardcoding :22
* blktests: record kernel config via get_kernel_config
* Kernel::utils: add get_kernel_config
* Merge pull request #26377 from bzoltan1/gdb-increase-serial-timeout
* kernel/blktests: record blktests package version
* gdb: increase wait_serial_or_die default timeout to 20s
* Improve error reporting for GraphicsMagick tests
* Merge pull request #26375 from ggardet/master
* Merge pull request #26331 from bzoltan1/fix-consoletest-post-fail-cascade
* Force the PNG encoder to fix image
* Merge pull request #26374 from grisu48/pc_ltp
* Merge pull request #26330 from bzoltan1/fix-gdb-post-fail-cleanup
* Merge pull request #26328 from bzoltan1/fix-shar-data-url
* Merge pull request #26373 from dzedro/tcpdump
* feat: Reorganize routines by priority
* Merge pull request #26275 from tinawang123/tomcat_enhance
* flash_sd_rootless.sh: handle case when NUMDISK=2
* Merge pull request #26220 from hadeskun/checkStatusRegister
* tcpdump: Old iptuils on 12-SP3 has no -4 option
* Merge pull request #26371 from mloviska/bci_no_post_run2
* fix(bci): avoid clear in host config
* Merge pull request #26286 from hjluo/full_media_registered
* Merge pull request #26349 from rfan1/zypper_wrapper
* Merge pull request #26355 from dzedro/openssl_nodejs
* Merge pull request #26369 from hjluo/refix_s390x_hostname
* coverage_setup: chunk funkoverage install and report failures
* Test Full medium can  be registered against registration server
* Set correct hostname in validate_hostname for s390x
* Zypper wrapper for transactional update
* Merge pull request #26354 from foursixnine/yast2_ftp
* Merge pull request #26345 from bzoltan1/fix-irqbalance-single-cpu
* Merge pull request #26363 from mloviska/bci_no_post_run
* coverage_report: handle large target sets
* fix(bci): avoid clear command
* irqbalance: skip gracefully on single-cpu systems instead of dying
* Merge pull request #26361 from ilmanzo/pincoverage_poc
* Adapt the schedule to the new eBPF tracer
* Merge pull request #26358 from mloviska/bci_no_snapshots
* chore(bci): avoid snapshot updates
* fix(bci): do not clear serial console
* Merge pull request #26359 from ricardobranco777/docker
* docker: Remove dead code since we no longer test Docker v28
* gdb: clean up interactive session in post_fail_hook
* openssl_nodejs: Exclude PQC tests
* fix(publiccloud): gate prepare_instance on passwordless sudo (#26350)
* fix(yast2_ftp): don't split long command with new line
* Merge pull request #26351 from dzedro/php_postgresql
* Merge pull request #26348 from dzedro/journal_check
* Merge pull request #26353 from mpagot/doc_PUBLIC_CLOUD_SSH_CONFIG
* Merge pull request #26327 from bzoltan1/fix-tcpdump-timing-race
* Merge pull request #26329 from bzoltan1/fix-run0-multiline-config
* Merge pull request #26346 from m-dati/which_supportconf
* Add documentation for PUBLIC_CLOUD_SSH_CONFIG
* fix(p.c.): check supportconfig existence with command
* journal_check: Ignore pam_wtmpdb* expected 1, got 0
* Enable validation product registration
* php_postgresql: Reinstall serial marker hook
* Merge pull request #26338 from rfan1/reconn_pvm_console
* Merge pull request #26344 from grisu48/boottime
* fix: Add softfailure for bsc#1264275
* Reconnect console after reboot on pvm setup
* Test tcnative support in tomcat
* consoletest: prevent post_fail_hook cascade on console switch failure
* tcpdump: fix timing race by waiting for readiness
* run0: use write_sut_file for polkit config
* shar: fetch test data via data_url instead of ~/data
