### PR TITLE
Fix SLE Micro 5.x container HTTP test under SELinux

### DIFF
--- a/lib/containers/container_images.pm
+++ b/lib/containers/container_images.pm
@@ -79,7 +79,12 @@ sub build_and_run_image {
 
     # Test that we can execute programs in the container and test container's variables
     assert_script_run("$runtime run --rm --entrypoint 'printenv' myapp WORLD_VAR | grep Arda");
-    assert_script_run("$runtime run -d --name myapp -p 8888:80 myapp");
+    my $security_opt = '';
+    if (is_sle_micro('<6.0')) {
+        record_soft_failure('bsc#1277097 - SELinux container labeling prevents HTTP processing on SLE Micro 5.x');
+        $security_opt = '--security-opt label=disable';
+    }
+    assert_script_run("$runtime run -d --name myapp $security_opt -p 8888:80 myapp");
     validate_script_output_retry("$runtime ps -a", sub { m/myapp/ }, retry => 3, delay => 5, timeout => 300);
     assert_script_run("$runtime logs myapp");
 


### PR DESCRIPTION
## Summary

Work around bsc#1277097 on SLE Micro 5.x, where SELinux container labeling accepts TCP connections but drops HTTP requests before the test server can process them. Disable labeling only for the disposable HTTP test container and record the product bug as a soft failure so maintenance aggregates can proceed.

## Changes

- apply `--security-opt label=disable` only on SLE Micro 5.x
- record `bsc#1277097` as a soft failure when the workaround is active
- retain default SELinux labeling on SLE Micro 6.x, SLES, and openSUSE

## Testing

- `prove -l t/01_style.t`
- diagnostic job 24102624: default labeling and `seccomp=unconfined` return curl 52; `label=disable` returns HTTP 200 and logs the request
- verification run: https://openqa.suse.de/tests/24103744