### PR TITLE
Revert "Chromium: Skip initial dialogs with --no-first-run"

### DIFF
--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -31,7 +31,7 @@ sub run {
 
     # avoid async keyring popups
     # allow key input before rendering is done, see poo#109737 for details
-    x11_start_program('chromium --password-store=basic --allow-pre-commit-input --no-first-run', target_match => [qw(chromium-main-window authentication-required)], match_timeout => 50);
+    x11_start_program('chromium --password-store=basic --allow-pre-commit-input', target_match => [qw(chromium-main-window authentication-required)], match_timeout => 50);
     if (match_has_tag 'authentication-required') {
         type_password;
         assert_and_click "unlock";


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#26469

Since there's already https://build.opensuse.org/request/show/1373487 in staging, this is not needed anymore (what a short life!).

Among [unintended side-effects](https://openqa.opensuse.org/tests/6184121#step/chromium/25) the job that should have ran the VR didn't run anything it had `openqa-clone` instead of `openqa: clone` so it was a noop. That script needs to be fixed to at least skip if nothing happened.

```
++ awk '/into:/{f=1; next} /{"blocked_by_id/{f=0} f && / - /{print $NF}' /tmp/OSADO-PR-26469-mhGa/0_clone_mentioned_job.txt
+ cloned_urls=
```