### PR TITLE
Kselftests: Install libdw-devel dependency

### DIFF
--- a/lib/Kselftests/utils.pm
+++ b/lib/Kselftests/utils.pm
@@ -75,6 +75,9 @@ sub build
     install_package('-t pattern --recommends devel_kernel', trup_apply => 1);
     zypper_call('rl kernel-source kernel-syms') if $lock_kernel_pkgs;
 
+    # CONFIG_GENDWARFKSYMS=y
+    install_package('libdw-devel', trup_apply => 1) if is_tumbleweed;
+
     # On immutable systems the build dir is read-only; mount a writable overlayfs on it.
     my $real_build_dir = script_output("readlink -f $build_dir");
     if (script_run("test -w $real_build_dir") != 0) {


### PR DESCRIPTION
Tumbleweed has CONFIG_GENDWARFKSYMS=y which needs dwarf.h, from libdw-devel package. Install it before `modules_prepare` step.

- Verification run: https://openqa.opensuse.org/tests/6182906#step/kselftests_prepare/27
