### PR TITLE
Remove unreachable public cloud instance finalize call from base class

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -22,7 +22,6 @@ use main_common 'opensuse_welcome_applicable';
 use isotovideo;
 use IO::Socket::INET;
 use x11utils qw(handle_login ensure_unlocked_desktop handle_additional_polkit_windows);
-use publiccloud::ssh_interactive 'select_host_console';
 use Utils::Logging qw(save_and_upload_log tar_and_upload_log export_healthcheck_basic select_log_console upload_coredumps export_logs);
 
 # Base class for all openSUSE tests
@@ -1076,14 +1075,6 @@ sub post_fail_hook {
     }
 
     export_logs;
-
-    if (is_public_cloud() && $self->{run_args}->{my_provider}) {
-        select_host_console(force => 1);
-
-        # Destroy the public cloud instance in case of fatal test failure
-        my $flags = $self->test_flags();
-        $self->{run_args}->{my_provider}->finalize() if ($flags->{fatal});
-    }
 }
 
 sub test_flags {


### PR DESCRIPTION
The post_fail_hook in lib/opensusebasetest.pm contained a block to destroy public cloud instances in case of fatal failure, calling finalize() on the public cloud provider object. This call is buggy since provider objects do not implement a finalize() method, only teardown().
Remove the entire block because it is unreachable code:
1. Test modules that populate run_args->{my_provider} inherit from publiccloud::basetest or sles4sap::publiccloud_basetest, which override post_fail_hook and do not call SUPER::post_fail_hook.
2. The teardown responsibility is now handled out of the class hierarchy by the dedicated, scheduled "always_run" test module tests/publiccloud/destroy.pm at the end of every suite.

- Related ticket: https://progress.opensuse.org/issues/206052
