### PR TITLE
Use GitHub releases instead of pushing the bundler files to repo

### DIFF
--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -6,12 +6,18 @@
 # Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
 
 use Mojo::Base 'Yam::Agama::patch_agama_base';
-use testapi qw(assert_script_run get_required_var select_console);
+use testapi qw(assert_script_run get_required_var select_console script_run assert_script_run script_output);
 
 sub run {
     select_console 'install-shell';
     my ($repo, $branch) = split /#/, get_required_var('YUPDATE_GIT');
-    assert_script_run("AGAMA_TEST=" . get_required_var('AGAMA_TEST') . " yupdate patch $repo $branch", timeout => 60);
+    my $agama_test = get_required_var("AGAMA_TEST");
+    my $destination = "/usr/share/agama/system-tests";
+    my $latest_commit_sha = script_output("curl -s 'https://api.github.com/repos/$repo/commits/$branch' | jq -r '.sha'");
+    script_run("mkdir -p $destination");
+    assert_script_run("curl -sfL https://github.com/$repo/releases/download/$branch/$latest_commit_sha.tar.gz | tar -xz",
+        fail_message => "Error: CI build artifact (tarball) for $repo/$branch is not available yet. The CI run may still be in progress.");
+    script_run("cp -t $destination dist/vendor.js dist/$agama_test* ");
 }
 
 1;


### PR DESCRIPTION
Changed `patch_agama_test` to download latest release from specified branch, then unpack tests.

- Related ticket: https://progress.opensuse.org/issues/189948
- Related PR: https://github.com/qe-installation-and-migration/agama-integration-test-webpack/pull/297
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/24049919#
- Verification of CI: https://github.com/okynos/agama-integration-test-webpack/actions/runs/32725571081/job/97425964433
