### PR TITLE
docker-py: Backport PR#3431 for python3-docker 7.2.0

### DIFF
--- a/data/containers/patches.yaml
+++ b/data/containers/patches.yaml
@@ -76,6 +76,7 @@ docker-py:
   # https://github.com/docker/docker-py/pull/3380 - integration: Remove test_build_squash tests
   # https://github.com/docker/docker-py/pull/3393 - tests: Make stream assertions robust to chunk splitting
   # https://github.com/docker/docker-py/pull/3407 - Fix integration tests on non-amd64 hosts
+  # https://github.com/docker/docker-py/pull/3431 - tests: isolate FromContextTest from ambient TLS env vars
   3261:
   3290:
   3354:
@@ -87,6 +88,8 @@ docker-py:
   3380:
   3393:
   3407:
+  3431:
+    min: "7.2.0"
 
 moby:
   # https://github.com/moby/moby/pull/51794 - integration: Support iputils ping

--- a/data/containers/patches/docker-py/3431.patch
+++ b/data/containers/patches/docker-py/3431.patch
@@ -1,0 +1,33 @@
+From a65402296b29aec13e8fd835702d999ec16e6cae Mon Sep 17 00:00:00 2001
+From: Ricardo Branco <rbranco@suse.de>
+Date: Sat, 22 Aug 2026 22:50:15 +0200
+Subject: [PATCH] tests: isolate FromContextTest from ambient TLS env vars
+
+DOCKER_TLS_VERIFY/DOCKER_CERT_PATH leaking from the host running the
+tests (e.g. openQA) broke from_env()'s base_url scheme and caused
+TLSParameterError. Pop both in setUp alongside DOCKER_HOST, etc.
+
+Signed-off-by: Ricardo Branco <rbranco@suse.de>
+---
+ tests/unit/client_test.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/tests/unit/client_test.py b/tests/unit/client_test.py
+index e299e5906..ed7af11ad 100644
+--- a/tests/unit/client_test.py
++++ b/tests/unit/client_test.py
+@@ -269,9 +269,13 @@ class FromContextTest(unittest.TestCase):
+ 
+     def setUp(self):
+         self.os_environ = os.environ.copy()
+-        # Make sure DOCKER_HOST does not short-circuit the context path
++        # Make sure DOCKER_HOST does not short-circuit the context path,
++        # and that ambient DOCKER_TLS_VERIFY/DOCKER_CERT_PATH from the host
++        # running the tests don't leak into kwargs_from_env.
+         os.environ.pop('DOCKER_HOST', None)
+         os.environ.pop('DOCKER_CONTEXT', None)
++        os.environ.pop('DOCKER_CERT_PATH', None)
++        os.environ.pop('DOCKER_TLS_VERIFY', None)
+ 
+     def tearDown(self):
+         os.environ.clear()


### PR DESCRIPTION
Backport https://github.com/docker/docker-py/pull/3431 to fix tests with python3-docker 7.2.0

Failed job: https://openqa.opensuse.org/tests/6179403
Verification run: https://openqa.opensuse.org/tests/6180415