### PR TITLE
No repo enabled on Full medium on s390x after installation

### DIFF
--- a/schedule/yam/agama_full_registered_s390x.yaml
+++ b/schedule/yam/agama_full_registered_s390x.yaml
@@ -1,0 +1,10 @@
+---
+name: agama_full_registered_s390x
+description: >
+  Perform Agama unattended installation with offline medium and register the system before installation on s390x.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - boot/reconnect_mgmt_console
+  - installation/first_boot

--- a/schedule/yam/agama_full_s390x.yaml
+++ b/schedule/yam/agama_full_s390x.yaml
@@ -1,0 +1,18 @@
+---
+name: agama_full_s390x
+description: >
+  Perform interactive installation with agama on Full medium on s390x.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/patch_agama_tests
+  - yam/agama/agama
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - yam/validate/validate_selinux
+  - yam/validate/validate_base_product
+  - yam/validate/validate_product
+  - yam/validate/validate_connectivity
+  - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
+  - yam/validate/validate_snapshots
+  - yam/validate/validate_registered_products

--- a/schedule/yam/agama_remote_full_access_disabled_s390x.yaml
+++ b/schedule/yam/agama_remote_full_access_disabled_s390x.yaml
@@ -1,0 +1,20 @@
+---
+name: agama_remote_full_access_disabled_s390x
+description: >
+  Perform interactive installation with agama for remote access disabled on s390x.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/import_agama_profile
+  - yam/agama/patch_agama_tests
+  - yam/agama/validate_remote_access_disabled
+  - yam/agama/agama
+  - boot/reconnect_mgmt_console
+  - installation/first_boot
+  - yam/validate/validate_selinux
+  - yam/validate/validate_base_product
+  - yam/validate/validate_product
+  - yam/validate/validate_connectivity
+  - yam/validate/validate_first_user
+  - yam/validate/validate_hostname
+  - yam/validate/validate_snapshots
+  - yam/validate/validate_registered_products


### PR DESCRIPTION
For SLES 16.1, no repo enabled on Full medium on s390x after installation. Detail discussion refer to https://suse.slack.com/archives/C082VE1U2F5/p1787898909003189

- Related ticket: N/A
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/897
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/overview?version=16.1&distri=sle&build=lemon-suse%2Fos-autoinst-distri-opensuse%23no-full-repo-enabled
