### PR TITLE
Elemental3: use internal SUSE CA when needed

### DIFF
--- a/lib/elemental3.pm
+++ b/lib/elemental3.pm
@@ -31,12 +31,21 @@ Execute elemental3 command from container.
 sub elemental3_cmd {
     my (%args) = @_;
     my $runtime = get_required_var('CONTAINER_RUNTIMES');
+    my $ca_vol;
 
     croak('Missing arguments!') if (!%args);
 
+    # Check if we need to mount the local CA in the container
+    # This could be needed when we have to test updates on released versions,
+    # as internal SUSE CAs are not installed in that case!
+    unless (get_var('TOTEST_PATH', '') =~ /Main:/) {
+        # NOTE: ':z' is needed because of SELinux!
+        $ca_vol = '--volume /var/lib/ca-certificates:/var/lib/ca-certificates:ro,z --volume /etc/ssl:/etc/ssl:ro,z';
+    }
+
     # NOTE: ':z' is needed because of SELinux!
     assert_script_run(
-        "$runtime run --rm --volume $args{config_dir}:/config:z $args{uri} $args{cmd}",
+        "$runtime run --rm ${ca_vol} --volume $args{config_dir}:/config:z $args{uri} $args{cmd}",
         timeout => $args{timeout}
     );
 }


### PR DESCRIPTION
Mount the local CA in the elemental container image when we need to test updates on released versions, as internal SUSE CA are not installed in these images.

This should fix this issue: https://openqa.suse.de/tests/23635464#step/generate_image/126.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://10.168.203.107/tests/470
