### PR TITLE
Environment using system site packages without internal ensurepip

### DIFF
--- a/tests/console/python3_setuptools.pm
+++ b/tests/console/python3_setuptools.pm
@@ -64,8 +64,10 @@ sub run_tests ($python3_spec_release) {
 # Creating the source package with the name 'dist/user_package_setuptools-1.0.tar.gz' in the dist folder.
 sub build_package ($python_binary, $env) {
     if ($env eq 'pip') {
-        assert_script_run("$python_binary -m venv myenv --system-site-packages");
+        # Refer bsc#1262467
+        assert_script_run("$python_binary -m venv myenv --system-site-packages --without-pip");
         assert_script_run("source myenv/bin/activate");
+        assert_script_run("pip --version");
         assert_script_run("cd /root/data") if is_transactional;
     }
     assert_script_run("$python_binary setup.py sdist");


### PR DESCRIPTION
Creates the environment using system site packages without internal ensurepip installer

- Related ticket: https://progress.opensuse.org/issues/206133
- Verification run: https://openqa.suse.de/tests/24081287#step/python3_setuptools/65
