### PR TITLE
console/rsync: add test_flags for coverage compatibility

### DIFF
--- a/tests/console/rsync.pm
+++ b/tests/console/rsync.pm
@@ -70,4 +70,8 @@ sub post_run_hook {
     }
 }
 
+sub test_flags {
+    return {fatal => 0, no_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
Add fatal => 0 and no_rollback => 1. The module cleans up after itself and does not require snapshot rollback.