### PR TITLE
container_diff: authenticate before pulling released LTSS image

### DIFF
--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -33,7 +33,7 @@ sub run {
     if (is_sle("=12-sp5")) {
         assert_script_run('mkdir -p ~/.docker');
         assert_script_run(
-            q{printf '{"auths":{"registry.suse.com":{"auth":"%s"}}}' "$(awk -F= '/^username/{u=$2} /^password/{p=$2} END{printf "%s:%s", u, p}' /etc/zypp/credentials.d/SCCcredentials | base64 -w0)" > ~/.docker/config.json}
+q{printf '{"auths":{"registry.suse.com":{"auth":"%s"}}}' "$(awk -F= '/^username/{u=$2} /^password/{p=$2} END{printf "%s:%s", u, p}' /etc/zypp/credentials.d/SCCcredentials | base64 -w0)" > ~/.docker/config.json}
         );
     }
 

--- a/tests/containers/container_diff.pm
+++ b/tests/containers/container_diff.pm
@@ -14,7 +14,7 @@ use utils;
 use containers::common;
 use containers::container_images;
 use containers::urls 'get_image_uri';
-use version_utils 'is_leap';
+use version_utils qw(is_leap is_sle);
 
 sub run {
     my ($self) = @_;
@@ -26,6 +26,16 @@ sub run {
     zypper_call('addrepo -fG -p 150 obs://Virtualization:containers/' . get_required_var('VERSION') . ' containers') if is_leap("16.0+");
 
     zypper_call("install container-diff") if (script_run("which container-diff") != 0);
+
+    # Authenticate against registry.suse.com before pulling the released
+    # LTSS image (bsc#1274889). Avoids "docker login -u/-p", which would
+    # print the credentials in the test logs.
+    if (is_sle("=12-sp5")) {
+        assert_script_run('mkdir -p ~/.docker');
+        assert_script_run(
+            q{printf '{"auths":{"registry.suse.com":{"auth":"%s"}}}' "$(awk -F= '/^username/{u=$2} /^password/{p=$2} END{printf "%s:%s", u, p}' /etc/zypp/credentials.d/SCCcredentials | base64 -w0)" > ~/.docker/config.json}
+        );
+    }
 
     my $unreleased_image = get_image_uri(released => 0);
     my $released_image = get_image_uri(released => 1);


### PR DESCRIPTION
container_diff fails on SLE-12-SP5 with "pull access denied" when
pulling the released LTSS image from registry.suse.com, since
nothing authenticates against it. This writes ~/.docker/config.json
using the SUT's own SCC credentials before the pull, instead of
"docker login -u/-p" which would print the credentials in the test
logs.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1274889
- Needles: not applicable - this change doesn't touch any needle-based steps
- Verification run: https://openqa.suse.de/tests/24094098