### PR TITLE
Fix invalid method call in saptune mr_test post_fail_hook

### DIFF
--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -158,20 +158,26 @@ sub run {
 
     # Preserve args for post_fail_hook
     $self->{provider} = $run_args->{my_provider};    # required for cleanup
-    $self->setup;
 
     my $test_list = get_required_var("MR_TEST");
     record_info("MR_TEST=$test_list");
     mr_test_lib::load_mr_tests("$test_list", $run_args);
+
+    $self->setup;
 }
 
 sub post_fail_hook {
     my ($self) = @_;
     if (get_var('PUBLIC_CLOUD_SLES4SAP')) {
         select_host_console(force => 1);
-        my $run_args = OpenQA::Test::RunArgs->new();
-        $run_args->{my_provider} = $self->{provider};
-        $run_args->{my_provider}->finalize($run_args);
+        # SLES4SAP public cloud deployments are managed by qe-sap-deployment
+        # (qesap). The correct teardown is deployment_cleanup() (the same one used by
+        # publiccloud::basetest and sles4sap::publiccloud_basetest).
+        deployment_cleanup(
+            $self,
+            cleanup_called => $self->{cleanup_called} // undef,
+            ansible_present => $self->{ansible_present} // 0
+        );
         return;
     }
     $self->SUPER::post_fail_hook;


### PR DESCRIPTION
In commit a87ef17c71, public cloud provider cleanups were renamed to 'teardown'. However, the method call in the saptune mr_test module's post_fail_hook was incorrectly renamed to 'finalize' instead of 'teardown'.

Because 'finalize' is a test module method (on publiccloud::basetest) rather than a method on the provider instance itself (such as publiccloud::ec2), calling it on the provider resulted in an unhandled method location error during post-failure hooks:

Can't locate object method "finalize" via package "publiccloud::ec2"

This change restores the correct method call by switching 'finalize' to 'teardown', allowing the public cloud provider to clean up resources properly when a test fails.

- Related to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21749

- Related ticket: https://jira.suse.com/browse/TEAM-11501

- Verification run:

sle-12-SP5-EC2-SAP-BYOS-Incidents-saptune-x86_64-Build:smelt:45952:vim-sles4sap_gnome_saptune_overrides ec2_r5.8xlarge
 - http://openqa.suse.de/tests/24053012 this is a VR with an artificial die in the code

 - sle-12-SP5-EC2-SAP-BYOS-Incidents-saptune-x86_64-Build:smelt:45952:vim-sles4sap_gnome_saptune_overrides ec2_r5.8xlarge -> http://openqa.suse.de/tests/24053795

 - sle-15-SP7-Azure-SAP-BYOS-Incidents-saptune-x86_64-Build:smelt:45895:cloud-init-sles4sap_gnome_saptune_delete_rename az_Standard_E4s_v3 -> http://openqa.suse.de/tests/24053804