### PR TITLE
Fix SDAF cleanup errors

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
@@ -69,8 +69,8 @@ sub full_cleanup {
     }
     my $sut_cleanup_message
       = $redirection_works
-      ? 'Console redirection to Deployer VM does not seem to work. Destroying SUT infrastructure is not possible.'
-      : 'Console redirection works, proceeding with SUT cleanup';
+      ? 'Console redirection works, proceeding with SUT cleanup'
+      : 'Console redirection to Deployer VM does not seem to work. Destroying SUT infrastructure is not possible.';
     record_info('SUT cleanup', $sut_cleanup_message);
 
     # Trigger SDAF remover script to destroy 'workload zone' and 'sap systems' resources

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment_connector.pm
@@ -316,7 +316,7 @@ sub destroy_resources {
       ref($args{resource_cleanup_list}) eq 'ARRAY';
 
     $args{timeout} //= '800';
-    my $retries = 3;    # retry to delete 3x
+    my $retries = 15;    # retry to delete 15x
     my $deployer_resource_group = get_required_var('SDAF_DEPLOYER_RESOURCE_GROUP');
 
     unless ($args{resource_cleanup_list}) {
@@ -331,7 +331,7 @@ sub destroy_resources {
 
         last unless az_resource_delete(ids => join(' ', @resource_cleanup_list),
             resource_group => $deployer_resource_group, verbose => 'yes', timeout => $args{timeout});
-        sleep 5;    # Just give things few secs to avoid command spamming.
+        sleep 30;    # Just give things few secs to avoid command spamming.
         die "Failed to clean up resources:\n" . join("\n", @resource_cleanup_list) if ($attempt == $retries);
     }
     record_info('Destroy resources', 'All resources destroyed');


### PR DESCRIPTION
Fix SDAF cleanup errors
1. Fix  cleanup failed on "No registered resource provider found": increase the retry times
2. Fix record_info msg is misleading: correct the logic error

- Related ticket:
[TEAM-11333](https://jira.suse.com/browse/TEAM-11333) - [SDAF] Investigate `record_info` error message 
[TEAM-11493](https://jira.suse.com/browse/TEAM-11493) - [SDAF] cleanup failed on "No registered resource provider found for location 'swedencentral' and API version '2026-03-01' for type 'networkInterfaces'"

- Verification runs (all passed):
https://openqaworker15.qe.prg2.suse.org/tests/382784#step/cleanup/290 (succeeded on Attempt#3)
https://openqaworker15.qe.prg2.suse.org/tests/382788#step/cleanup/277 (succeeded on Attempt#2)	
http://openqaworker15.qe.prg2.suse.org/tests/382789#step/cleanup/290 (succeeded on Attempt#3)
http://openqaworker15.qe.prg2.suse.org/tests/382790#step/cleanup/329 (succeeded on Attempt#6)
http://openqaworker15.qe.prg2.suse.org/tests/382791#step/cleanup/277 (succeeded on Attempt#2)
https://openqaworker15.qe.prg2.suse.org/tests/382793#step/cleanup/303 (succeeded on Attempt#４)
https://openqaworker15.qe.prg2.suse.org/tests/382793#step/cleanup/71 (record_info msg is correct now)
https://openqaworker15.qe.prg2.suse.org/tests/382800#step/cleanup/287 (succeeded on Attempt#9)
https://openqaworker15.qe.prg2.suse.org/tests/382800#step/cleanup/71  (record_info msg is correct now)
https://openqaworker15.qe.prg2.suse.org/tests/383030#step/cleanup/205 (succeeded on Attempt#2)