### PR TITLE
feat: Introduce PUBLIC_CLOUD_SSH_KEY_ALGO

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -96,8 +96,20 @@ variable "subnet_id" {
   default = ""
 }
 
+variable "ssh_key_algo" {
+  type        = string
+  default     = "rsa"
+  description = "SSH key algorithm"
+}
+
 variable "ssh_public_key" {
-  default = "/root/.ssh/id_rsa.pub"
+  type        = string
+  default     = ""
+  description = "Explicit path to the SSH public key. Overrides ssh_key_algo when non-empty."
+}
+
+locals {
+  ssh_public_key = var.ssh_public_key != "" ? var.ssh_public_key : "/root/.ssh/id_${var.ssh_key_algo}.pub"
 }
 
 resource "random_id" "service" {
@@ -197,7 +209,7 @@ resource "azurerm_linux_virtual_machine" "openqa-vm" {
 
   admin_ssh_key {
     username   = "azureuser"
-    public_key = file(var.ssh_public_key)
+    public_key = file(local.ssh_public_key)
   }
 
   os_disk {

--- a/data/publiccloud/terraform/azure_cloud-netconfig.tf
+++ b/data/publiccloud/terraform/azure_cloud-netconfig.tf
@@ -76,8 +76,20 @@ variable "subnet_id" {
   default = ""
 }
 
+variable "ssh_key_algo" {
+  type        = string
+  default     = "rsa"
+  description = "SSH key algorithm"
+}
+
 variable "ssh_public_key" {
-  default = "/root/.ssh/id_rsa.pub"
+  type        = string
+  default     = ""
+  description = "Explicit path to the SSH public key. Overrides ssh_key_algo when non-empty."
+}
+
+locals {
+  ssh_public_key = var.ssh_public_key != "" ? var.ssh_public_key : "/root/.ssh/id_${var.ssh_key_algo}.pub"
 }
 
 resource "random_id" "service" {
@@ -218,7 +230,7 @@ resource "azurerm_linux_virtual_machine" "openqa-vm" {
 
   admin_ssh_key {
     username   = "azureuser"
-    public_key = file("${var.ssh_public_key}")
+    public_key = file(local.ssh_public_key)
   }
 
   os_disk {

--- a/data/publiccloud/terraform/azure_nfstest.tf
+++ b/data/publiccloud/terraform/azure_nfstest.tf
@@ -61,8 +61,20 @@ variable "subnet_id" {
   default = ""
 }
 
+variable "ssh_key_algo" {
+  type        = string
+  default     = "rsa"
+  description = "SSH key algorithm"
+}
+
 variable "ssh_public_key" {
-  default = "/root/.ssh/id_rsa.pub"
+  type        = string
+  default     = ""
+  description = "Explicit path to the SSH public key. Overrides ssh_key_algo when non-empty."
+}
+
+locals {
+  ssh_public_key = var.ssh_public_key != "" ? var.ssh_public_key : "/root/.ssh/id_${var.ssh_key_algo}.pub"
 }
 
 
@@ -208,7 +220,7 @@ resource "azurerm_linux_virtual_machine" "openqa-vm" {
 
   admin_ssh_key {
     username   = "azureuser"
-    public_key = file("${var.ssh_public_key}")
+    public_key = file(local.ssh_public_key)
   }
 
   os_disk {

--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -84,8 +84,20 @@ variable "ipv6_address_count" {
   default = 0
 }
 
+variable "ssh_key_algo" {
+  type        = string
+  default     = "ed25519"
+  description = "SSH key algorithm"
+}
+
 variable "ssh_public_key" {
-  default = "/root/.ssh/id_ed25519.pub"
+  type        = string
+  default     = ""
+  description = "Explicit path to the SSH public key. Overrides ssh_key_algo when non-empty."
+}
+
+locals {
+  ssh_public_key = var.ssh_public_key != "" ? var.ssh_public_key : "/root/.ssh/id_${var.ssh_key_algo}.pub"
 }
 
 variable "nitro_enclave" {
@@ -106,7 +118,7 @@ resource "random_id" "service" {
 
 resource "aws_key_pair" "openqa-keypair" {
   key_name   = "openqa-${element(random_id.service[*].hex, 0)}"
-  public_key = file(var.ssh_public_key)
+  public_key = file(local.ssh_public_key)
 }
 
 resource "aws_instance" "openqa" {

--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -28,7 +28,8 @@ data "external" "gce_cred" {
 }
 
 locals {
-  zone = "${var.region}-${var.availability_zone}"
+  zone           = "${var.region}-${var.availability_zone}"
+  ssh_public_key = var.ssh_public_key != "" ? var.ssh_public_key : "/root/.ssh/id_${var.ssh_key_algo}.pub"
 }
 
 variable "cred_file" {
@@ -105,8 +106,16 @@ variable "vm_create_timeout" {
   default = "20m"
 }
 
+variable "ssh_key_algo" {
+  type        = string
+  default     = "ed25519"
+  description = "SSH key algorithm"
+}
+
 variable "ssh_public_key" {
-  default = "/root/.ssh/id_ed25519.pub"
+  type        = string
+  default     = ""
+  description = "Explicit path to the SSH public key. Overrides ssh_key_algo when non-empty."
 }
 
 variable "stack_type" {
@@ -159,7 +168,7 @@ resource "google_compute_instance" "openqa" {
   }
 
   metadata = merge({
-    sshKeys             = "susetest:${file(var.ssh_public_key)}"
+    sshKeys             = "susetest:${file(local.ssh_public_key)}"
     openqa_created_by   = var.name
     openqa_created_date = timestamp()
     openqa_created_id   = element(random_id.service[*].hex, count.index)

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -39,7 +39,8 @@ has terraform_applied => 0;
 has resource_name => sub { get_var('PUBLIC_CLOUD_RESOURCE_NAME', 'openqa-vm') };
 has provider_client => undef;
 
-has ssh_key => get_ssh_private_key_path();
+# Use lazy evaluation otherwise unit tests will not work
+has ssh_key => sub { get_ssh_private_key_path() };
 
 my $runner = get_var('PUBLIC_CLOUD_TERRAFORM_RUNNER', 'tofu');
 unless ($runner eq 'terraform' || $runner eq 'tofu') {
@@ -134,8 +135,8 @@ Creates an ssh keypair in a given file path by $args{ssh_private_key_file}
 
 sub create_ssh_key {
     my ($self) = @_;
-    my $alg = $self->ssh_key;
-    $alg =~ s@[a-z0-9/-_~.]*id_@@;
+    my ($alg) = $self->ssh_key =~ m/id_([a-z0-9]+)$/;
+    die "Cannot derive ssh key algorithm from '" . $self->ssh_key . "'" unless $alg;
     record_info($alg, "The $alg key will be generated.");
     if (script_run('test -f ' . $self->ssh_key) != 0) {
         assert_script_run('SSH_DIR=`dirname ' . $self->ssh_key . '`; mkdir -p $SSH_DIR');
@@ -150,6 +151,7 @@ Creates ~/.ssh/config file with all the common ssh client settings
 =cut
 
 sub place_ssh_config {
+    my ($self) = @_;
     # configure ssh client
     # ssh will be configured by a ~/.ssh/config file, the config file come from a template.
     # By default the template is in publiccloud/ssh_config data directory.
@@ -157,7 +159,7 @@ sub place_ssh_config {
     # From now on all ssh calls will use this configuration file.
     my $ssh_config_url = data_url(get_var('PUBLIC_CLOUD_SSH_CONFIG', 'publiccloud/ssh_config'));
     assert_script_run("curl $ssh_config_url -o ~/.ssh/config");
-    file_content_replace("~/.ssh/config", "%SSH_KEY%" => get_ssh_private_key_path());
+    file_content_replace("~/.ssh/config", "%SSH_KEY%" => $self->ssh_key);
 }
 
 =head2 get_image_id

--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -52,6 +52,7 @@ our @EXPORT = qw(
   register_addon
   register_addons_in_pc
   gcloud_install
+  get_ssh_key_algo
   get_ssh_private_key_path
   permit_root_login
   prepare_ssh_tunnel
@@ -376,9 +377,40 @@ sub gcloud_install {
     record_info('GCE', script_output('gcloud version'));
 }
 
-sub get_ssh_private_key_path {
+=head2 get_ssh_key_algo
+
+    my $algo = get_ssh_key_algo();
+
+Returns the SSH key algorithm used for public cloud testing.
+
+The openQA setting B<PUBLIC_CLOUD_SSH_KEY_ALGO> overrides the default when set.
+Supported values are C<rsa> or C<ed25519>.
+
+The default is C<ed25519> except for Azure and for C<PUBLIC_CLOUD_LTP>
+runs where it is C<rsa>.
+
+=cut
+
+sub get_ssh_key_algo {
+    my $algo = get_var('PUBLIC_CLOUD_SSH_KEY_ALGO');
+    if ($algo) {
+        die "Unsupported PUBLIC_CLOUD_SSH_KEY_ALGO" unless grep { $_ eq $algo } qw(rsa ed25519);
+        return $algo;
+    }
     # Paramiko needs to be updated for ed25519 https://stackoverflow.com/a/60791079
-    return (is_azure() || get_var('PUBLIC_CLOUD_LTP')) ? "~/.ssh/id_rsa" : '~/.ssh/id_ed25519';
+    return (is_azure() || get_var('PUBLIC_CLOUD_LTP')) ? 'rsa' : 'ed25519';
+}
+
+=head2 get_ssh_private_key_path
+
+    my $path = get_ssh_private_key_path();
+
+Returns the path of the SSH private key used for public cloud testing.
+
+=cut
+
+sub get_ssh_private_key_path {
+    return '~/.ssh/id_' . get_ssh_key_algo();
 }
 
 sub permit_root_login {

--- a/t/45_publiccloud_provider.t
+++ b/t/45_publiccloud_provider.t
@@ -85,6 +85,39 @@ subtest '[create_ssh_key] derives algorithm and generates when absent' => sub {
     $mod->redefine(script_run => sub { 0 });    # key file exists
     $provider->create_ssh_key();
     ok(!(grep { /ssh-keygen/ } @asr), 'does not regenerate existing key');
+
+    # rsa needs the PEM format for paramiko, ed25519 must not get -m pem
+    @asr = ();
+    $mod->redefine(script_run => sub { 1 });    # key file absent
+    publiccloud::provider->new(ssh_key => '~/.ssh/id_rsa')->create_ssh_key();
+    ok((grep { /ssh-keygen -t rsa .* -m pem / } @asr), 'rsa key is generated in PEM format');
+    ok(!(grep { /ssh-keygen -t ed25519 .*-m pem/ } @asr), 'ed25519 key is not forced to PEM');
+};
+
+subtest '[create_ssh_key] rejects a key path without a derivable algorithm' => sub {
+    my $provider = publiccloud::provider->new(ssh_key => '~/.ssh/some_key');
+    my $mod = Test::MockModule->new('publiccloud::provider', no_auto => 1);
+    $mod->noop('record_info');
+    $mod->redefine(script_run => sub { 1 });
+    $mod->redefine(assert_script_run => sub { 0 });
+
+    throws_ok { $provider->create_ssh_key() } qr/Cannot derive ssh key algorithm/,
+      'dies instead of running ssh-keygen with an empty algorithm';
+};
+
+subtest '[ssh_key] is resolved lazily from PUBLIC_CLOUD_SSH_KEY_ALGO' => sub {
+    set_var('PUBLIC_CLOUD', 1);
+    set_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
+
+    # The attribute must not be baked in at compile time, otherwise the job
+    # setting could never influence it.
+    set_var('PUBLIC_CLOUD_SSH_KEY_ALGO', 'rsa');
+    is(publiccloud::provider->new()->ssh_key, '~/.ssh/id_rsa', 'override honoured');
+
+    set_var('PUBLIC_CLOUD_SSH_KEY_ALGO', undef);
+    is(publiccloud::provider->new()->ssh_key, '~/.ssh/id_ed25519', 'default honoured');
+
+    _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_SSH_KEY_ALGO/);
 };
 
 subtest '[terraform_apply] minimal happy path' => sub {

--- a/t/50_publiccloud_utils.t
+++ b/t/50_publiccloud_utils.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use Test::MockModule;
+use Test::Exception;
 use Test::Warnings;
 use testapi 'set_var';
 
@@ -22,7 +23,7 @@ subtest '[export boundary] exported vs internal helpers' => sub {
     for my $exported (qw(
         is_byos is_ondemand is_ec2 is_ec2_xen is_azure is_gce
         is_container_host is_hardened is_cloudinit_supported
-        get_python_exec get_ssh_private_key_path pc_data_url
+        get_python_exec get_ssh_key_algo get_ssh_private_key_path pc_data_url
         additional_repos calculate_custodian_ttl
         )) {
         ok(__PACKAGE__->can($exported), "$exported is exported into caller");
@@ -199,6 +200,44 @@ subtest '[get_ssh_private_key_path] depends on provider/LTP' => sub {
     is(get_ssh_private_key_path(), '~/.ssh/id_rsa', 'LTP forces rsa');
 
     _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_LTP/);
+};
+
+subtest '[get_ssh_key_algo] PUBLIC_CLOUD_SSH_KEY_ALGO overrides the default' => sub {
+    set_var('PUBLIC_CLOUD', 1);
+
+    # Unset and empty behave alike: fall back to the provider/LTP default.
+    set_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
+    set_var('PUBLIC_CLOUD_SSH_KEY_ALGO', undef);
+    is(get_ssh_key_algo(), 'ed25519', 'unset falls back to the default');
+    set_var('PUBLIC_CLOUD_SSH_KEY_ALGO', '');
+    is(get_ssh_key_algo(), 'ed25519', 'empty string falls back to the default');
+
+    # The override wins over the ed25519 default ...
+    set_var('PUBLIC_CLOUD_SSH_KEY_ALGO', 'rsa');
+    is(get_ssh_key_algo(), 'rsa', 'rsa override on a ed25519-by-default provider');
+    is(get_ssh_private_key_path(), '~/.ssh/id_rsa', 'key path follows the override');
+
+    # ... over the azure rsa default ...
+    set_var('PUBLIC_CLOUD_PROVIDER', 'AZURE');
+    set_var('PUBLIC_CLOUD_SSH_KEY_ALGO', 'ed25519');
+    is(get_ssh_key_algo(), 'ed25519', 'ed25519 override beats the azure rsa default');
+    is(get_ssh_private_key_path(), '~/.ssh/id_ed25519', 'key path follows the override');
+
+    # ... and over the LTP rsa default.
+    set_var('PUBLIC_CLOUD_PROVIDER', 'EC2');
+    set_var('PUBLIC_CLOUD_LTP', 1);
+    is(get_ssh_key_algo(), 'ed25519', 'ed25519 override beats the LTP rsa default');
+    _unset(qw/PUBLIC_CLOUD_LTP/);
+
+    # Anything else is a hard error: a silently wrong algorithm would only
+    # surface much later as an unexplained ssh timeout. The match is
+    # case-sensitive on purpose, so the setting has exactly one spelling.
+    for my $bogus (qw(dsa ecdsa id_rsa 1 ED25519 RSA Rsa)) {
+        set_var('PUBLIC_CLOUD_SSH_KEY_ALGO', $bogus);
+        throws_ok { get_ssh_key_algo() } qr/Unsupported PUBLIC_CLOUD_SSH_KEY_ALGO/, "'$bogus' is rejected";
+    }
+
+    _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_LTP PUBLIC_CLOUD_SSH_KEY_ALGO/);
 };
 
 subtest '[pc_data_url] github/gitlab/gitea URL conversion' => sub {

--- a/variables.md
+++ b/variables.md
@@ -404,6 +404,7 @@ PUBLIC_CLOUD_SCC_ENDPOINT | string | "registercloudguest" | Name of binary which
 PUBLIC_CLOUD_SKIP_MU | boolean | false | Run tests without downloading/applying maintenance updates.
 PUBLIC_CLOUD_SLES4SAP | boolean | false | If set, sles4sap test module is added to the job.
 PUBLIC_CLOUD_SSH_CONFIG | string | "publiccloud/ssh_config" | Allows to override the default ssh config template location.
+PUBLIC_CLOUD_SSH_KEY_ALGO | string | "" | SSH key algorithm used for public cloud testing. Supported values are `rsa` or `ed25519`.
 PUBLIC_CLOUD_SSH_TIMEOUT | int | 300 | Sets the timeout for ssh wait operations.
 PUBLIC_CLOUD_STORAGE_ACCOUNT | string | "" | Storage account used e.g. for custom disk and container images
 PUBLIC_CLOUD_SUPPORTCONFIG_EXCLUDE | string | "" | List of comma-separated features to exclude from 'supportconfig' execution


### PR DESCRIPTION
Adds the `PUBLIC_CLOUD_SSH_KEY_ALGO` setting that allows to configure the used ssh key algorithm.

This is used in the context of FIPS-enabled CHOST images, where the default (ed25519) is not accepted anymore.

- Related ticket: https://progress.opensuse.org/issues/206124

## Verification runs

* [15-SP7 Azure with rsa](https://openqa.suse.de/tests/24066443)
* [15-SP7 EC2 with ed25519](https://openqa.suse.de/tests/24066444)
* [15-SP7 EC2 with rsa](https://openqa.suse.de/tests/24066445)
* [15-SP7 GCE with ed25519](https://openqa.suse.de/tests/24066446)
* [15-SP7 GCE with rsa](https://openqa.suse.de/tests/24066447)