### PR TITLE
feat(publiccloud): install kirk with uv instead of a pip virtualenv

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -61,6 +61,7 @@ our @EXPORT = qw(
   ssh_update_transactional_system
   create_script_file
   install_in_venv
+  install_uv
   venv_activate
   get_python_exec
   detect_worker_ip
@@ -563,6 +564,27 @@ sub create_script_file {
     save_tmp_file($filename, $content);
     assert_script_run(sprintf('curl -o "%s" "%s/files/%s"', $fullpath, autoinst_url, $filename));
     assert_script_run(sprintf('chmod +x %s', $fullpath));
+}
+
+=head2 install_uv
+
+install_uv()
+
+Installs the C<uv> Python package/project manager if it is not already present, using the
+pinned standalone installer from astral.sh (no rpm exists for SLE, see UV_VERSION default).
+The install directory is fixed to C</usr/local/bin> so C<uv>/C<uvx> land on the default PATH
+regardless of user or shell type.
+
+=cut
+
+sub install_uv {
+    return if script_run('command -v uv') == 0;
+
+    my $version = get_var('UV_VERSION', '0.12.7');
+    script_retry("curl -LsSf https://astral.sh/uv/$version/install.sh -o /tmp/uv-install.sh",
+        retry => 3, delay => 30, timeout => 120);
+    assert_script_run('env UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh /tmp/uv-install.sh', timeout => 300);
+    record_info('uv', script_output('uv --version'));
 }
 
 =head2 install_in_venv

--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -16,7 +16,7 @@ use utils;
 use version_utils qw(is_sle is_opensuse);
 use repo_tools 'generate_version';
 
-use publiccloud::utils qw(install_in_venv create_script_file get_python_exec);
+use publiccloud::utils qw(install_in_venv install_uv create_script_file get_python_exec);
 
 my $python_exec = get_python_exec();
 
@@ -100,6 +100,10 @@ EOT
     create_script_file('tofu', '/usr/local/bin/tofu', $opentofu_wrapper);
     validate_script_output("tofu version", qr/OpenTofu v?$opentofu_version/);
     record_info('OpenTofu', script_output('tofu version'));
+
+    # Bake uv into the image so kirk (tests/publiccloud/run_ltp.pm) does not
+    # have to install it at runtime on every job (poo#205596)
+    install_uv();
 
     # Ansible install with pip
     # Default version is chosen as low as possible so it run also on SLE12's

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -26,7 +26,6 @@ use Data::Dumper;
 use version_utils;
 use Utils::Architectures qw(is_aarch64);
 
-my $kirk_virtualenv = 'kirk-virtualenv';
 our $root_dir = '/root';
 our $ltp_timeout = get_var('LTP_TIMEOUT', 12600);
 
@@ -241,15 +240,24 @@ sub prepare_kirk {
     my $kirk_repo = get_var("LTP_RUN_NG_REPO", "https://github.com/linux-test-project/kirk.git");
     my $kirk_branch = get_var("LTP_RUN_NG_BRANCH", "master");
     record_info('LTP RUNNER REPO', "Repo: " . $kirk_repo . "\nBranch: " . $kirk_branch);
-    script_retry("git clone -q --single-branch -b $kirk_branch --depth 1 $kirk_repo", retry => 5, delay => 60, timeout => 300);
     $instance->ssh_assert_script_run(cmd => 'sudo CREATE_ENTRIES=1 ' . get_ltproot() . '/IDcheck.sh', timeout => 300);
     record_info('Kernel info', $instance->ssh_script_output(cmd => q(rpm -qa 'kernel*' --qf '%{NAME}\n' | sort | uniq | xargs rpm -qi)));
-    assert_script_run("cd kirk");
-    my $ghash = script_output("git rev-parse HEAD", proceed_on_failure => 1);
+
+    # uv is normally already baked into the PC Tools image (see
+    # tests/publiccloud/prepare_tools.pm), but install it here too so this
+    # module keeps working against older images (poo#205596).
+    install_uv();
+
+    # tail picks the peeled commit of an annotated tag, LTP_RUN_NG_BRANCH is often one
+    my $ghash = script_output("git ls-remote $kirk_repo $kirk_branch | cut -f1 | tail -n1", proceed_on_failure => 1);
+    $ghash = $kirk_branch unless $ghash =~ /^[0-9a-f]{40}$/;
     set_var("LTP_RUN_NG_GIT_HASH", $ghash);
     record_info("KIRK_GIT_HASH", "$ghash");
-    my $venv = install_in_venv($kirk_virtualenv, pip_packages => "asyncssh msgpack");
-    venv_activate($venv);
+
+    # Install kirk straight from git as a uv tool, matching its declared ssh/ltx
+    # extras (asyncssh, msgpack), instead of a pip virtualenv.
+    assert_script_run("env UV_TOOL_BIN_DIR=/usr/local/bin UV_PYTHON_DOWNLOADS=never uv tool install --python "
+          . get_python_exec() . " 'kirk[ssh,ltx] \@ git+$kirk_repo\@$ghash'", timeout => 600);
 }
 
 sub printk_loglevel {
@@ -279,8 +287,7 @@ sub prepare_ltp_cmd {
         $env_prefix = join(' ', @vars) . ' ';
     }
 
-    my $python_exec = get_python_exec();
-    my $cmd = "$env_prefix$python_exec kirk";
+    my $cmd = "${env_prefix}kirk";
     $cmd .= " --verbose";
     $cmd .= " --exec-timeout=$exec_timeout";
     $cmd .= " --suite-timeout=$ltp_timeout";

--- a/variables.md
+++ b/variables.md
@@ -161,7 +161,7 @@ LTP_KNOWN_ISSUES | string | | Used to specify a url for a json file with well kn
 LTP_MIN_UPTIME | integer | | Minimum uptime in seconds before LTP tests start. It applies only to the native openQA runner, not to tests run by kirk.
 LTP_REPO | string | | The repo which will be added and is used to install LTP package.
 LTP_RUN_NG_BRANCH | string | master | Define the branch of the LTP_RUN_NG_REPO.
-LTP_RUN_NG_REPO | string | https://github.com/linux-test-project/kirk.git | Define the runltp-ng repo to be used.
+LTP_RUN_NG_REPO | string | https://github.com/linux-test-project/kirk.git | Define the kirk repo to be used.
 LTP_PC_RUNLTP_ENV | string | empty | Contains eventual internal environment new parameters for `runltp-ng`, defined with the `--env` option, initialized in a column-separated string format: "PAR1=xxx:PAR2=yyy:...". By default it is empty, undefined.
 LTP_SUITE_TIMEOUT | integer | 9600 |Used to define --suite-timeout value passed to kirk
 LTP_TAINT_EXPECTED | integer | 0x80019801 | Bitmask of expected kernel taint flags.
@@ -264,6 +264,7 @@ ULP_THREAD_SLEEP | integer | 100 | Sleep length after each thread loop iteration
 UPGRADE | boolean | false | Indicates upgrade scenario.
 USBBOOT | boolean | false | Indicates booting to the usb device.
 USEIMAGES |||
+UV_VERSION | string | 0.12.7 | Pins the version of the `uv` Python package/project manager installed via the astral.sh standalone installer, used to run/install `kirk` (see `tests/publiccloud/run_ltp.pm` and `tests/publiccloud/prepare_tools.pm`).
 VALIDATE_ETC_HOSTS | boolean | false | Validate changes in /etc/hosts when using YaST network module. Is used in yast2_lan and yast2_lan_restart test modules which test module in ncurses and x11 respectively.
 VALIDATE_INST_SRC | boolean | false | Validate installation source in /etc/install.inf
 VALIDATE_CHECKSUM | boolean | false | Validate checksum of the mediums. Also see CHECKSUM_*.


### PR DESCRIPTION
### Problem

`tests/publiccloud/run_ltp.pm` installed kirk in three steps: a shallow git
clone, a pip virtualenv for `asyncssh` and `msgpack`, and a `cd` into the clone
so `python3.11 kirk` would find the checked-out script.

### Fix

`uv tool install` does all three in one command: same `LTP_RUN_NG_REPO`
revision, kirk's own `ssh` and `ltx` extras instead of a hand-maintained
package list, and a real `kirk` entry point on PATH.
`LTP_RUN_NG_GIT_HASH` still gets recorded, now from `git ls-remote`.

uv has no rpm for SLE 15-SP7, so `install_uv()` fetches the pinned astral.sh
installer into `/usr/local/bin`, version in a new `UV_VERSION` variable.
`prepare_tools.pm` bakes it into the PC Tools image; `run_ltp.pm` calls it too
and returns early when uv is present, so the module keeps working against
older images. No rebuilt image is needed for this to land.

Scope is kirk only — the `ec2uploadimg`, `az` and ansible pip installs and the
`install_in_venv` / `venv_*` helpers are untouched.

Once a uv rpm is available for every SLE variant we test on, `install_uv()` can
be swapped for a plain `zypper in uv` in a follow-up PR. It already returns
early when uv is present, so an rpm landing in the meantime costs nothing here.

### Verification runs

- Tools image build, publish targets renamed:
  https://openqa.suse.de/tests/24131675#step/prepare_tools/77
- Public cloud LTP on GCE 16.1, booting the production
  `publiccloud_tools_0113.qcow2` which has no uv, so it exercises the runtime
  install and the full kirk path:
  https://openqa.suse.de/tests/24131664#step/run_ltp/21

Not covered: aarch64, which uses the same x86_64 tools image.

This LTP scenario is not reliably green in production — of the twenty most
recent `PUBLIC_CLOUD_LTP=1` jobs, twelve passed, three softfailed, four failed
and one was cancelled. One clean run shows the new install path works, not
that nothing else can go wrong.

- Related ticket: https://progress.opensuse.org/issues/205596
