### PR TITLE
console/tcpdump: add test_flags for coverage compatibility

### DIFF
--- a/tests/console/tcpdump.pm
+++ b/tests/console/tcpdump.pm
@@ -35,4 +35,8 @@ sub run {
     record_info("TEST LOG", script_output("cat $tcpdump_log_file"));
     validate_script_output("cat $tcpdump_log_file", sub { m/0 packets dropped by kernel/ });
 }
+sub test_flags {
+    return {fatal => 0, no_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
Add fatal => 0 and no_rollback => 1. The module captures on loopback, writes to /tmp, and kills its own process. No system state changes.