### PR TITLE
xfstests: calculate partitions for XFSTESTS_DEVICE

### DIFF
--- a/lib/filesystem_utils.pm
+++ b/lib/filesystem_utils.pm
@@ -94,7 +94,7 @@ sub partition_num_by_start_end {
     my ($dev, $start, $end) = @_;
     my $output = parted_print(dev => $dev);
     my $match;
-    if ($output =~ /(\d+)\s+($start)MB\s+($end)MB\s+(\d+\.?\d*)MB/i) {
+    if ($output =~ /(\d+)\s+(\Q$start\E(?:\.\d*)?)MB\s+(\Q$end\E(?:\.\d*)?)MB\s+(\d+\.?\d*)MB/i) {
         $match = $1;
     }
     return $match;

--- a/lib/filesystem_utils.pm
+++ b/lib/filesystem_utils.pm
@@ -220,12 +220,13 @@ sub create_partition {
     if ($space_size == 0) {
         die 'No space left in device!';
     }
+    # Align partition start to 1MB if it is less than 1MB (e.g., 0.02MiB on a clean GPT table).
+    # This avoids GNU parted error "Use a smaller unit instead of a value < 1"
+    $part_start = $space{start} < 1 ? 1 : $space{start};
     if ($size =~ /max/ || $part_type =~ /extended/) {
-        $part_start = $space{start};
         $part_end = $space{end};
     }
     else {
-        $part_start = $space{start};
         $part_end = int($space{start}) + $size;
     }
     my $cmd = "parted -s -a min $dev mkpart $part_type $part_start" . "MB $part_end" . "MB";

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -650,8 +650,13 @@ sub run {
     }
     elsif ($device) {
         assert_script_run("parted $device --script -- mklabel gpt");
+        my $dev_bytes = script_output("lsblk -bno SIZE $device");
+        my $dev_mb = int($dev_bytes / (1024 * 1024));
+        my %size_num = partition_amount_by_homesize("${dev_mb}M");
         $para{fstype} = $filesystem;
         $para{dev} = $device;
+        $para{amount} = $size_num{num};
+        $para{size} = $size_num{size};
         post_env_info(do_partition_for_xfstests(\%para));
     }
     else {

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -44,6 +44,10 @@ my $SCRATCH_FOLDER = '/opt/scratch';
 sub partition_amount_by_homesize {
     my $home_size = shift;
     $home_size = str_to_mb($home_size);
+
+    # Leave 100MB margin to prevent partition No space error
+    $home_size -= 100 if $home_size > 100;
+
     my %ret;
     if ($home_size && check_var('XFSTESTS', 'btrfs')) {
         # If enough space, then have 5 disks in SCRATCH_DEV_POOL, or have 2 disks in SCRATCH_DEV_POOL

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -87,8 +87,9 @@ sub do_partition_for_xfstests {
     unless ($para{amount}) {
         $para{amount} = 1;
     }
-    if ($para{fstype} =~ /btrfs/ && $para{amount} > 5) {
-        $para{amount} = 5;
+    # Btrfs SCRATCH_DEV up to 5. If amount exceeds 5, set it at 5.
+    if ($para{fstype} =~ /btrfs/) {
+        $para{amount} = 5 if $para{amount} > 5;
     }
     else {
         # Mandatory xfs and ext4 has only 1 SCRATCH_DEV


### PR DESCRIPTION
1. Enable dynamic partition size and amount calculation in physical disk mode (XFSTESTS_DEVICE) by querying total bytes via `lsblk` and converting to MB. This fully reuses `partition_amount_by_homesize` and eliminates code redundancy.

2. Fix a logical bug in `do_partition_for_xfstests` where Btrfs partition amounts between 1 and 5 (such as 2 or 5 calculated from homesize) were incorrectly overridden to 1 due to a faulty conditional check. Valid Btrfs partition amounts up to 5 are now correctly preserved.

3. Guard `$part_start` in `create_partition` to ensure it is at least 1MB
instead of extremely small offsets like 0.02MB found on clean GPT tables.

This prevents the GNU parted error "Use a smaller unit instead of a value < 1"
which occurs when `mkpart` receives fractional MB values less than 1.

4. Introduce a 100MB safety margin in `partition_amount_by_homesize` to prevent
   "No space left in device!" errors on the final partition.

5. Update the partition_num_by_start_end() with a more robust regular
    expression. This fix can handle cases where values format as decimals.


- Related ticket: https://progress.opensuse.org/issues/205980
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/24050085  (XFSTESTS_DEVICE=/dev/vdb)