### PR TITLE
Update ref documentation link

### DIFF
--- a/tests/publiccloud/registration_lifecycle.pm
+++ b/tests/publiccloud/registration_lifecycle.pm
@@ -5,7 +5,7 @@
 
 # Package: cloud-regionsrv-client
 # Summary: Test system (re)registration
-# https://github.com/SUSE-Enceladus/cloud-regionsrv-client/blob/master/integration_test-process.txt
+# https://github.com/SUSE-Enceladus/cloud-regionsrv-client/blob/master/doc/integration_test-process.txt
 # Leave system in *registered* state
 #
 # Maintainer: QE-C team <qa-c@suse.de>


### PR DESCRIPTION
Update link to cloud-regionsrv-client documentation in registration_lifecycle test module.

Related ticket: [poo#109304](https://progress.opensuse.org/issues/109304)