### PR TITLE
Remove $SDAF_Azure_podman_flake_filter workaround

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -90,11 +90,6 @@ our @EXPORT = qw(
   az_role_definition_list
 );
 
-# Workaround for bsc#1261229 - az-cli-cmd 'Launching flake' message breaks JSON output format
-our $SDAF_Azure_podman_flake_filter = (get_var('SDAF_GIT_AUTOMATION_BRANCH', '') =~ /feature\/sles16/)
-  ? "2> >(grep -Ev 'FutureWarning|Launching flake|self.' >&2)"
-  : '';
-
 =head2 az
 
     az(az_args => 'group list' [, query => '[].name']);
@@ -150,8 +145,12 @@ sub az(%args) {
 
     $result{rc} = script_run(join(' ', @az_cmd),
         quiet => $args{quiet}, timeout => $args{timeout});
-    $result{output} = decode_json(script_output("cat $out_file",
-            quiet => $args{quiet}));
+    my $out = script_output("cat $out_file", quiet => $args{quiet});
+    if (defined $out && $out =~ /\S/) {
+        $result{output} = decode_json($out);
+    } else {
+        $result{output} = {};
+    }
     $result{error} = script_output("cat $err_file",
         quiet => $args{quiet});
 
@@ -409,12 +408,9 @@ sub az_network_vnet_get(%args) {
     croak("Argument < resource_group > missing") unless $args{resource_group};
     $args{query} //= '[].name';
 
-    my $az_cmd = join(' ', 'az network vnet list',
-        '-g', $args{resource_group},
-        "--query \"$args{query}\"",
-        '-o json',
-        $SDAF_Azure_podman_flake_filter);
-    return decode_json(script_output($az_cmd));
+    my $az_args = "network vnet list -g $args{resource_group}";
+    my $az_out = az(az_args => $az_args, query => $args{query});
+    return $az_out->{output};
 }
 
 =head2 az_network_nsg_create
@@ -1254,15 +1250,19 @@ sub az_nic_create(%args) {
     foreach (qw(resource_group name vnet subnet nsg pubip_name)) {
         croak("Argument < $_ > missing") unless $args{$_}; }
 
-    assert_script_run(join(' ', 'az network nic create',
-            '--resource-group', $args{resource_group},
-            '--name', $args{name},
-            '--vnet-name', $args{vnet},
-            '--subnet', $args{subnet},
-            '--network-security-group', $args{nsg},
-            '--private-ip-address-version IPv4',
-            '--public-ip-address', $args{pubip_name},
-            $SDAF_Azure_podman_flake_filter));
+    my $az_args = join(' ',
+        'network nic create',
+        '--resource-group', $args{resource_group},
+        '--name', $args{name},
+        '--vnet-name', $args{vnet},
+        '--subnet', $args{subnet},
+        '--network-security-group', $args{nsg},
+        '--private-ip-address-version IPv4',
+        '--public-ip-address', $args{pubip_name}
+    );
+
+    my $az_out = az(az_args => $az_args);
+    return $az_out->{output};
 }
 
 =head2 az_nic_get
@@ -1643,22 +1643,21 @@ sub az_network_peering_create(%args) {
     foreach (qw(name source_rg source_vnet target_rg target_vnet)) {
         croak("Argument < $_ > missing") unless $args{$_}; }
 
-    my $az_cmd = join(' ', 'az network vnet show',
-        '--query id',
-        '--output tsv',
+    my $az_args = join(' ', 'network vnet show',
         '--resource-group', $args{target_rg},
         '--name', $args{target_vnet});
 
-    my $target_vnet_id = script_output($az_cmd);
+    my $az_out = az(az_args => $az_args, query => 'id');
+    my $target_vnet_id = $az_out->{output};
 
-    $az_cmd = join(' ', 'az network vnet peering create',
+    $az_args = join(' ', 'network vnet peering create',
         '--name', $args{name},
         '--resource-group', $args{source_rg},
         '--vnet-name', $args{source_vnet},
         '--remote-vnet', $target_vnet_id,
-        '--allow-vnet-access',
-        '--output table');
-    assert_script_run($az_cmd);
+        '--allow-vnet-access');
+    $az_out = az(az_args => $az_args);
+    return $az_out->{output};
 }
 
 =head2 az_network_peering_list
@@ -1685,14 +1684,12 @@ sub az_network_peering_list(%args) {
         croak("Argument < $_ > missing") unless $args{$_}; }
     $args{query} //= '[].name';
 
-    my $az_cmd = join(' ', 'az network vnet peering list',
+    my $az_args = join(' ', 'network vnet peering list',
         '--resource-group', $args{resource_group},
-        '--vnet-name', $args{vnet},
-        "--query \"$args{query}\"",
-        '-o json',
-        $SDAF_Azure_podman_flake_filter
+        '--vnet-name', $args{vnet}
     );
-    return decode_json(script_output($az_cmd));
+    my $az_out = az(az_args => $az_args, query => $args{query});
+    return $az_out->{output};
 }
 
 =head2 az_network_peering_delete
@@ -2032,22 +2029,21 @@ sub az_storage_blob_lease_acquire(%args) {
     }
     $args{lease_duration} //= '-1';    # -1 = infinite lease
 
-    my $az_cmd = join(' ',
-        'az storage blob lease acquire',
-        '--only-show-errors',
+    my $az_args = join(' ',
+        'storage blob lease acquire',
         "--container-name $args{container_name}",
         "--account-name $args{storage_account_name}",
         "--blob-name $args{blob_name}",
         "--lease-duration $args{lease_duration}",
-        '--output tsv',
         # Json output won't work here.
         # If it is not possible to acquire lease command will return a message which is not in json format.
         # decode_json() would cause function to fail instead of just returning
-        $SDAF_Azure_podman_flake_filter
     );
 
-    my $lease_id = script_output($az_cmd, $args{timeout}, proceed_on_failure => 1, timeout => 180);
+    my $az_out = az(az_args => $az_args, timeout => 180);
+    my $lease_id = $az_out->{output};
     record_info('AZ CLI out', "AZ CLI returned output:\n $lease_id");
+
     # Return a string if az_validate_uuid_pattern return "true"
     # otherwise return undef, thanks to Perl's implicit return that get value from the if statement.
     return $lease_id if (az_validate_uuid_pattern(uuid => $lease_id));
@@ -2117,17 +2113,15 @@ sub az_storage_blob_update(%args) {
         croak "Missing mandatory argument: '$_'" unless $args{$_};
     }
 
-    my @az_cmd = ('az storage blob update',
-        '--only-show-errors',
+    my @az_args = ('storage blob update',
         '--container-name', $args{container_name},
         '--account-name', $args{account_name},
         '--name', $args{name},
-        '--output json',
-        $SDAF_Azure_podman_flake_filter
     );
-    push(@az_cmd, "--lease-id $args{lease_id}") if $args{lease_id};
+    push(@az_args, "--lease-id $args{lease_id}") if $args{lease_id};
 
-    return script_run(join(' ', @az_cmd), timeout => 180);
+    my $az_out = az(az_args => join(' ', @az_args), timeout => 180);
+    return $az_out->{rc};
 }
 
 =head2 az_keyvault_list
@@ -2150,15 +2144,8 @@ sub az_keyvault_list(%args) {
     croak "Missing mandatory argument: 'resource_group'" unless $args{resource_group};
     $args{query} //= '[].name';
 
-    my @az_cmd = ('az keyvault list',
-        '--only-show-errors',
-        '--resource-group', $args{resource_group},
-        '--query', "$args{query}",
-        '--output json',
-        $SDAF_Azure_podman_flake_filter
-    );
-
-    return decode_json(script_output(join(' ', @az_cmd)));
+    my $az_out = az(az_args => "keyvault list --resource-group $args{resource_group}", query => $args{query});
+    return $az_out->{output};
 }
 
 =head2 az_keyvault_secret_list
@@ -2181,15 +2168,8 @@ sub az_keyvault_secret_list(%args) {
     croak "Missing mandatory argument: 'vault_name'" unless $args{vault_name};
     $args{query} //= '[].name';
 
-    my @az_cmd = ('az keyvault secret list',
-        '--only-show-errors',
-        '--vault-name', $args{vault_name},
-        '--query', "$args{query}",
-        '--output json',
-        $SDAF_Azure_podman_flake_filter
-    );
-
-    return decode_json(script_output(join(' ', @az_cmd)));
+    my $az_out = az(az_args => "keyvault secret list --vault-name $args{vault_name}", query => $args{query}, timeout => 120);
+    return $az_out->{output};
 }
 
 =head2 az_keyvault_secret_show
@@ -2267,14 +2247,18 @@ sub az_network_vnet_show {
     foreach (@mandatory_args) {
         croak "Missing mandatory argument: '$_'" unless $args{$_};
     }
-    my @cmd = ('az network vnet show',
+    my @az_args = ('network vnet show',
         "--resource-group $args{resource_group}",
-        "--name $args{name}",
-        $SDAF_Azure_podman_flake_filter
+        "--name $args{name}"
     );
-    push @cmd, "--query \"$args{query}\"" if $args{query};
 
-    return decode_json(script_output(join(' ', @cmd)));
+    my $az_out;
+    if ($args{query}) {
+        $az_out = az(az_args => join(' ', @az_args), query => $args{query});
+    } else {
+        $az_out = az(az_args => join(' ', @az_args));
+    }
+    return $az_out->{output};
 }
 
 =head2 az_network_dns_zone_create
@@ -2295,13 +2279,12 @@ Creates private DNS zone within specified B<resource_group>.
 sub az_network_dns_zone_create {
     my (%args) = @_;
     foreach ('resource_group', 'name') { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
-    my @cmd = ('az network private-dns zone create',
+    my @az_args = ('network private-dns zone create',
         "--resource-group $args{resource_group}",
         "--name $args{name}",
-        $SDAF_Azure_podman_flake_filter
     );
-
-    return assert_script_run(join(' ', @cmd));
+    my $az_out = az(az_args => join(' ', @az_args));
+    return $az_out->{rc};
 }
 
 =head2 az_network_dns_zone_delete
@@ -2322,14 +2305,14 @@ Deletes private DNS zone within B<resource_group> specified by B<zone_name>.
 sub az_network_dns_zone_delete {
     my (%args) = @_;
     foreach ('resource_group', 'zone_name') { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
-    my @cmd = ('az network private-dns zone delete',
+    my @az_args = ('network private-dns zone delete',
         "--resource-group $args{resource_group}",
         "--name $args{zone_name}",
-        '--yes',
-        $SDAF_Azure_podman_flake_filter
+        '--yes'
     );
 
-    return assert_script_run(join(' ', @cmd));
+    my $az_out = az(az_args => (join(' ', @az_args)));
+    return $az_out->{rc};
 }
 
 =head2 az_network_dns_zone_list
@@ -2351,9 +2334,8 @@ sub az_network_dns_zone_list {
     my (%args) = @_;
     croak "Missing mandatory argument: 'resource_group'" unless $args{resource_group};
     $args{query} //= '[].name';
-    return decode_json(
-        script_output("az network private-dns zone list --resource-group $args{resource_group} --query \"$args{query}\" $SDAF_Azure_podman_flake_filter")
-    );
+    my $az_out = az(az_args => "network private-dns zone list --resource-group $args{resource_group}", query => $args{query});
+    return $az_out->{output};
 }
 
 =head2 az_network_dns_add_record
@@ -2384,16 +2366,16 @@ sub az_network_dns_add_record {
     my (%args) = @_;
     my @mandatory_args = qw(resource_group zone_name record_name ip_addr);
     foreach (@mandatory_args) { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
-    my @cmd = (' ',
-        'az network private-dns record-set a add-record',    # 'a' here is not a typo
+    my @az_args = (' ',
+        'network private-dns record-set a add-record',    # 'a' here is not a typo
         "--resource-group $args{resource_group}",
         "--zone-name $args{zone_name}",
         "--record-set-name $args{record_name}",
-        "--ipv4-address $args{ip_addr}",
-        $SDAF_Azure_podman_flake_filter
+        "--ipv4-address $args{ip_addr}"
     );
 
-    return assert_script_run(join(' ', @cmd));
+    my $az_out = az(az_args => join(' ', @az_args));
+    return $az_out->{rc};
 }
 
 =head2 az_network_dns_link_create
@@ -2427,17 +2409,17 @@ sub az_network_dns_link_create {
     my (%args) = @_;
     my @mandatory_args = qw(resource_group zone_name vnet name);
     foreach (@mandatory_args) { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
-    my @cmd = (' ',
-        'az network private-dns link vnet create',
+    my @az_args = (' ',
+        'network private-dns link vnet create',
         "--resource-group $args{resource_group}",
         "--zone-name $args{zone_name}",
         "--virtual-network $args{vnet}",
         "--name $args{name}",
-        '--registration-enabled false',
-        $SDAF_Azure_podman_flake_filter    # This updates all VMs A records immediately
+        '--registration-enabled false'
     );
 
-    return assert_script_run(join(' ', @cmd));
+    my $az_out = az(az_args => join(' ', @az_args));
+    return $az_out->{rc};
 }
 
 =head2 az_network_dns_link_delete
@@ -2465,16 +2447,16 @@ sub az_network_dns_link_delete {
     my (%args) = @_;
     my @mandatory_args = qw(resource_group zone_name link_name);
     foreach (@mandatory_args) { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
-    my @cmd = (' ',
-        'az network private-dns link vnet delete',
+    my @az_args = (' ',
+        'network private-dns link vnet delete',
         "--resource-group $args{resource_group}",
         "--zone-name $args{zone_name}",
         "--name $args{link_name}",
-        '--yes',
-        $SDAF_Azure_podman_flake_filter
+        '--yes'
     );
 
-    return assert_script_run(join(' ', @cmd));
+    my $az_out = az(az_args => join(' ', @az_args));
+    return $az_out->{rc};
 }
 
 =head2 az_network_dns_link_list
@@ -2499,15 +2481,14 @@ sub az_network_dns_link_list {
     $args{query} //= '[].name';
     my @mandatory_args = qw(resource_group zone_name);
     foreach (@mandatory_args) { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
-    my @cmd = (' ',
-        'az network private-dns link vnet list',
+    my @az_args = (' ',
+        'network private-dns link vnet list',
         "--resource-group $args{resource_group}",
-        "--zone-name $args{zone_name}",
-        "--query \"$args{query}\"",
-        $SDAF_Azure_podman_flake_filter
+        "--zone-name $args{zone_name}"
     );
 
-    return decode_json(script_output(join(' ', @cmd)));
+    my $az_out = az(az_args => join(' ', @az_args), query => $args{query});
+    return $az_out->{output};
 }
 
 =head2 az_network_dns_links_cleanup

--- a/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/deployment.pm
@@ -504,7 +504,7 @@ sub sdaf_ssh_key_from_keyvault {
     $args{target_file} //= homedir() . '/.ssh/id_rsa';
     my ($target_filename, $target_path) = fileparse($args{target_file});
     my @secret_ids = @{az_keyvault_secret_list(
-            vault_name => $args{key_vault}, query => "\"[?ends_with(name, \'$args{query}\')].id\"")};
+            vault_name => $args{key_vault}, query => "[?ends_with(name, \'$args{query}\')].id")};
 
     croak "Multiple or no secrets found: \n" . join("\n", @secret_ids) unless @secret_ids == 1;
 

--- a/t/15_qesap_azure.t
+++ b/t/15_qesap_azure.t
@@ -205,17 +205,18 @@ subtest '[qesap_az_clean_old_peerings] integrate test' => sub {
             push @calls, $_[0];
             return 0;
     });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
     $azcli->redefine(script_output => sub {
             push @calls, $_[0];
-            if ($_[0] =~ /az network vnet peering list.*/) {
-                return '["COCCO100001", "COCCO100002", "COCCO100003"]'; }
-            return 'INVALID'; });
+            return 'out.json' if grep /az.json/, $_[0];
+            return '["COCCO100001", "COCCO100002", "COCCO100003"]' if grep /out.json/, $_[0]; });
 
     qesap_az_clean_old_peerings(rg => 'myresourcegroup', vnet => 'myvnetname');
     note("\n  C-->  " . join("\n  C-->  ", @calls));
-    ok((any { /az network vnet peering delete --name COCCO100001/ } @calls), "Peering1 was deleted");
-    ok((none { /az network vnet peering delete --name COCCO100002/ } @calls), "Peering2 was not deleted");
-    ok((any { /az network vnet peering delete --name COCCO100003/ } @calls), "Peering3 was deleted");
+    ok((any { /network vnet peering delete --name COCCO100001/ } @calls), "Peering1 was deleted");
+    ok((none { /network vnet peering delete --name COCCO100002/ } @calls), "Peering2 was not deleted");
+    ok((any { /network vnet peering delete --name COCCO100003/ } @calls), "Peering3 was deleted");
 };
 
 subtest '[qesap_az_create_sas_token] mandatory arguments' => sub {

--- a/t/21_sles4sap_azure_cli.t
+++ b/t/21_sles4sap_azure_cli.t
@@ -199,7 +199,11 @@ subtest '[az_network_vnet_create] die on invalid IP' => sub {
 subtest '[az_network_vnet_get]' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { push @calls, $_[0]; return '{"name": "Arlecchino"}'; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            return 'out.json' if grep /az.json/, $_[0];
+            return '{"name": "Arlecchino"}' if grep /out.json/, $_[0]; });
 
     my $res = az_network_vnet_get(resource_group => 'Arlecchino');
 
@@ -754,7 +758,12 @@ subtest '[az_nic_name_get]' => sub {
 subtest '[az_nic_create]' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            return 'out.json' if grep /az.json/, $_[0];
+            return '"Mirandolina"' if grep /out.json/, $_[0]; });
+
     az_nic_create(
         resource_group => 'Arlecchino',
         name => 'Fabrizio',
@@ -978,8 +987,12 @@ subtest '[az_storage_account_create]' => sub {
 subtest '[az_network_peering_create]' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { push @calls, $_[0]; return '/some/long/id/string'; });
-    $azcli->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            return 'out.json' if grep /az.json/, $_[0];
+            return '"\/some\/long\/id\/string"' if grep /out.json/, $_[0]; });
 
     az_network_peering_create(
         name => 'Pantalone',
@@ -989,7 +1002,7 @@ subtest '[az_network_peering_create]' => sub {
         target_vnet => 'TruffaldinoLi');
 
     note("\n  -->  " . join("\n  -->  ", @calls));
-    ok((any { /az network vnet show --query id/ } @calls), 'Correct composition of the main command');
+    ok((any { /az network vnet show.*--query \"id\"/ } @calls), 'Correct composition of the main command');
     ok((any { /az network vnet peering create/ } @calls), 'Correct composition of the main command');
     ok((any { /--remote-vnet.*\/some\/long\/id\/string/ } @calls), 'Correct target ID');
 };
@@ -997,7 +1010,11 @@ subtest '[az_network_peering_create]' => sub {
 subtest '[az_network_peering_list]' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { push @calls, $_[0]; return '{"name": "Arlecchino"}'; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return '{"name": "Arlecchino"}' if grep /out.json/, $_[0]; });
 
     my $res = az_network_peering_list(
         resource_group => 'ArlecchinoQui',
@@ -1194,7 +1211,12 @@ subtest '[az_storage_blob_lease_acquire] valid UUID' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
     my $uuid = '521fa121-4e04-448e-a8ec-d17e6b9c5e78';
-    $azcli->redefine(script_output => sub { @calls = $_[0]; return $uuid; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return 'out.json' if grep /az.json/, $_[0];
+            return qq/"$uuid"/ if grep /out.json/, $_[0]; });
     $azcli->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
     my $ret = az_storage_blob_lease_acquire(
@@ -1217,7 +1239,12 @@ subtest '[az_storage_blob_lease_acquire] valid UUID' => sub {
 subtest '[az_storage_blob_lease_acquire] invalid UUID' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { @calls = $_[0]; return 'Pantalone'; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return 'out.json' if grep /az.json/, $_[0];
+            return '"Pantalone"' if grep /out.json/, $_[0]; });
     $azcli->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
     my $ret = az_storage_blob_lease_acquire(
@@ -1235,7 +1262,12 @@ subtest '[az_storage_blob_lease_acquire] invalid UUID' => sub {
 subtest '[az_storage_blob_lease_acquire] valid UUID with error ErrorCode' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { @calls = $_[0]; return '521fa121-4e04-448e-a8ec-d17e6b9c5e78 ErrorCode'; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return 'out.json' if grep /az.json/, $_[0];
+            return '"521fa121-4e04-448e-a8ec-d17e6b9c5e78 ErrorCode"' if grep /out.json/, $_[0]; });
     $azcli->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
     my $ret = az_storage_blob_lease_acquire(
@@ -1274,7 +1306,12 @@ subtest '[az_storage_blob_list]' => sub {
 subtest '[az_storage_blob_update]' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_run => sub { @calls = @_; return 'wololo'; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return 'out.json' if grep /az.json/, $_[0];
+            return '"wololo"' if grep /out.json/, $_[0]; });
 
     az_storage_blob_update(
         container_name => 'Arlecchino',
@@ -1302,7 +1339,12 @@ subtest '[az_storage_blob_update]' => sub {
 subtest '[az_keyvault_list]' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { @calls = $_[0]; return '["Arlecchino", "Pantalone"]'; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return 'out.json' if grep /az.json/, $_[0];
+            return '["Arlecchino", "Pantalone"]' if grep /out.json/, $_[0]; });
 
     my $return_value = az_keyvault_list(
         resource_group => 'Arlecchino',
@@ -1313,7 +1355,7 @@ subtest '[az_keyvault_list]' => sub {
     ok((any { /az keyvault list/ } @calls), 'Correct composition of the main command');
     ok(grep(/--only-show-errors/, @calls), 'Check for argument "--only-show-errors"');
     ok(grep(/--resource-group Arlecchino/, @calls), 'Check for argument "--resource_group"');
-    ok(grep(/--query \[\].Pantalone/, @calls), 'Check for argument "--query"');
+    ok(grep(/--query \"\[\].Pantalone\"/, @calls), 'Check for argument "--query"');
     ok(grep(/--output json/, @calls), 'Return output in "json" format');
     is(join(' ', @$return_value), 'Arlecchino Pantalone', 'Return correct value');
 };
@@ -1330,7 +1372,12 @@ subtest '[az_keyvault_list] Test exception' => sub {
 subtest '[az_keyvault_secret_list]' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { @calls = $_[0]; return '["Arlecchino", "Pantalone"]'; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return 'out.json' if grep /az.json/, $_[0];
+            return '["Arlecchino", "Pantalone"]' if grep /out.json/, $_[0]; });
 
     my $return_value = az_keyvault_secret_list(
         vault_name => 'Arlecchino',
@@ -1341,7 +1388,7 @@ subtest '[az_keyvault_secret_list]' => sub {
     ok((any { /az keyvault secret list/ } @calls), 'Correct composition of the main command');
     ok(grep(/--only-show-errors/, @calls), 'Check for argument "--only-show-errors"');
     ok(grep(/--vault-name Arlecchino/, @calls), 'Check for argument "--vault-name"');
-    ok(grep(/--query \[\].Pantalone/, @calls), 'Check for argument "--query"');
+    ok(grep(/--query \"\[\].Pantalone\"/, @calls), 'Check for argument "--query"');
     ok(grep(/--output json/, @calls), 'Return output in "json" format');
     is(join(' ', @$return_value), 'Arlecchino Pantalone', 'Return correct value');
 };
@@ -1456,7 +1503,9 @@ subtest '[az_nic_list] Optional args' => sub {
 subtest '[az_network_vnet_show] Compose command' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { @calls = $_[0]; return '[]'; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub { return '[]' if grep /out.json/, $_[0]; });
 
     az_network_vnet_show(resource_group => 'Pantalone', name => 'calzini');
 
@@ -1469,7 +1518,9 @@ subtest '[az_network_vnet_show] Compose command' => sub {
 subtest '[az_network_vnet_show] Optional arg' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { @calls = $_[0]; return '[]'; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub { return '[]' if grep /out.json/, $_[0]; });
 
     az_network_vnet_show(resource_group => 'Pantalone', name => 'calzini', query => 'id');
 
@@ -1480,7 +1531,11 @@ subtest '[az_network_vnet_show] Optional arg' => sub {
 subtest '[az_network_dns_zone_create] Compose command' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(assert_script_run => sub { @calls = $_[0]; return; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return '[]' if grep /out.json/, $_[0]; });
 
     az_network_dns_zone_create(resource_group => 'Pantalone', name => 'calzini');
 
@@ -1493,7 +1548,11 @@ subtest '[az_network_dns_zone_create] Compose command' => sub {
 subtest '[az_network_dns_zone_delete] Compose command' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(assert_script_run => sub { @calls = $_[0]; return; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return '[]' if grep /out.json/, $_[0]; });
 
     az_network_dns_zone_delete(resource_group => 'Pantalone', zone_name => 'calzini');
 
@@ -1507,7 +1566,11 @@ subtest '[az_network_dns_zone_delete] Compose command' => sub {
 subtest '[az_network_dns_add_record] Compose command' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(assert_script_run => sub { @calls = $_[0]; return; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return '[]' if grep /out.json/, $_[0]; });
 
     az_network_dns_add_record(
         resource_group => 'Pantalone',
@@ -1517,7 +1580,7 @@ subtest '[az_network_dns_add_record] Compose command' => sub {
     );
 
     note("\n --> " . join("\n --> ", @calls));
-    ok((any { /az network private-dns record-set a add-record/ } @calls), 'Correct composition of the main command');
+    ok((any { /az.*network private-dns record-set a add-record/ } @calls), 'Correct composition of the main command');
     ok(grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"');
     ok(grep(/--zone-name opensuse.org/, @calls), 'Check for argument "--zone-name"');
     ok(grep(/--record-set-name openqa/, @calls), 'Check for argument "--record-set-name"');
@@ -1527,7 +1590,11 @@ subtest '[az_network_dns_add_record] Compose command' => sub {
 subtest '[az_network_dns_link_create] Compose command' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(assert_script_run => sub { @calls = $_[0]; return; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return '[]' if grep /out.json/, $_[0]; });
 
     az_network_dns_link_create(
         resource_group => 'Pantalone',
@@ -1537,7 +1604,7 @@ subtest '[az_network_dns_link_create] Compose command' => sub {
     );
 
     note("\n --> " . join("\n --> ", @calls));
-    ok((any { /az network private-dns link vnet create/ } @calls), 'Correct composition of the main command');
+    ok((any { /az.*network private-dns link vnet create/ } @calls), 'Correct composition of the main command');
     ok(grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"');
     ok(grep(/--zone-name opensuse.org/, @calls), 'Check for argument "--zone-name"');
     ok(grep(/--virtual-network vnet_rg/, @calls), 'Check for argument "--virtual-network"');
@@ -1548,7 +1615,12 @@ subtest '[az_network_dns_link_create] Compose command' => sub {
 subtest '[az_network_dns_zone_list] Compose command' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { @calls = $_[0]; return '["zone1", "zone2"]'; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return 'out.json' if grep /az.json/, $_[0];
+            return '["zone1", "zone2"]' if grep /out.json/, $_[0]; });
 
     az_network_dns_zone_list(resource_group => 'Pantalone');
 
@@ -1561,7 +1633,12 @@ subtest '[az_network_dns_zone_list] Compose command' => sub {
 subtest '[az_network_dns_zone_list] check custom query' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { @calls = $_[0]; return '["zone1", "zone2"]'; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return 'out.json' if grep /az.json/, $_[0];
+            return '["zone1", "zone2"]' if grep /out.json/, $_[0]; });
 
     az_network_dns_zone_list(resource_group => 'Pantalone', query => '[].id');
 
@@ -1572,12 +1649,17 @@ subtest '[az_network_dns_zone_list] check custom query' => sub {
 subtest '[az_network_dns_link_list] Compose command' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { @calls = $_[0]; return '["zone1", "zone2"]'; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return 'out.json' if grep /az.json/, $_[0];
+            return '["zone1", "zone2"]' if grep /out.json/, $_[0]; });
 
     az_network_dns_link_list(resource_group => 'Pantalone', zone_name => 'opensuse.org');
 
     note("\n --> " . join("\n --> ", @calls));
-    ok((any { /az network private-dns link vnet list/ } @calls), 'Correct composition of the main command');
+    ok((any { /az.*network private-dns link vnet list/ } @calls), 'Correct composition of the main command');
     ok(grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"');
     ok(grep(/--zone-name opensuse.org/, @calls), 'Check for argument "--zone-name"');
     ok(grep(/--query "\[].name"/, @calls), 'Check for custom argument "--query" value');
@@ -1586,7 +1668,12 @@ subtest '[az_network_dns_link_list] Compose command' => sub {
 subtest '[az_network_dns_link_list] Compose command' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(script_output => sub { @calls = $_[0]; return '["zone1", "zone2"]'; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return 'out.json' if grep /az.json/, $_[0];
+            return '["zone1", "zone2"]' if grep /out.json/, $_[0]; });
 
     az_network_dns_link_list(resource_group => 'Pantalone', zone_name => 'opensuse.org', query => '[].id');
 
@@ -1597,7 +1684,12 @@ subtest '[az_network_dns_link_list] Compose command' => sub {
 subtest '[az_network_dns_link_delete] Compose command' => sub {
     my $azcli = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     my @calls;
-    $azcli->redefine(assert_script_run => sub { @calls = $_[0]; return; });
+    $azcli->noop('assert_script_run');
+    $azcli->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azcli->redefine(script_output => sub {
+            push @calls, $_[0];
+            return 'out.json' if grep /az.json/, $_[0];
+            return '[]' if grep /out.json/, $_[0]; });
 
     az_network_dns_link_delete(
         resource_group => 'Pantalone',
@@ -1606,7 +1698,7 @@ subtest '[az_network_dns_link_delete] Compose command' => sub {
     );
 
     note("\n --> " . join("\n --> ", @calls));
-    ok((any { /az network private-dns link vnet delete/ } @calls), 'Correct composition of the main command');
+    ok((any { /az.*network private-dns link vnet delete/ } @calls), 'Correct composition of the main command');
     ok(grep(/--resource-group Pantalone/, @calls), 'Check for argument "--resource-group"');
     ok(grep(/--zone-name opensuse.org/, @calls), 'Check for argument "--zone-name"');
     ok(grep(/--name link_to_rg_vnet/, @calls), 'Check for argument "--name"');

--- a/t/35_ibsm.t
+++ b/t/35_ibsm.t
@@ -83,7 +83,7 @@ subtest '[ibsm_network_peering_azure_create] az integration' => sub {
 
     my @calls;
     $az_cli->redefine(script_run => sub {
-            push @calls, 'SR: ' . $_[0];
+            push @calls, 'MockASR: ' . $_[0];
             return; });
 
     $az_cli->redefine(assert_script_run => sub {
@@ -92,9 +92,28 @@ subtest '[ibsm_network_peering_azure_create] az integration' => sub {
 
     $az_cli->redefine(script_output => sub {
             push @calls, 'SO: ' . $_[0];
-            if ($_[0] =~ /az network vnet list.* -g (.*) --query.*/) { return '["VNET-' . $1 . '"]'; }
-            if ($_[0] =~ /az network vnet show.* --query id.*--name (.*)/) { return $1 . '-ID'; }
-            return 'NOT VALID'; });
+            my $cmd = $_[0];
+
+            return 'error.log' if grep /az.err/, $cmd;
+            return 'out.json' if grep /az.json/, $cmd;
+            return if grep /error.log/, $cmd;
+
+            if ($cmd =~ /out\.json/) {
+                my ($last_az_cmd) = grep { /az network vnet/ } reverse @calls;
+                if ($last_az_cmd && $last_az_cmd =~ /vnet list.*-g\s+(\S+)/) {
+                    return qq|["VNET-$1"]|;
+                }
+                if ($last_az_cmd && $last_az_cmd =~ /vnet show/) {
+                    if ($last_az_cmd =~ /(?:--name|-n)\s+(\S+)/) {
+                        return qq|"$1-ID"|;
+                    }
+                    if ($last_az_cmd =~ /-g\s+(\S+)/) {
+                        return qq|"VNET-$1-ID"|;
+                    }
+                }
+                return '[]';
+            }
+            return '"NOT VALID"'; });
 
     $ibsm->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
 
@@ -157,11 +176,26 @@ subtest '[ibsm_network_peering_azure_delete] including az_cli code layer' => sub
 
     $az_cli->redefine(script_output => sub {
             push @calls, 'SO: ' . $_[0];
-            if ($_[0] =~ /az network vnet list.* -g (.*) --query.*/) { return '["VNET-' . $1 . '"]'; }
-            if ($_[0] =~ /az network vnet show --query id.*--name (.*)/) { return $1 . '-ID'; }
-            if ($_[0] =~ /az network vnet peering list/) { return '["GABBIANO"]'; }
-            if ($_[0] =~ /az network vnet peering delete/) { return 0; }
-            return 'NOT VALID'; });
+            my $cmd = $_[0];
+
+            return 'error.log' if $cmd =~ /az\.err/;
+            return 'out.json' if $cmd =~ /az\.json/;
+
+            if ($cmd =~ /out\.json/) {
+                my ($last_az_cmd) = grep { /az network vnet/ } reverse @calls;
+                if ($last_az_cmd && $last_az_cmd =~ /vnet list.*-g\s+(\S+)/) {
+                    return qq|["VNET-$1"]|;
+                }
+                if ($last_az_cmd && $last_az_cmd =~ /vnet show.*(?:--name|-n)\s+(\S+)/) {
+                    return qq|"$1-ID"|;
+                }
+                if ($last_az_cmd && $last_az_cmd =~ /vnet peering list/) {
+                    return '["GABBIANO"]';
+                }
+                return '[]';
+            }
+            return;
+    });
 
     ibsm_network_peering_azure_delete(sut_rg => 'PICCIONE', ibsm_rg => 'COLOMBA');
     note("\n  C-->  " . join("\n  C-->  ", @calls));

--- a/t/37_sles4sap_crash.t
+++ b/t/37_sles4sap_crash.t
@@ -20,6 +20,10 @@ subtest '[crash_deploy_azure]' => sub {
     $crash->redefine(az_vm_wait_running => sub { push @calls, 'az_vm_wait_running'; return; });
     my $azure = Test::MockModule->new('sles4sap::azure_cli', no_auto => 1);
     $azure->redefine(assert_script_run => sub { push @calls, $_[0]; return; });
+    $azure->redefine(script_run => sub { push @calls, $_[0]; return 0; });
+    $azure->redefine(script_output => sub {
+            return 'out.json' if grep /az.json/, $_[0];
+            return '"Arlecchino"' if grep /out.json/, $_[0]; });
 
     crash_deploy_azure(
         region => 'AmanitaMuscaria',


### PR DESCRIPTION
TEAM-11429 - [SDAF][az cli] Remove $SDAF_Azure_podman_flake_filter workaround

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run:
sle-15-SP4 deploy_HanaSR:
https://openqaworker15.qe.prg2.suse.org/tests/383351#dependencies (passed)
sle-15-SP7 Incidents deploy_ENSA2_sbd:
https://openqaworker15.qe.prg2.suse.org/tests/383770#dependencies (wip)
sle-15-SP6 qesap_azure_angi_test:
https://openqaworker15.qe.prg2.suse.org/tests/383544 (passed)
sle-15-SP7 hanasr_azure_test_msi:
http://openqaworker15.qe.prg2.suse.org/tests/383536 (passed)
sle-16.0 qesap_azure_saptune_test_msi:
https://openqaworker15.qe.prg2.suse.org/tests/383741  (passed)
sle-15-SP7 Incidents SAPHanaSR-ScaleUp-PerfOpt-msi:  
https://openqa.suse.de/tests/24080124  (passed)
sle-15-SP7 Incidents ipaddr2:
https://openqa.suse.de/tests/24079886  (passed)
sle-15-SP7 Incidents SDAF_LAB_deploy_HanaSR: 
https://openqaworker15.qe.prg2.suse.org/tests/383769#dependencies (passed)
