### PR TITLE
coverage: add ftrace execve tracing modules

### DIFF
--- a/schedule/coverage/tw_execve_trace.yaml
+++ b/schedule/coverage/tw_execve_trace.yaml
@@ -1,0 +1,27 @@
+name: execve trace - binary execution discovery
+description: >
+    Discovers which binaries a test schedule executes using
+    the kernel ftrace sched_process_exec tracepoint.
+    Place execve_trace_start early and execve_trace_report
+    at the end. Add test modules between them as needed.
+    Maintainer: balogh
+schedule:
+    - autoyast/prepare_profile
+    - installation/isosize
+    - installation/bootloader_uefi
+    - autoyast/installation
+    - autoyast/console
+    - autoyast/login
+    - autoyast/autoyast_reboot
+    - installation/grub_test
+    - installation/first_boot
+    - console/system_prepare
+    - coverage/execve_trace_start
+    - coverage/execve_trace_report
+test_data:
+    helper_packages:
+        - gzip
+        - iputils
+        - systemd
+        - wget
+    coverage_targets: {}

--- a/tests/coverage/execve_trace_report.pm
+++ b/tests/coverage/execve_trace_report.pm
@@ -1,0 +1,55 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Collect ftrace sched_process_exec data and upload a binary
+#          execution inventory.  Produces two files:
+#          - execve_inventory.txt: all executed paths with call counts
+#          - execve_elf_binaries.txt: only ELF binaries (scripts filtered out)
+#          Pair with coverage/execve_trace_start at the beginning of
+#          the schedule.
+# Maintainer: QE Core <qe-core@suse.de>
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+
+sub run {
+    select_serial_terminal;
+
+    # Stop tracing
+    assert_script_run('echo 0 > /sys/kernel/tracing/tracing_on', timeout => 10);
+
+    # Check for ring buffer overruns
+    my $overrun = script_output('cat /sys/kernel/tracing/stats/overrun 2>/dev/null || echo 0', timeout => 10);
+    record_info('Overrun', "Ring buffer overruns: $overrun") if $overrun && $overrun ne '0';
+
+    # Extract filenames from sched_process_exec events
+    assert_script_run(
+        q{grep -oP 'filename=\K\S+' /sys/kernel/tracing/trace | sort | uniq -c | sort -rn > /tmp/execve_inventory.txt},
+        timeout => 600
+    );
+
+    my $count = script_output('wc -l < /tmp/execve_inventory.txt', timeout => 30);
+    record_info('Inventory', "$count unique binaries executed");
+
+    my $top = script_output('head -50 /tmp/execve_inventory.txt', timeout => 30);
+    record_info('Top 50', $top);
+
+    # Filter to ELF binaries only (batch xargs + file for speed)
+    assert_script_run(
+        q{awk '{print $2}' /tmp/execve_inventory.txt | xargs -r file -L 2>/dev/null | grep ELF | cut -d: -f1 > /tmp/execve_elf_binaries.txt},
+        timeout => 600
+    );
+
+    my $elf_count = script_output('wc -l < /tmp/execve_elf_binaries.txt', timeout => 30);
+    record_info('ELF binaries', "$elf_count unique ELF binaries executed");
+
+    upload_logs('/tmp/execve_inventory.txt');
+    upload_logs('/tmp/execve_elf_binaries.txt');
+}
+
+sub test_flags {
+    return {fatal => 0};
+}
+
+1;

--- a/tests/coverage/execve_trace_start.pm
+++ b/tests/coverage/execve_trace_start.pm
@@ -1,0 +1,31 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Enable ftrace sched_process_exec tracing to capture all
+#          binary executions during a test run. Place this module at
+#          the beginning of a schedule (after system_prepare) and pair
+#          it with coverage/execve_trace_report at the end.
+# Maintainer: QE Core <qe-core@suse.de>
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+
+sub run {
+    select_serial_terminal;
+
+    assert_script_run('mount -t tracefs tracefs /sys/kernel/tracing 2>/dev/null; true');
+    assert_script_run('echo 0 > /sys/kernel/tracing/tracing_on');
+    # 16 MB per-CPU ring buffer; enough for a full-length schedule
+    assert_script_run('echo 16384 > /sys/kernel/tracing/buffer_size_kb');
+    assert_script_run('echo > /sys/kernel/tracing/trace');
+    assert_script_run('echo 1 > /sys/kernel/tracing/events/sched/sched_process_exec/enable');
+    assert_script_run('echo 1 > /sys/kernel/tracing/tracing_on');
+    record_info('Tracing', 'ftrace sched_process_exec enabled');
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Add two test modules for discovering which binaries a test schedule executes, using the kernel ftrace sched_process_exec tracepoint.

- `execve_trace_start.pm`: enables ftrace tracing with a 16 MB per-CPU ring buffer
- `execve_trace_report.pm`: extracts executed binary paths, filters to ELF only, uploads inventory

Near-zero runtime overhead. Place start after system_prepare, report at the end of any schedule. Uploads `execve_inventory.txt` (all paths with counts) and `execve_elf_binaries.txt` (ELF only).

Used this to discover 33 binary targets our tests exercise but were not measured by funkoverage coverage. Details: https://bzoltan1.github.io/binary-function-coverage-part-2-scaling-up-fixing-daemons-and-asking-the-kernel/