### PR TITLE
fix: update bug_refs with new journal message

### DIFF
--- a/data/journal_check/bug_refs.json
+++ b/data/journal_check/bug_refs.json
@@ -1347,6 +1347,16 @@
         },
         "type": "ignore"
     },
+    "ntp-cant-synchronise": {
+        "description": "Can't synchronise: no selectable sources \\([0-9]+ unreachable sources\\)",
+        "products": {
+            "sle": [
+                "16.0",
+                "16.1"
+            ]
+        },
+        "type": "ignore"
+    },
     "boo#1212970": {
         "description": "systemd-vconsole-setup\\[.*\\]: /usr/bin/setfont failed with exit status 71.*",
         "products": {


### PR DESCRIPTION
- add in `bug_refs` a new chrony journal message `ntp-cant-synchronise` to ignore. 
  This because in [t23644271](https://openqa.suse.de/tests/23644271/modules/journal_check/steps/9) on purpose the network was turned down-up and therefore ntp lost then restored the connectivity.

- ref. tkt https://progress.opensuse.org/issues/204849#note-10
- Verification run: 
  https://openqa.suse.de/tests/23965435#step/journal_check/1
  https://openqa.suse.de/tests/23965445#step/journal_check/1