### PR TITLE
fix(publiccloud): retry ssh-keyscan when it records no host key

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -425,14 +425,21 @@ sub scan_ssh_host_key {
       ? "/home/$testapi::username/.ssh/known_hosts"
       : "";
 
-    script_retry("ssh-keyscan $self->{public_ip} | tee -a ~/.ssh/known_hosts $user_known_hosts", retry => 6, delay => 10);
+    # ssh-keyscan exits 0 even when it retrieves nothing, and 'tee' masks its status anyway, so
+    # a still-booting instance silently leaves known_hosts empty. 'grep -q .' makes the pipeline
+    # fail so script_retry retries it. '-T 20' raises ssh-keyscan's 5s connect timeout, still
+    # well inside the 30s script_retry timeout.
+    script_retry("ssh-keyscan -T 20 $self->{public_ip} | tee -a ~/.ssh/known_hosts $user_known_hosts | grep -q .",
+        retry => 6, delay => 10, fail_message => "ssh-keyscan did not return a host key for $self->{public_ip} after retries");
 }
 
 sub wait_for_ssh {
     my ($self, %args) = @_;
     $self->wait_for_ssh_reachable(%args);
-    $self->scan_ssh_host_key(%args) if $args{scan_ssh_host_key};
+    # wait_for_ssh_login relaxes host key checking, so it can loop until sshd is really serving.
+    # Scanning only after it returns means ssh-keyscan talks to a ready sshd instead of racing it.
     $self->wait_for_ssh_login(%args);
+    $self->scan_ssh_host_key(%args) if $args{scan_ssh_host_key};
 }
 
 sub wait_for_ssh_reachable {
@@ -554,7 +561,8 @@ sub wait_for_sudo {
 
     ## ControlPath=none is required: the public cloud ssh config keeps a persistent ControlMaster and
     ## group membership is resolved at login, so a master opened before the sudoers group was added
-    ## would never see it
+    ## would never see it. That forces a fresh connection, which verifies the host key for real, so
+    ## scan_ssh_host_key must have recorded one by now.
     my $ssh_opts = $self->ssh_opts() . ' -o ControlPath=none';
     $self->ssh_script_retry('sudo -n true', ssh_opts => $ssh_opts, retry => $retry, delay => $delay, fail_message => "sudo still requires a password after $timeout seconds");
 }


### PR DESCRIPTION
### Problem

GCE smoketests fail in `prepare_instance` roughly 30% of the time with "sudo still requires a password after 180 seconds". Sudo is not the problem. In https://openqa.suse.de/tests/24075919#step/prepare_instance/83 ssh exits 255 eighteen times, and `ssh_sut.txt` gives the real reason: `Host key verification failed.`

### Root cause

An open port 22 is not a working sshd. `wait_for_ssh` probed the port with `nc`, then ran `ssh-keyscan`, and only then waited for a usable login, so on a slow instance the scan raced sshd's startup and came back empty. `ssh-keyscan` exits 0 even when it retrieves nothing, and `tee` masks its status anyway, so `script_retry` saw success while known_hosts stayed empty.

`wait_for_sudo` is the first thing to trip over that. It forces `ControlPath=none` on purpose, since group membership is resolved at login, so it opens a fresh connection that has to verify the host key against the empty file. `wait_for_ssh_login` survives the same conditions seconds earlier only because it passes `strictHostKeyChecking=no` and `UserKnownHostsFile=/dev/null`. The multiplexed master it leaves behind is also why post-failure log collection still works while sudo does not.

### Fix

Scan after `wait_for_ssh_login` rather than before it. That call relaxes host key checking, so it can afford to loop until sshd really answers, and nothing between the two steps needs known_hosts. Credit to @pdostal for spotting this.

Keep a guard for a scan that comes back empty for some other reason: `grep -q .` makes the pipeline fail so `script_retry` retries it, and `-T 20` raises ssh-keyscan's 5s connect timeout, still well inside the 30s `script_retry` timeout.

Host keys keep being verified everywhere they were before. An earlier revision of this PR also relaxed the check in `wait_for_sudo`; that is dropped.

Not addressed here: the ticket blames `_prepare_ssh_cmd`'s `$args{ssh_opts} //= $self->ssh_opts()`. That is a real trap for callers passing flat ssh_opts, but it does not break this job, because `has ssh_opts => ''` leaves the base empty and nothing gets overridden. Worth a separate fix.

### Testing

`make tidy-check`, `make test-compile-changed`, `prove t/44_publiccloud_instance.t` (22/22).

### Verification runs

Clones of OSD jobs with CASEDIR pointed at this branch. Links go to the `sudo -n true` step, which now runs immediately after the keyscan.

QE-C, GCE 16.1, cloned from the failing job 24129135:

- https://openqa.suse.de/tests/24130890#step/prepare_instance/65
- https://openqa.suse.de/tests/24130891#step/prepare_instance/64
- https://openqa.suse.de/tests/24130892#step/prepare_instance/64
- https://openqa.suse.de/tests/24130893#step/prepare_instance/64

QE-C, Azure-BYOS 16.1:

- https://openqa.suse.de/tests/24130899#step/prepare_instance/72
- https://openqa.suse.de/tests/24130900#step/prepare_instance/72

QE-C, EC2-BYOS 15-SP4, which also covers the second keyscan after a reboot:

- https://openqa.suse.de/tests/24130895#step/prepare_instance/56
- https://openqa.suse.de/tests/24130896#step/prepare_instance/56
- https://openqa.suse.de/tests/24130897#step/prepare_instance/55
- https://openqa.suse.de/tests/24130898#step/prepare_instance/55

QE-SAP, GCE-SAP-BYOS 16.1 `hanasr_native_fencing`, which reaches the change through `sles4sap::publiccloud::stop_hana` and runs the keyscan six times, still running at time of writing:

- https://openqa.suse.de/tests/24130894

`prepare_instance` passed in all ten finished runs. https://openqa.suse.de/tests/24130890#step/prepare_instance/64 shows the new order on an instance that needed five `nc` probes to come up, one of them refused. Ten clean runs against a ~30% failure rate is about 3% by chance, so evidence rather than proof.

No EC2 16.1 runs: those have failed 100% since 2026-08-27 at `wait_for_ssh_reachable`, upstream of this change and unrelated to it. The `check_services` softfail on GCE and Azure is pre-existing.

- Related ticket: https://progress.opensuse.org/issues/206214
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&build=KuxaBeast%2Fos-autoinst-distri-opensuse%23poo206214-ssh-host-key-fix
