### PR TITLE
nginx: stop service after test to free port 80

### DIFF
--- a/lib/services/nginx.pm
+++ b/lib/services/nginx.pm
@@ -78,6 +78,10 @@ sub enable_service {
     common_service_action 'nginx', $service_type, 'enable';
 }
 
+sub stop_service {
+    common_service_action 'nginx', $service_type, 'stop';
+}
+
 sub start_service {
     common_service_action('apache2', $service_type, 'stop') if (script_run("systemctl is-active apache2.service") == 0);
     common_service_action 'nginx', $service_type, 'start';

--- a/tests/console/nginx.pm
+++ b/tests/console/nginx.pm
@@ -23,6 +23,10 @@ sub run {
     services::nginx::check_function();
 }
 
+sub post_run_hook {
+    services::nginx::stop_service();
+}
+
 sub test_flags {
     return {fatal => 0};
 }


### PR DESCRIPTION
The nginx test starts the service but never stops it. This leaves port 80 occupied for any later test module that needs it (e.g. apache).

Add stop_service to services::nginx and call it from post_run_hook so the port is released when the test finishes.

verification run: https://openqa.opensuse.org/tests/6187334