### PR TITLE
data/delete_users: Wait until user processes are killed

### DIFF
--- a/data/delete_users
+++ b/data/delete_users
@@ -3,10 +3,9 @@ set -eu
 
 n_users="$1"
 
-killall -u user1 || true
-sleep 1
-ps auxf|grep user1
-
 for i in `seq 1 $n_users` ; do
-	userdel -r "user${i}"
+	user="user${i}"
+	# Loop until pkill no longer finds matching processes.
+	while pkill -u "$user"; do sleep 1; done
+	userdel -r "$user"
 done


### PR DESCRIPTION
Replace the unreliable sleep 1 with a loop.

- Sporadic failure: https://openqa.opensuse.org/tests/6171854#step/multi_users_dm/39
- Verification runs: [![opensuse-Tumbleweed-DVD-ppc64le-Build20260818-extra_tests_on_kde@ppc64le test result](https://openqa.opensuse.org/tests/6173036/badge)](https://openqa.opensuse.org/tests/6173036) [![opensuse-Tumbleweed-DVD-ppc64le-Build20260818-extra_tests_on_kde@ppc64le test result](https://openqa.opensuse.org/tests/6173127/badge)](https://openqa.opensuse.org/tests/6173127) [![opensuse-Tumbleweed-DVD-ppc64le-Build20260818-extra_tests_on_kde@ppc64le test result](https://openqa.opensuse.org/tests/6173128/badge)](https://openqa.opensuse.org/tests/6173128) [![opensuse-Tumbleweed-DVD-ppc64le-Build20260818-extra_tests_on_kde@ppc64le test result](https://openqa.opensuse.org/tests/6173129/badge)](https://openqa.opensuse.org/tests/6173129)[![opensuse-Tumbleweed-DVD-ppc64le-Build20260818-extra_tests_on_kde@ppc64le test result](https://openqa.opensuse.org/tests/6173131/badge)](https://openqa.opensuse.org/tests/6173131)[![opensuse-Tumbleweed-DVD-ppc64le-Build20260818-extra_tests_on_kde@ppc64le test result](https://openqa.opensuse.org/tests/6173132/badge)](https://openqa.opensuse.org/tests/6173132)
