### PR TITLE
Containers add second bridge

### DIFF
--- a/tests/containers/container_engine.pm
+++ b/tests/containers/container_engine.pm
@@ -151,8 +151,8 @@ sub check_network_macvlan {
     my %args = @_;
     my $runtime = $args{runtime};
     my $image = "registry.opensuse.org/opensuse/busybox";
-    my $ip1 = "192.168.60.10";
-    my $ip2 = "192.168.60.11";
+    my $ip1 = "10.88.1.10";
+    my $ip2 = "10.88.1.11";
 
     record_info "Start macvlan test";
 
@@ -173,7 +173,7 @@ sub check_network_macvlan {
     assert_script_run("ip link set $macvlan_dev up");
 
     # Create macvlan network
-    assert_script_run("$runtime network create -d macvlan -o parent=$macvlan_dev --subnet=192.168.60.0/24 --gateway=192.168.60.254 $macvlan_netname");
+    assert_script_run("$runtime network create -d macvlan -o parent=$macvlan_dev --subnet=10.88.1.0/24 --gateway=10.88.1.254 $macvlan_netname");
     validate_script_output("$runtime network ls", qr/$macvlan_netname/);
     record_info("macvlan network", script_output("$runtime network inspect $macvlan_netname"));
 
@@ -217,8 +217,8 @@ sub check_network_ipvlan {
     my %args = @_;
     my $runtime = $args{runtime};
     my $image = "registry.opensuse.org/opensuse/busybox";
-    my $ip1 = "192.168.61.10";
-    my $ip2 = "192.168.61.11";
+    my $ip1 = "10.88.2.10";
+    my $ip2 = "10.88.2.11";
 
     record_info "Start ipvlan test";
 
@@ -245,7 +245,7 @@ sub check_network_ipvlan {
     assert_script_run("ip link set $ipvlan_dev up");
 
     # Create ipvlan network
-    assert_script_run("$runtime network create -d ipvlan -o parent=$ipvlan_dev -o mode=l2 --subnet=192.168.61.0/24 --gateway=192.168.61.254 $ipvlan_netname");
+    assert_script_run("$runtime network create -d ipvlan -o parent=$ipvlan_dev -o mode=l2 --subnet=10.88.2.0/24 --gateway=10.88.2.254 $ipvlan_netname");
     validate_script_output("$runtime network ls", qr/$ipvlan_netname/);
     validate_script_output("$runtime network inspect -f '{{.Driver}}' $ipvlan_netname", qr/ipvlan/);
     record_info("ipvlan network", script_output("$runtime network inspect $ipvlan_netname"));
@@ -276,6 +276,90 @@ sub check_network_ipvlan {
     cleanup_ipvlan(runtime => $runtime);
 }
 
+my $bridge_netname = 'bridge_test';
+my $bridge_iface = 'br_test0';
+my $bridge_conf = "/etc/containers/networks/$bridge_netname.json";
+my $bridge_json;
+
+sub cleanup_bridge {
+    my %args = @_;
+    my $runtime = $args{runtime};
+    script_run("$runtime rm -f busybox_1");
+    script_run("$runtime rm -f busybox_2");
+    return unless defined $bridge_json;
+    record_info "Clean up bridge test";
+    script_run("$runtime network rm $bridge_netname");
+    script_run("rm -f $bridge_conf");
+    undef $bridge_json;
+}
+
+sub check_network_bridge {
+    my %args = @_;
+    my $runtime = $args{runtime};
+    my $image = "registry.opensuse.org/opensuse/busybox";
+    my $ip1 = "10.88.3.10";
+    my $ip2 = "10.88.3.11";
+
+    record_info "Start bridge test";
+
+    record_info "Check that backend netavark is used";
+    validate_script_output("$runtime info -f '{{.Host.NetworkBackend}}'", qr/netavark/, fail_message => "Test requires the netavark backend");
+
+    script_retry("$runtime image pull $image", timeout => 600, retry => 3, delay => 120);
+    assert_script_run("mkdir -p /etc/containers/networks");
+
+    # Import a second bridge network from a configuration file.
+    $bridge_json = <<"EOF";
+{
+  "name": "$bridge_netname",
+  "id": "0000000000000000000000000000000000000000000000000000000000000000",
+  "driver": "bridge",
+  "network_interface": "$bridge_iface",
+  "subnets": [
+    {
+      "subnet": "10.88.3.0/24",
+      "gateway": "10.88.3.1"
+    }
+  ],
+  "ipv6_enabled": false,
+  "internal": false,
+  "dns_enabled": false,
+  "ipam_options": {
+    "driver": "host-local"
+  }
+}
+EOF
+    write_sut_file($bridge_conf, $bridge_json);
+    record_info("bridge config", script_output("cat $bridge_conf"));
+
+    # The network must be picked up from the configuration file.
+    validate_script_output("$runtime network ls", qr/$bridge_netname/);
+    validate_script_output("$runtime network inspect -f '{{.Driver}}' $bridge_netname", qr/bridge/);
+    record_info("bridge network", script_output("$runtime network inspect $bridge_netname"));
+
+    # Create containers with the second bridge network
+    assert_script_run("$runtime run -d --network $bridge_netname --ip $ip1 --name busybox_1 $image sleep infinity");
+    assert_script_run("$runtime run -d --network $bridge_netname --ip $ip2 --name busybox_2 $image sleep infinity");
+    assert_script_run("ip link show $bridge_iface", fail_message => "bridge interface $bridge_iface from the configuration file was not created");
+
+    # Check if containers really use the second bridge network
+    validate_script_output("$runtime container inspect busybox_1", qr/$bridge_netname/);
+    validate_script_output("$runtime container inspect busybox_2", qr/$bridge_netname/);
+    validate_script_output("$runtime exec busybox_1 ip a", qr/$ip1/);
+    validate_script_output("$runtime exec busybox_2 ip a", qr/$ip2/);
+
+    # Containers using the second bridge network can reach each other
+    assert_script_run("$runtime exec busybox_1 ping -c3 $ip2");
+    assert_script_run("$runtime exec busybox_2 ping -c3 $ip1");
+
+    # Containers using the second bridge network can reach the outside
+    assert_script_run("$runtime exec busybox_1 ping -c3 1.1.1.1", fail_message => "container cannot reach the internet");
+    script_retry("$runtime exec busybox_1 ping -c3 google.com", retry => 3, delay => 60, fail_message => "container cannot resolve DNS");
+
+    # Clean up
+    cleanup_bridge(runtime => $runtime);
+}
+
 sub run {
     my ($self, $args) = @_;
     die('You must define a engine') unless ($args->{runtime});
@@ -301,6 +385,11 @@ sub run {
         check_network_ipvlan(runtime => $self->{runtime});
     }
 
+    # Only Podman supports importing bridge configurations from /etc/containers/networks
+    if (is_tumbleweed || is_sle(">=15.4") || is_sle_micro('>=6.0')) {
+        check_network_bridge(runtime => $self->{runtime}) if ($self->{runtime} eq 'podman');
+    }
+
     # Build an image from Dockerfile and run it
     my $base = (is_opensuse ? 'registry.opensuse.org/opensuse/bci/python:latest' : 'registry.suse.com/bci/python:latest');
     build_and_run_image(runtime => $engine, base => $base);
@@ -316,6 +405,7 @@ sub post_fail_hook {
     my ($self) = @_;
     cleanup_macvlan(runtime => $self->{runtime});
     cleanup_ipvlan(runtime => $self->{runtime});
+    cleanup_bridge(runtime => $self->{runtime});
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
Adds new `sub check_network_bridge` to test second network bridge on the container engine.

- Related ticket: https://progress.opensuse.org/issues/204729
- Needles: N/A
- Verification run: in comment below

