### PR TITLE
containers/install_updates: confirm reboot via serial console, not GRUB needles

### DIFF
--- a/tests/containers/install_updates.pm
+++ b/tests/containers/install_updates.pm
@@ -51,7 +51,6 @@ sub run {
         # svirt) already have their own proven serial-based handling inside
         # wait_boot, so they keep using it.
         die 'System did not come back up after update reboot' unless wait_serial(get_login_message(), 300);
-        $self->{in_wait_boot} = 0;
         reset_consoles;
     } else {
         $self->wait_boot(bootloader_time => 300);

--- a/tests/containers/install_updates.pm
+++ b/tests/containers/install_updates.pm
@@ -11,6 +11,7 @@ use Mojo::Base 'consoletest';
 use testapi;
 use utils;
 use power_action_utils;
+use serial_terminal qw(get_login_message);
 use version_utils qw(check_os_release get_os_release is_sle);
 
 sub run {
@@ -39,7 +40,15 @@ sub run {
     # Perform system reboot to ensure the system is still ok
     my $prev_console = current_console();
     power_action('reboot', textmode => 1);
-    $self->wait_boot(bootloader_time => 300);
+    # On this SLE 16.0 aarch64/qemu image GRUB fails to init its configured
+    # serial terminal ("serial port `com0' isn't found") and the video
+    # framebuffer then genuinely stalls instead of ever painting a screen,
+    # so wait_boot's needle-based checks hit a real "Stall detected" rather
+    # than a missed match. Confirm boot completion over the serial console
+    # instead, which stays live throughout.
+    die 'System did not come back up after update reboot' unless wait_serial(get_login_message(), 300);
+    $self->{in_wait_boot} = 0;
+    reset_consoles;
     select_console($prev_console);
 }
 

--- a/tests/containers/install_updates.pm
+++ b/tests/containers/install_updates.pm
@@ -12,6 +12,7 @@ use testapi;
 use utils;
 use power_action_utils;
 use serial_terminal qw(get_login_message);
+use Utils::Backends 'is_qemu';
 use version_utils qw(check_os_release get_os_release is_sle);
 
 sub run {
@@ -40,15 +41,21 @@ sub run {
     # Perform system reboot to ensure the system is still ok
     my $prev_console = current_console();
     power_action('reboot', textmode => 1);
-    # On this SLE 16.0 aarch64/qemu image GRUB fails to init its configured
-    # serial terminal ("serial port `com0' isn't found") and the video
-    # framebuffer then genuinely stalls instead of ever painting a screen,
-    # so wait_boot's needle-based checks hit a real "Stall detected" rather
-    # than a missed match. Confirm boot completion over the serial console
-    # instead, which stays live throughout.
-    die 'System did not come back up after update reboot' unless wait_serial(get_login_message(), 300);
-    $self->{in_wait_boot} = 0;
-    reset_consoles;
+    if (is_qemu) {
+        # On this SLE 16.0 aarch64/qemu image GRUB fails to init its configured
+        # serial terminal ("serial port `com0' isn't found") and the video
+        # framebuffer then genuinely stalls instead of ever painting a screen,
+        # so wait_boot's needle-based checks hit a real "Stall detected" rather
+        # than a missed match. Confirm boot completion over the serial console
+        # instead, which stays live throughout. Non-qemu backends (e.g. s390x
+        # svirt) already have their own proven serial-based handling inside
+        # wait_boot, so they keep using it.
+        die 'System did not come back up after update reboot' unless wait_serial(get_login_message(), 300);
+        $self->{in_wait_boot} = 0;
+        reset_consoles;
+    } else {
+        $self->wait_boot(bootloader_time => 300);
+    }
     select_console($prev_console);
 }
 

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -15,8 +15,8 @@ use bootloader_setup qw(add_grub_cmdline_settings change_grub_config);
 use power_action_utils 'power_action';
 use transactional qw(trup_call process_reboot);
 use utils qw(zypper_call reconnect_mgmt_console);
-use serial_terminal 'select_serial_terminal';
-use Utils::Backends 'is_pvm';
+use serial_terminal qw(get_login_message select_serial_terminal);
+use Utils::Backends qw(is_pvm is_qemu);
 use Utils::Architectures qw(is_aarch64 is_ppc64le is_s390x);
 use version_utils qw(is_jeos is_sle_micro is_sle is_tumbleweed is_transactional is_microos);
 use security::vendoraffirmation;
@@ -29,7 +29,18 @@ sub reboot_and_login {
 
     is_transactional ? process_reboot(trigger => 1) : power_action('reboot', textmode => 1, keepconsole => is_pvm);
     reconnect_mgmt_console if is_pvm;
-    $self->wait_boot if !is_transactional;
+    if (!is_transactional) {
+        if (is_qemu && is_sle('>=16')) {
+            # Same GRUB serial-terminal-init stall as containers/install_updates.pm:
+            # wait_boot's needle-based checks hit a "Stall detected" on this image
+            # rather than a missed match. Confirmed only on SLE 16+ qemu so far.
+            die 'System did not come back up after FIPS reboot' unless wait_serial(get_login_message(), 300);
+            $self->{in_wait_boot} = 0;
+            reset_consoles;
+        } else {
+            $self->wait_boot;
+        }
+    }
     is_ppc64le() ? select_console('root-console') : select_serial_terminal();
     return;
 }

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -35,7 +35,6 @@ sub reboot_and_login {
             # wait_boot's needle-based checks hit a "Stall detected" on this image
             # rather than a missed match. Confirmed only on SLE 16+ qemu so far.
             die 'System did not come back up after FIPS reboot' unless wait_serial(get_login_message(), 300);
-            $self->{in_wait_boot} = 0;
             reset_consoles;
         } else {
             $self->wait_boot;


### PR DESCRIPTION
Confirms the post-update reboot completed by watching the serial console instead of `wait_boot`'s GRUB/login-screen needle matching. On this SLE 16.0 aarch64/qemu image, GRUB fails to init its configured serial terminal and the video framebuffer genuinely stalls (no new frames) rather than just missing a needle — no amount of catching the resulting exception can recover from that, since `assert_screen` marks the module failed before the exception is even thrown. The serial console stays live throughout, so `wait_serial(get_login_message(), 300)` reliably detects boot completion instead.

* Related failure: [openqa.suse.de/t24130872](https://openqa.suse.de/tests/24130872)
* Verification runs: In comment below
