### PR TITLE
Updated patch agama test to include tag name

### DIFF
--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -15,7 +15,7 @@ sub run {
     my $destination = "/usr/share/agama/system-tests";
     my $latest_commit_sha = script_output("curl -s 'https://api.github.com/repos/$repo/commits/$branch' | jq -r '.sha'");
     script_run("mkdir -p $destination");
-    assert_script_run("curl -sfL https://github.com/$repo/releases/download/$branch/$latest_commit_sha.tar.gz | tar -xz",
+    assert_script_run("curl -sfL https://github.com/$repo/releases/download/tag-$branch/$latest_commit_sha.tar.gz | tar -xz",
         fail_message => "Error: CI build artifact (tarball) for $repo/$branch is not available yet. The CI run may still be in progress.");
     script_run("cp dist/vendor.js dist/${agama_test}* $destination");
 }


### PR DESCRIPTION
We have updated the naming of tags from patch agama tests CI.
When we push and tag + branch are named the same git is not able to resolve where to push automatically, this solves the issue.

- Related ticket: https://progress.opensuse.org/issues/189948
- Related PR: https://github.com/qe-installation-and-migration/agama-integration-test-webpack/pull/299
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/24132705#
