### PR TITLE
Redirect debug output from CSP cli to a file to avoid noisy terminal log

### DIFF
--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -45,7 +45,9 @@ sub init {
         assert_script_run('mkdir -p ~/.aws');
         # CAVEAT: Use the bash environment variables to prevent credential leaks.
         assert_script_run('printf "[default]\naws_access_key_id=$AWS_ACCESS_KEY_ID\naws_secret_access_key=$AWS_SECRET_ACCESS_KEY\nregion=$AWS_DEFAULT_REGION\n" > ~/.aws/credentials');
-        script_run("PILOT_DEBUG=1 aws %silent --help");
+        my $debug = "aws-cli-debug.txt";
+        script_run("PILOT_DEBUG=1 aws %silent --help &> $debug");
+        upload_logs($debug, failok => 1);
     }
 
     # Disable pager (see poo#133226 - EC2: WARNING: terminal is not fully functional)

--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -42,7 +42,11 @@ sub init {
           . '"galleryEndpointUrl": "https://gallery.azure.com/", ' . $/
           . '"managementEndpointUrl": "https://management.core.windows.net/" ' . $/
           . '}');
-    script_run("PILOT_DEBUG=1 az %silent --help") if is_sle(">=16");
+    if (is_sle(">=16")) {
+        my $debug = "az-cli-debug.txt";
+        script_run("PILOT_DEBUG=1 az %silent --help &> $debug");
+        upload_logs($debug, failok => 1);
+    }
 
     $self->az_login();
     assert_script_run("az account set --subscription \$ARM_SUBSCRIPTION_ID");


### PR DESCRIPTION
`PILOT_DEBUG=1` generates verbose logs from `rsync -av` when running `aws --help` & `az --help`.  

Redirect them to a log instead to avoid a noisy terminal log that also consumes lots of tokens when agents are analyzing jobs.

https://openqa.suse.de/tests/23892192/logfile?filename=serial_terminal.txt

VR not needed.