### PR TITLE
Kselftests: Use modules_prepare build target when KSELFTEST_FROM_SRC=1

### DIFF
--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -94,9 +94,14 @@ sub build
 
     assert_script_run("make -j$jobs -C $source_dir headers O=$build_dir $build_env");
 
-    # Mount the source dir overlay only after make headers. Mounting it earlier
-    # disturbs make's timestamp evaluation and causes it to try to regenerate
-    # headers from source files absent in the kernel-source package.
+    # Needed for resolve_btfids/BTF module builds. Only safe for
+    # KSELFTEST_FROM_SRC, where .config is in sync with the source tree
+    assert_script_run("make -j$jobs -C $source_dir modules_prepare O=$build_dir $build_env") if get_var('KSELFTEST_FROM_SRC', 0);
+
+    # Mount the source dir overlay only after make headers/modules_prepare.
+    # Mounting it earlier disturbs make's timestamp evaluation and causes it
+    # to try to regenerate headers from source files absent in the
+    # kernel-source package.
     my $real_source_dir = script_output("readlink -f $source_dir");
     if (script_run("test -w $real_source_dir") != 0) {
         (my $tag = $real_source_dir) =~ s|[/ ]|_|g;

--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -92,11 +92,11 @@ sub build
     my $make_cmd = "make -j$jobs -C $source_dir/tools/testing/selftests install O=$build_dir SKIP_TARGETS= TARGETS=$targets FORCE_TARGETS=1 $build_env";
     $make_cmd =~ s/\s+$//;
 
-    assert_script_run("make -j$jobs -C $source_dir modules_prepare O=$build_dir $build_env");
+    assert_script_run("make -j$jobs -C $source_dir headers O=$build_dir $build_env");
 
-    # Mount the source dir overlay only after make modules_prepare. Mounting it
-    # earlier disturbs make's timestamp evaluation and causes it to try to
-    # regenerate headers from source files absent in the kernel-source package.
+    # Mount the source dir overlay only after make headers. Mounting it earlier
+    # disturbs make's timestamp evaluation and causes it to try to regenerate
+    # headers from source files absent in the kernel-source package.
     my $real_source_dir = script_output("readlink -f $source_dir");
     if (script_run("test -w $real_source_dir") != 0) {
         (my $tag = $real_source_dir) =~ s|[/ ]|_|g;


### PR DESCRIPTION
`modules_prepare` is needed, along with `headers`, for resolve_btfids/BTF
module builds. However, it should only be used when KSELFTEST_FROM_SRC=1,
so that the .config is guaranteed to match. Otherwise, the interactive
prompts from Kconfig would break the test.

- Verification run: 
https://openqa.suse.de/tests/23986740 (cgroup, KSELFTEST_FROM_GIT=1)
https://openqa.opensuse.org/tests/6177244 (mm, KSELFTEST_FROM_SRC=1)
https://openqa.suse.de/tests/23986741 (net, KSELFTEST_FROM_SRC=1)
