### PR TITLE
Upload logs from serial in case network issue

### DIFF
--- a/lib/Utils/Logging.pm
+++ b/lib/Utils/Logging.pm
@@ -22,8 +22,9 @@ use utils qw(clear_console show_oom_info remount_tmp_if_ro detect_bsc_1063638 do
 use Utils::Systemd 'get_started_systemd_services';
 use File::Basename 'basename';
 use Mojo::File 'path';
-use serial_terminal 'select_serial_terminal';
+use serial_terminal qw(select_serial_terminal upload_file);
 use version_utils qw(is_tumbleweed is_transactional);
+use network_utils;
 
 our @EXPORT = qw(
   save_and_upload_log
@@ -56,8 +57,16 @@ sub save_and_upload_log {
     my ($cmd, $file, $args) = @_;
     script_run("$cmd | tee $file", timeout => $args->{timeout});
     my $lname = $args->{logname} ? $args->{logname} : '';
-    upload_logs($file, failok => 1, log_name => $lname) unless $args->{noupload};
-    save_screenshot if $args->{screenshot};
+    if (can_upload_logs()) {
+        upload_logs($file, failok => 1, log_name => $lname) unless $args->{noupload};
+        save_screenshot if $args->{screenshot};
+    }
+    else {
+        select_serial_terminal;
+        my $file_name = $file =~ s|^/||r =~ tr|/|_|r;
+        upload_file($file, $file_name);
+    }
+
 }
 
 =head2 tar_and_upload_log
@@ -144,7 +153,13 @@ echo -e "\nALL Processes" >> $health_log_file
 ps axwwo user,pid,ppid,%cpu,%mem,vsz,rss,stat,time,cmd >> $health_log_file
 EOF
     script_run($_) foreach (split /\n/, $cmd);
-    upload_logs "/tmp/basic_health_check.txt";
+    if (can_upload_logs()) {
+        upload_logs "/tmp/basic_health_check.txt";
+    }
+    else {
+        select_serial_terminal;
+        upload_file("/tmp/basic_health_check.txt", "basic_health_check.txt");
+    }
 
 }
 


### PR DESCRIPTION
    https://progress.opensuse.org/issues/205986
    
    When openQA jobs fail, post_run_hook script will try to upload
    log files via log-console, however it will rely on network connection
    between SUT and worker.
    We can enhance the tests to upload logs as well via serial console
    in case upload files fails.

- Verification run: https://openqa.suse.de/tests/24133101#downloads