### PR TITLE
Add a test to install and verify 7zip

### DIFF
--- a/schedule/functional/sle16/extra_tests_textmode.yaml
+++ b/schedule/functional/sle16/extra_tests_textmode.yaml
@@ -109,6 +109,7 @@ schedule:
     - console/osinfo_db
     - console/journalctl
     - console/tar
+    - console/sevenzip
     - console/ruby
     - console/coredump_collect
     - console/valgrind

--- a/schedule/functional/sle16/extra_tests_textmode_immutable.yaml
+++ b/schedule/functional/sle16/extra_tests_textmode_immutable.yaml
@@ -92,6 +92,7 @@ schedule:
     - console/osinfo_db
     - console/journalctl
     - console/tar
+    - console/sevenzip
     - console/ruby
     - console/coredump_collect
     - console/valgrind

--- a/schedule/opensuse/textmode_extra_tests_utils.yaml
+++ b/schedule/opensuse/textmode_extra_tests_utils.yaml
@@ -90,3 +90,4 @@ schedule:
     - console/systemd_rpm_macros
     - console/journalctl
     - console/tar
+    - console/sevenzip

--- a/schedule/qam/common/mau-extratests2.yaml
+++ b/schedule/qam/common/mau-extratests2.yaml
@@ -51,6 +51,7 @@ conditional_schedule:
         - console/journald_fss
         - console/valgrind
         - console/valkey
+        - console/sevenzip
         - console/ds389_advanced_functional
       15-SP7:
         - console/pkcon
@@ -70,6 +71,7 @@ conditional_schedule:
         - '{{arch_specific}}'
         - console/valgrind
         - console/valkey
+        - console/sevenzip
         - console/ds389_advanced_functional
       15-SP6:
         - console/pkcon
@@ -89,6 +91,7 @@ conditional_schedule:
         - '{{arch_specific}}'
         - console/valgrind
         - console/valkey
+        - console/sevenzip
         - console/ds389_advanced_functional
       15-SP5:
         - console/pkcon
@@ -107,6 +110,7 @@ conditional_schedule:
         - console/nginx
         - '{{arch_specific}}'
         - console/valgrind
+        - console/sevenzip
         - console/ds389_advanced_functional
       15-SP4:
         - console/pkcon

--- a/tests/console/sevenzip.pm
+++ b/tests/console/sevenzip.pm
@@ -1,0 +1,64 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Package: 7zip
+# Summary: testsuite 7zip
+# Maintainer: QE Core <qe-core@suse.com>
+
+use Mojo::Base 'consoletest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use package_utils 'install_package';
+
+sub run {
+    select_serial_terminal;
+
+    # Install 7zip if it is not installed
+    install_package('7zip', trup_apply => 1) if (script_run('rpm -q 7zip'));
+    record_info("7zip package version", script_output("rpm -q 7zip"));
+
+    # Prepare test directory.
+    assert_script_run 'mkdir -p /tmp/7zip-test/input/nested';
+    assert_script_run 'cd /tmp/7zip-test';
+
+    # Create test files.
+    assert_script_run 'printf "SUSE 7-Zip openQA test\n" > input/test25.txt';
+    assert_script_run 'printf "test nested file\n" > input/nested/nested.txt';
+
+    # 1. Create 7z archive.
+    assert_script_run '7z a test.7z input/';
+
+    # 2. List archive contents.
+    my $listing = script_output '7z l test.7z';
+
+    die 'Expected files not found in archive' unless $listing =~ "test25.txt" && $listing =~ "nested.txt";
+
+    # 3. Test archive integrity.
+    assert_script_run '7z t test.7z';
+
+    # 4. Extract archive.
+    assert_script_run 'mkdir extract';
+    assert_script_run '7z x test.7z -oextract';
+
+    # 5. Verify extracted file contents.
+    assert_script_run 'cmp input/test25.txt extract/input/test25.txt';
+    assert_script_run 'cmp input/nested/nested.txt extract/input/nested/nested.txt';
+
+    # Explicitly verify the expected content.
+    my $content = script_output 'cat extract/input/test25.txt';
+
+    die "Unexpected content in test25.txt: $content" unless $content eq 'SUSE 7-Zip openQA test';
+
+    # 6. Extract only test25.txt.
+    assert_script_run 'mkdir single';
+    assert_script_run '7z e test.7z -osingle input/test25.txt';
+
+    assert_script_run 'test -f single/test25.txt';
+    assert_script_run 'cmp input/test25.txt single/test25.txt';
+
+    # Cleanup.
+    assert_script_run 'rm -rf /tmp/7zip-test';
+}
+1;


### PR DESCRIPTION
The 7zip test is scheduled to run on SLES 15 SP5, SP6, and SP7, as well as on SLE 16.0 and SLE 16.1.

- Related ticket: https://progress.opensuse.org/issues/195203
- Needles: NO
- Verification run: 
https://openqa.suse.de/tests/overview?&distri=sle&build=DeepthiYV%2Fos-autoinst-distri-opensuse%2326514 
Tumbleweed: [x86_64](https://openqa.opensuse.org/tests/6195591#step/sevenzip/1)