### PR TITLE
Insert REG_ARGS into playbook section for hanaSR

### DIFF
--- a/lib/sles4sap/publiccloud.pm
+++ b/lib/sles4sap/publiccloud.pm
@@ -1084,6 +1084,7 @@ sub create_playbook_section_list {
         push @reg_args, "-e reg_code=$args{scc_code} -e email_address=''";
         push @reg_args, '-e use_suseconnect=true' if ($args{registration} eq 'suseconnect');
         push @reg_args, qesap_ansible_reg_module(reg => $args{ltss}) if ($args{ltss});
+        push @reg_args, get_var('REG_ARGS') if get_var('REG_ARGS');
         # Add registration module as first element
         push @playbook_list, join(' ', @reg_args);
     }

--- a/tests/sles4sap/qesapdeployment/configure.pm
+++ b/tests/sles4sap/qesapdeployment/configure.pm
@@ -156,6 +156,10 @@ The IP address of the IBSm server, used for repository redirection.
 
 The hostname of the repository server to redirect to the IBSm.
 
+=item B<REG_ARGS>
+
+Additional registration arguments for the registration playbook.
+
 =back
 
 =head1 MAINTAINER


### PR DESCRIPTION
This PR enables the injection of the content of `REG_ARGS` openqa variable (if it exists) in the registration playbook call.

- Related ticket: https://jira.suse.com/browse/TEAM-11499
- Verification run: https://openqa.suse.de/tests/24136098 - is_flavor injected (PAYG in this case)
without REG_ARGS set: https://openqa.suse.de/tests/24153239
