### PR TITLE
journal_check: Update for bsc#1272527 on micro 6.0 & 6.1

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -1061,9 +1061,11 @@
         "type": "bug"
     },
     "bsc#1272527": {
-        "description": "pam_wtmpdb\\(login:session\\): Update of logout time changed wrong number of rows, expected 1, got 0",
+        "description": "pam_wtmpdb\\(login:session\\): (Update of logout time changed|update_logout: Updated) wrong number of rows, expected 1, got 0",
         "products": {
             "sle-micro": [
+                "6.0",
+                "6.1",
                 "6.2"
             ],
             "microos": [


### PR DESCRIPTION
- Related ticket: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26348 https://bugzilla.suse.com/show_bug.cgi?id=1272527
- Verification run:
https://openqa.suse.de/tests/overview?distri=sle-micro&build=jpupava_jc
 https://openqa.suse.de/tests/23943503#step/journal_check/10 6.1
 https://openqa.suse.de/tests/23943507#step/journal_check/10 6.2