### PR TITLE
console/cryptsetup: add test_flags for coverage compatibility

### DIFF
--- a/tests/console/cryptsetup.pm
+++ b/tests/console/cryptsetup.pm
@@ -58,4 +58,8 @@ sub run {
     assert_script_run('rm -rf /test.dm');
 }
 
+sub test_flags {
+    return {fatal => 0, no_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
Add fatal => 0 and no_rollback => 1. The module cleans up after itself and does not require snapshot rollback.