### PR TITLE
kernel: fix PSI test scheduling on s390x/zVM on o3

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -302,7 +302,8 @@ sub is_kernel_test {
         || get_var('TRINITY')
         || get_var('NUMA_IRQBALANCE')
         || get_var('TUNED')
-        || get_var('KDUMP'));
+        || get_var('KDUMP')
+        || get_var('PSI'));
 }
 
 sub is_systemd_test {

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -137,6 +137,9 @@ sub load_kernel_tests {
     elsif (get_var('KDUMP')) {
         loadtest_kernel 'kdump';
     }
+    elsif (get_var('PSI')) {
+        loadtest_kernel 'pressure_stall_information';
+    }
 
     if (is_svirt && get_var('PUBLISH_HDD_1')) {
         loadtest_kernel '../shutdown/svirt_upload_assets';

--- a/tests/kernel/pressure_stall_information.pm
+++ b/tests/kernel/pressure_stall_information.pm
@@ -28,10 +28,15 @@ sub boot {
     }
 }
 
+sub select_test_console {
+    my $self = shift;
+    return get_var('PSI') && is_s390x() ? select_console('root-console') : $self->boot;
+}
+
 sub run {
     my $self = shift;
 
-    $self->boot;
+    $self->select_test_console;
 
     if (is_sle('>=16.1') || is_tumbleweed()) {
         # Starting with SLE-16.1 along with Tumbleweed (jsc#PED-15418),


### PR DESCRIPTION
Add PSI test to is_kernel_test()/load_kernel_tests() so the pressure_stall_information module is
scheduled on o3's s390x z/VM machines.  (the same way as kdump module)

- Related ticket: https://progress.opensuse.org/issues/199745
- Verification run: TW - https://openqa.opensuse.org/tests/6168782
SLE - https://openqa.suse.de/tests/23929371# 
