### PR TITLE
kernel/update_kernel: Install extra and optional kernel subpackages

### DIFF
--- a/lib/package_utils.pm
+++ b/lib/package_utils.pm
@@ -73,11 +73,14 @@ sub install_package {
 C<packages> defines packages to install for both zypper and trup call,
 keyword parameters are identical to C<install_package()>.
 C<trup_continue> will be enabled by default.
+C<repo> restricts both the availability check and the installation to the
+given repository alias.
 
 =cut
 
 sub install_available_packages {
     my ($packlist, %args) = @_;
+    my $repo = defined($args{repo}) ? "-r $args{repo} " : '';
 
     if (is_transactional) {
         $packlist .= ' ' . ($args{trup_extra} // '');
@@ -86,14 +89,15 @@ sub install_available_packages {
         $packlist .= ' ' . ($args{zypper_extra} // '');
     }
 
-    my $result = zypper_search("-t package --match-exact $packlist");
+    my $result = zypper_search("-t package --match-exact $repo$packlist");
     my @foundpacks = map { $_->{name} } @$result;
 
     return 0 unless @foundpacks;
     $args{trup_continue} //= 1;
     delete $args{trup_extra};
     delete $args{zypper_extra};
-    return install_package(join(' ', @foundpacks), %args);
+    delete $args{repo};
+    return install_package($repo . join(' ', @foundpacks), %args);
 }
 
 =head2 uninstall_package

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -421,6 +421,7 @@ sub install_kotd {
     remove_kernel_packages;
     zypper_ar($repo, name => 'KOTD', priority => 90, no_gpg_check => 1);
     install_package("-r KOTD $kernel_flavor", trup_continue => 1);
+    install_available_packages("$kernel_flavor-extra $kernel_flavor-optional", repo => 'KOTD');
     my $kver = script_output("rpm -q --qf '%{VERSION}-%{RELEASE}' $kernel_flavor");
     install_package("$src_flavor=$kver kernel-syms=$kver", trup_continue => 1);
     install_package("--recommends $devel_flavor", trup_continue => 1);


### PR DESCRIPTION
remove_kernel_packages() drops every kernel-* package, including
kernel-<flavor>-extra and -optional, but install_kotd() only reinstalls
the base flavor. The unsupported modules shipped there are then missing
after the update, e.g. mpls_iptunnel and mpls_gso, which makes the
bpf:test_tc_tunnel.sh kselftest fail on its mpls subtests.

- Verification runs (custom SL-16.0 job cloned with `INSTALL_KOTD=1 KOTD_REPO="http://download.suse.de/ibs/home:/rmarliere:/SL-16.0/standard/"`):
  - **before** https://openqa.suse.de/tests/24105010/logfile?filename=test_tc_tunnel_sh.tap.txt#line-165 
  - **after** https://openqa.suse.de/tests/24111542
