### PR TITLE
Remove obsolete linuxrc from sle16.0 guests and host

### DIFF
--- a/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/SLE_16_0_QU_sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
@@ -29,7 +29,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/SLES-16.0-Online-x86_64-Build12345.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/SLES-16.0-Online-x86_64-Build12345.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_sev_es_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_sev_es_x86_64_agama_online_iso.xml
@@ -30,7 +30,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/fixed/SLES-16.0-Online-x86_64-GM.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/fixed/SLES-16.0-Online-x86_64-GM.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_sev_snp_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_sev_snp_x86_64_agama_online_iso.xml
@@ -30,7 +30,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/fixed/SLES-16.0-Online-x86_64-GM.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/fixed/SLES-16.0-Online-x86_64-GM.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso.xml
@@ -29,7 +29,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/fixed/SLES-16.0-Online-x86_64-GM.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/fixed/SLES-16.0-Online-x86_64-GM.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso_qcow2_nvram.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_64_kvm_hvm_x86_64_agama_online_iso_qcow2_nvram.xml
@@ -29,7 +29,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/fixed/SLES-16.0-Online-x86_64-GM.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/fixed/SLES-16.0-Online-x86_64-GM.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200 linuxrc.log=/dev/ttyS0 linuxrc.core=/dev/ttyS0 linuxrc.debug=4,trace</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyS0,115200</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>

--- a/data/virt_autotest/guest_params_xml_files/sles_16_kvm_hvm_aarch64_agama_online_iso.xml
+++ b/data/virt_autotest/guest_params_xml_files/sles_16_kvm_hvm_aarch64_agama_online_iso.xml
@@ -29,7 +29,7 @@
     <guest_installation_media>http://openqa.suse.de/assets/iso/fixed/SLES-16.0-Online-aarch64-GM.install.iso</guest_installation_media>
     <guest_installation_fine_grained_media>http://openqa.suse.de/assets/repo/fixed/SLES-16.0-Online-aarch64-GM.install/</guest_installation_fine_grained_media>
     <guest_installation_fine_grained_repos/>
-    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyAMA0,115200 linuxrc.log=/dev/ttyAMA0 linuxrc.core=/dev/ttyAMA0 linuxrc.debug=4,trace ip=dhcp rd.neednet arm64.nompam</guest_installation_fine_grained_kernel_args>
+    <guest_installation_fine_grained_kernel_args>live.password=ROOTPASSWORD console=ttyAMA0,115200 ip=dhcp rd.neednet arm64.nompam</guest_installation_fine_grained_kernel_args>
     <guest_installation_fine_grained_kernel_args_overwrite/>
     <guest_installation_fine_grained_others/>
     <guest_os_variant>sles16</guest_os_variant>


### PR DESCRIPTION
linuxrc is obsolete in sle16.0. It was mentioned in a few places that linuxrc is removed from sle16+. I checked rpm and lsinitrd there is no mention of linuxrc.

This is followup of
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25238

- Related ticket: https://progress.opensuse.org/issues/199343
- Verification run:
  - 16.0:
    - [qam-kvm-install-and-snapshot-test](https://openqa.suse.de/tests/24120205)
  - 16.1:
    - [snapshot-gi-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/24120202) 
    - [sev-snp-guest_developing-on-host_developing-kvm](https://openqa.suse.de/tests/24120204)