### PR TITLE
Fix SDAF sporadic prepare_ssh_config timed out

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/inventory_tools.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/inventory_tools.pm
@@ -234,7 +234,19 @@ sub verify_ssh_proxy_connection {
         my $hosts = $args{inventory_data}->{$instance_type}{hosts};
         for my $hostname (keys %$hosts) {
             # run simple 'hostname' command on each host
-            my $hostname_output = script_output("ssh $hostname hostname", quiet => 1);
+            my $max_retries = 10;
+            my $hostname_output = '';
+            for my $attempt (1 .. $max_retries) {
+                $hostname_output = script_output("ssh $hostname hostname", timeout => 15, quiet => 1, proceed_on_failure => 1);
+                last if defined $hostname_output && $hostname_output ne '';
+
+                if ($attempt < $max_retries) {
+                    my $delay = 30;
+                    record_info('SSH Retry', "Failed to connect to $hostname. Retrying ($attempt/$max_retries) in ${delay}s...");
+                    sleep $delay;
+                }
+            }
+
             die "Hostname returned does not match target host.\nExpected: $hostname\nGot: $hostname_output"
               unless $hostname_output =~ $hostname;
             record_info('SSH check', "SSH proxy connection to $hostname: OK");


### PR DESCRIPTION
Fix SDAF sporadic prepare_ssh_config timed out: add retry mechanism

- Related ticket: [TEAM-11450](https://jira.suse.com/browse/TEAM-11450) - [SDAF][sporadic] prepare_ssh_config timed out
- Verification run:
http://openqaworker15.qe.prg2.suse.org/tests/383994#dependencies (passed)
http://openqaworker15.qe.prg2.suse.org/tests/384000#dependencies (passed)

This PR does not introduce any regressions I will keep an eye on the osd jobs after it is merged.