### PR TITLE
refactor(publiccloud): run instance_overview.pm over ssh instead of the tunnel

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -368,8 +368,8 @@ sub load_slem_on_pc_tests {
             loadtest("publiccloud/aistack_rbac_run", run_args => $args);
             loadtest("publiccloud/aistack_sanity_run", run_args => $args);
         } elsif (is_container_test) {
-            loadtest("publiccloud/ssh_interactive_start", run_args => $args);
             loadtest("publiccloud/instance_overview", run_args => $args);
+            loadtest("publiccloud/ssh_interactive_start", run_args => $args);
             loadtest("publiccloud/slem_prepare", run_args => $args);
             my $runtime = get_required_var('CONTAINER_RUNTIMES');
             for (split(',\s*', $runtime)) {
@@ -385,7 +385,6 @@ sub load_slem_on_pc_tests {
             } else {
                 loadtest("publiccloud/slem_basic", run_args => $args);
                 loadtest "publiccloud/systemd_detect_virt", run_args => $args;
-                loadtest "publiccloud/ssh_interactive_start", run_args => $args;
                 loadtest "publiccloud/instance_overview", run_args => $args;
             }
         }

--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -74,8 +74,8 @@ sub load_maintenance_publiccloud_tests {
         loadtest("publiccloud/check_services", run_args => $args) if (get_var('PUBLIC_CLOUD_SMOKETEST'));
         loadtest("publiccloud/systemd_detect_virt", run_args => $args) if (get_var('PUBLIC_CLOUD_SMOKETEST'));
         loadtest("publiccloud/smoketest", run_args => $args) if ($smoketest);
-        loadtest "publiccloud/ssh_interactive_start", run_args => $args;
         loadtest "publiccloud/instance_overview", run_args => $args;
+        loadtest "publiccloud/ssh_interactive_start", run_args => $args;
         if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
             load_publiccloud_consoletests($args);
         } elsif (get_var('PUBLIC_CLOUD_BTRFS')) {
@@ -171,8 +171,8 @@ sub load_latest_publiccloud_tests {
                 loadtest("publiccloud/check_services", run_args => $args) if (get_var('PUBLIC_CLOUD_SMOKETEST'));
                 loadtest("publiccloud/systemd_detect_virt", run_args => $args) if (get_var('PUBLIC_CLOUD_SMOKETEST'));
                 loadtest("publiccloud/smoketest", run_args => $args) if ($smoketest);
-                loadtest "publiccloud/ssh_interactive_start", run_args => $args;
                 loadtest "publiccloud/instance_overview", run_args => $args;
+                loadtest "publiccloud/ssh_interactive_start", run_args => $args;
                 if (get_var('PUBLIC_CLOUD_CONSOLE_TESTS')) {
                     load_publiccloud_consoletests($args);
                 } elsif (get_var('PUBLIC_CLOUD_BTRFS')) {

--- a/schedule/sles4sap/sles4sap_gnome_saptune.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune.yaml
@@ -29,5 +29,5 @@ conditional_schedule:
         - publiccloud/registration
         - publiccloud/transfer_repos
         - publiccloud/patch_and_reboot
-        - publiccloud/ssh_interactive_start
         - publiccloud/instance_overview
+        - publiccloud/ssh_interactive_start

--- a/schedule/sles4sap/sles4sap_gnome_saptune_maintenance.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune_maintenance.yaml
@@ -30,5 +30,5 @@ conditional_schedule:
         - publiccloud/registration
         - sles4sap/publiccloud/cluster_add_repos
         - publiccloud/patch_and_reboot
-        - publiccloud/ssh_interactive_start
         - publiccloud/instance_overview
+        - publiccloud/ssh_interactive_start

--- a/schedule/sles4sap/sles4sap_gnome_saptune_product.yaml
+++ b/schedule/sles4sap/sles4sap_gnome_saptune_product.yaml
@@ -26,5 +26,5 @@ conditional_schedule:
         - sles4sap/publiccloud/mr_test_setup_env
         - publiccloud/network_test
         - publiccloud/registration
-        - publiccloud/ssh_interactive_start
         - publiccloud/instance_overview
+        - publiccloud/ssh_interactive_start

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -13,62 +13,64 @@
 use Mojo::Base 'publiccloud::basetest';
 use registration;
 use testapi;
-use utils;
-use publiccloud::utils;
-use publiccloud::zypper 'pc_wait_quit_local';
+use publiccloud::ssh_interactive 'select_host_console';
+use publiccloud::zypper qw(pc_refresh pc_zypper_call pc_wait_quit);
 use version_utils qw(is_sle is_sle_micro);
-use Utils::Logging 'tar_and_upload_log';
 
 sub run {
     my ($self, $args) = @_;
-    script_run("hostname -f");
-    assert_script_run("uname -a");
+    select_host_console();
 
-    assert_script_run("cat /etc/os-release");
+    my $instance = $args->{my_instance};
 
-    assert_script_run("ps aux | nl");
+    $instance->ssh_script_run("hostname -f");
+    $instance->ssh_assert_script_run("uname -a");
+
+    $instance->ssh_assert_script_run("cat /etc/os-release");
+
+    $instance->ssh_assert_script_run("ps aux | nl");
 
     # Workaround for missing iproute2 package in 15-SP4 CHOST images (bsc#1264714)
-    if (get_required_var('FLAVOR') =~ 'GCE-CHOST-BYOS' && (is_sle("=15-SP4") || is_sle("=15-SP5")) && script_run("ip l") != 0) {
+    if (get_required_var('FLAVOR') =~ 'GCE-CHOST-BYOS' && (is_sle("=15-SP4") || is_sle("=15-SP5")) && $instance->ssh_script_run('ip l') != 0) {
         record_soft_failure("bsc#1264714 Missing iproute2 package");
-        script_retry("zypper -n in iproute2", retry => 3, timeout => 300);
+        pc_zypper_call($instance, 'in iproute2', timeout => 300);
     }
 
     my $ip_color = (is_sle('>=15-SP3')) ? '-c=never' : '';
-    assert_script_run("ip $ip_color a s");
-    assert_script_run("ip $ip_color r s");
-    assert_script_run("ip $ip_color -6 r s");
+    $instance->ssh_assert_script_run("ip $ip_color a s");
+    $instance->ssh_assert_script_run("ip $ip_color r s");
+    $instance->ssh_assert_script_run("ip $ip_color -6 r s");
 
-    assert_script_run("cat /etc/hosts");
-    assert_script_run("cat /etc/resolv.conf");
+    $instance->ssh_assert_script_run("cat /etc/hosts");
+    $instance->ssh_assert_script_run("cat /etc/resolv.conf");
 
-    assert_script_run("lsblk");
+    $instance->ssh_assert_script_run("lsblk");
 
     # Check for bsc#1165915
-    zypper_call("ref");
-    my $register = (is_sle_micro) ? "transactional-update register --status-text" : "SUSEConnect --status-text";
+    pc_refresh($instance);
+    my $register = (is_sle_micro) ? "sudo transactional-update register --status-text" : "sudo SUSEConnect --status-text";
     # poo#204534: a background transactional-update task (e.g. snapper
     # cleanup) may still hold the lock right after boot/registration.
-    pc_wait_quit_local() if is_sle_micro;
-    assert_script_run($register, 300);
+    pc_wait_quit($instance) if is_sle_micro;
+    $instance->ssh_assert_script_run($register, timeout => 300);
 
-    zypper_call("lr -d");
+    pc_zypper_call($instance, 'lr -d');
 
-    collect_system_information($self);
+    collect_system_information($instance);
 }
 
 sub collect_system_information {
-    my ($self) = @_;
+    my ($instance) = @_;
 
     # Collect various system information and pack them to instance_overview.tar
-    script_run("cd /var/tmp");
-    assert_script_run("mkdir -p instance_overview");
-    assert_script_run("rpm -qa | tee instance_overview/rpm.list.txt", timeout => 90);
-    assert_script_run("cat /proc/cpuinfo | tee instance_overview/cpuinfo.txt");
-    assert_script_run("cat /proc/meminfo | tee instance_overview/meminfo.txt");
-    assert_script_run("uname -a | tee instance_overview/uname.txt");
-    tar_and_upload_log("instance_overview/", "instance_overview.tar.gz", {gzip => 1});
-    script_run("cd");
+    my $dir = '/var/tmp/instance_overview';
+    $instance->ssh_assert_script_run("mkdir -p $dir");
+    $instance->ssh_assert_script_run("rpm -qa | tee $dir/rpm.list.txt", timeout => 90);
+    $instance->ssh_assert_script_run("cat /proc/cpuinfo | tee $dir/cpuinfo.txt");
+    $instance->ssh_assert_script_run("cat /proc/meminfo | tee $dir/meminfo.txt");
+    $instance->ssh_assert_script_run("uname -a | tee $dir/uname.txt");
+    $instance->ssh_assert_script_run("tar -czf /var/tmp/instance_overview.tar.gz -C /var/tmp instance_overview");
+    $instance->upload_log('/var/tmp/instance_overview.tar.gz', failok => 1);
 }
 
 sub test_flags {


### PR DESCRIPTION
## Why

`instance_overview.pm` ran its checks as plain `assert_script_run`/`script_run`/`zypper_call` over the serial console, which only reaches the cloud instance because `ssh_interactive_start` had already redirected `$serialdev` through the SSH tunnel. That coupling is unnecessary: the repo's established tunnel-free pattern (`publiccloud::basetest` + `select_host_console()` + `$instance->ssh_*`) already works for equivalent checks in `check_services.pm`, `systemd_detect_virt.pm` (poo#205173) and `smoketest.pm` (poo#205176), part of the wider ssh-tunnel-usage evaluation in poo#202752.

## What changed

- `tests/publiccloud/instance_overview.pm`: switched to `publiccloud::basetest` + `select_host_console()`, running all commands via `$args->{my_instance}->ssh_*`. Zypper plumbing routed through `publiccloud::zypper` (`pc_refresh`/`pc_zypper_call`/`pc_wait_quit`). Registration commands now carry an explicit `sudo` since they execute as the cloud user rather than root. `collect_system_information` builds the tarball on the instance under absolute paths (no persistent `cd` across one-shot ssh invocations) and uploads it via `$instance->upload_log` instead of `tar_and_upload_log`.
- `lib/main_publiccloud.pm`: in both `load_maintenance_publiccloud_tests` and `load_latest_publiccloud_tests`, hoisted `instance_overview` above `ssh_interactive_start`.
- `lib/main_micro_alp.pm`: same hoist in the container branch; in the `slem_basic` branch `ssh_interactive_start` was left as the last scheduled test with nothing downstream needing the tunnel (only the tunnel-free `destroy` follows), so it is dropped there entirely instead of just reordered.
- `schedule/sles4sap/sles4sap_gnome_saptune*.yaml`: swapped the last two schedule entries so `instance_overview` precedes `ssh_interactive_start` (the tunnel must still be up for the following `sles4sap/saptune/mr_test`).

## Testing

- `make test-compile-changed`
- `make tidy-check`
- `make perlcritic`
- `make test-yaml-valid-changed`
- `make test-modules-in-yaml-schedule`

openQA verification runs (cloned via `openqa-clone-custom-git-refspec` against this PR):

- https://openqa.suse.de/tests/23932026 — `publiccloud_containers` (maintenance, `PUBLIC_CLOUD_CONTAINERS` branch)
- https://openqa.suse.de/tests/23932027 — `publiccloud_consoletests` (maintenance, `PUBLIC_CLOUD_CONSOLE_TESTS` branch)
- https://openqa.suse.de/tests/23932029 — `publiccloud_smoketests` (latest, `$smoketest` branch)
- https://openqa.suse.de/tests/23932030 — `slem_basic` (SL Micro on PC; `ssh_interactive_start` removed here)
- https://openqa.suse.de/tests/23932031 — `publiccloud_slem_containers` (SL Micro on PC, container branch)
- https://openqa.suse.de/tests/23932032 — `sles4sap_gnome_saptune_notes` (`sles4sap_gnome_saptune_maintenance.yaml` reorder)

poo#205170
