### PR TITLE
console/libaom: add test_flags for coverage compatibility

### DIFF
--- a/tests/console/libaom.pm
+++ b/tests/console/libaom.pm
@@ -50,4 +50,8 @@ sub run {
     assert_script_run('ffmpeg -c:v libaom-av1 -i input.mp4 -f rawvideo input_yuv', timeout => 50);
 }
 
+sub test_flags {
+    return {fatal => 0, no_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
Add fatal => 0 and no_rollback => 1. The module cleans up after itself and does not require snapshot rollback.