### PR TITLE
Improve ntp validation

### DIFF
--- a/data/yam/agama/auto/autoyast_supported.xml
+++ b/data/yam/agama/auto/autoyast_supported.xml
@@ -107,7 +107,7 @@ systemLog:
   <ntp-client>
     <ntp_servers config:type="list">
       <ntp_server>
-        <address>3.suse.pool.ntp.org</address>
+        <address>2.suse.pool.ntp.org</address>
         <iburst config:type="boolean">true</iburst>
       </ntp_server>
     </ntp_servers>

--- a/data/yam/agama/auto/autoyast_supported_x86_64.xml
+++ b/data/yam/agama/auto/autoyast_supported_x86_64.xml
@@ -145,7 +145,7 @@ systemLog:
   <ntp-client>
     <ntp_servers config:type="list">
       <ntp_server>
-        <address>3.suse.pool.ntp.org</address>
+        <address>2.suse.pool.ntp.org</address>
         <iburst config:type="boolean">true</iburst>
       </ntp_server>
     </ntp_servers>

--- a/test_data/yam/agama_autoyast_supported.yaml
+++ b/test_data/yam/agama_autoyast_supported.yaml
@@ -9,4 +9,4 @@ files:
     owner: 'root'
     sha256sum: 'c7ed38f682068cdacf04c61783c3bdf034cd8703de0aa6a0b8c6796f5be3e62b'
 ntp_servers:
-  - 3.suse.pool.ntp.org
+  - 2.suse.pool.ntp.org

--- a/test_data/yam/agama_sle_extended.yaml
+++ b/test_data/yam/agama_sle_extended.yaml
@@ -14,4 +14,4 @@ repos:
 bootloader_timeout: '8'
 self_update_enabled: 1
 ntp_servers:
-  - 3.suse.pool.ntp.org
+  - 2.suse.pool.ntp.org

--- a/test_data/yam/agama_sle_extended_s390x.yaml
+++ b/test_data/yam/agama_sle_extended_s390x.yaml
@@ -14,4 +14,4 @@ repos:
 bootloader_timeout: '30'
 self_update_enabled: 1
 ntp_servers:
-  - 3.suse.pool.ntp.org
+  - 2.suse.pool.ntp.org

--- a/test_data/yam/agama_sle_extended_unattended.yaml
+++ b/test_data/yam/agama_sle_extended_unattended.yaml
@@ -37,3 +37,5 @@ repos:
     enabled: 'Yes'
     filter: name
 bootloader_timeout: '30'
+ntp_servers:
+  - 2.suse.pool.ntp.org

--- a/test_data/yam/agama_sle_extended_unattended_s390x_ppc64le.yaml
+++ b/test_data/yam/agama_sle_extended_unattended_s390x_ppc64le.yaml
@@ -27,3 +27,5 @@ repos:
     enabled: 'Yes'
     filter: name
 bootloader_timeout: '30'
+ntp_servers:
+  - 2.suse.pool.ntp.org

--- a/tests/yam/validate/validate_ntp.pm
+++ b/tests/yam/validate/validate_ntp.pm
@@ -5,7 +5,8 @@
 
 # Summary: Validate the ntp servers and chronyc tracking by checking
 # - NTP servers are present in /etc/chrony.d/99-installer.conf
-# - No Pending Leap Seconds are detected via chronyc tracking.
+# - The system is actively synchronized to an external time source
+#   rather than being unsynchronized or relying on its own local clock
 
 # Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
 
@@ -20,6 +21,21 @@ sub run {
     my $chrony_config = '/etc/chrony.d/99-installer.conf';
     assert_script_run("cat $chrony_config");
     assert_script_run("grep '$_' $chrony_config") foreach @{$test_data->{ntp_servers}};
+
+    assert_script_run('chronyc waitsync 24 0 0 5');
+
+    my $tracking_output = script_output('chronyc -c tracking');
+    my @fields = split(/,/, $tracking_output);
+
+    if (@fields >= 2) {
+        my $ref_id = $fields[1];
+        # 00000000 means unsynced/error; 1F1F0101 means local directive active
+        if ($ref_id eq '00000000' || $ref_id eq '1F1F0101') {
+            die "NTP synchronization failed: Invalid Reference ID ($ref_id)";
+        }
+    } else {
+        die "Failed to parse Reference ID from 'chronyc -c tracking' output: $tracking_output";
+    }
 }
 
 1;


### PR DESCRIPTION
##
### Improve ntp validation based on suggestions from bsc#1270221

- Related ticket: 
  - https://progress.opensuse.org/issues/203742
- Related MR:
  - https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/891
### what's Changed/Added
- use `2.suse.pool.ntp.org` which is IPv6 safe.
- add `chronyc waitsync 24 0 0 5` before checking`chronyc tracking`.
- add check for `Reference ID` for `chronyc tracking`.

### Test result
- Verification run: 
  - [**sles_extended_unattended_dev**](https://openqa.suse.de/tests/overview?build=hjluo_sles_extended_unattended_dev_3333&version=16.1&distri=sle)
  - [**sles_extended_dev**](https://openqa.suse.de/tests/overview?build=hjluo_sles_extended_dev_8888&distri=sle&version=16.1) [**all reruns are needed for grub_test failure**]

### related information:
- [**bsc#127022**](https://bugzilla.suse.com/show_bug.cgi?id=1270221)
- [**Discussion_1**](https://progress.opensuse.org/issues/203742#note-10)
- [**Discussion_2**](https://progress.opensuse.org/issues/203742#note-11)
##