### PR TITLE
Use new testapi function 'become_user'

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -283,12 +283,7 @@ sub test_pgsql {
     assert_script_run 'echo "postgres ALL=(root) NOPASSWD: ALL" >/etc/sudoers.d/postgres';
     assert_script_run "gpasswd -a postgres \$(stat -c %G /dev/$serialdev)";
     assert_script_run 'sudo chsh postgres -s /bin/bash';
-    enter_cmd "su - postgres", wait_still_screen => 1;
-    enter_cmd "PS1='# '", wait_still_screen => 1;
-    # The login shell of $user does not have the openQA prompt hook for
-    # PRETTY_SERIAL_MARKER in its ~/.bashrc yet, so force a re-install on the
-    # next command, same as become_root does. poo#205122
-    $testapi::distri->invalidate_serial_marker_hook();
+    become_user('postgres');
     # upgrade db from oldest version to latest version
     if (script_run('test $(sudo update-alternatives --list postgresql|wc -l) -gt 1') == 0) {
         assert_script_run 'for v in $(sudo update-alternatives --list postgresql); do rpm -q ${v##*/};done';

--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -140,15 +140,7 @@ sub get_slurm_logs {
 
 sub switch_user {
     my ($self, $username) = @_;
-
-    # poo#183761 nested user switches are not supported by the pretty_serial feature.
-    # We use pretty_serial_marker_guard(0) to temporarily fall back to classic markers,
-    # ensuring terminal synchronization remains reliable during the user transition.
-    my $marker_guard = $testapi::distri->pretty_serial_marker_guard(0);
-    enter_cmd("su - $username");
-    type_string(qq/PS1="# "\n/);
-    wait_serial(qr/PS1="# "/);
-    assert_script_run("whoami|grep $username");
+    become_user($username);
 }
 
 =head2 master_node_names

--- a/tests/jeos/glibc_locale.pm
+++ b/tests/jeos/glibc_locale.pm
@@ -38,10 +38,7 @@ my %test_data_lang = (
 );
 
 sub switch_user {
-    # In aarch64 the user change takes some time, causing the next command to get
-    # lost
-    enter_cmd("su - $testapi::username", wait_still_screen => 10);
-    validate_script_output('whoami', sub { m/$testapi::username/ });
+    become_user($testapi::username);
 }
 
 sub change_locale {

--- a/tests/security/vsftpd/vsftpd.pm
+++ b/tests/security/vsftpd/vsftpd.pm
@@ -23,11 +23,7 @@ sub run {
         assert_script_run("restorecon -R $ftp_users_path");
     }
 
-    enter_cmd("su - $user");
-    # The login shell of $user does not have the openQA prompt hook for
-    # PRETTY_SERIAL_MARKER in its ~/.bashrc yet, so force a re-install on the
-    # next command, same as become_root does. poo#205122
-    $testapi::distri->invalidate_serial_marker_hook();
+    become_user($user);
 
     # Download/upload file using atomatic SSL method selection
     assert_script_run("curl -v -k --ssl ftp://$user:$pwd\@localhost/served/f1.txt -o $ftp_users_path/$user/$ftp_received_dir/f1.txt");


### PR DESCRIPTION
* jeos: Use become_user helper in glibc_locale
* hpcbase: Use become_user helper for user switching
* apachetest: Use become_user helper for switching to postgres
* vsftpd: Use become_user helper for user switching

Verification jobs:
```
BADGE=1 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26424 https://openqa.opensuse.org/tests/6167647
BADGE=1 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26424 https://openqa.suse.de/tests/23798136
BADGE=1 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26424 https://openqa.suse.de/tests/23915444
BADGE=1 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26424 https://openqa.suse.de/tests/23853161
```

* glibc_locale [![opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20260815-jeos@64bit_virtio](https://openqa.opensuse.org/tests/6168601/badge)](https://openqa.opensuse.org/tests/6168601)
* hpcbase:
  * [![sle-15-SP6-Server-DVD-HPC-Incidents-aarch64-Buildcoolgw_os-autoinst-distri-opensuse_fix_hpc_serial-hpc_pdsh_master@coolgw_os-autoinst-distri-opensuse_fix_hpc_serial@aarch64](https://openqa.suse.de/tests/23920293/badge)](https://openqa.suse.de/tests/23920293) (asset not found)
  * [![sle-15-SP6-Server-DVD-HPC-Incidents-aarch64-Buildcoolgw_os-autoinst-distri-opensuse_fix_hpc_serial-hpc_pdsh_slave@coolgw_os-autoinst-distri-opensuse_fix_hpc_serial@aarch64](https://openqa.suse.de/tests/23920291/badge)](https://openqa.suse.de/tests/23920291) (asset not found)
  * [![sle-15-SP6-Server-DVD-HPC-Incidents-aarch64-Buildcoolgw_os-autoinst-distri-opensuse_fix_hpc_serial-hpc_pdsh_supportserver@coolgw_os-autoinst-distri-opensuse_fix_hpc_serial@aarch64](https://openqa.suse.de/tests/23920292/badge)](https://openqa.suse.de/tests/23920292) (asset not found)
* vsftpd [![sle-15-SP6-Server-DVD-Updates-x86_64-Build20260816-1-fips_env_mode_textmode_extra@64bit](https://openqa.suse.de/tests/23936036/badge)](https://openqa.suse.de/tests/23936036)
* apachetest [![sle-16.1-Online-aarch64-Build62.2-stack_tests_php@aarch64](https://openqa.suse.de/tests/23936037/badge)](https://openqa.suse.de/tests/23936037)