### PR TITLE
Skip AITL verify_dri_node on SLE 16.1+ Azure

### DIFF
--- a/data/publiccloud/aitl/custom.json
+++ b/data/publiccloud/aitl/custom.json
@@ -6,6 +6,7 @@
             "selections": [
                 {
                     "caseName": [
+                        "verify_drm_driver",
                         "verify_connection_status",
                         "verify_no_error_output",
                         "verify_dri_node",

--- a/tests/publiccloud/azure_aitl.pm
+++ b/tests/publiccloud/azure_aitl.pm
@@ -19,6 +19,7 @@ use JSON;
 use XML::LibXML;
 use Data::Dumper;
 use publiccloud::utils qw(calculate_custodian_ttl);
+use version_utils 'is_sle';
 
 
 sub is_cleaned_up {
@@ -101,6 +102,14 @@ sub run {
         foreach my $aitl_test (@excluded_tests_list) {
             assert_script_run(qq(sed -i -e "/$aitl_test/d" /tmp/$aitl_manifest));
         }
+    }
+
+    # poo#204309: verify_dri_node fails chronically on SLE 16.1+ Azure VMs --
+    # SLE 16.1+ disables debugfs by default (PED-8812) and the upstream LISA
+    # fix (mounting it late) doesn't populate the DRM debugfs directory.
+    # Skip only on affected versions; other products keep testing it.
+    if (is_sle('>=16.1')) {
+        assert_script_run(qq(sed -i -e "/verify_dri_node/d" /tmp/$aitl_manifest));
     }
 
     # Create AITL Job based on a manifest


### PR DESCRIPTION
Adds `verify_drm_driver` to the AITL Azure case selection for an extra diagnostic signal.

Skips `verify_dri_node` on SLE 16.1+ only.

* Related ticket: [poo#204309](https://progress.opensuse.org/issues/204309)
* Related failure: [openqa.suse.de/t24118539](https://openqa.suse.de/tests/24118539)
* Verification runs: In comment below

## Commits

- 76b0f5ae8d test(publiccloud): Add verify_drm_driver to AITL Azure case selection
- 5172d7dfa9 test(publiccloud): Skip verify_dri_node on SLE 16.1+ Azure AITL runs
