### PR TITLE
Adapt upstream container tests that now only run on 15-SP6+ & Tumbleweed

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -320,16 +320,6 @@ sub go_arch {
     return $arch;
 }
 
-sub install_git {
-    # We need git 2.47.0+ to use `--ours` with `git apply -3`
-    return if (script_run("test -f /etc/zypp/repos.d/Kernel_tools.repo") == 0);
-    my $version = get_var("VERSION");
-    $version =~ s/-/_/;
-    $version = "SLE_$version";
-    run_command "zypper addrepo https://download.opensuse.org/repositories/Kernel:/tools/$version/Kernel:tools.repo";
-    run_command "zypper --gpg-auto-import-keys -n install --allow-vendor-change git-core", timeout => 300;
-}
-
 sub install_gotestsum {
     # We need gotestsum to parse "go test" and create JUnit XML output
     return if (script_run("command -v gotestsum") == 0);
@@ -417,11 +407,9 @@ sub setup_pkgs {
     if ($oci_runtime && !grep { $_ eq $oci_runtime } @pkgs) {
         push @pkgs, $oci_runtime;
     }
-    push @pkgs, qw(jq xz);
+    push @pkgs, qw(git jq xz);
     @pkgs = uniq sort @pkgs;
-    push @pkgs, "git" unless is_sle("<16.0");
     run_command "zypper --gpg-auto-import-keys -n install --allow-vendor-change @pkgs", timeout => 1200;
-    install_git if is_sle("<16.0");
 
     configure_oci_runtime $oci_runtime;
 

--- a/tests/containers/bats/README.md
+++ b/tests/containers/bats/README.md
@@ -68,7 +68,7 @@ Please add this warning on each bug report you open when adding instructions on 
 - [Tumbleweed aarch64](https://github.com/os-autoinst/opensuse-jobgroups/blob/master/job_groups/opensuse_tumbleweed_aarch64.yaml)
 - [Tumbleweed ppc64le](https://github.com/os-autoinst/opensuse-jobgroups/blob/master/job_groups/opensuse_tumbleweed_powerpc.yaml)
 - [SLES 16.x](https://gitlab.suse.de/qac/qac-openqa-yaml/-/blob/master/containers/latest_host_sle16.yaml)
-- [SLES 15-SP4+](https://gitlab.suse.de/qac/qac-openqa-yaml/-/blob/master/containers/updates.yaml)
+- [SLES 15-SP6+](https://gitlab.suse.de/qac/qac-openqa-yaml/-/blob/master/containers/updates.yaml)
 
 ## Tools
 

--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -60,11 +60,6 @@ sub run_tests {
         "run.bats::Check if containers run with correct open files/processes limits",
     ) if (version->parse(numeric_version($version)) < version->parse("1.39.5") && !$rootless);
     push @xfails, (
-        "bud.bats::bud-multiple-platform-no-partial-manifest-list",
-        # Fails with cgroups v1
-        "namespaces.bats::use containers.conf namespace settings",
-    ) if (is_sle("<15-SP6"));
-    push @xfails, (
         "run.bats::run check /etc/resolv.conf",
     ) unless (is_aarch64 || is_x86_64);
     push @xfails, (
@@ -108,8 +103,7 @@ sub run {
     my ($self) = @_;
     select_serial_terminal;
 
-    my @pkgs = qw(buildah docker git-daemon glibc-devel-static go1.26 libgpgme-devel libseccomp-devel make openssl podman selinux-tools);
-    push @pkgs, "qemu-linux-user" if (is_tumbleweed || is_sle('>=15-SP6'));
+    my @pkgs = qw(buildah docker git-daemon glibc-devel-static go1.26 libgpgme-devel libseccomp-devel make openssl podman qemu-linux-user selinux-tools);
     # Packages needed for conformance tests
     push @pkgs, "busybox-static docker-buildx libbtrfs-devel" unless is_sle;
 

--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -25,7 +25,7 @@ sub run_tests {
     # systemd cgroups manager only works on cgroup v2
     $env{RUNC_USE_SYSTEMD} = "1" if (script_run("test -f /sys/fs/cgroup/cgroup.controllers") == 0);
 
-    if ($rootless && !is_sle("<15-SP6")) {
+    if ($rootless) {
         # /etc/subgid is keyed by user, not group
         my ($gid_start, $gid_len) = split / /, script_output(
             q(awk -F: -v user="$(id -un)" '$1 == user { print $2, $3; exit }' /etc/subgid)

--- a/tests/containers/docker_cli.pm
+++ b/tests/containers/docker_cli.pm
@@ -18,7 +18,7 @@ use containers::bats;
 
 my $firewall_backend;
 my $version;
-my $port = 2375;
+my $port = 2376;
 
 sub setup {
     my $self = shift;
@@ -27,12 +27,7 @@ sub setup {
     $self->setup_pkgs(@pkgs);
     install_gotestsum;
 
-    # On SLES 15-SP4 & 15-SP5, dockerd fails with:
-    # invalid TLS configuration: failed to append certificates from PEM file: "/etc/docker/ca.pem"
-    my $tls = is_sle("<15-SP6") ? 0 : 1;
-    $port++ if $tls;
-
-    configure_docker(selinux => 1, tls => $tls);
+    configure_docker(selinux => 1, tls => 1);
 
     run_command "docker run -d --name registry -p 5000:5000 registry.opensuse.org/opensuse/registry:2";
 


### PR DESCRIPTION
We removed the tests from 15-SP4 & 15-SP5 on https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2947 

- Use git from official repos.  We don't need `install_git` on 15-SP6+ because the git version is fine: 2.51.0
- Adapt tests & documentation accordingly.

VR not needed. 