### PR TITLE
Kselftests: Use modules_prepare instead of headers target

### DIFF
--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -92,11 +92,11 @@ sub build
     my $make_cmd = "make -j$jobs -C $source_dir/tools/testing/selftests install O=$build_dir SKIP_TARGETS= TARGETS=$targets FORCE_TARGETS=1 $build_env";
     $make_cmd =~ s/\s+$//;
 
-    assert_script_run("make -j$jobs -C $source_dir headers O=$build_dir $build_env");
+    assert_script_run("make -j$jobs -C $source_dir modules_prepare O=$build_dir $build_env");
 
-    # Mount the source dir overlay only after make headers. Mounting it earlier
-    # disturbs make's timestamp evaluation and causes it to try to regenerate
-    # headers from source files absent in the kernel-source package.
+    # Mount the source dir overlay only after make modules_prepare. Mounting it
+    # earlier disturbs make's timestamp evaluation and causes it to try to
+    # regenerate headers from source files absent in the kernel-source package.
     my $real_source_dir = script_output("readlink -f $source_dir");
     if (script_run("test -w $real_source_dir") != 0) {
         (my $tag = $real_source_dir) =~ s|[/ ]|_|g;

--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -198,6 +198,10 @@ sub install_dependencies
         trup_apply() if is_transactional;
     }
 
+    if ($collection eq 'mm') {
+        install_package('libcap-devel liburing-devel libnuma-devel libdw-devel', trup_continue => 1);
+    }
+
     if ($collection eq 'bpf') {
         # install build deps
         install_package('clang llvm-devel lld python3-docutils rsync', trup_continue => 1);


### PR DESCRIPTION
modules_prepare depends on headers and is the correct choice for
SLE/Tumbleweed since it will also do other things such as build
resolve_btfids tool which is needed for building out of tree builds due to
CONFIG_DEBUG_INFO_BTF_MODULES=y.

Also, install dependencies for `mm` collection.

- VR: https://openqa.opensuse.org/tests/6173487
