### PR TITLE
yast2_cmd/yast_timezone: add test_flags for coverage compatibility

### DIFF
--- a/tests/yast2_cmd/yast_timezone.pm
+++ b/tests/yast2_cmd/yast_timezone.pm
@@ -28,4 +28,8 @@ sub run {
     validate_script_output 'yast timezone summary 2>&1', sub { m#Africa/Cairo# };
     assert_script_run("yast timezone set timezone=$timezone", timeout => 300);
 }
+sub test_flags {
+    return {fatal => 0, no_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
Add fatal => 0 and no_rollback => 1. The module restores settings after the test and does not require snapshot rollback.