### PR TITLE
virtmanager: wait for the console to settle after ctrl-q

### DIFF
--- a/lib/virtmanager.pm
+++ b/lib/virtmanager.pm
@@ -7,7 +7,7 @@ use version_utils 'is_sle';
 our @ISA = qw(Exporter);
 our @EXPORT = qw(launch_virtmanager connection_details create_vnet create_new_pool
   create_new_volume create_netinterface delete_netinterface create_guest powercycle
-  detect_login_screen select_guest close_guest establish_connection);
+  detect_login_screen select_guest close_guest establish_connection quit_virtmanager);
 
 
 sub launch_virtmanager {
@@ -677,6 +677,13 @@ sub close_guest {
     assert_and_click 'virt-manager_file';
     mouse_set(1023, 0);
     assert_and_click 'virt-manager_close';
+}
+
+# Quit virt-manager and wait for the console to be usable again
+# A bare wait_screen_change returns too early, the next command loses its first characters
+sub quit_virtmanager {
+    wait_screen_change { send_key 'ctrl-q'; };
+    wait_still_screen(stilltime => 3, timeout => 60);
 }
 
 sub powercycle {

--- a/tests/virtualization/universal/virtmanager_add_devices.pm
+++ b/tests/virtualization/universal/virtmanager_add_devices.pm
@@ -79,7 +79,7 @@ sub run_test {
         }
     }
 
-    wait_screen_change { send_key 'ctrl-q'; };
+    quit_virtmanager();
 }
 
 1;

--- a/tests/virtualization/universal/virtmanager_final.pm
+++ b/tests/virtualization/universal/virtmanager_final.pm
@@ -30,7 +30,7 @@ sub run_test {
         close_guest();
     }
 
-    wait_screen_change { send_key 'ctrl-q'; };
+    quit_virtmanager();
 }
 
 1;

--- a/tests/virtualization/universal/virtmanager_init.pm
+++ b/tests/virtualization/universal/virtmanager_init.pm
@@ -30,7 +30,7 @@ sub run_test {
 
     establish_connection();
 
-    wait_screen_change { send_key 'ctrl-q'; };
+    quit_virtmanager();
 }
 
 sub test_flags {

--- a/tests/virtualization/universal/virtmanager_offon.pm
+++ b/tests/virtualization/universal/virtmanager_offon.pm
@@ -34,10 +34,8 @@ sub run_test {
         close_guest();
     }
 
-    wait_screen_change { send_key 'ctrl-q'; };
+    quit_virtmanager();
 
-    # Wait a while untill the ssh console fully reacts after closing the X window of virt-manager
-    sleep 5;
     # Reconnect if the text console does not respond well after long time no use
     reconnect_console_if_not_good;
 }

--- a/tests/virtualization/universal/virtmanager_rm_devices.pm
+++ b/tests/virtualization/universal/virtmanager_rm_devices.pm
@@ -62,7 +62,7 @@ sub run_test {
             close_guest();
         }
     }
-    wait_screen_change { send_key 'ctrl-q'; };
+    quit_virtmanager();
 
     # Workaround to return guests to initial sate, related to bsc#1221917
     shutdown_guests();


### PR DESCRIPTION
Quitting virt-manager with `wait_screen_change { send_key 'ctrl-q' }` returns as soon as the window *starts* to disappear. The next command then gets typed while virt-manager still holds the keyboard, and its leading characters are swallowed and the shell runs something like `rsh list --all` and the following `wait_serial` waits for a marker that can never appear.

This moves the quit into `virtmanager::quit_virtmanager`, which follows the `ctrl-q` with `wait_still_screen`, and updates the five call sites. It also drops the `sleep 5` in `virtmanager_offon` that was working around the same race. 

- Verification run: https://openqa.suse.de/tests/24121312 — SLE 15-SP6,  `qam-kvm-install-and-features-test@64bit-ipmi-legacy-large-mem`
- Same machine without change fails at `virtmanager_add_devices`:  https://openqa.suse.de/tests/24120150
- Related ticket: https://progress.opensuse.org/issues/205818