### PR TITLE
Set explicit timeout on BCI-tests git operations

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -127,7 +127,7 @@ sub update_test_repos {
     record_info('Clone', "Cloning BCI tests repository: $bci_tests_repo\nBranch: $bci_tests_branch");
     my $branch = $bci_tests_branch ? "-b $bci_tests_branch" : '';
     assert_script_run('rm -rf /root/BCI-tests');
-    assert_script_run("git clone $branch -q --depth 1 $bci_tests_repo /root/BCI-tests");
+    assert_script_run("git clone $branch -q --depth 1 $bci_tests_repo /root/BCI-tests", timeout => 300);
 }
 
 sub run {

--- a/tests/containers/bci_test.pm
+++ b/tests/containers/bci_test.pm
@@ -136,7 +136,7 @@ sub run {
     assert_script_run('source bci/bin/activate');
 
     record_info('Run', "Starting the tests for the following environments:\n$test_envs");
-    assert_script_run("cd /root/BCI-tests && git fetch && git reset --hard $bci_tests_branch");
+    assert_script_run("cd /root/BCI-tests && git fetch && git reset --hard $bci_tests_branch", timeout => 300);
     assert_script_run("export TOX_PARALLEL_NO_SPINNER=1");
     assert_script_run("export TOX_SKIP_ENV=" . get_var('BCI_SKIP_ENVS', ''));
     assert_script_run("export CONTAINER_RUNTIME=$engine");


### PR DESCRIPTION
Sets an explicit 300s timeout on the BCI-tests repo clone in bci_prepare.pm and the fetch/reset in bci_test.pm, instead of relying on assert_script_run's default timeout, matching the pattern used by other git clones in this repo.

* Related failure: [openqa.suse.de/t24136494](https://openqa.suse.de/tests/24136494), [openqa.suse.de/t24136542](https://openqa.suse.de/tests/24136542), [openqa.suse.de/t24078506](https://openqa.suse.de/tests/24078506)
* Verification runs:
