### PR TITLE
yast2_cmd/yast_lang: add test_flags for coverage compatibility

### DIFF
--- a/tests/yast2_cmd/yast_lang.pm
+++ b/tests/yast2_cmd/yast_lang.pm
@@ -22,4 +22,8 @@ sub run {
     assert_script_run('yast language set lang=en_US', timeout => 300);
 }
 
+sub test_flags {
+    return {fatal => 0, no_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
Add fatal => 0 and no_rollback => 1. The module restores settings after the test and does not require snapshot rollback.