### PR TITLE
Default ENABLE_VM_INSTALL to 1 unless it was set to 0 explicitly

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2641,7 +2641,7 @@ sub set_sles16_mu_virt_vars {
     set_var('SLES16_MU_INSTALL_TYPE', $install_type);
 
     set_var('ENABLE_HOST_INSTALLATION', '1') unless get_var('ENABLE_HOST_INSTALLATION');
-    set_var('ENABLE_VM_INSTALL', '1') unless get_var('ENABLE_VM_INSTALL');
+    set_var('ENABLE_VM_INSTALL', '1') unless (check_var('ENABLE_VM_INSTALL', 0));
 
     diag("SLES16 MU variables configured: test_mode=staging, install_type=$install_type, host_install=" .
           get_var('ENABLE_HOST_INSTALLATION') . ", vm_install=" . get_var('ENABLE_VM_INSTALL'));


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/194098 (https://openqa.suse.de/tests/24038594)
- Verification run:
- [ENABLE_VM_INSTALL=0](https://openqa.suse.de/tests/24038593)
- [ENABLE_VM_INSTALL=a](https://openqa.suse.de/tests/24040504)
- [ENABLE_VM_INSTALL=1](https://openqa.suse.de/tests/24040505)
- [ENABLE_VM_INSTALL=](https://openqa.suse.de/tests/24040506)
- [15-SP6 ENABLE_VM_INSTALL=0](https://openqa.suse.de/tests/24050650)
- [15-SP6 ENABLE_VM_INSTALL=1](https://openqa.suse.de/tests/24050652)