### PR TITLE
add a local log for SLEPerf deploy script

### DIFF
--- a/tests/kernel_performance/install_sleperf.pm
+++ b/tests/kernel_performance/install_sleperf.pm
@@ -29,7 +29,7 @@ sub install_pkg {
         $deploy = '16.1';
     }
     assert_script_run("curl $repo >>sleperf_deploy.sh");
-    assert_script_run("sh sleperf_deploy.sh -t sles$deploy");
+    assert_script_run("sh sleperf_deploy.sh -t sles$deploy | tee -a /root/sleperf_deploy.log ");
 
 }
 


### PR DESCRIPTION
Currently, our SLEPerf deploy script only outputs logs to the screen without saving them locally. This makes debugging quite difficult.So we want to add local log for SLEPerf deploy script

- Related ticket: https://progress.opensuse.org/issues/204942
- Needles: N/A
- Verification run: http://10.200.129.6/tests/89470#
