### PR TITLE
Scope EC2 CloudWatch agent setup to LTP only

### DIFF
--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -380,8 +380,7 @@ sub _download_ec2_cloudwatch_logs {
     my ($self, $instance) = @_;
 
     my $instance_id = $instance->instance_id;
-
-    $self->_disable_and_stop_ec2_cloudwatch_agent($instance);
+    my @downloaded_entries;
 
     for my $entry (@$EC2_CW_LOGS) {
 
@@ -416,9 +415,23 @@ sub _download_ec2_cloudwatch_logs {
 
         upload_logs($log_filename);
 
+        push @downloaded_entries, $entry;
+    }
+
+    return \@downloaded_entries;
+}
+
+# Delete the CloudWatch log streams for $entries (as returned by
+# _download_ec2_cloudwatch_logs), so only streams known to exist are deleted.
+sub _delete_ec2_cloudwatch_logs {
+    my ($self, $instance, $entries) = @_;
+
+    my $log_stream = $instance->instance_id;
+
+    for my $entry (@$entries) {
         assert_script_run(
             "aws logs delete-log-stream " .
-              "--log-group-name '$log_group' " .
+              "--log-group-name '$entry->{log_group}' " .
               "--log-stream-name '$log_stream'"
         );
     }
@@ -572,16 +585,32 @@ sub initialize_logging {
     my ($self, $instance) = @_;
     $self->upload_boot_diagnostics(log_name => "console-beginning");
     record_info('Logging', 'Initializing logging for EC2 instance');
-    my $err = $self->_install_ec2_cloudwatch_agent($instance);
-    if ($err) {
-        record_soft_failure("poo#205539 - CloudWatch agent setup failed: $err");
-    }
 }
 
 sub finalize_logging {
     my ($self, $instance) = @_;
     $self->upload_boot_diagnostics(log_name => "console-end");
     record_info('Logging', 'Finalizing logging for EC2 instance');
-    $self->_download_ec2_cloudwatch_logs($instance);
+}
+
+# Install & start the EC2 CloudWatch agent. Called from run_ltp's run(),
+# after check_cloudinit has already waited for cloud-init to finish, so it
+# can't race it for the zypper lock (poo#205539).
+sub setup_cloudwatch_agent {
+    my ($self, $instance) = @_;
+    my $err = $self->_install_ec2_cloudwatch_agent($instance);
+    if ($err) {
+        record_soft_failure("poo#205539 - CloudWatch agent setup failed: $err");
+    }
+}
+
+# Stop the CloudWatch agent, download the EC2 CloudWatch logs, then delete
+# the log streams. Counterpart of setup_cloudwatch_agent, called from
+# run_ltp's cleanup().
+sub teardown_cloudwatch_agent {
+    my ($self, $instance) = @_;
+    $self->_disable_and_stop_ec2_cloudwatch_agent($instance);
+    my $entries = $self->_download_ec2_cloudwatch_logs($instance);
+    $self->_delete_ec2_cloudwatch_logs($instance, $entries);
 }
 1;

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -606,11 +606,15 @@ sub setup_cloudwatch_agent {
 
 # Stop the CloudWatch agent, download the EC2 CloudWatch logs, then delete
 # the log streams. Counterpart of setup_cloudwatch_agent, called from
-# run_ltp's cleanup().
+# run_ltp's cleanup(). Never dies, so a CloudWatch hiccup can't skip the
+# rest of cleanup (log_instance.sh stop, instance log upload, etc.).
 sub teardown_cloudwatch_agent {
     my ($self, $instance) = @_;
-    $self->_disable_and_stop_ec2_cloudwatch_agent($instance);
-    my $entries = $self->_download_ec2_cloudwatch_logs($instance);
-    $self->_delete_ec2_cloudwatch_logs($instance, $entries);
+    eval {
+        $self->_disable_and_stop_ec2_cloudwatch_agent($instance);
+        my $entries = $self->_download_ec2_cloudwatch_logs($instance);
+        $self->_delete_ec2_cloudwatch_logs($instance, $entries);
+        1;
+    } or record_soft_failure("poo#205539 - CloudWatch agent teardown failed: $@");
 }
 1;

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -615,6 +615,6 @@ sub teardown_cloudwatch_agent {
         my $entries = $self->_download_ec2_cloudwatch_logs($instance);
         $self->_delete_ec2_cloudwatch_logs($instance, $entries);
         1;
-    } or record_soft_failure("poo#205539 - CloudWatch agent teardown failed: $@");
+    } or record_info("cleanup error", CloudWatch agent teardown failed: $@", result=>'fail');
 }
 1;

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -615,6 +615,6 @@ sub teardown_cloudwatch_agent {
         my $entries = $self->_download_ec2_cloudwatch_logs($instance);
         $self->_delete_ec2_cloudwatch_logs($instance, $entries);
         1;
-    } or record_info("cleanup error", CloudWatch agent teardown failed: $@", result=>'fail');
+    } or record_info('cleanup error', "poo#205539 - CloudWatch agent teardown failed: $@", result => 'fail');
 }
 1;

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -343,6 +343,14 @@ sub cleanup {
         die('cleanup: Either $self->{run_args} or $self->{run_args}->{my_instance} is not available. Maybe the test died before the instance has been created?');
     }
 
+    # EC2-only: download & clean up the CloudWatch logs collected by
+    # setup_cloudwatch_agent(). Runs here so it still collects post-mortem
+    # dmesg logs, and never blocks the rest of cleanup, even if run() died.
+    if (is_ec2()) {
+        select_host_console(force => 1);
+        $self->{run_args}->{my_provider}->teardown_cloudwatch_agent($self->{run_args}->{my_instance});
+    }
+
     if (script_run("test -f $root_dir/log_instance.sh") == 0) {
         my $log_instance_stop_command = $root_dir . '/log_instance.sh stop ' . instance_log_args($self->{run_args}->{my_provider}, $self->{run_args}->{my_instance});
         script_run($log_instance_stop_command, timeout => 600);
@@ -367,6 +375,11 @@ sub run {
 
     my $instance = $args->{my_instance};
     my $provider = $args->{my_provider};
+
+    # EC2-only: install & start the CloudWatch agent for centralized dmesg
+    # logging, after check_cloudinit so it can't race cloud-init for the
+    # zypper lock (poo#205539).
+    $provider->setup_cloudwatch_agent($instance) if is_ec2();
 
     prepare_scripts();
 


### PR DESCRIPTION
Splits the EC2 CloudWatch agent install/download out of the generic `initialize_logging`/`finalize_logging` hooks (which ran for every EC2 publiccloud test) into new `publiccloud/cloudwatch_setup` and `publiccloud/cloudwatch_teardown` test modules, scheduled after `publiccloud/check_cloudinit` and only for LTP runs.

This removes the race between the CloudWatch agent's zypper install and cloud-init's own package operations: by the time `cloudwatch_setup` runs, `check_cloudinit` has already waited for cloud-init to finish, so the two can no longer contend for the zypper lock. It also restores the pre-#25535 scope where CloudWatch logging was LTP-only, rather than running (and occasionally softfailing) on every EC2 test.

* Related ticket: [poo#205539](https://progress.opensuse.org/issues/205539)
* Related failure: [openqa.suse.de/t23654027](https://openqa.suse.de/tests/23654027)
* Related merge requests: #26231, #26402
* Verification runs: In comment below