### PR TITLE
Test all available rabbitmq/erlang versions

### DIFF
--- a/tests/console/rabbitmq.pm
+++ b/tests/console/rabbitmq.pm
@@ -11,15 +11,16 @@ use Mojo::Base 'consoletest';
 use testapi;
 use utils;
 use version_utils qw(is_sle);
-use package_utils 'install_package';
+use package_utils qw(install_package uninstall_package);
 use serial_terminal qw(select_serial_terminal);
 
-sub run {
-    select_serial_terminal;
-    install_package('rabbitmq-server go curl', trup_reboot => 1);
-    record_info('rabbitmq-server&erlang versions: ', script_output('rpm -qa | grep -E "rabbitmq-server|erlang"'));
-    systemctl 'start rabbitmq-server';
-    systemctl 'status rabbitmq-server';
+sub get_all_rabbitmq_versions() {
+    my @rabbitmq_versions = split(/\n/, script_output(qq[zypper se -t package rabbitmq-server | awk -F '|' '\$2 ~ /rabbitmq-server[0-9]* / {print \$2}' | tr -d ' ' | sort -u]));
+    record_info("Available versions", "All available rabbitmq versions are: @rabbitmq_versions");
+    return @rabbitmq_versions;
+}
+
+sub download_go_script() {
     my $curl_opts = "--retry 1 --retry-max-time 60 -D - -O";
     my $cmd = <<EOF;
 mkdir rabbitmq
@@ -28,41 +29,42 @@ curl $curl_opts https://raw.githubusercontent.com/rabbitmq/rabbitmq-tutorials/ma
 go mod init amqp-go
 go get github.com/rabbitmq/amqp091-go
 go mod tidy
-go run send.go
 curl $curl_opts https://raw.githubusercontent.com/rabbitmq/rabbitmq-tutorials/master/go/receive.go
 EOF
     assert_script_run($_) foreach (split /\n/, $cmd);
-    enter_cmd('timeout 2 go run receive.go');
-    wait_serial(".*Received.*Hello World.*");
-    # should be simple assert_script_run but takes too long to stop so
-    # workaround
-    my $ret = script_run('systemctl stop rabbitmq-server');
-    if (!defined($ret)) {
-        record_soft_failure 'boo#1029031 stopping systemd service takes more than 90s';
-        send_key 'ctrl-c';
-        # ignore non-zero exit code when collecting more data on soft fail
-        script_run('systemctl status --no-pager rabbitmq-server');
-        script_run('rpm -q --changelog rabbitmq-server | head -n 60');
-        systemctl 'stop rabbitmq-server', timeout => 300;
-    }
-    # poo#166541, test rabbitmq-server 3.11+ and erlang 25+ on sle15sp6/sp7
-    if (is_sle('>=15-SP6') && is_sle('<16.0')) {
-        record_info 'Test rabbitmq-server 3.11+';
-        # clean up
-        script_run('systemctl stop epmd.socket');
-        systemctl 'stop epmd';
-        zypper_call 'rm rabbitmq-server erlang';
-        script_run('rm -rf /var/lib/rabbitmq');
-        script_run('rm -rf /usr/lib{.64}/rabbitmq');
+}
 
-        zypper_call 'in rabbitmq-server31*';
+sub run {
+    select_serial_terminal;
+    install_package('go curl', trup_apply => 1);
+    download_go_script();
+    my @rabbitmq_versions = get_all_rabbitmq_versions();
+    foreach my $rabbitmq_spec_version (@rabbitmq_versions) {
+        install_package("$rabbitmq_spec_version", trup_reboot => 1);
         record_info('rabbitmq-server&erlang versions: ', script_output('rpm -qa | grep -E "rabbitmq-server|erlang"'));
         systemctl 'start rabbitmq-server';
         systemctl 'status rabbitmq-server';
-        enter_cmd 'go run send.go';
+        record_info('Send/receive message: "Hello World!"');
+        script_run('go run send.go');
         enter_cmd('timeout 2 go run receive.go');
-        wait_serial(".*Received.*Hello World.*");
-        systemctl 'stop rabbitmq-server';
+        wait_serial(".*Received.*Hello World.*") || die 'Failed to receive message';
+        # should be simple assert_script_run but takes too long to stop so
+        # workaround
+        my $ret = script_run('systemctl stop rabbitmq-server');
+        if (!defined($ret)) {
+            record_soft_failure 'boo#1029031 stopping systemd service takes more than 90s';
+            send_key 'ctrl-c';
+            # ignore non-zero exit code when collecting more data on soft fail
+            script_run('systemctl status --no-pager rabbitmq-server');
+            script_run('rpm -q --changelog rabbitmq-server | head -n 60');
+            systemctl 'stop rabbitmq-server', timeout => 300;
+        }
+        # clean up
+        script_run('systemctl stop epmd.socket');
+        systemctl 'stop epmd';
+        uninstall_package("$rabbitmq_spec_version erlang*", trup_reboot => 1);
+        script_run('rm -rf /var/lib/rabbitmq');
+        script_run('rm -rf /usr/lib{.64}/rabbitmq');
     }
 }
 


### PR DESCRIPTION
1. Get all aviable rabbitmq-sever package versions and test them for 
   all sle versions
2. Fix test logic at `wait_serial` and fail the job if expect result is
   not seen
3. Use function `install_package` to install/remove packages


- Related ticket: https://progress.opensuse.org/issues/205698
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22040#discussion_r3802004816

- [Verification run](https://openqa.suse.de/tests/overview?build=rfan0818&distri=sle)