### PR TITLE
snapper_ create, used_space: est_flags fatal => 0, no_rollback => 1

### DIFF
--- a/tests/console/snapper_create.pm
+++ b/tests/console/snapper_create.pm
@@ -64,5 +64,9 @@ sub run {
     wait_serial('LOAD_OK', timeout => 600, no_regex => 1) or die 'System average load was not settled after taking snapshots';
 }
 
+sub test_flags {
+    return {fatal => 0, no_rollback => 1};
+}
+
 1;
 

--- a/tests/console/snapper_used_space.pm
+++ b/tests/console/snapper_used_space.pm
@@ -89,4 +89,8 @@ sub run {
     query_space_several_snapshot;
 }
 
+sub test_flags {
+    return {fatal => 0, no_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
A snapper failure should not abort subsequent test modules. These modules can fail due to D-Bus service activation issues, btrfs qgroup delays, or shim limitations without affecting other tests.

snapper_cleanup already has these flags. snapper_create and snapper_used_space did not - a failure in either one cascaded and skipped everything after them.

Validation: https://openqa.opensuse.org/tests/6196921