### PR TITLE
feat: Add schema check for bug_refs.json

### DIFF
--- a/data/journal_check/README.md
+++ b/data/journal_check/README.md
@@ -1,0 +1,159 @@
+# journal_check bug references
+
+`bug_refs.json` is the list of known journal messages used by
+[`tests/console/journal_check.pm`](../../tests/console/journal_check.pm).
+
+The test module reads the system journal and compares every line against
+the entries in this file.
+
+## Format
+
+Example:
+
+```json
+{
+    "bsc#1188238": {
+        "description": "Bluetooth: hci0: command 0x0c03 tx timeout|Bluetooth: hci0: BCM: Reset failed (-110)",
+        "products": {
+            "sle-micro": ["5.0", "5.1"],
+            "opensuse": ["Tumbleweed", "15.2", "15.3"]
+        },
+        "type": "ignore"
+    }
+}
+```
+
+Each top-level key identifies one known issue. The value is an object with
+exactly three required fields: `description`, `products` and `type`. No other
+fields are allowed.
+
+### Key
+
+Preferably a bug reference, so the entry can be traced back and eventually
+retired.
+
+| Form | Example |
+| --- | --- |
+| `bsc#`, `boo#`, `poo#` + number | `bsc#1188238` |
+| `gh#owner/repo#` + number | `gh#OSInside/kiwi#1867` |
+
+Several references may be joined with `|` when one message is tracked by more
+than one bug, e.g. `bsc#1022525|bsc#1177461`.
+
+A free-form slug such as `chrony` or `tpm-auth-session` is also accepted.
+It should however only be used for `type: ignore`.
+
+### `description`
+
+A **Perl regular expression**, matched unanchored against each journal line.
+Alternatives can be combined with `|`.
+
+Because it is a regex and not a literal string, metacharacters that are meant
+literally have to be escaped:
+
+```json
+"description": "Activation request for 'org\\.freedesktop\\.nm_dispatcher' failed\\."
+```
+
+Keep patterns as specific as the message allows. A pattern like `.*failed.*`
+would hide unrelated errors on every product it is enabled for.
+
+### `products`
+
+A map of openQA `DISTRI` to the list of affected `VERSION` values. An entry only
+applies when the job's `DISTRI` is a key here *and* the job's `VERSION` appears
+in the corresponding array.
+
+```json
+"products": {
+   "opensuse": [
+         "Tumbleweed"
+   ],
+   "microos": [
+         "Tumbleweed"
+   ],
+   "sle-micro": [
+         "6.2"
+   ],
+   "sle": [
+         "16.0",
+         "16.1"
+   ]
+}
+```
+
+Supported `DISTRI` include: `opensuse`, `sle`, `microos`, `sle-micro`,
+`leap-micro`.
+
+The value must always be an **array**, even for a single version.
+
+#### Version matching
+
+Version comparison is a plain string equality against the job's `VERSION`, after
+two transformations:
+
+1. `VERSION` is truncated at the first `:`, so a staging job running
+   `VERSION=16.1:PR-5106` matches the entry `16.1`.
+2. For openSUSE only, a `VERSION` starting with `Staging:` is treated as
+   `Tumbleweed`, so staging projects reuse the Tumbleweed entries.
+
+### `type`
+
+| Value | Effect in openQA |
+| --- | --- |
+| `bug` | `record_soft_failure` — the job turns *softfailed* and shows up for review |
+| `ignore` | `bmwqemu::diag` only — nothing is shown in the web UI |
+| `feature` | `record_info` — an informational step, the job result is unaffected |
+
+Use `bug` with a real bug reference for anything that is a genuine defect, so it
+stays visible until the bug is fixed. Reserve `ignore` for messages that are
+expected and harmless (deliberate test actions, hardware quirks of the worker,
+noisy-but-benign kernel chatter).
+
+### `arch`
+
+Optional list of architectures the entry is applied on. If set, the entry is only applied
+to those architectures and ignored otherwise. If not set, all architectures will be included.
+
+Example:
+
+```json
+"ntp-cant-synchronise": {
+   "description": "Can't synchronise: no selectable sources \\([0-9]+ unreachable sources\\)",
+   "products": {
+      "sle": [
+            "16.0",
+            "16.1"
+      ]
+   },
+   "arch": [
+      "s390x"
+   ],
+   "type": "ignore"
+}
+```
+
+## Adding an entry
+
+1. Get the exact message from the failing job's `Unknown issue` step or from the
+   uploaded `full_journal.txt`.
+2. Pick the key: a bug reference if at all possible; a slug only for `ignore`.
+3. Turn the message into a regex — escape metacharacters, drop volatile parts
+   such as PIDs, timestamps and device numbers, but keep enough context that the
+   pattern cannot match unrelated errors.
+4. List only the products and versions actually affected. Do not blanket-add
+   versions "just in case": that is how real regressions get hidden.
+5. Choose `type` per the table above.
+6. Run `make unit-test` (or `prove -l t/52_journal_check_bug_refs.t`).
+
+## Validation
+
+`bug_refs.json` is checked by
+[`t/52_journal_check_bug_refs.t`](../../t/52_journal_check_bug_refs.t), which
+runs as part of `make unit-test` and therefore in CI. It verifies that the file
+is valid JSON, that it conforms to `schema.yaml`.
+
+```bash
+prove -l t/52_journal_check_bug_refs.t   # this file only
+make unit-test                           # whole suite
+```

--- a/data/journal_check/schema.yaml
+++ b/data/journal_check/schema.yaml
@@ -1,0 +1,84 @@
+# JSON Schema for bug_refs.json.
+# 
+# Schema is checked by t/52_journal_check_bug_refs.t
+---
+$id: schema.yaml
+$schema: http://json-schema.org/draft-04/schema#
+title: journal_check bug references
+description: >
+    Known journal messages for tests/console/journal_check.pm. Each top-level
+    key identifies one known issue
+type: object
+minProperties: 1
+
+additionalProperties:
+  $ref: '#/definitions/entry'
+
+definitions:
+
+  entry:
+    type: object
+    additionalProperties: false
+    required:
+    - description
+    - products
+    - type
+
+    properties:
+
+      description:
+        type: string
+        minLength: 1
+        description: >
+            A Perl regular expression, matched against each journalctl line.
+            Alternatives may be combined with "|".
+
+      products:
+        type: object
+        minProperties: 1
+        additionalProperties: false
+        description: >
+            Which products the entry applies to, structured as a
+            map of DISTRI to VERSION. See bug_refs.json for examples.
+        properties:
+          opensuse:
+            $ref: '#/definitions/versions'
+          sle:
+            $ref: '#/definitions/versions'
+          microos:
+            $ref: '#/definitions/versions'
+          sle-micro:
+            $ref: '#/definitions/versions'
+          leap-micro:
+            $ref: '#/definitions/versions'
+
+      type:
+        description: >
+            How journal_check.pm reacts to a match. "bug" records a soft
+            failure, "ignore" only writes a diagnostic line to the autoinst
+            log, and "feature" records an informational step that does not
+            affect the job result.
+        enum:
+        - bug
+        - ignore
+        - feature
+      
+      arch:
+        type: "array"
+        items: {
+          "type": "string"
+        }
+        description: >
+            Optional array of architectures the element should match to.
+            The element will only be applied to the defined architectures otherwise
+            it is ignored.
+
+  versions:
+    type: array
+    minItems: 1
+    uniqueItems: true
+    description: >
+        openQA VERSION values truncated at the first colon (e.g. for Tumbleweed:Stating)
+    items:
+      type: string
+      minLength: 1

--- a/t/52_journal_check_bug_refs.t
+++ b/t/52_journal_check_bug_refs.t
@@ -1,0 +1,48 @@
+use Mojo::Base -strict;
+
+use FindBin '$Bin';
+use Mojo::File 'path';
+use Mojo::JSON 'decode_json';
+use JSON::Validator;
+use Test::More;
+use Test::Warnings;
+
+# Validates data/journal_check/bug_refs.json, the known-issue list consumed by
+# tests/console/journal_check.pm, against data/journal_check/schema.yaml.
+#
+# Note that tools/check_jsonnet deliberately excludes bug_refs.json from the
+# generic data/ JSON check, so this test is the only CI coverage it has.
+
+my $data_file = path($Bin, '..', 'data', 'journal_check', 'bug_refs.json');
+my $schema_file = path($Bin, '..', 'data', 'journal_check', 'schema.yaml');
+
+ok -f $data_file, 'data/journal_check/bug_refs.json exists';
+ok -f $schema_file, 'data/journal_check/schema.yaml exists';
+
+my $validator = JSON::Validator->new;
+$validator = eval { $validator->load_and_validate_schema("$schema_file") };
+BAIL_OUT("Schema $schema_file is itself invalid: $@") if $@;
+pass 'schema is a valid JSON schema';
+
+my $bugs = eval { decode_json($data_file->slurp) };
+BAIL_OUT("$data_file is not valid JSON: $@") if $@;
+pass 'bug_refs.json is valid JSON';
+
+subtest 'bug_refs.json matches the schema' => sub {
+    my @errors = $validator->validate($bugs);
+    diag "  $_" for @errors;
+    is scalar(@errors), 0, 'no schema violations';
+    done_testing;
+};
+
+subtest 'every description is a usable Perl regex' => sub {
+    # journal_check.pm interpolates the description straight into a match, so
+    # an uncompilable pattern only blows up once the job is already running.
+    for my $bugid (sort keys %$bugs) {
+        my $re = $bugs->{$bugid}{description};
+        ok eval { qr/$re/; 1 }, "$bugid: description compiles" or diag "  $@";
+    }
+    done_testing;
+};
+
+done_testing;

--- a/variables.md
+++ b/variables.md
@@ -131,6 +131,7 @@ ISO_MAXSIZE | integer | | Max size of the iso, used in `installation/isosize.pm`
 IS_MM_SERVER | boolean | | If set, run server-specific part of the multimachine job
 IS_MM_CLIENT | boolean | | If set, run client-specific part of the multimachine job
 JEOS_CHECK_SERIAL | boolean | true | Skip the check weather the JeOS Firstboot wizard shows up on the serial terminal
+JOURNAL_LOG_LEVEL | string | err | Maximum journalctl priority inspected by the `journal_check` test module
 K3S_SYMLINK | string | | Can be 'skip' or 'force'. Skips the installation of k3s symlinks to tools like kubectl or forces the creation of symlinks
 K3S_BIN_DIR | string | | If defined, install k3s to this provided directory instead of `/usr/local/bin/`
 K3S_CHANNEL | string | | Set the release channel to pick the k3s version from. Options include "stable", "latest" and "testing"


### PR DESCRIPTION
Adds a schema check for journal_check's `bug_refs.json`.

* Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26468
* Related discussion: https://suse.slack.com/archives/C02CGKBCGT1/p1787642100757149?thread_ts=1787559068.641229&cid=C02CGKBCGT1