### PR TITLE
services::sshd: Extend check to cover for older ssh versions

### DIFF
--- a/lib/services/sshd.pm
+++ b/lib/services/sshd.pm
@@ -103,8 +103,8 @@ sub ssh_basic_check {
 
         # Check that we are really in the SSH session
         assert_script_run '[ -n "$SSH_TTY" ]';
-        assert_script_run 'grep  "$PPID (sshd-session)" /proc/$PPID/stat';
-        assert_script_run 'ps ux | grep sshd-session';
+        assert_script_run 'grep -E "$PPID \(sshd(-session)?\)" /proc/$PPID/stat';
+        assert_script_run "ps ux | grep -E '$ssh_testman.*sshd(-session)?'";
         assert_script_run "whoami | grep $ssh_testman";
         assert_script_run "mkdir .ssh";
 


### PR DESCRIPTION
In v9.8 sshd was split into two, the main sshd and sshd-session binary, #26433 didn't take this into account and broke some maintenance tests

openqa: clone https://openqa.opensuse.org/tests/6182608 EXCLUDE_MODULES=vsftpd

SLE VR: 
- 15-sp6: https://openqa.suse.de/tests/24034534
- 12-sp5: https://openqa.suse.de/tests/24034537

Tumbleweed::
- https://openqa.opensuse.org/tests/6182807#step/sshd/24