### PR TITLE
Elemental3: add missing unit tests for shared library

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -102,3 +102,15 @@ schedule/yast @chcao @hadeskun @hjluo @jknphy @lemon-suse @okynos @rakoenig
 test_data/yam @chcao @hadeskun @hjluo @jknphy @lemon-suse @okynos @rakoenig
 test_data/yast @chcao @hadeskun @hjluo @jknphy @lemon-suse @okynos @rakoenig
 tests/yam @chcao @hadeskun @hjluo @jknphy @lemon-suse @okynos @rakoenig
+
+# Elemental
+data/elemental @ldevulder
+schedule/elemental @ldevulder
+tests/elemental @ldevulder
+
+# Elemental3 (aka. UnifiedCore)
+data/elemental3 @ldevulder
+lib/elemental3.pm @ldevulder
+schedule/elemental3 @ldevulder
+t/42_elemental3.t @ldevulder
+tests/elemental3 @ldevulder

--- a/lib/elemental3.pm
+++ b/lib/elemental3.pm
@@ -93,6 +93,9 @@ sub get_container_uri {
     else {
         croak("Cannot get '$args{url}/${fn}': " . $res->message);
     }
+
+    # If we reach this point, no match was found
+    croak("Could not find any URI matching the regex in '$args{url}'");
 }
 
 =head2 get_sysext
@@ -184,13 +187,13 @@ sub kubectl_cmd {
     my $retry = 10;
     my $delay = $timeout / $retry;
 
-    croak('Argument <cmd> missing') unless $args{cmd};
+    croak('Missing required argument <cmd>!') unless $args{cmd};
 
     return script_retry(
         "kubectl $args{cmd}",
         delay => $delay,
         retry => $retry,
-        fail_message => "kubectl command not found!"
+        fail_message => "kubectl command '$args{cmd}' failed!"
     );
 }
 
@@ -284,7 +287,7 @@ sub wait_on_cmd {
     my $retry = 10;
     my $delay = $timeout / $retry;
 
-    croak('Argument <cmd> missing') unless $args{cmd};
+    croak('Missing required argument <cmd>!') unless $args{cmd};
 
     return script_retry(
         $args{cmd},
@@ -309,13 +312,13 @@ sub wait_script_output {
     my $retry = 10;
     my $delay = $timeout / $retry;
 
-    croak('Argument <cmd> missing') unless $args{cmd};
+    croak('Missing required argument <cmd>!') unless $args{cmd};
 
     return script_output_retry(
         cmd => $args{cmd},
         delay => $delay,
         retry => $retry,
-        fail_message => "command '$args{cmd}' timed out after $timeout seconds!"
+        fail_message => "Command '$args{cmd}' timed out after $timeout seconds!"
     );
 }
 

--- a/schedule/elemental3/generate.yaml
+++ b/schedule/elemental3/generate.yaml
@@ -1,3 +1,4 @@
+# See in tests/ for file '- elemental3/README.md' for some informations
 name: generate
 description: |
   - Generate Elemental OS image

--- a/schedule/elemental3/master.yaml
+++ b/schedule/elemental3/master.yaml
@@ -1,3 +1,4 @@
+# See in tests/ for file '- elemental3/README.md' for some informations
 name: master
 description: |
   - Run distros-test-framework K8s tests

--- a/schedule/elemental3/os_image.yaml
+++ b/schedule/elemental3/os_image.yaml
@@ -1,3 +1,4 @@
+# See in tests/ for file '- elemental3/README.md' for some informations
 name: os_image
 description: |
   - Test boot of Elemental OS image

--- a/schedule/elemental3/validate.yaml
+++ b/schedule/elemental3/validate.yaml
@@ -1,3 +1,4 @@
+# See in tests/ for file '- elemental3/README.md' for some informations
 name: validate
 description: |
   - Validate container images

--- a/t/42_elemental3.t
+++ b/t/42_elemental3.t
@@ -4,6 +4,8 @@ use Test::Exception;
 use Test::MockModule;
 use Test::More;
 use Test::Warnings;
+use Mojo::Message::Response;
+use Mojo::Transaction::HTTP;
 use List::Util qw(any);
 use testapi;
 
@@ -31,18 +33,16 @@ subtest '[elemental3_cmd]' => sub {
     dies_ok { elemental3_cmd() } 'Croak if no argument is provided';
 
     # Simulate passing
-    $elemental3->redefine(assert_script_run => sub { return 1 });
+    $elemental3->redefine('assert_script_run' => sub { return 1 });
     ok(elemental3_cmd(%params), 'Pass with all args defined');
 
     # Check container runtime call
-    $elemental3->redefine(assert_script_run => sub { push @calls, $_[0] });
+    $elemental3->redefine('assert_script_run' => sub { push @calls, $_[0] });
     elemental3_cmd(%params);
     ok((any { /podman/ } @calls), 'podman called');
 };
 
 # Test get_container_uri function
-# NOTE: not easy to test this function, but if it does not work it will return
-#       nothing and openQA tests will fail anyway, so issue will be seen quickly
 subtest '[get_container_uri]' => sub {
     my $elemental3 = Test::MockModule->new('elemental3', no_auto => 1);
 
@@ -54,33 +54,211 @@ subtest '[get_container_uri]' => sub {
 
     # Check with no arguments
     dies_ok { get_container_uri() } 'Croak if no argument is provided';
+
+    # Mock get_values to avoid testing it again here
+    $elemental3->redefine('get_values' => sub {
+            return ('.my-manifest-(123)-(abc).aarch64-1.0.tar.registry.txt', '123', 'abc');
+    });
+
+    # Mock Mojo::UserAgent to simulate HTTP GET request
+    my $ua_mock = Test::MockModule->new('Mojo::UserAgent');
+    $ua_mock->redefine('get' => sub {
+            my $res = Mojo::Message::Response->new;
+            $res->code(200)->message('OK')->body("some text\npull my-registry.com/my/image:123-abc\nmore text");
+            my $tx = Mojo::Transaction::HTTP->new;
+            $tx->res($res);
+            return $tx;
+    });
+
+    my $uri = get_container_uri(%params);
+    is($uri, 'my-registry.com/my/image:123-abc', 'get_container_uri returns correct URI');
+
+    # Test failed web request
+    $ua_mock->redefine('get', sub {
+            my $res = Mojo::Message::Response->new;
+            $res->code(404)->message('Not Found');
+            my $tx = Mojo::Transaction::HTTP->new;
+            $tx->res($res);
+            return $tx;
+    });
+    throws_ok { get_container_uri(%params) } qr/Cannot get '$params{url}\/.*': Not Found/, 'croaks on failed web request';
+
+    # Test no match
+    $ua_mock->redefine('get', sub {
+            my $res = Mojo::Message::Response->new;
+            $res->code(200)->message('OK')->body('<a href="no-match.txt">no match</a>');
+            my $tx = Mojo::Transaction::HTTP->new;
+            $tx->res($res);
+            return $tx;
+    });
+    throws_ok { get_container_uri(%params) } qr/Could not find any URI matching the regex/, 'croaks on no match';
 };
 
 # Test get_sysext function
 subtest '[get_sysext]' => sub {
     my $elemental3 = Test::MockModule->new('elemental3', no_auto => 1);
     my @calls;
-    $elemental3->noop(qw(record_info));
+    $elemental3->noop('record_info');
 
     # Check with no arguments
     dies_ok { get_sysext() } 'Croak if no argument is provided';
 
     # Simulate with variable set
     set_var('SYSEXT_IMAGES_TO_TEST', 'sysext1,sysext2,sysext3');
-    $elemental3->redefine(assert_script_run => sub { push @calls, $_[0] });
+    $elemental3->redefine('assert_script_run' => sub { push @calls, $_[0] });
     get_sysext(tmpdir => '/my-test-dir');
     ok((any { /mkdir/ } @calls), 'mkdir called');
     ok((any { /unpack-image/ } @calls), 'unpack-image called');
 };
 
 # Test get_values function
-# NOTE: not easy to test this function, but if it does not work it will return
-#       nothing and openQA tests will fail anyway, so issue will be seen quickly
 subtest '[get_values]' => sub {
     my $elemental3 = Test::MockModule->new('elemental3', no_auto => 1);
 
+    my %params = (
+        url => 'https://dist.suse.de/ibs/Devel:/UnifiedCore:/Main:/ToTest',
+        arch => 'aarch64',
+        regex => '.*my-manifest-([0-9]*)-(.*)'
+    );
+
     # Check with no arguments
     dies_ok { get_values() } 'Croak if no argument is provided';
+
+    # Mock Mojo::UserAgent to simulate HTTP GET request
+    my $ua_mock = Test::MockModule->new('Mojo::UserAgent');
+    $ua_mock->redefine('get' => sub {
+            my $res = Mojo::Message::Response->new;
+            my $html_body = q{
+                <a href="some-other-file.txt">some-other-file.txt</a>
+                <a href="base-my-manifest-123-abc.aarch64-1.0.tar.registry.txt">base-my-manifest-123-abc.aarch64-1.0.tar.registry.txt</a>
+            };
+            $res->code(200)->message('OK')->body($html_body);
+            my $tx = Mojo::Transaction::HTTP->new;
+            $tx->res($res);
+            return $tx;
+    });
+
+    my ($fn, $version, $build) = get_values(%params);
+    is($fn, 'base-my-manifest-123-abc.aarch64-1.0.tar.registry.txt', 'get_values returns correct filename');
+    is($version, '123', 'get_values returns correct version');
+    is($build, 'abc', 'get_values returns correct build');
+
+    # Test failed web request
+    $ua_mock->redefine('get', sub {
+            my $res = Mojo::Message::Response->new;
+            $res->code(404)->message('Not Found');
+            my $tx = Mojo::Transaction::HTTP->new;
+            $tx->res($res);
+            return $tx;
+    });
+    throws_ok { get_values(%params) } qr/Cannot get '$params{url}\/': Not Found/, 'croaks on failed web request';
+
+    # Test no match
+    $ua_mock->redefine('get', sub {
+            my $res = Mojo::Message::Response->new;
+            $res->code(200)->message('OK')->body('<a href="no-match.txt">no match</a>');
+            my $tx = Mojo::Transaction::HTTP->new;
+            $tx->res($res);
+            return $tx;
+    });
+    throws_ok { get_values(%params) } qr/Could not find any file matching the regex/, 'croaks on no match';
+};
+
+# Test kubectl_cmd function
+subtest '[kubectl_cmd]' => sub {
+    my $elemental3 = Test::MockModule->new('elemental3');
+
+    # Test success
+    $elemental3->redefine('script_retry' => sub { 0 });
+    is(kubectl_cmd(cmd => 'get pods'), 0, 'kubectl_cmd: success');
+
+    # Test failure
+    my $my_cmd = 'get pods';
+    $elemental3->redefine('script_retry' => sub { die "kubectl command '$my_cmd' failed!\n" });
+    throws_ok { kubectl_cmd(cmd => $my_cmd) } qr/kubectl command '$my_cmd' failed!/, 'dies on failure';
+
+    # Test missing cmd
+    throws_ok { kubectl_cmd() } qr/Missing required argument <cmd>!/, 'croaks on missing cmd';
+    throws_ok { kubectl_cmd(cmd => '') } qr/Missing required argument <cmd>!/, 'croaks on empty cmd';
+};
+
+# Test wait_k8s_state function
+subtest '[wait_k8s_state]' => sub {
+    my $elemental3 = Test::MockModule->new('elemental3');
+
+    # Test success
+    $elemental3->redefine('script_retry' => sub { 0 });
+    is(wait_k8s_state(regex => 'Running'), 0, 'wait_k8s_state: success');
+
+    # Test failure
+    $elemental3->redefine('script_retry' => sub { die "K8s cluster did not reach the required state\n" });
+    throws_ok { wait_k8s_state(regex => 'Running') } qr/K8s cluster did not reach the required state/, 'dies on failure';
+
+    # Test missing regex
+    throws_ok { wait_k8s_state() } qr/A regex should be defined!/, 'croaks on missing regex';
+    throws_ok { wait_k8s_state(regex => '') } qr/A regex should be defined!/, 'croaks on empty regex';
+};
+
+# Test wait_kubectl_cmd function
+subtest '[wait_kubectl_cmd]' => sub {
+    my $elemental3 = Test::MockModule->new('elemental3');
+
+    # Test success
+    $elemental3->redefine('script_retry' => sub { 0 });
+    is(wait_kubectl_cmd(), 0, 'wait_kubectl_cmd: success');
+
+    # Test failure
+    $elemental3->redefine('script_retry' => sub { die "kubectl command did not appear\n" });
+    throws_ok { wait_kubectl_cmd() } qr/kubectl command did not appear/, 'dies on failure';
+};
+
+# Test wait_nodes_ready function
+subtest '[wait_nodes_ready]' => sub {
+    my $elemental3 = Test::MockModule->new('elemental3');
+
+    # Test success
+    $elemental3->redefine('validate_script_output_retry' => sub { 0 });
+    is(wait_nodes_ready(), 0, 'wait_nodes_ready: success');
+
+    # Test failure
+    $elemental3->redefine('validate_script_output_retry' => sub { die "K8s nodes not ready\n" });
+    throws_ok { wait_nodes_ready() } qr/K8s nodes not ready/, 'dies on failure';
+};
+
+# Test wait_on_cmd function
+subtest '[wait_on_cmd]' => sub {
+    my $elemental3 = Test::MockModule->new('elemental3');
+
+    # Test success
+    $elemental3->redefine(script_retry => sub { 0 });
+    is(wait_on_cmd(cmd => 'true'), 0, 'wait_on_cmd: success');
+
+    # Test failure
+    my $my_cmd = 'not_found_cmd';
+    $elemental3->redefine('script_retry' => sub { die "Command '$my_cmd' did not appear\n" });
+    throws_ok { wait_on_cmd(cmd => $my_cmd) } qr/Command '$my_cmd' did not appear/, 'dies on failure';
+
+    # Test missing cmd
+    throws_ok { wait_on_cmd() } qr/Missing required argument <cmd>!/, 'croaks on missing cmd';
+    throws_ok { wait_on_cmd(cmd => '') } qr/Missing required argument <cmd>!/, 'croaks on empty cmd';
+};
+
+# Test wait_script_output function
+subtest '[wait_script_output]' => sub {
+    my $elemental3 = Test::MockModule->new('elemental3');
+
+    # Test success
+    $elemental3->redefine(script_output_retry => sub { 'output' });
+    is(wait_script_output(cmd => 'echo output'), 'output', 'wait_script_output: success');
+
+    # Test failure
+    my $my_cmd = 'not_found_cmd';
+    $elemental3->redefine('script_output_retry' => sub { die "Command '$my_cmd' timed out\n" });
+    throws_ok { wait_script_output(cmd => $my_cmd) } qr/Command '$my_cmd' timed out/, 'dies on failure';
+
+    # Test missing cmd
+    throws_ok { wait_script_output() } qr/Missing required argument <cmd>!/, 'croaks on missing cmd';
+    throws_ok { wait_script_output(cmd => '') } qr/Missing required argument <cmd>!/, 'croaks on empty cmd';
 };
 
 done_testing;

--- a/tests/elemental3/README.md
+++ b/tests/elemental3/README.md
@@ -1,0 +1,48 @@
+# Elemental3 Tests
+
+This test suite validates the functionality of `elemental3`, a tool for managing Elemental-based Linux distributions. The tests cover various `elemental3` operations, including command execution within containers, interaction with Kubernetes clusters, and management of system extensions (sysext).
+
+## Shared Library (`lib/elemental3.pm`)
+
+The tests rely on a set of shared helper functions defined in `lib/elemental3.pm`. These functions provide a common interface for interacting with the system under test and its components.
+
+*   `elemental3_cmd`: Executes an `elemental3` command from within a specified container image. It handles mounting necessary volumes like configuration directories and CA certificates.
+*   `get_container_uri`: Fetches a specific container image URI from a web-based registry by parsing the page content.
+*   `get_sysext`: Downloads and prepares systemd system extensions (`sysext`) from a list of images, making them available for `elemental3`.
+*   `get_values`: A generic function to scrape information (like file names and version numbers) from a web page based on a regex.
+*   `kubectl_cmd`: A wrapper to execute a `kubectl` command, retrying until it succeeds or a timeout is reached.
+*   `wait_k8s_state`: Waits for the Kubernetes cluster to reach a desired state by polling pod statuses against a given regex.
+*   `wait_kubectl_cmd`: Waits for the `kubectl` command-line tool to become available on the system.
+*   `wait_nodes_ready`: Waits until all nodes in the Kubernetes cluster report a `Ready` status.
+*   `wait_on_cmd`: A generic polling function that repeatedly runs a command until it succeeds.
+*   `wait_script_output`: Waits for a command to produce non-empty output and returns that output.
+
+## Test Scenarios
+
+The test modules in this directory likely cover scenarios such as:
+
+*   Installing or upgrading an Elemental system using `elemental3`.
+*   Deploying and managing system extensions.
+*   Verifying the state of a Kubernetes cluster managed by or related to Elemental.
+*   Testing specific `elemental3` sub-commands.
+
+## Prerequisites
+
+*   A system with a configured container runtime (e.g., Docker, Podman) as specified by the `CONTAINER_RUNTIMES` openQA variable.
+*   Access to the container registries and web repositories containing the Elemental images and metadata.
+
+## Configuration
+
+The tests are configured through various openQA variables, including:
+
+*   `CONTAINER_RUNTIMES`: Specifies the container runtime to use.
+*   `SYSEXT_IMAGES_TO_TEST`: A comma-separated list of system extension images to download and test.
+*   `TOTEST_PATH`: Used to determine if internal SUSE CAs need to be mounted in the container.
+
+## Running the tests
+
+These tests are designed to be executed by the openQA framework. Select the relevant test modules from the `elemental3` group in an appropriate test suite.
+
+## License
+
+The files in this directory are licensed under the "FSF All Permissive License" except if indicated otherwise in the file.


### PR DESCRIPTION
- Related ticket: N/A
- Needles: N/A
- Verification run: [extract_iso](https://openqa.suse.de/tests/24195917) - As the modifications in this PR are mainly on the unit tests I don't need to do lot of VR.
&nbsp;

**NOTE:** this PR as been made with the help of Gemini AI to see how it can help me on Elemental3/UnifiedCore testing. I focused on unit tests and small fixes first, as unit tests are important but take time to develop, so AI can be very helpful here.
&nbsp;

This PR adds/fixes the following:
- add missing unit tests for shared library
- fix AI generated unit tests
- add a README.md
- update CODEOWNERS