### PR TITLE
Workaround for "systemctl is-system-running" Exit code 1

### DIFF
--- a/lib/sles4sap/ipaddr2.pm
+++ b/lib/sles4sap/ipaddr2.pm
@@ -882,9 +882,27 @@ sub ipaddr2_os_sanity(%args) {
     ipaddr2_os_ssh_sanity(user => $args{user}, bastion_ip => $args{bastion_ip});
 
     foreach (1 .. 2) {
-        ipaddr2_ssh_internal(id => $_,
+        my $ret = ipaddr2_ssh_internal(id => $_,
             cmd => 'sudo systemctl is-system-running',
-            bastion_ip => $args{bastion_ip});
+            bastion_ip => $args{bastion_ip},
+            no_assert => 1);
+
+        if (defined $ret && $ret == 0) {
+            next;
+        }
+        elsif (defined $ret && $ret == 1) {
+            # get the names of the failed services
+            my $failed_services = ipaddr2_ssh_internal_output(id => $_,
+                cmd => 'sudo systemctl --failed --no-pager',
+                bastion_ip => $args{bastion_ip});
+
+            # record the failed services for investigating
+            record_info('Error', "The Services failed on VM $_:\n$failed_services", result => 'fail');
+            die "Test died on VM $_ due to failed services.";
+        }
+        else {
+            die "VM $_ is not in a running state with exit code " . ($ret // 'undef');
+        }
     }
 
     ipaddr2_cloudinit_sanity(bastion_ip => $args{bastion_ip});

--- a/t/22_ipaddr2.t
+++ b/t/22_ipaddr2.t
@@ -369,7 +369,8 @@ subtest '[ipaddr2_os_sanity]' => sub {
             push @calls, ['bastion', $args{cmd}]; });
     $ipaddr2->redefine(ipaddr2_ssh_internal => sub {
             my (%args) = @_;
-            push @calls, ["VM$args{id}", $args{cmd}]; });
+            push @calls, ["VM$args{id}", $args{cmd}];
+            return 0; });
     $ipaddr2->redefine(ipaddr2_ssh_internal_output => sub {
             my (%args) = @_;
             # return exactly what ipaddr2_os_ssh_sanity needs
@@ -404,7 +405,8 @@ subtest '[ipaddr2_os_sanity] root' => sub {
             push @calls, ['bastion', $args{cmd}]; });
     $ipaddr2->redefine(ipaddr2_ssh_internal => sub {
             my (%args) = @_;
-            push @calls, ["VM$args{id}", $args{cmd}]; });
+            push @calls, ["VM$args{id}", $args{cmd}];
+            return 0; });
     $ipaddr2->redefine(ipaddr2_ssh_internal_output => sub {
             my (%args) = @_;
             # return exactly what ipaddr2_os_ssh_sanity needs
@@ -436,7 +438,8 @@ subtest '[ipaddr2_os_sanity] enable_dig' => sub {
             push @calls, ['bastion', $args{cmd}]; });
     $ipaddr2->redefine(ipaddr2_ssh_internal => sub {
             my (%args) = @_;
-            push @calls, ["VM$args{id}", $args{cmd}]; });
+            push @calls, ["VM$args{id}", $args{cmd}];
+            return 0; });
     $ipaddr2->redefine(ipaddr2_ssh_internal_output => sub {
             my (%args) = @_;
             # return exactly what ipaddr2_os_ssh_sanity needs
@@ -454,6 +457,41 @@ subtest '[ipaddr2_os_sanity] enable_dig' => sub {
     # extract just the command strings
     my @cmds = map { $_->[1] } @calls;
     ok((any { /dig/ } @cmds), 'dig command present when enable_dig is set');
+};
+
+subtest '[ipaddr2_os_sanity] Failure Scenarios' => sub {
+    my $ipaddr2 = Test::MockModule->new('sles4sap::ipaddr2', no_auto => 1);
+    $ipaddr2->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+    $ipaddr2->redefine(ipaddr2_get_internal_vm_name => sub { return 'Galileo'; });
+    $ipaddr2->redefine(ipaddr2_bastion_pubip => sub { return 'Invalid_IP_Galileo'; });
+    my @calls;
+    $ipaddr2->redefine(script_run => sub {
+            push @calls, ['local', $_[0]]; });
+    $ipaddr2->redefine(assert_script_run => sub {
+            push @calls, ['local', $_[0]]; });
+    $ipaddr2->redefine(ipaddr2_ssh_bastion_assert_script_run => sub {
+            my (%args) = @_;
+            push @calls, ['bastion', $args{cmd}]; });
+    $ipaddr2->redefine(ipaddr2_ssh_internal_output => sub {
+            my (%args) = @_;
+            push @calls, ["VM$args{id}", $args{cmd}];
+            return "example.service" if ($args{cmd} =~ /failed/);
+            # return exactly what ipaddr2_os_ssh_sanity needs
+            return 3; });
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub {
+            my (%args) = @_;
+            push @calls, ["VM$args{id}", $args{cmd}];
+            return 1 if ($args{id} == 1);
+            return 0; });
+    throws_ok { ipaddr2_os_sanity(); } qr/Test died on VM 1/, 'Test die due to failed services';
+
+    $ipaddr2->redefine(ipaddr2_ssh_internal => sub {
+            my (%args) = @_;
+            push @calls, ["VM$args{id}", $args{cmd}];
+            return 0 if ($args{id} == 1);
+            return 3 if ($args{id} == 2);
+            return 0; });
+    throws_ok { ipaddr2_os_sanity(); } qr/VM 2 .* with exit code 3/, 'Unexpected non-zero exit code';
 };
 
 subtest '[ipaddr2_bastion_pubip]' => sub {


### PR DESCRIPTION
there are many jobs failed because Exit Code of the command "systemctl is-system-running" is 1 since `guestregister.service` failed , and then they passed after re-run, so I create this PR to handle the case (Exit Code 1), it will record the failed services and mark the test as `Error`.
I checked the version of the package `cloud-regionsrv-client`, the version on all products is already `11.0.3`, so we don't need to consider the package version in the PR, the test will die once any systemd service fails.

- Related ticket: https://jira.suse.com/browse/TEAM-11453
- Verification run:
    https://openqa.suse.de/tests/24049532 (16.0)
    https://openqa.suse.de/tests/24049533 (15-SP7)
    https://openqa.suse.de/tests/24049534 (15-SP6)
    https://openqa.suse.de/tests/24049534 (15-SP5)
    https://openqa.suse.de/tests/24049534 (15-SP4)
    https://openqa.suse.de/tests/24049531 (12-SP5)
    https://openqa.suse.de/tests/ (12-SP5 failure, but it will be fixed in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26434 by Michele)