### PR TITLE
kernel/install_ltp: switch from exfat-utils to exfatprogs

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -78,8 +78,7 @@ sub install_runtime_dependencies {
       dosfstools
       e2fsprogs
       evmctl
-      exfat-utils
-      fuse-exfat
+      exfatprogs
       ibmtss
       keyutils
       lvm2
@@ -103,9 +102,6 @@ sub install_runtime_dependencies {
     # modules then fail on SLE-12 because the required driver is available but
     # modprobe refuses to load it.
     push @maybe_deps, 'kernel-default-extra' unless is_sle('<15');
-
-    # exfatprogs create a conflict with exfat-utils on Tumbleweed.
-    push @maybe_deps, 'exfatprogs' unless is_tumbleweed();
 
     install_available_packages(join(' ', @maybe_deps));
 }


### PR DESCRIPTION
exfat-utils is the older, legacy package designed for the FUSE implementation. Switch to exfatprogs which is now official user-space utility for the Linux kernel's native exFAT driver.

- Related LTP change: https://github.com/linux-test-project/ltp/pull/1340#issuecomment-5430504210
- Verification run: 
TW - https://openqa.opensuse.org/tests/6187798
SLE15-SP7 - https://openqa.suse.de/tests/24106292
SLE15-SP4 - https://openqa.suse.de/tests/24106285
