### PR TITLE
coverage: add sshd/tcpdump coverage schedule, fix postgres timeout

### DIFF
--- a/schedule/coverage/sshd_tcpdump.yaml
+++ b/schedule/coverage/sshd_tcpdump.yaml
@@ -1,0 +1,37 @@
+# schedule tests for coverage measurement ;
+# when you add a test, you need to fill out the last
+# section about coverage targets as well
+
+name: measure test coverage for sshd and tcpdump
+description: >
+    Maintainer: amanzini
+    Boots from an existing Agama-installed HDD (chained after
+    create_hdd_agama_textmode) to verify
+    https://github.com/ilmanzo/BinaryCoverage/issues/152
+vars:
+    BOOT_HDD_IMAGE: 1
+    HDD_1: opensuse-Tumbleweed-x86_64-%BUILD%-textmode-agama@%MACHINE%.qcow2
+    UEFI_PFLASH_VARS: opensuse-Tumbleweed-x86_64-%BUILD%-textmode-agama@%MACHINE%-uefi-vars.qcow2
+schedule:
+    - installation/bootloader_start
+    - boot/boot_to_desktop
+    - console/system_prepare
+    - console/consoletest_setup
+    - coverage/coverage_setup
+    - console/cups
+    - console/postgresql_server
+    - console/rpcbind
+    - console/tcpdump
+    - console/sshd
+    - coverage/coverage_report
+test_data:
+    helper_packages:
+        - pam-extra-debuginfo
+        - wget
+    # package -> binary (or list of binaries) to instrument
+    coverage_targets:
+        openssh-server: /usr/sbin/sshd
+        tcpdump: /usr/sbin/tcpdump
+        cups: /usr/sbin/cupsd
+        postgresql18-server: /usr/lib/postgresql18/bin/postgres
+        rpcbind: /usr/sbin/rpcbind

--- a/tests/coverage/coverage_setup.pm
+++ b/tests/coverage/coverage_setup.pm
@@ -32,6 +32,21 @@ use serial_terminal 'select_serial_terminal';
 use scheduler 'get_test_suite_data';
 use repo_tools 'add_qa_head_repo';
 
+# postgres's initdb bootstrap makes tens of thousands of instrumented
+# function calls; under full eBPF tracing that consistently costs ~90s of
+# CPU time even though postgresql.service itself starts up fine, which on
+# slower/shared CI hardware exceeds systemd's default TimeoutStartSec and
+# fails the unit before postgres ever gets a chance to finish.
+# See https://github.com/ilmanzo/BinaryCoverage/issues/152
+#
+# Returns true on success, false (without dying) on failure, so this
+# best-effort enhancement can't abort the rest of coverage setup.
+sub raise_postgres_start_timeout {
+    return 0 if script_run('mkdir -p /etc/systemd/system/postgresql.service.d') != 0;
+    write_sut_file('/etc/systemd/system/postgresql.service.d/coverage_timeout.conf', "[Service]\nTimeoutStartSec=150\n");
+    return script_run('systemctl daemon-reload') == 0;
+}
+
 sub run {
     select_serial_terminal;
     # enable debug repos
@@ -81,6 +96,8 @@ sub run {
         my @pkg_bins = ref($targets) eq 'ARRAY' ? @$targets : ($targets);
         push @binaries, @pkg_bins;
     }
+    # keep a copy before the destructive splice loop below empties @binaries
+    my @all_binaries = @binaries;
     for (@{$test_data->{helper_packages} // []}) {
         push @packages, $_;
     }
@@ -130,6 +147,15 @@ sub run {
         }
     }
     record_info('shim summary', "$failures of " . scalar(@bin_chunks) . " batches had failures") if $failures;
+
+    if (grep { /\/postgres$/ } @all_binaries) {
+        if (raise_postgres_start_timeout()) {
+            record_info('postgres timeout', 'Raised postgresql.service TimeoutStartSec to 150s to cover coverage instrumentation overhead (issue #152)');
+        }
+        else {
+            record_info('postgres timeout', 'Failed to raise postgresql.service TimeoutStartSec', result => 'softfail');
+        }
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
## Summary

- Adds `schedule/coverage/sshd_tcpdump.yaml`, instrumenting sshd, tcpdump, cups, postgresql18-server, and rpcbind for binary coverage measurement against [ilmanzo/BinaryCoverage#152](https://github.com/ilmanzo/BinaryCoverage/issues/152), chained after an existing Agama-installed Tumbleweed HDD image.
- Fixes a consistent `postgresql_server` timeout: postgres's `initdb` bootstrap makes tens of thousands of instrumented function calls under full eBPF tracing, costing ~90s of CPU time even though `postgresql.service` starts up correctly — on slower/shared CI hardware that exceeds systemd's default `TimeoutStartSec`, failing the unit before postgres gets a chance to finish. Confirmed against 3 independent job failures (6187638, 6187659, 6187727), all showing the identical ~87-91s CPU-bound signature.
- `coverage_setup.pm` now drops in `TimeoutStartSec=150` for `postgresql.service` specifically when postgres is among the schedule's `coverage_targets`, leaving the shared `postgresql_server.pm` test module untouched. The override lives in its own `raise_postgres_start_timeout` function, uses `script_run` + explicit return-code checks (no `eval`, matching this file's existing softfail pattern for shim-install failures) so this best-effort enhancement can't abort the rest of coverage setup, and writes the systemd drop-in via `write_sut_file` instead of a shell `printf` redirect.

## Test plan

- [x] `perl -c` syntax check
- [x] `schedule/coverage/sshd_tcpdump.yaml` passing green with all five daemons (cups, postgresql_server, rpcbind, sshd, tcpdump) plus coverage_setup/coverage_report — two independent green runs: https://openqa.opensuse.org/tests/6187737 and https://openqa.opensuse.org/tests/6187800