### PR TITLE
Elemental3: add missing timeout

### DIFF
--- a/tests/elemental3/generate_image.pm
+++ b/tests/elemental3/generate_image.pm
@@ -228,7 +228,7 @@ sub extract_iso {
     my $runtime = get_required_var('CONTAINER_RUNTIMES');
     my $out = "$args{img_filename}.iso";
 
-    assert_script_run("$runtime pull $args{image}");
+    assert_script_run("$runtime pull $args{image}", timeout => $args{timeout});
     my $run_id = script_output("$runtime run -d $args{image}");
     assert_script_run("$runtime cp ${run_id}:/iso/$args{iso} .");
     assert_script_run("mv $args{iso} '$out'");


### PR DESCRIPTION
Call to `extract_iso` misses the `timeout` option, so we can sporadically hit the timeout.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/tests/24105618#step/generate_image/21
- Verification run: https://openqa.suse.de/tests/24110009
