### PR TITLE
agnosticTestRunner: move to generic lib/ namespace

### DIFF
--- a/lib/agnosticTestRunner.pm
+++ b/lib/agnosticTestRunner.pm
@@ -1,0 +1,104 @@
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Summary: Generic helper for openQA-agnostic tests
+#
+# Runs standalone test artifacts (Go/Python/Java) both inside openQA
+# and on a bare SUT. The 'domain' constructor arg controls which data/
+# subtree test files are fetched from (e.g. 'security', 'console').
+#
+# Maintainer: QE Core <qe-core@suse.de>
+
+package agnosticTestRunner;
+
+use strict;
+use warnings;
+use testapi qw(assert_script_run data_url parse_extra_log script_output enter_cmd);
+use registration 'add_suseconnect_product', 'get_addon_fullname';
+use utils 'zypper_call';
+use version_utils 'is_sle';
+
+sub new {
+    my ($class, $args) = @_;
+
+    die "Constructor requires a hashref" unless ref($args) eq 'HASH';
+    die "Attribute 'name' is mandatory" unless defined $args->{name};
+    die "Attribute 'language' is mandatory" unless defined $args->{language};
+    die "Unsupported language '$args->{language}'. Supported: go, python, java"
+      unless $args->{language} =~ /^(go|python|java)$/;
+
+    $args->{domain} //= 'security';
+    $args->{test_dir} //= '~/' . $args->{name};
+    $args->{result_format} //= $args->{language} eq 'java' ? 'TAP' : 'XUnit';
+    $args->{result_file} //= '/tmp/' . lc($args->{name}) . ($args->{language} eq 'java' ? '_results.tap' : '_results.xml');
+    $args->{data_url_path} //= $args->{domain} . '/openqa_agnostic/' . $args->{language} . '/' . $args->{name};
+    $args->{helper_path} //= $args->{domain} . '/openqa_agnostic/lib/helper.sh';
+    $args->{run_command} //= 'runtest';
+    $args->{skip_phub} //= 0;
+    return bless $args, $class;
+}
+
+sub latest_java_devel {
+    my $out = script_output(
+        q{zypper --terse -n se  'java-*-openjdk-devel'},
+        proceed_on_failure => 1);
+    my @majors = sort { $a <=> $b } ($out =~ /\bjava-(\d+)-openjdk-devel\b/g);
+    die 'No java-*-openjdk-devel package available in configured repos' unless @majors;
+    return "java-$majors[-1]-openjdk-devel";
+}
+
+sub setup {
+    my ($self) = @_;
+    my $url = data_url($self->{data_url_path});
+
+    add_suseconnect_product(get_addon_fullname('phub')) if !$self->{skip_phub} && is_sle('<16.0');
+
+    my %lang_deps = (go => 'go gotestsum', python => 'python3-pytest');
+    my $packages = $self->{language} eq 'java' ? latest_java_devel() : $lang_deps{$self->{language}};
+    zypper_call "in $packages";
+
+    # Create test_dir and sibling lib/ for shared helpers in one shot
+    my $test_dir = $self->{test_dir};
+    assert_script_run "mkdir -p $test_dir/../lib";
+    my $helper_url = data_url($self->{helper_path});
+    assert_script_run "curl -s -o $test_dir/../lib/helper.sh $helper_url";
+
+    # Download and discover test files via runtest -f
+    my $run_script = $self->{run_command};
+    assert_script_run "curl -s -o $test_dir/$run_script $url/$run_script";
+    assert_script_run "chmod +x $test_dir/$run_script";
+
+    my $file_list_output = script_output("cd $test_dir && ./$run_script -f");
+    $file_list_output =~ s/^\s+|\s+$//g;
+    if ($file_list_output) {
+        my @files = split(/\s+/, $file_list_output);
+        assert_script_run "cd $test_dir && curl -s " . join(' ', map { "-O $url/$_" } @files) if @files;
+    }
+
+    return $self;
+}
+
+sub run_test {
+    my ($self) = @_;
+    my $run_script = $self->{run_command};
+    $run_script = "./$run_script" unless $run_script =~ m{^/|^\./};
+    my $result_src = $self->{result_format} eq 'TAP' ? 'results.tap' : 'results.xml';
+    my $command = 'cd ' . $self->{test_dir} . ' && chmod +x ' . $run_script . ' && ' . $run_script . ' && mv ' . $result_src . ' ' . $self->{result_file};
+    assert_script_run($command);
+    enter_cmd('reset');
+    return $self;
+}
+
+sub parse_results {
+    my ($self) = @_;
+    parse_extra_log($self->{result_format}, $self->{result_file});
+    return $self;
+}
+
+sub cleanup {
+    my ($self) = @_;
+    assert_script_run 'cd ~ && rm -rf ' . $self->{test_dir};
+    return $self;
+}
+
+1;

--- a/lib/security/agnosticTestRunner.pm
+++ b/lib/security/agnosticTestRunner.pm
@@ -1,7 +1,10 @@
 #
 # Copyright SUSE LLC
 # SPDX-License-Identifier: FSFAP
-# Summary: helper module for openQA-agnostic security tests
+# Summary: Backward-compatible wrapper for security agnostic tests
+#
+# Delegates to lib/agnosticTestRunner.pm with domain => 'security'.
+# New code should use agnosticTestRunner directly.
 #
 # Maintainer: QE Security <none@suse.de>
 
@@ -9,94 +12,12 @@ package security::agnosticTestRunner;
 
 use strict;
 use warnings;
-use testapi qw(assert_script_run data_url parse_extra_log script_output enter_cmd);
-use registration 'add_suseconnect_product', 'get_addon_fullname';
-use utils 'zypper_call';
-use version_utils 'is_sle';
+use agnosticTestRunner;
 
 sub new {
     my ($class, $args) = @_;
-
-    die "Constructor requires a hashref" unless ref($args) eq 'HASH';
-    die "Attribute 'name' is mandatory" unless defined $args->{name};
-    die "Attribute 'language' is mandatory" unless defined $args->{language};
-    die "Unsupported language '$args->{language}'. Supported: go, python, java"
-      unless $args->{language} =~ /^(go|python|java)$/;
-
-    $args->{test_dir} //= '~/' . $args->{name};
-    $args->{result_format} //= $args->{language} eq 'java' ? 'TAP' : 'XUnit';
-    $args->{result_file} //= '/tmp/' . lc($args->{name}) . ($args->{language} eq 'java' ? '_results.tap' : '_results.xml');
-    $args->{data_url_path} //= 'security/openqa_agnostic/' . $args->{language} . '/' . $args->{name};
-    $args->{run_command} //= 'runtest';
-    return bless $args, $class;
-}
-
-sub latest_java_devel {
-    my $out = script_output(
-        q{zypper --terse -n se  'java-*-openjdk-devel'},
-        proceed_on_failure => 1);
-    my @majors = sort { $a <=> $b } ($out =~ /\bjava-(\d+)-openjdk-devel\b/g);
-    die 'No java-*-openjdk-devel package available in configured repos' unless @majors;
-    return "java-$majors[-1]-openjdk-devel";
-}
-
-sub setup {
-    my ($self) = @_;
-    my $url = data_url($self->{data_url_path});
-
-    add_suseconnect_product(get_addon_fullname('phub')) if is_sle('<16.0');
-
-    my %lang_deps = (go => 'go gotestsum', python => 'python3-pytest');
-    my $packages = $self->{language} eq 'java' ? latest_java_devel() : $lang_deps{$self->{language}};
-    zypper_call "in $packages";
-
-    # Create test_dir and sibling lib/ for shared helpers in one shot
-    my $test_dir = $self->{test_dir};
-    assert_script_run "mkdir -p $test_dir/../lib";
-    my $helper_url = data_url('security/openqa_agnostic/lib/helper.sh');
-    assert_script_run "curl -s -o $test_dir/../lib/helper.sh $helper_url";
-
-    # Download and discover test files via runtest -f
-    my $run_script = $self->{run_command};
-    assert_script_run "curl -s -o $test_dir/$run_script $url/$run_script";
-    assert_script_run "chmod +x $test_dir/$run_script";
-
-    my $file_list_output = script_output("cd $test_dir && ./$run_script -f");
-    $file_list_output =~ s/^\s+|\s+$//g;
-    if ($file_list_output) {
-        my @files = split(/\s+/, $file_list_output);
-        assert_script_run "cd $test_dir && curl -s " . join(' ', map { "-O $url/$_" } @files) if @files;
-    }
-
-    return $self;
-}
-
-sub run_test {
-    my ($self) = @_;
-    my $run_script = $self->{run_command};
-    # Ensure run_command is treated as a path inside test_dir
-    $run_script = "./$run_script" unless $run_script =~ m{^/|^\./};
-    my $result_src = $self->{result_format} eq 'TAP' ? 'results.tap' : 'results.xml';
-    my $command = 'cd ' . $self->{test_dir} . ' && chmod +x ' . $run_script . ' && ' . $run_script . ' && mv ' . $result_src . ' ' . $self->{result_file};
-    assert_script_run($command);
-    # Prevent previous command from breaking the terminal, leaving it unusable for further testing
-    enter_cmd('reset');
-    return $self;
-}
-
-sub parse_results {
-    my ($self) = @_;
-    parse_extra_log($self->{result_format}, $self->{result_file});
-    return $self;
-}
-
-sub cleanup {
-    my ($self) = @_;
-    # Return to home before removing test_dir, otherwise the shell's
-    # cwd points to a deleted directory and subsequent commands fail
-    # with "getcwd: cannot access parent directories".
-    assert_script_run 'cd ~ && rm -rf ' . $self->{test_dir};
-    return $self;
+    $args->{domain} //= 'security';
+    return agnosticTestRunner->new($args);
 }
 
 1;

--- a/tests/security/oqa_agnostic/apachessl_pqc.pm
+++ b/tests/security/oqa_agnostic/apachessl_pqc.pm
@@ -9,7 +9,7 @@
 use Mojo::Base 'opensusebasetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use security::agnosticTestRunner;
+use agnosticTestRunner;
 use version_utils 'is_sle';
 use utils 'zypper_call';
 use Utils::Architectures 'is_s390x';
@@ -48,9 +48,10 @@ sub run {
     assert_script_run "curl -s -o $test_dir/pqc-ssl.conf $data_url/pqc-ssl.conf";
 
     # run test
-    my $test = security::agnosticTestRunner->new({
+    my $test = agnosticTestRunner->new({
             language => 'python',
             name => 'testApacheSSLPQC',
+            domain => 'security',
             files => 'runtest apache_pqc_ssl_test.py'
         }
     );

--- a/tests/security/oqa_agnostic/fips_java_crypto.pm
+++ b/tests/security/oqa_agnostic/fips_java_crypto.pm
@@ -9,12 +9,12 @@
 use Mojo::Base 'opensusebasetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use security::agnosticTestRunner;
+use agnosticTestRunner;
 
 sub run {
     select_serial_terminal;
     for my $name (qw(java_hashing java_elliptic)) {
-        security::agnosticTestRunner->new({language => 'java', name => $name})
+        agnosticTestRunner->new({language => 'java', name => $name, domain => 'security'})
           ->setup()->run_test()->parse_results()->cleanup();
     }
 }

--- a/tests/security/oqa_agnostic/openssl_pqc.pm
+++ b/tests/security/oqa_agnostic/openssl_pqc.pm
@@ -9,7 +9,7 @@
 use Mojo::Base 'opensusebasetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use security::agnosticTestRunner;
+use agnosticTestRunner;
 use version_utils 'is_sle';
 use package_utils 'install_package';
 
@@ -21,9 +21,10 @@ sub run {
     }
     install_package("openssl", trup_continue => 1);
     record_info('openssl version:', script_output('rpm -q openssl'));
-    my $test = security::agnosticTestRunner->new({
+    my $test = agnosticTestRunner->new({
             language => 'python',
             name => 'testPostQuantumCrypto',
+            domain => 'security',
         }
     );
     if (is_sle('=15-SP7')) {

--- a/tests/security/oqa_agnostic/oqs_provider_openssl.pm
+++ b/tests/security/oqa_agnostic/oqs_provider_openssl.pm
@@ -12,7 +12,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils 'zypper_call';
 use version_utils 'package_version_cmp';
-use security::agnosticTestRunner;
+use agnosticTestRunner;
 
 # Older providers predate the algorithm names and the '-provider oqs' CLI handling
 # the test relies on, so there is nothing meaningful to assert against them.
@@ -36,9 +36,10 @@ sub run {
     }
     record_info('oqs-provider', "version $oqs_version");
 
-    my $test = security::agnosticTestRunner->new({
+    my $test = agnosticTestRunner->new({
             language => 'python',
             name => 'testOqsProvider',
+            domain => 'security',
         }
     );
     $test->setup()->run_test()->parse_results()->cleanup();

--- a/tests/security/oqa_agnostic/polkit_rules.pm
+++ b/tests/security/oqa_agnostic/polkit_rules.pm
@@ -9,13 +9,14 @@
 use Mojo::Base 'opensusebasetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use security::agnosticTestRunner;
+use agnosticTestRunner;
 
 sub run {
     select_serial_terminal;
-    my $test = security::agnosticTestRunner->new({
+    my $test = agnosticTestRunner->new({
             language => 'go',
             name => 'testPolkit',
+            domain => 'security',
         }
     );
 

--- a/tests/security/oqa_agnostic/yama.pm
+++ b/tests/security/oqa_agnostic/yama.pm
@@ -9,7 +9,7 @@
 use Mojo::Base 'opensusebasetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
-use security::agnosticTestRunner;
+use agnosticTestRunner;
 use package_utils 'install_package';
 use power_action_utils 'power_action';
 
@@ -33,9 +33,10 @@ sub run {
     power_action('reboot', textmode => 1);
     $self->wait_boot;
     select_serial_terminal;
-    my $test = security::agnosticTestRunner->new({
+    my $test = agnosticTestRunner->new({
             language => 'python',
             name => 'yama',
+            domain => 'security',
         }
     );
 


### PR DESCRIPTION
Move the openQA-agnostic test runner from `lib/security/` to
`lib/` so other test domains (console, kernel, etc.) can use it
without depending on the security namespace.

**What changed:**
- `lib/agnosticTestRunner.pm`: generic runner with a `domain` arg
  that controls which `data/` subtree test files are fetched from.
  Also adds `helper_path` and `skip_phub` options.
- `lib/security/agnosticTestRunner.pm`: reduced to a thin wrapper
  that delegates to the generic runner with `domain => security`.
  Kept for backward compatibility.
- All 5 security test wrappers updated to `use agnosticTestRunner`
  directly with `domain => security`.

**What did NOT change:**
- Test data files under `data/security/openqa_agnostic/` are untouched.
- Schedule YAML files are untouched.
- `helper.sh` stays where it is.
- `go_post_quantum.pm` does not use the runner and is not affected.

Verification jobs (all against this branch):

o3:
- security_misc_o3 (polkit_rules): https://openqa.opensuse.org/tests/6189468
- apachessl_pqc: https://openqa.opensuse.org/tests/6189471

osd:
- yama: https://openqa.suse.de/tests/24123503
- fips_env_mode_textmode_extra (go_post_quantum): https://openqa.suse.de/tests/24123511
- fips_ker_mode_java (fips_java_crypto): https://openqa.suse.de/tests/24123525

poo#205869