### PR TITLE
fix(publiccloud): name the actual cause when no repos are enabled

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -265,7 +265,7 @@ sub register_addons_in_pc {
         # "No enabled repositories" is a symptom with (at least) two causes:
         # the system was never registered, or it was registered and the
         # repos were dropped afterwards. Collect the evidence to tell them
-        # apart instead of asserting one of them - see poo#205965.
+        # apart.
         record_info('repos (lr)', $instance->ssh_script_output(
                 cmd => 'sudo zypper lr -u', proceed_on_failure => 1));
         my $reg = $instance->ssh_script_output(

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -265,7 +265,9 @@ sub register_addons_in_pc {
         # "No enabled repositories" is a symptom with (at least) two causes:
         # the system was never registered, or it was registered and the
         # repos were dropped afterwards. Collect the evidence to tell them
-        # apart.
+        # apart. Only the second case is bsc#1245651, which is closed but
+        # still reachable on images shipping cloud-regionsrv-client < 11.0.0,
+        # see poo#205101.
         record_info('repos (lr)', $instance->ssh_script_output(
                 cmd => 'sudo zypper lr -u', proceed_on_failure => 1));
         my $reg = $instance->ssh_script_output(
@@ -273,7 +275,7 @@ sub register_addons_in_pc {
         record_info('SUSEConnect -s', $reg);
         die 'No enabled repos: the system is not registered'
           if ($reg =~ /Not Registered/m || $reg !~ /\S/);
-        die 'No enabled repos although the system reports as registered';
+        die 'No enabled repos on registered system (bsc#1245651)';
     }
     die 'System management is locked by the application with pid xxx (/usr/bin/zypper)' if $ret == publiccloud::zypper::EXIT_LOCKED;
     for my $addon (@addons) {

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -251,7 +251,7 @@ sub register_addons_in_pc {
     # Refresh repos. publiccloud::zypper::pc_refresh always uses plain zypper
     # (never transactional-update, which does not support repo actions, see
     # poo#195920). Accept all exit codes and inspect the result here so we
-    # can give the historical bsc references.
+    # can diagnose the failure.
     my $ret = publiccloud::zypper::pc_refresh(
         $instance,
         timeout => $timeout,
@@ -261,7 +261,20 @@ sub register_addons_in_pc {
             publiccloud::zypper::EXIT_LOCKED,
         ],
     );
-    die 'No enabled repos defined: bsc#1245651' if $ret == publiccloud::zypper::EXIT_NO_REPOS;
+    if ($ret == publiccloud::zypper::EXIT_NO_REPOS) {
+        # "No enabled repositories" is a symptom with (at least) two causes:
+        # the system was never registered, or it was registered and the
+        # repos were dropped afterwards. Collect the evidence to tell them
+        # apart instead of asserting one of them - see poo#205965.
+        record_info('repos (lr)', $instance->ssh_script_output(
+                cmd => 'sudo zypper lr -u', proceed_on_failure => 1));
+        my $reg = $instance->ssh_script_output(
+            cmd => 'sudo SUSEConnect -s', proceed_on_failure => 1);
+        record_info('SUSEConnect -s', $reg);
+        die 'No enabled repos: the system is not registered'
+          if ($reg =~ /Not Registered/m || $reg !~ /\S/);
+        die 'No enabled repos although the system reports as registered';
+    }
     die 'System management is locked by the application with pid xxx (/usr/bin/zypper)' if $ret == publiccloud::zypper::EXIT_LOCKED;
     for my $addon (@addons) {
         next if ($addon =~ /^\s+$/);

--- a/t/50_publiccloud_utils.t
+++ b/t/50_publiccloud_utils.t
@@ -278,23 +278,20 @@ subtest '[additional_repos] xfs repo composition' => sub {
 };
 
 subtest '[register_addons_in_pc] discriminates the no-enabled-repos cause' => sub {
-    # poo#205965: EXIT_NO_REPOS used to be asserted as always meaning the
-    # closed/INVALID bsc#1245651. It has at least two distinct causes -
-    # never registered, or registered and repos dropped afterwards - so the
-    # code must name the actual one instead, and never mention that bug.
+    # poo#205965
     my $zypper = Test::MockModule->new('publiccloud::zypper', no_auto => 1);
     my $utils = Test::MockModule->new('publiccloud::utils', no_auto => 1);
     $utils->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)) });
     set_var('SCC_ADDONS', '');
 
+    my $output;
     my $mock_instance = sub {
-        my (%outputs) = @_;
         my $inst = Test::MockObject->new;
         $inst->mock(username => sub { 'susetest' });
         $inst->mock(public_ip => sub { '1.2.3.4' });
         $inst->mock(ssh_script_output => sub {
                 my (undef, %args) = @_;
-                return $args{cmd} =~ /SUSEConnect/ ? ($outputs{suseconnect} // '') : '';
+                return $args{cmd} =~ /SUSEConnect/ ? ($output // '') : '';
         });
         return $inst;
     };
@@ -303,13 +300,15 @@ subtest '[register_addons_in_pc] discriminates the no-enabled-repos cause' => su
     lives_ok { register_addons_in_pc($mock_instance->()) } 'EXIT_OK does not die';
 
     $zypper->redefine(pc_refresh => sub { return publiccloud::zypper::EXIT_NO_REPOS });
+    $output = "SLES15-SP6-x86_64 is not managed by SUSEConnect (Not Registered)\n";
     throws_ok {
-        register_addons_in_pc($mock_instance->(suseconnect => "SLES15-SP6-x86_64 is not managed by SUSEConnect (Not Registered)\n"));
+        register_addons_in_pc($mock_instance->());
     }
     qr/not registered/, 'unregistered system is named as the cause';
 
+    $output = "SUSE Linux Enterprise Server 15 SP6 x86_64 (Activated)\n";
     throws_ok {
-        register_addons_in_pc($mock_instance->(suseconnect => "SUSE Linux Enterprise Server 15 SP6 x86_64 (Activated)\n"));
+        register_addons_in_pc($mock_instance->());
     }
     qr/reports as registered/, 'registered system is named as the cause';
     unlike($@, qr/bsc#1245651/, 'no reference to the closed/INVALID bug remains');

--- a/t/50_publiccloud_utils.t
+++ b/t/50_publiccloud_utils.t
@@ -305,13 +305,13 @@ subtest '[register_addons_in_pc] discriminates the no-enabled-repos cause' => su
         register_addons_in_pc($mock_instance->());
     }
     qr/not registered/, 'unregistered system is named as the cause';
+    unlike($@, qr/bsc#1245651/, 'the unregistered case does not claim to be bsc#1245651');
 
     $output = "SUSE Linux Enterprise Server 15 SP6 x86_64 (Activated)\n";
     throws_ok {
         register_addons_in_pc($mock_instance->());
     }
-    qr/reports as registered/, 'registered system is named as the cause';
-    unlike($@, qr/bsc#1245651/, 'no reference to the closed/INVALID bug remains');
+    qr/registered system \(bsc#1245651\)/, 'registered system is named as the cause';
 
     _unset(qw/SCC_ADDONS/);
 };

--- a/t/50_publiccloud_utils.t
+++ b/t/50_publiccloud_utils.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use Test::MockModule;
+use Test::MockObject;
 use Test::Exception;
 use Test::Warnings;
 use testapi 'set_var';
@@ -274,6 +275,46 @@ subtest '[additional_repos] xfs repo composition' => sub {
     like($repos[0], qr{QA:/Head/SLE-15-SP6/}, 'repo path uses SLE prefix and version');
 
     _unset(qw/PUBLIC_CLOUD_XFS VERSION/);
+};
+
+subtest '[register_addons_in_pc] discriminates the no-enabled-repos cause' => sub {
+    # poo#205965: EXIT_NO_REPOS used to be asserted as always meaning the
+    # closed/INVALID bsc#1245651. It has at least two distinct causes -
+    # never registered, or registered and repos dropped afterwards - so the
+    # code must name the actual one instead, and never mention that bug.
+    my $zypper = Test::MockModule->new('publiccloud::zypper', no_auto => 1);
+    my $utils = Test::MockModule->new('publiccloud::utils', no_auto => 1);
+    $utils->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)) });
+    set_var('SCC_ADDONS', '');
+
+    my $mock_instance = sub {
+        my (%outputs) = @_;
+        my $inst = Test::MockObject->new;
+        $inst->mock(username => sub { 'susetest' });
+        $inst->mock(public_ip => sub { '1.2.3.4' });
+        $inst->mock(ssh_script_output => sub {
+                my (undef, %args) = @_;
+                return $args{cmd} =~ /SUSEConnect/ ? ($outputs{suseconnect} // '') : '';
+        });
+        return $inst;
+    };
+
+    $zypper->redefine(pc_refresh => sub { return publiccloud::zypper::EXIT_OK });
+    lives_ok { register_addons_in_pc($mock_instance->()) } 'EXIT_OK does not die';
+
+    $zypper->redefine(pc_refresh => sub { return publiccloud::zypper::EXIT_NO_REPOS });
+    throws_ok {
+        register_addons_in_pc($mock_instance->(suseconnect => "SLES15-SP6-x86_64 is not managed by SUSEConnect (Not Registered)\n"));
+    }
+    qr/not registered/, 'unregistered system is named as the cause';
+
+    throws_ok {
+        register_addons_in_pc($mock_instance->(suseconnect => "SUSE Linux Enterprise Server 15 SP6 x86_64 (Activated)\n"));
+    }
+    qr/reports as registered/, 'registered system is named as the cause';
+    unlike($@, qr/bsc#1245651/, 'no reference to the closed/INVALID bug remains');
+
+    _unset(qw/SCC_ADDONS/);
 };
 
 subtest '[calculate_custodian_ttl] ISO 8601 with offset' => sub {


### PR DESCRIPTION
`register_addons_in_pc()` died with `No enabled repos defined: bsc#1245651` whenever
`zypper ref` returned 6. That bug describes one specific scenario, repos disappearing
*after* a successful registration. Exit code 6 also shows up when the system was never
registered at all, which is what happened in https://openqa.suse.de/tests/23939014
(guestregister ended in `failed`, the test carried on, and then the die named a bug
that did not apply).

### Change

On exit 6, collect `zypper lr -u` and `SUSEConnect -s` from the instance, record both,
and die naming the cause the evidence supports:

- `No enabled repos: the system is not registered` when SUSEConnect reports
  `Not Registered` or returns nothing
- `No enabled repos on registered system (bsc#1245651)` otherwise

The bug reference stays on the second branch only. It is closed, but the defect is
still reachable on images shipping `cloud-regionsrv-client` below 11.0.0, and those are
not refreshed before mid-September, see
https://progress.opensuse.org/issues/205101.

The die stays hard. Muting it was already tried in #23069 and deliberately reverted in
a4080c58d5, because the soft-failure hid real registration failures.

### Verification

The failure reproduced on a live run with this branch: `zypper ref` returned 6,
`repos (lr)` showed `Warning: No repositories defined.`, `SUSEConnect -s` showed every
module as `Not Registered`, and the test died with
`No enabled repos: the system is not registered`.

- Related ticket: https://progress.opensuse.org/issues/205965
- Verification run: https://openqa.suse.de/tests/24041884#step/registration/21
