### PR TITLE
coverage_setup: add notify_override for shimmed Type=notify daemons

### DIFF
--- a/tests/coverage/coverage_setup.pm
+++ b/tests/coverage/coverage_setup.pm
@@ -148,13 +148,17 @@ sub run {
     }
     record_info('shim summary', "$failures of " . scalar(@bin_chunks) . " batches had failures") if $failures;
 
-    if (grep { /\/postgres$/ } @all_binaries) {
-        if (raise_postgres_start_timeout()) {
-            record_info('postgres timeout', 'Raised postgresql.service TimeoutStartSec to 150s to cover coverage instrumentation overhead (issue #152)');
-        }
-        else {
-            record_info('postgres timeout', 'Failed to raise postgresql.service TimeoutStartSec', result => 'softfail');
-        }
+    # For shimmed daemons with Type=notify, the shim sits between systemd
+    # and the real binary, so sd_notify never reaches systemd and service
+    # start times out. Create a drop-in override to use Type=simple.
+    # See https://github.com/ilmanzo/BinaryCoverage/issues/143
+    for my $svc (@{$test_data->{notify_override} // []}) {
+        assert_script_run "mkdir -p /etc/systemd/system/${svc}.d";
+        assert_script_run "printf '[Service]\\nType=simple\\nNotifyAccess=none\\nExecStartPost=/bin/sleep 10\\n' > /etc/systemd/system/${svc}.d/coverage.conf";
+    }
+    if (@{$test_data->{notify_override} // []}) {
+        assert_script_run 'systemctl daemon-reload';
+        record_info('notify override', join(', ', @{$test_data->{notify_override}}));
     }
 }
 


### PR DESCRIPTION
When funkoverage shims a Type=notify daemon, sd_notify from the child never reaches systemd and the service start times out. Add support for a notify_override list in test_data that creates systemd drop-in overrides (Type=simple) for listed services.

See https://github.com/ilmanzo/BinaryCoverage/issues/143