### PR TITLE
bats/runc: Redirect stderr to /dev/null

### DIFF
--- a/tests/containers/bats/runc.pm
+++ b/tests/containers/bats/runc.pm
@@ -73,7 +73,7 @@ sub run {
     patch_sources "runc", "v$runc_version", "tests/integration";
 
     # Compile helpers used by the tests
-    my $helpers = script_output "find contrib/cmd tests/cmd -mindepth 1 -maxdepth 1 -type d ! -name _bin -printf '%f '", proceed_on_failure => 1;
+    my $helpers = script_output "find contrib/cmd tests/cmd -mindepth 1 -maxdepth 1 -type d ! -name _bin -printf '%f ' 2>/dev/null", proceed_on_failure => 1;
     record_info("helpers", $helpers);
     run_command "make $helpers || true";
 


### PR DESCRIPTION
Redirect stderr to /dev/null, otherwise it's assigned to the variable.

Failed job: https://openqa.opensuse.org/tests/6196979#step/runc/84
Verification run: https://openqa.opensuse.org/tests/6196991