### PR TITLE
Adapt console selecting to more backends and scenarios

### DIFF
--- a/lib/guest_installation_and_configuration_base.pm
+++ b/lib/guest_installation_and_configuration_base.pm
@@ -2778,7 +2778,7 @@ sub verify_guest_agama_installation_done {
         enter_cmd("exit");
         wait_still_screen(15);
         if (!check_screen('text-logged-in-root', timeout => 30)) {
-            select_backend_console(init => 0);
+            select_backend_console;
             $self->get_guest_installation_session if ($self->{guest_installation_session} eq '');
             type_string("reset\n");
             wait_still_screen;
@@ -2839,7 +2839,7 @@ sub save_guest_agama_installation_logs {
         enter_cmd("exit");
         wait_still_screen(15);
         if (!check_screen('text-logged-in-root', timeout => 30)) {
-            select_backend_console(init => 0);
+            select_backend_console;
             $self->get_guest_installation_session if ($self->{guest_installation_session} eq '');
             type_string("reset\n");
             wait_still_screen;
@@ -3228,7 +3228,7 @@ sub do_detach_guest_installation_screen {
     }
     else {
         record_info("Failed to detach $self->{guest_name} installation screen process $self->{guest_installation_session}", "Bad luck !");
-        select_backend_console(init => 0);
+        select_backend_console;
         $self->get_guest_installation_session if ($self->{guest_installation_session} eq '');
         type_string("reset\n");
         wait_still_screen;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -146,6 +146,8 @@ our @EXPORT = qw(
   render_scc_url
   query_installed_packages
   remove_installed_packages
+  is_textmode
+  select_backend_console
 );
 
 our @EXPORT_OK = qw(
@@ -3771,6 +3773,97 @@ sub query_installed_packages {
     my $ret = 0;
     $ret |= script_run("rpm -q $_") foreach (split(/,/, $args{packages}));
     return ($ret ? 0 : 1);
+}
+
+=head2 is_textmode
+
+  is_textmode()
+
+Check whether system runs in 'textmode' or not.
+=cut
+
+sub is_textmode {
+    return check_var('DESKTOP', 'textmode') || check_var('TEXTMODE', 1);
+}
+
+=head2 select_backend_console
+
+This subroutine aims to serve console selecting for different backends, including
+ipmi, qemu, pvm_hvm, svirt except s390x and s390 backends, and uses the most common
+values as default consoles. This can help eliminate the need to specify console and
+avoid if...else code block in test modules being shared across functions. In order
+to have universal functionality, some arguments are introduced to facilitate console
+selecting at different phases and for different purposes. If argument init is set,
+select the initial or initialization console to start, for example, sol console for
+ipmi, or powerhmc-ssh for pvm_hmc because test is at the very beginning phase, still
+booting up or just for reference purpose, for example, system bootup, already spilled
+login prompt, confirm the system state and etc, especially if system is ready (up
+and running) and init is also set, the initial and desired consoles will be selected
+in order (e.g. sol and root-ssh for ipmi). In the latter case, user can check both
+consoles in order after coming back from other tasks. User can also specify desired
+console or choose whether to wait for the selected console. 
+C<%args> have following keys to be defined:
+- C<console>: desired console to be selected or use backend default.
+- C<reset_times>: specifies the number of times (default to 1) reset_consoles to 
+                  be done.
+- C<init>: Whether select the initial or initialization console (default to 0).
+           By the way, some backends may not use it at all, for example, qemu
+           backend.
+- C<wait>: Whether wait for asserting the selected console (default to 1).
+- C<ready>: Whether system is alread up and running (default to 0).
+=cut
+
+sub select_backend_console {
+    my (%args) = @_;
+    $args{reset_times} //= 1;
+    $args{init} //= 0;
+    $args{wait} //= 1;
+    $args{ready} //= 0;
+
+    reset_consoles for (0 .. $args{reset_times} - 1);
+    if (is_ipmi) {
+        $args{console} //= ($args{init} ? 'sol' : 'root-ssh');
+        select_console($args{console}, await_console => $args{wait});
+        use_ssh_serial_console if ($args{init} and $args{ready});
+    }
+    elsif (is_qemu) {
+        $args{console} //= (is_textmode ? 'root-console' : 'x11');
+        console('x11')->set_tty(get_x11_console_tty);
+        console('root-console')->set_tty(get_root_console_tty);
+        reset_consoles;
+        select_console($args{console}, await_console => $args{wait});
+        ensure_serialdev_permissions;
+        serial_terminal::prepare_serial_console();
+    }
+    elsif (is_pvm_hmc) {
+        $args{console} //= ($args{init} ? 'powerhmc-ssh' : 'root-ssh');
+        select_console($args{console}, await_console => $args{wait});
+        select_console('root-ssh') if ($args{init} and $args{ready});
+    }
+    elsif (is_svirt_except_s390x) {
+        $args{console} //= ($args{init} ? 'svirt' : (is_textmode ? 'root-console' : 'x11'));
+        if ($args{init}) {
+            return select_console($args{console}, await_console => $args{wait});
+        }
+        else {
+            select_console($args{console}, await_console => $args{wait});
+            save_svirt_pty if (is_s390x and is_textmode);
+        }
+    }
+    elsif (is_backend_s390x) {
+        $args{console} //= ($args{init} ? 'x3270' : 'root-console');
+        if ($args{init}) {
+            console('installation')->disable_vnc_stalls;
+            return console($args{console});
+        }
+        else {
+            select_console($args{console}, await_console => $args{wait});
+        }
+    }
+    else {
+        $args{console} //= 'root-console';
+        select_console($args{console}, await_console => $args{wait});
+    }
 }
 
 1;

--- a/lib/virt_autotest/utils.pm
+++ b/lib/virt_autotest/utils.pm
@@ -107,7 +107,6 @@ our @EXPORT = qw(
   reconnect_console_if_not_good
   get_guest_settings
   reselect_openqa_console
-  select_backend_console
   double_check_xen_role
   check_kvm_modules
   install_product_software
@@ -1945,49 +1944,6 @@ sub reselect_openqa_console {
         }
         enter_cmd("reset") for (0 .. 2);
         $reselect_console_counter -= $countdown;
-    }
-}
-
-=head2 select_backend_console
-
-Select corresponding ipmi, qemu or pvm_hmc backend console, namely 'root-ssh' or
-'root-console'. If argument init is set, select 'sol' console for ipmi backend, 
-or powerhmc-ssh for pvm_hmc backend because test run is in initialization or the
-very beginning phase, for example, pxe boot, host installation or startup. User
-can also set desired console or choose whether to wait for the selected console.
-Argument reset_times specifies the number of times reset_consoles to be done.
-=cut
-
-sub select_backend_console {
-    my (%args) = @_;
-    $args{reset_times} //= 1;
-    $args{init} //= 1;
-    $args{wait} //= 0;
-
-    if (is_ipmi) {
-        $args{console} //= ($args{init} ? 'sol' : 'root-ssh');
-    }
-    elsif (is_qemu) {
-        $args{console} //= 'root-console';
-    }
-    elsif (is_ppc64le) {
-        $args{console} //= ($args{init} ? 'powerhmc-ssh' : 'root-ssh') if (is_pvm_hmc);
-    }
-
-    reset_consoles for (0 .. $args{reset_times} - 1);
-    if (is_ipmi) {
-        select_console($args{console}, await_console => $args{wait});
-        use_ssh_serial_console if (!$args{init});
-    }
-    elsif (is_qemu) {
-        migration::reset_consoles_tty();
-        select_console($args{console}, await_console => $args{wait});
-        ensure_serialdev_permissions;
-        serial_terminal::prepare_serial_console();
-    }
-    elsif (is_ppc64le) {
-        select_console($args{console}, await_console => $args{wait});
-        select_console('root-ssh') if (!$args{init});
     }
 }
 

--- a/lib/virt_autotest/virtual_network_utils.pm
+++ b/lib/virt_autotest/virtual_network_utils.pm
@@ -21,7 +21,7 @@ use Data::Dumper;
 use XML::Writer;
 use IO::File;
 use Carp;
-use utils qw(script_retry query_installed_packages);
+use utils qw(script_retry query_installed_packages select_backend_console);
 use upload_system_log 'upload_supportconfig_log';
 use version_utils qw(is_sle is_alp is_opensuse is_transactional);
 use Utils::Architectures;
@@ -123,7 +123,7 @@ sub create_host_bridge_nm {
         script_output($execute_script, $wait_script, type_command => 0, proceed_on_failure => 0);
         save_screenshot;
         # Re-establish the backend console connection, poo#187197
-        select_backend_console(init => 0);
+        select_backend_console;
         # Set metric the lowest to make br0 always be the default route
         script_run("nmcli con modify br0 ipv4.route-metric 50");
         script_run("nmcli con up br0");

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -30,7 +30,7 @@ use suseconnect_register qw(command_register);
 
 sub run {
     my ($self) = @_;
-    select_console 'root-console';
+    select_backend_console;
     ensure_serialdev_permissions;
     prepare_serial_console;
     if (!check_var('DESKTOP', 'textmode')) {

--- a/tests/console/validate_repos.pm
+++ b/tests/console/validate_repos.pm
@@ -11,11 +11,12 @@ use Mojo::Base 'consoletest';
 use testapi;
 use repo_tools 'validate_repo_properties';
 use scheduler 'get_test_suite_data';
+use utils 'select_backend_console';
 
 sub run {
     my $test_data = get_test_suite_data();
 
-    select_console 'root-console';
+    select_backend_console;
 
     my %expected_repos = map { $_->{alias} => 1 } @{$test_data->{repos}};
     my @actual_aliases = split(/\n/, script_output("zypper -n lr --uri | awk \'NR>4 && \$1 ~ /[0-9]/ {print \$3}\'"));

--- a/tests/virt_autotest/prepare_non_transactional_server.pm
+++ b/tests/virt_autotest/prepare_non_transactional_server.pm
@@ -60,7 +60,7 @@ sub prepare_ground {
 sub prepare_console {
     my $self = shift;
 
-    select_backend_console(init => 0);
+    select_backend_console;
 }
 
 sub prepare_storages {

--- a/tests/virt_autotest/restore_upgrade_system.pm
+++ b/tests/virt_autotest/restore_upgrade_system.pm
@@ -11,12 +11,12 @@
 
 use Mojo::Base 'opensusebasetest';
 use testapi;
-use virt_autotest::utils qw(select_backend_console reset_network_config subscribe_extensions_and_modules);
-use utils qw(remove_installed_packages);
+use virt_autotest::utils qw(reset_network_config subscribe_extensions_and_modules);
+use utils qw(remove_installed_packages select_backend_console);
 
 sub run {
     # Login as root
-    select_backend_console(init => 0) if (!check_screen('text-logged-in-root'));
+    select_backend_console if (!check_screen('text-logged-in-root'));
     # Remove unnecessary or unsupported packages
     remove_installed_packages(packages => get_var('INSTALL_OTHER_PACKAGES', ''));
     # Deregister unnecessary or unsupported extensions

--- a/tests/virt_autotest/unified_guest_installation.pm
+++ b/tests/virt_autotest/unified_guest_installation.pm
@@ -73,13 +73,13 @@ use Mojo::Base 'concurrent_guest_installations';
 use testapi;
 use Carp;
 use Utils::Backends;
-use virt_autotest::utils qw(select_backend_console);
 use virt_autotest::domain_management_utils;
+use utils 'select_backend_console';
 
 sub run {
     my $self = shift;
 
-    select_backend_console(init => 0);
+    select_backend_console;
 
     $self->reveal_myself;
     return if get_var('SKIP_GUEST_INSTALL');

--- a/tests/virt_autotest/verify_virtualization.pm
+++ b/tests/virt_autotest/verify_virtualization.pm
@@ -29,7 +29,7 @@ our @guest_list = ();
 sub run {
     my $self = shift;
 
-    select_backend_console(init => 0);
+    select_backend_console;
     $self->verify_bootloader;
     $self->verify_system;
     $self->verify_hypervisor;

--- a/tests/yam/migration/zypper_migration.pm
+++ b/tests/yam/migration/zypper_migration.pm
@@ -11,6 +11,7 @@ use Mojo::Base 'opensusebasetest';
 use power_action_utils 'power_action';
 use serial_terminal 'select_serial_terminal';
 use Utils::Logging 'upload_solvertestcase_logs';
+use utils 'select_backend_console';
 
 sub run {
     my $self = shift;
@@ -24,7 +25,7 @@ sub run {
         continue => qr/^Continue\? \[y/m,
     };
 
-    select_console 'root-console';
+    select_backend_console;
 
     # Register openSUSE Leap against SCC; Leap can not be registered against ProxySCC, it is not available on ProxySCC.
     assert_script_run("SUSEConnect -r " . get_var("SCC_REGCODE"), timeout => 60) if (get_var("ISO") =~ /Leap/);
@@ -49,7 +50,7 @@ sub run {
 
     wait_serial(qr/^$zypper_done/m, 900) || die "zypper migration completion was not found";
 
-    select_console('root-console', await_console => 0);
+    select_backend_console(wait => 0);
     power_action('reboot', textmode => 1);
     $self->wait_boot(textmode => 1, bootloader_time => 300);
 }

--- a/tests/yam/validate/validate_connectivity.pm
+++ b/tests/yam/validate/validate_connectivity.pm
@@ -12,7 +12,7 @@ use testapi;
 use utils;
 
 sub run {
-    select_console 'root-console';
+    select_backend_console;
     my $ip_address_show = script_output("ip address show");
     record_info("ip address show", $ip_address_show);
     my $connectivity = check_var('INST_COPY_NETWORK', '0') || check_var('OFFLINE_SUT', '1') ? 'none|unknown' : 'full';

--- a/tests/yam/validate/validate_migration_logs.pm
+++ b/tests/yam/validate/validate_migration_logs.pm
@@ -8,7 +8,7 @@
 
 use Mojo::Base 'consoletest';
 use testapi;
-use utils 'upload_folders';
+use utils qw(upload_folders select_backend_console);
 use Utils::Architectures;
 
 sub run {
@@ -16,7 +16,7 @@ sub run {
         record_soft_failure('bsc#1259353 - Failed to log in root after migration from 15sp{5-7} to sles16.1 on s390x kvm');
         sleep 120;
     }
-    select_console 'root-console';
+    select_backend_console;
 
     upload_logs("/var/log/distro_migration.log", failok => 1);
     script_run 'tar zcvf /tmp/cache_wicked_config.tar.gz /var/cache/wicked_config/*';

--- a/tests/yam/validate/validate_product.pm
+++ b/tests/yam/validate/validate_product.pm
@@ -11,9 +11,10 @@ use testapi;
 use Config::Tiny;
 use Test::Assert ':all';
 use scheduler 'get_test_suite_data';
+use utils 'select_backend_console';
 
 sub run {
-    select_console 'root-console';
+    select_backend_console;
 
     my $test_data = get_test_suite_data()->{os_release};
     my $os_release = Config::Tiny->read_string(script_output('cat /etc/os-release'))->{_};


### PR DESCRIPTION
* **Move** subroutine ```select_backend_console``` from module ```lib/virt_autotest/utils.pm``` to module ```lib/utils.pm```.

* **Adapt** subroutine ```select_backend_console``` to more architectures and backends, including ipmi, qemu, pvm_hmc, svirt, s390x and etc. Please refer to subroutine description for details.

* **Update** subroutine calling in modules:
  * ```lib/guest_installation_and_configuration_base.pm```
  * ```lib/virt_autotest/virtual_network_utils.pm```
  * ```tests/console/system_prepare.pm```
  * ```tests/console/validate_repos.pm```
  * ```tests/virt_autotest/prepare_non_transactional_server.pm```
  * ```tests/virt_autotest/restore_upgrade_system.pm```
  * ```tests/virt_autotest/unified_guest_installation.pm```
  * ```tests/virt_autotest/verify_virtualization.pm```
  * ```tests/yam/migration/zypper_migration.pm```
  * ```tests/yam/validate/validate_connectivity.pm```
  * ```tests/yam/validate/validate_migration_logs.pm```
  * ```tests/yam/validate/validate_product.pm```

* **Please** also review https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26480 which leads to this pull request if you are interested in host upgrade test.

* **Verification Runs:**
  * [sle-16.1-Online-s390x-Build63.1-sles_default_standard_unattended@s390x-kvm](https://openqa.suse.de/tests/24077505)
  * [sle-16.1-Online-s390x-Build63.1-sles_default_standard_unattended@s390x-zVM](https://openqa.suse.de/tests/24077506)
  * [sle-16.1-Online-s390x-Build63.1-gi-online-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/24077541)
  * [sle-16.1-Online-aarch64-Build63.1-sles_migration_15sp6_textmode](https://openqa.suse.de/tests/24080864)
  * [ sle-16.1-Online-ppc64le-Build63.1-sles_migration_15sp6_textmode_all_modules_and_extensions](https://openqa.suse.de/tests/24080866)
  * [sle-16.1-Online-ppc64le-Build63.1-sles_migration_160](https://openqa.suse.de/tests/24080867)
  * [sle-16.1-Online-s390x-Build63.1-sles_migration_15sp5_textmode](https://openqa.suse.de/tests/24081080)
  * [sle-16.1-Online-x86_64-Build63.1-sles_migration_15sp6_textmode](https://openqa.suse.de/tests/24081083)
  * [sle-16.1-Online-x86_64-Build63.1-sles_sap_migration_15sp6](https://openqa.suse.de/tests/24081084)
  * [sle-16.1-Online-aarch64-Build63.1-sles_default_standard_unattended](https://openqa.suse.de/tests/24081814)
  * [sle-16.1-Online-ppc64le-Build63.1-sles_default_standard_unattended](https://openqa.suse.de/tests/24081818)
  * [sle-16.1-Online-x86_64-Build63.1-sles_default_standard_unattended](https://openqa.suse.de/tests/24081827)
  * [sle-16.1-Online-x86_64-Build63.1-uefi-gi-full-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/24081831)
  * [sle-16.1-Online-aarch64-Build63.1-slmicro_migration](https://openqa.suse.de/tests/24081833)
  * [sle-16.1-Online-aarch64-Build63.1-uefi-gi-guest_postsles16-on-host_developing-kvm](https://openqa.suse.de/tests/24096574)
  * [sle-16.1-Online-aarch64-Build63.1-uefi-gi-guest_developing-on-host_sles15sp7-kvm](https://openqa.suse.de/tests/24096576)
  * [sle-16.1-Online-x86_64-Build63.1-uefi-gi-guest_sles16_0-online-on-host_developing-kvm](https://openqa.suse.de/tests/24102019)