### PR TITLE
console/lsof: add test_flags for coverage compatibility

### DIFF
--- a/tests/console/lsof.pm
+++ b/tests/console/lsof.pm
@@ -77,4 +77,8 @@ sub run {
 
 }
 
+sub test_flags {
+    return {fatal => 0, no_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
Add fatal => 0 and no_rollback => 1. The module cleans up after itself and does not require snapshot rollback.