### PR TITLE
img_proof: The SCAP report is relevant only on hardened images

### DIFF
--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -138,8 +138,10 @@ sub run {
     upload_logs($img_proof->{results}, log_name => sprintf('%s-%s.%s', $log_prefix, basename($img_proof->{results}), 'json'));
     parse_extra_log(IPA => $img_proof->{results});
 
-    $instance->ssh_script_run(cmd => 'sudo chmod a+r /var/tmp/report.html || true');
-    $instance->upload_log('/var/tmp/report.html', failok => 1);
+    if (is_hardened() && !check_var('SCAP_REPORT', 'skip')) {
+        $instance->ssh_script_run(cmd => 'sudo chmod a+r /var/tmp/report.html || true');
+        $instance->upload_log('/var/tmp/report.html', failok => 1);
+    }
 
     my $log = script_output('cat ' . $img_proof->{logfile});
     eval { analyze_results($log, $img_proof->{output}, $self->{extra_test_results}) };


### PR DESCRIPTION
Avoid this step on non-hardened images where this report doesn't exist.  We use the same condition just a few lines [above](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/publiccloud/img_proof.pm#L131)

https://openqa.suse.de/tests/23944836#step/img_proof/18
> scp: /var/tmp/report.html: No such file or directory