### PR TITLE
sshd: Improve how the test asserts that shell is in a ssh session

### DIFF
--- a/lib/services/sshd.pm
+++ b/lib/services/sshd.pm
@@ -94,6 +94,7 @@ sub ssh_basic_check {
         my $marker_guard = $testapi::distri->pretty_serial_marker_guard(0);
         # ssh writes prompts to its own tty, not stdout, so give it a fresh pty via `script` (poo#205149).
         script_start_io("script -qe -c 'ssh -4 -v -E /tmp/ssh_log0 $ssh_testman\@localhost -t' /dev/null");
+        set_var('SUBSHELL_NOT_AS_ROOT', 1);
         # Host key is always untrusted: prepare_test_data cleared ~/.ssh.
         die "host key prompt did not appear\n" unless wait_serial('Are you sure', timeout => 300);
         enter_cmd('yes');
@@ -111,6 +112,7 @@ sub ssh_basic_check {
         enter_cmd('exit');
         script_finish_io(timeout => 300, exitcodes => [0]);
         assert_script_run "whoami | grep root";
+        set_var('SUBSHELL_NOT_AS_ROOT', 0);
     }
 
     # Generate RSA key for root and the user

--- a/lib/services/sshd.pm
+++ b/lib/services/sshd.pm
@@ -101,8 +101,9 @@ sub ssh_basic_check {
         enter_cmd($ssh_testman_passwd);
 
         # Check that we are really in the SSH session
-        assert_script_run 'echo $SSH_TTY | grep "\/dev\/pts\/"';
-        assert_script_run 'ps ux | grep -E ".* \? .* sshd(-session)?\:"';
+        assert_script_run '[ -n "$SSH_TTY" ]';
+        assert_script_run 'grep  "$PPID (sshd-session)" /proc/$PPID/stat';
+        assert_script_run 'ps ux | grep sshd-session';
         assert_script_run "whoami | grep $ssh_testman";
         assert_script_run "mkdir .ssh";
 

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -121,6 +121,14 @@ sub post_run_hook {
 
 sub post_fail_hook {
     my $self = shift;
+
+    # If the test fails inside the subshell, many commands can fail
+    if (get_var('SUBSHELL_NOT_AS_ROOT', 0)) {
+        script_run "ps -aux";
+        script_run "env";
+        enter_cmd('exit');
+    }
+
     $self->cleanup();
     $self->SUPER::post_fail_hook;
 }

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -127,6 +127,8 @@ sub post_fail_hook {
         script_run "ps -aux";
         script_run "env";
         enter_cmd('exit');
+        # For some reason the serial guard seems to fail
+        $testapi::distri->pretty_serial_marker_guard(1);
     }
 
     $self->cleanup();


### PR DESCRIPTION
This test started failing in [Staging:I](https://openqa.opensuse.org/tests/6171019#step/sshd/25) and we can't tell if it is related to a procps update, due to some warnings from grep and lack of logs due to `post_fail_hook` failing because the shell is still logged in as sshboy

This also uncovered a bug in [procps](https://build.opensuse.org/requests/1371991/changes#diff_0_n5 :)), so we can check for the process in a stricter way, and collect extra information in the pfh if needed.

openqa: clone https://openqa.opensuse.org/tests/6171019
openqa: clone https://openqa.opensuse.org/tests/6174199 EXCLUDE_MODULE=vsftpd

#### Results from cloned jobs:
- [![https://openqa.opensuse.org/tests/6176183](https://openqa.opensuse.org/tests/6176183/badge)](https://openqa.opensuse.org/tests/6176183)
- [![https://openqa.opensuse.org/tests/6176184](https://openqa.opensuse.org/tests/6176184/badge)](https://openqa.opensuse.org/tests/6176184)

<sub>The above list is generated with a script with information from the "clone_mentioned_job" workflow.</sub>
