### PR TITLE
Move barrier_wait() call after status check in ha/qnetd

### DIFF
--- a/tests/ha/qnetd.pm
+++ b/tests/ha/qnetd.pm
@@ -175,10 +175,10 @@ sub run {
         ensure_resource_running('promotable-1', ":[[:blank:]]*$node_01\[[:blank:]]*([Mm]aster|[Pp]romoted)\$");
     }
 
-    barrier_wait("SPLIT_BRAIN_TEST_DONE_$cluster_name");
-
     # Show cluster status before ending the test
     save_state if (is_node(1) || !(get_var('USE_DISKLESS_SBD') || check_var('QDEVICE_TEST_ROLE', 'qnetd_server')));
+
+    barrier_wait("SPLIT_BRAIN_TEST_DONE_$cluster_name");
 
     # Restart stonith. This should fence node 2
     assert_script_run qq|crm configure property $fencing_property="true"| if is_node(1);


### PR DESCRIPTION
We have a race condition in the test module `ha/qnetd`: right after performing the `split-brain-check` on node 2 in scenarios with block-device-backed SBD, both nodes collect cluster status (via `crm_mon` and `crm configure show`), and after this node 1 causes node 2 to fence; if node 1 runs these commands faster than node 2, it's possible for node 2 to still be typing commands when the node is being fenced leading to unexpected failures. This commit moves the `barrier_wait()` call after the status collection, to ensure both nodes are alive while collecting status, and then right after the barrier call, the fence command is executed by node 1.

- Related Ticket: https://jira.suse.com/browse/TEAM-11497
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: https://openqa.suse.de/tests/overview?version=15-SP6&distri=sle&build=VR4PR26443 :green_circle: , https://openqa.suse.de/tests/overview?version=16.1&distri=sle&build=VR4PR26443 :green_circle: 
