### PR TITLE
fix(publiccloud): Reschedule systemd_detect_virt before ssh_interactive_start in SLEM PC

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -384,9 +384,9 @@ sub load_slem_on_pc_tests {
                 loadtest("publiccloud/img_proof", run_args => $args);
             } else {
                 loadtest("publiccloud/slem_basic", run_args => $args);
+                loadtest "publiccloud/systemd_detect_virt", run_args => $args;
                 loadtest "publiccloud/ssh_interactive_start", run_args => $args;
                 loadtest "publiccloud/instance_overview", run_args => $args;
-                loadtest "publiccloud/systemd_detect_virt", run_args => $args;
             }
         }
         loadtest("publiccloud/destroy", run_args => $args);


### PR DESCRIPTION
05929d8411 moved `systemd_detect_virt` ahead of `ssh_interactive_start` in `main_publiccloud.pm` so it runs on the host console instead of the SSH tunnel, but missed `load_slem_on_pc_tests` in `main_micro_alp.pm`. There, `systemd_detect_virt` still ran after `ssh_interactive_start`, so `select_host_console()` hard-died with `Called select_host_console but we are in TUNNELED mode`.

Failing job: https://openqa.suse.de/tests/23924310#step/systemd_detect_virt/2

Moves the `loadtest` line above `ssh_interactive_start` to match the already-fixed `main_publiccloud.pm` ordering. One line relocated, no other changes.