### PR TITLE
Increase playbook timeout

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/ansible.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/ansible.pm
@@ -99,7 +99,7 @@ sub set {
     # Run HA related playbooks at the end as it can mix up node order ###
     if (grep /db_ha/, @$components) {
         # SAP HANA high-availability configuration
-        push @playbook_list, {playbook_filename => 'playbook_04_00_01_db_ha.yaml', timeout => 3600};
+        push @playbook_list, {playbook_filename => 'playbook_04_00_01_db_ha.yaml', timeout => 5400};
     }
     # playbooks required for all nw* scenarios
     if (grep /nw/, @$components) {


### PR DESCRIPTION
With increased internal playbook loop times, execution takes longer than
 usual and command times out without collecting rest of the command logs
 . This PR increases command execution time to 1.5H.

Failure: 
https://openqaworker15.qe.prg2.suse.org/tests/383659#step/app_deployment/94

Ticket: https://github.com/sdaf-suse/sap-automation/issues/36

VRs:
https://openqaworker15.qe.prg2.suse.org/tests/383780#