### PR TITLE
containers/upgrade: validate container runtime upgrades on MinimalVM

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -652,7 +652,20 @@ sub load_jeos_tests {
         loadtest "jeos/efi_tid" if (get_var('UEFI') && is_sle('=12-sp5'));
     }
 
-    loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
+    if (is_updates_tests) {
+        if (get_var('CONTAINER_VALIDATE_UPGRADE')) {
+            my $run_args = OpenQA::Test::RunArgs->new();
+            $run_args->{phase} = "pre";
+            loadtest 'containers/upgrade', run_args => $run_args, name => "upgrade_" . $run_args->{phase};
+        }
+        loadtest 'qa_automation/patch_and_reboot';
+        if (get_var('CONTAINER_VALIDATE_UPGRADE')) {
+            my $run_args = OpenQA::Test::RunArgs->new();
+            $run_args->{phase} = "post";
+            loadtest 'containers/upgrade', run_args => $run_args, name => "upgrade_" . $run_args->{phase};
+            return;
+        }
+    }
     replace_opensuse_repos_tests if is_repo_replacement_required;
     loadtest 'console/verify_efi_mok' if get_var 'CHECK_MOK_IMPORT';
     # zypper_ref needs to run on jeos-containers. the is_sle is required otherwise is scheduled twice on o3

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -678,6 +678,7 @@ if (is_jeos) {
         return 1;
     } else {
         load_jeos_tests();
+        return 1 if (get_var('CONTAINER_VALIDATE_UPGRADE'));
     }
 }
 

--- a/tests/containers/upgrade.pm
+++ b/tests/containers/upgrade.pm
@@ -110,29 +110,23 @@ sub run {
     select_serial_terminal;
 
     my @runtimes = ();
-    if ($phase eq "standalone") {
-        @runtimes = split(/,/, get_var("CONTAINER_RUNTIMES", "docker,podman"));
-    } else {
+    if (get_var("TDUP")) {
         # The MicroOS image in the old2microosnext test doesn't come with docker pre-installed
         push @runtimes, "docker" if (script_run("which docker") == 0);
         push @runtimes, "podman" if (script_run("which podman") == 0);
-    }
-
-    if ($phase eq "standalone") {
-        my @packages = ();
-        push @packages, qw(docker docker-buildx docker-rootless-extras) if (grep { $_ eq "docker" } @runtimes);
-        push @packages, qw(podman) if (grep { $_ eq "podman" } @runtimes);
-        install_packages(@packages);
+    } else {
+        @runtimes = split(/,/, get_var("CONTAINER_RUNTIMES", "docker,podman"));
     }
 
     if ($phase ne "post") {
         my @packages = qw(jq);
-        if (is_sle("<16")) {
-            install_docker_compose;
-        } else {
-            push @packages, "docker-compose";
+        unless (get_var("TDUP")) {
+            push @packages, qw(docker docker-buildx docker-rootless-extras) if (grep { $_ eq "docker" } @runtimes);
+            push @packages, qw(podman) if (grep { $_ eq "podman" } @runtimes);
         }
+        push @packages, "docker-compose" unless is_sle("<16");
         install_packages(@packages);
+        install_docker_compose if is_sle("<16");
 
         for my $rootless (0, 1) {
             select_user_serial_terminal if $rootless;


### PR DESCRIPTION
Wrap `qa_automation/patch_and_reboot` with pre/post `containers/upgrade` calls in `load_jeos_tests`, mirroring the TDUP pattern already used in `main_micro_alp.pm`, so container runtimes are checked for regressions across MinimalVM maintenance updates.

Since JeOS doesn't ship docker in the base image, also make the pre-phase install the requested CONTAINER_RUNTIMES packages.

For this we introduce the CONTAINER_VALIDATE_UPGRADE variable.

Continuation of https://progress.opensuse.org/issues/183512 for SLES. This would have catched https://bugzilla.suse.com/show_bug.cgi?id=1244035

Verification runs:
- https://openqa.suse.de/tests/24080525#step/patch_and_reboot/113
- Tumbleweed container_host-old2microosnext: https://openqa.opensuse.org/tests/6185078#step/upgrade_post/13


Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2948