### PR TITLE
Make zdup upgrade tests compatible with Leap 16.x scenarios

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -399,19 +399,17 @@ Upload C</tmp/solverTestCase.tar.bz2>.
 =cut
 
 sub upload_solvertestcase_logs {
-    if (script_run('pgrep zypper') == 1) {
+    if (script_run('pkill zypper') == 0) {
         record_info('Zypper is locked', "zypper is still running in the background");
-        script_run('pkill zypper; while pgrep zypper; do sleep 1; done', timeout => 120);
+        script_run('while pgrep zypper; do sleep 1; done', timeout => 120);
     }
 
     my $ret = script_run("zypper -n patch --debug-solver --with-interactive -l");
     # if zypper had an error, we just skip upload solverTestCase.tar.bz2
-    # unless it is just locked (i.e test failed in zdup module)
     return if $ret;
 
     script_run("tar -cvjf /tmp/solverTestCase.tar.bz2 /var/log/zypper.solverTestCase/*");
     upload_logs "/tmp/solverTestCase.tar.bz2 ";
-
 }
 
 =head2 export_logs_basic

--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -399,11 +399,19 @@ Upload C</tmp/solverTestCase.tar.bz2>.
 =cut
 
 sub upload_solvertestcase_logs {
+    if (script_run('pgrep zypper') == 1) {
+        record_info('Zypper is locked', "zypper is still running in the background");
+        script_run('pkill zypper; while pgrep zypper; do sleep 1; done', timeout => 120);
+    }
+
     my $ret = script_run("zypper -n patch --debug-solver --with-interactive -l");
-    # if zypper was not found, we just skip upload solverTestCase.tar.bz2
-    return if $ret != 0;
+    # if zypper had an error, we just skip upload solverTestCase.tar.bz2
+    # unless it is just locked (i.e test failed in zdup module)
+    return if $ret;
+
     script_run("tar -cvjf /tmp/solverTestCase.tar.bz2 /var/log/zypper.solverTestCase/*");
     upload_logs "/tmp/solverTestCase.tar.bz2 ";
+
 }
 
 =head2 export_logs_basic

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -1070,7 +1070,14 @@ Check if agama installation is being used
 =cut
 
 sub is_agama {
-    return (get_var('AGAMA') || get_var('INST_AUTO'));
+    return 1 if get_var('AGAMA');
+    return 1 if get_var('INST_AUTO');
+
+    my $flavor = get_var('FLAVOR', '');
+    return 1 if $flavor =~ /agama/;
+    return 1 if is_opensuse && $flavor =~ /(online|offline)-install/;
+
+    return 0;
 }
 
 =head2 is_ltss

--- a/t/01_version_utils.t
+++ b/t/01_version_utils.t
@@ -31,6 +31,39 @@ subtest 'check_version' => sub {
     ok version_utils::check_version('>=10.4', '10.10-mariadb'), "check that poo#120918 doesn't happen";
 };
 
+subtest 'is_agama' => sub {
+    use version_utils 'is_agama';
+
+    ok !is_agama, "check !is_agama by default";
+
+    set_var('AGAMA', 1);
+    ok is_agama, "check is_agama with AGAMA=1";
+    set_var('AGAMA', undef);
+
+    set_var('INST_AUTO', 1);
+    ok is_agama, "check is_agama with INST_AUTO=1";
+    set_var('INST_AUTO', undef);
+
+    set_var('FLAVOR', 'agama');
+    ok is_agama, "check is_agama with FLAVOR=agama";
+
+    set_var('FLAVOR', 'agama-installer');
+    ok is_agama, "check is_agama with FLAVOR=agama-installer";
+
+    set_var('FLAVOR', 'online-installer');
+    ok !is_agama, "check !is_agama with FLAVOR=online-installer without opensuse";
+
+    set_var('DISTRI', 'opensuse');
+    ok is_agama, "check is_agama with FLAVOR=online-installer and DISTRI=opensuse";
+
+    set_var('FLAVOR', 'offline-install');
+    ok is_agama, "check is_agama with FLAVOR=offline-install and DISTRI=opensuse";
+
+    set_var('FLAVOR', 'Server-DVD');
+    ok !is_agama, "check !is_agama with FLAVOR=Server-DVD and DISTRI=opensuse";
+
+};
+
 subtest 'is_microos' => sub {
     use version_utils 'is_microos';
 

--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -130,9 +130,8 @@ sub run {
                     next;
                 }
 
-                $self->result('fail');
-                save_screenshot;
-                return;
+                # If we reached this line, this is an uknown conflict
+                die "Can't solve this conflict:\n$out";
             }
         }
         elsif ($out =~ $zypper_dup_continue) {
@@ -179,9 +178,9 @@ sub run {
             next;
         }
         elsif ($out =~ $zypper_dup_fileconflict) {
-            $self->result('fail');
-            save_screenshot;
-            return;
+            # Conflicts in files are bugs
+            type_string "no";
+            die "Conflicts in files found:\n$out";
         }
         else {
             # probably to avoid hitting black screen on video

--- a/tests/migration/reboot_to_upgrade.pm
+++ b/tests/migration/reboot_to_upgrade.pm
@@ -44,8 +44,9 @@ sub run {
     assert_script_run "sync", 300;
     power_action('reboot', textmode => 1, keepconsole => 1);
 
-    # After remove -f for reboot, we need wait more time for boot menu and avoid exception during reboot caused delay to boot up.
-    assert_screen('inst-bootmenu', 300) unless (is_s390x || is_pvm);
+    # openSUSE Agama based install media don't have a "Boot from Hard Disk", SLE 16 still does
+    my $tag = (is_opensuse && is_agama) ? get_default_bootloader() : 'inst-bootmenu';
+    assert_screen($tag, 300) unless (is_s390x || is_pvm);
 
     # we need to stop_grub_timeout after grub shows up or it will boot into HDD sometimes.
     # for x86_64 we need to make sure the start item is installation for needle matching.


### PR DESCRIPTION
As we're getting ready to enable 16.X to TW upgrades, there are couple of changes needed, for now this PR focuses on:

- Being able to Update to 16.X - ISO doesn't have `Boot from Hard Disk` anymore.
- Expanding `is_agama` behavior, so it doesn't just depend on two variables, but can match flavors too as a fallback

VR: 
- https://openqa.opensuse.org/tests/6200213#step/zdup/39
- SLE no recent jobs using these modules found.

Failure is already reported as https://bugzilla.opensuse.org/show_bug.cgi?id=1276463
