### PR TITLE
Remove softfailed tag bsc#1274029

### DIFF
--- a/lib/locale.pm
+++ b/lib/locale.pm
@@ -38,15 +38,8 @@ sub verify_default_keymap_textmode {
         select_console($tty{console});
     }
     else {
-        if ((is_sle('=15-SP6') || is_sle('=15-SP7')) && check_var('DESKTOP', 'gnome')) {
-            # Switching to tty1 is broken, use tty3 as workaround
-            record_soft_failure 'bsc#1274029 - plymouth blocks switch to tty1';
-            send_key('alt-f3');
-        } else {
-            # Check tty1, which is the initial console set up by kernel and initrd
-            send_key('alt-f1');
-        }
-
+        # Check tty1, which is the initial console set up by kernel and initrd
+        send_key('alt-f1');
         # remote backends can not provide a "not logged in console" so we use
         # a cleared remote terminal instead
         assert_screen(has_ttys() ? 'linux-login' : 'cleared-console');


### PR DESCRIPTION
Remove softfailed tag bsc#1274029

- Related ticket: https://progress.opensuse.org/issues/206172
- Verification run: https://openqa.suse.de/tests/overview?build=tinawang123%2Fos-autoinst-distri-opensuse%23keymap&distri=sle
