### PR TITLE
Elemental3: another boot fix

### DIFF
--- a/tests/elemental3/elemental_boot.pm
+++ b/tests/elemental3/elemental_boot.pm
@@ -18,27 +18,33 @@ sub run {
     # Set default root password
     $testapi::password = get_required_var('TEST_PASSWORD');
 
-    # 'install' command directly install the OS image without the installer step
-    unless (check_var('TESTED_CMD', 'install')) {
-        # Wait for OS installer boot
-        assert_screen('grub-unifiedcore_installer', timeout => 120);
-        wait_still_screen(stilltime => 2);
-    }
-
-    # This ISO image does not install anything
-    # It is just the basic container that should be used with 'customize' command
     if (check_var('TESTED_CMD', 'extract_iso')) {
-        # Just validate that the OS boot, no more
+        # This ISO image does not install anything, it is just the basic container
+        # that should be used with 'customize' command, validating the OS boot is enough
         $self->wait_boot_past_bootloader(ready_time => 120, textmode => 1, nologin => 1);
         wait_still_screen;
         record_info('ISO', 'ISO image booted!');
         return;
-    }
+    } elsif (check_var('TESTED_CMD', 'install')) {
+        # 'install' command directly installed the OS image previously without
+        # the installer step
+        $self->wait_boot(bootloader_time => bmwqemu::scale_timeout(300), textmode => 1, nologin => 1);
+        wait_still_screen;
+    } else {
+        # Wait for OS installer boot
+        assert_screen('grub-unifiedcore_installer', timeout => 120);
+        wait_still_screen();
 
-    # OS installation is done automatically as well as the reboot after installation
-    # We just have to wait for the VM to reboot
-    $self->wait_boot(bootloader_time => bmwqemu::scale_timeout(900), textmode => 1, nologin => 1);
-    wait_still_screen;
+        # Wait for the first automatic login screen
+        assert_screen('linux-login', timeout => 120);
+        wait_still_screen();
+
+        # OS installation is done automatically as well as the reboot after installation
+        # We just have to wait for the VM to reboot and a login screen to appear
+        wait_screen_change(undef, bmwqemu::scale_timeout(300));
+        assert_screen('linux-login', timeout => 120);
+        wait_still_screen();
+    }
 
     # No GUI, easier and quicker to use the serial console
     select_serial_terminal();


### PR DESCRIPTION
The issue mostly sporadicaly appears on aarch64, this is because the default GRUB timeout is very short. For now we cannot change this timeout, so an(other) way to try to workaround this is to check for the Linux login prompt that should appear after installation instead of the GRUB screen after OS installation.

There was multiple tentative to fix this issue, I rewrote the logic to try to fix it for good this time!

- Related ticket: N/A
- Needles: N/A
- Failing run: https://openqa.suse.de/tests/24131721#step/elemental_boot/3
- Verification run:  [test_with_build_installer_iso aarch64](https://openqa.suse.de/tests/24134434), [test_with_build_installer_iso 8x86_64](https://openqa.suse.de/tests/24134441), [test_with_install aarch64](https://openqa.suse.de/tests/24135267), [test_with_install x86_64](https://openqa.suse.de/tests/24135331), [test_extract_iso aarch64](https://openqa.suse.de/tests/24134559), [test_extract_iso x86_64](https://openqa.suse.de/tests/24134560)