### PR TITLE
Adapt record_soft_failure logic for libreoffice tests

### DIFF
--- a/tests/x11/libreoffice/libreoffice_open_specified_file.pm
+++ b/tests/x11/libreoffice/libreoffice_open_specified_file.pm
@@ -42,12 +42,8 @@ sub run {
         send_key "ctrl-f4";
         wait_still_screen(2);
         if (check_screen("libreoffice-test-$tag")) {
-            record_soft_failure("bsc#1209179 ctrl+f4 can't close libreoffice document");
+            record_info("bsc#1209179 ctrl+f4 can't close libreoffice document");
             assert_and_click("close-document");
-        }
-        if (check_screen('generic-desktop')) {
-            record_soft_failure 'bsc#1196648';
-            $self->libreoffice_start_program('libreoffice');
         }
         $i++;
     }

--- a/tests/x11/libreoffice/libreoffice_recent_documents.pm
+++ b/tests/x11/libreoffice/libreoffice_recent_documents.pm
@@ -46,7 +46,7 @@ sub run {
     wait_still_screen(2);
     assert_screen [qw(oowriter-menus-file oowriter)];
     if (match_has_tag 'oowriter') {
-        record_soft_failure('workaround for boo#1156745');
+        record_info('workaround for boo#1156745');
         assert_and_click('ooffice-writing-file', timeout => 10);
         assert_screen 'oowriter-menus-file';
     }


### PR DESCRIPTION
For below bugs, they are fixed or we can't reproduce the issue manually.

So remove the workaround or remove the softfail tag.

https://bugzilla.suse.com/show_bug.cgi?id=1209179
https://bugzilla.opensuse.org/show_bug.cgi?id=1196648
https://bugzilla.opensuse.org/show_bug.cgi?id=1156745

- Related issues: https://progress.opensuse.org/issues/187467

- Verification run: 
[sle](https://openqa.suse.de/tests/24118898)
[tw](https://openqa.opensuse.org/tests/overview?build=rfan0828&version=Tumbleweed&distri=opensuse)