### PR TITLE
Fix oscap setup on 15-SP7 QR ppc64le

### DIFF
--- a/lib/oscap_tests.pm
+++ b/lib/oscap_tests.pm
@@ -748,7 +748,7 @@ sub get_cac_code {
     if (is_sle) {
         zypper_call("in git-core");
     }
-    assert_script_run("mkdir src");
+    assert_script_run("mkdir -p src");
     assert_script_run("rm -r $cac_dir", quiet => 1) if (-e "$cac_dir");
     assert_script_run('git config --global http.sslVerify false', quiet => 1);
     assert_script_run("set -o pipefail ; $git_clone_cmd", timeout => 600, quiet => 1);

--- a/lib/oscap_tests.pm
+++ b/lib/oscap_tests.pm
@@ -748,8 +748,7 @@ sub get_cac_code {
     if (is_sle) {
         zypper_call("in git-core");
     }
-    assert_script_run("mkdir -p src");
-    assert_script_run("rm -r $cac_dir", quiet => 1) if (-e "$cac_dir");
+    assert_script_run("rm -rf $cac_dir && mkdir -p $cac_dir");
     assert_script_run('git config --global http.sslVerify false', quiet => 1);
     assert_script_run("set -o pipefail ; $git_clone_cmd", timeout => 600, quiet => 1);
 
@@ -1149,7 +1148,7 @@ sub oscap_security_guide_setup {
 
     Some hosts were unreachable during the run (login errors, host unavailable, etc). This will NOT end the run early.
     All of the hosts within a single batch were unreachable- i.e. if you set serial: 3 at the play level, and three hosts in a batch were unreachable. This WILL end the run early.
-    A synax or parsing error was encountered- either in command arguments, within a playbook, or within a static include (import_role or import_task). This is a fatal error. 
+    A synax or parsing error was encountered- either in command arguments, within a playbook, or within a static include (import_role or import_task). This is a fatal error.
 
 5 = Error with the options provided to the command
 6 = Command line args are not UTF-8 encoded

--- a/tests/security/oscap_profile_tests/oscap_security_guide_setup.pm
+++ b/tests/security/oscap_profile_tests/oscap_security_guide_setup.pm
@@ -1,4 +1,4 @@
-# Copyright 2024 SUSE LLC
+# Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Summary: Generic test for hardening profile in the 'scap-security-guide': setup environment
@@ -22,6 +22,14 @@ sub run {
     }
     if (get_var('OSCAP_UPLOAD_DEBUG_LOGS')) {
         $oscap_tests::oscap_upload_debug_logs = get_var('OSCAP_UPLOAD_DEBUG_LOGS');
+    }
+
+    # Ugly, but we need the development tools repo in order to satisfy
+    # package requirements of oscap_security_guide_setup.
+    # Particularly: ninja
+    if (is_sle('<16')) {
+        add_suseconnect_product('sle-module-desktop-applications');
+        add_suseconnect_product('sle-module-development-tools');
     }
 
     $self->oscap_security_guide_setup();

--- a/tests/security/oscap_profile_tests/oscap_security_guide_setup.pm
+++ b/tests/security/oscap_profile_tests/oscap_security_guide_setup.pm
@@ -8,6 +8,7 @@ use Mojo::Base 'oscap_tests';
 use testapi;
 use utils;
 use version_utils qw(is_sle);
+use registration qw(add_suseconnect_product);
 
 sub run {
     my ($self) = @_;


### PR DESCRIPTION
The setup phase was broken for quite a while. 
The issues that are tackled in this PR are:

- proper preparation for git checkout dir
- adding required modules to satisfy pkg requirements 


Related ticket
https://progress.opensuse.org/issues/201894

Needles
n/a

Verification run
https://openqa.suse.de/tests/23928449
