### PR TITLE
Elemental3: fix sporadic boot issues

### DIFF
--- a/tests/elemental3/elemental_boot.pm
+++ b/tests/elemental3/elemental_boot.pm
@@ -22,14 +22,14 @@ sub run {
     unless (check_var('TESTED_CMD', 'install')) {
         # Wait for OS installer boot
         assert_screen('grub-unifiedcore_installer', timeout => 120);
-        wait_still_screen;
+        wait_still_screen(stilltime => 2);
     }
 
     # This ISO image does not install anything
     # It is just the basic container that should be used with 'customize' command
     if (check_var('TESTED_CMD', 'extract_iso')) {
         # Just validate that the OS boot, no more
-        assert_screen('elemental3-tty1-selected', timeout => 120);
+        $self->wait_boot_past_bootloader(ready_time => 120, textmode => 1, nologin => 1);
         wait_still_screen;
         record_info('ISO', 'ISO image booted!');
         return;


### PR DESCRIPTION
Use `wait_boot_past_bootloader` instead `wait_boot` to avoid sporadic issues while waiting for boot. Also reduce default stilltime to better catch the reboot after OS installation.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/23960948#step/elemental_boot/6
- Verification run: [generate_raw_16.0](https://openqa.suse.de/tests/24053430), [test_raw_16.0](https://openqa.suse.de/tests/24053429), [test_extract_iso_16.0](https://openqa.suse.de/tests/24053787)

**NOTE:** as the initial issue is sporadic it's done really easy to validate the fix. I was able to run multiple VR without any issue, so it should be fine and at least nothing else is broken with this fix.