### PR TITLE
podman: Backport PR#29690 to fix issue with runc v1.5.x

### DIFF
--- a/data/containers/patches.yaml
+++ b/data/containers/patches.yaml
@@ -133,6 +133,7 @@ podman:
   # https://github.com/containers/podman/pull/28804 - More test fixes for new CI
   # https://github.com/containers/podman/pull/29380 - test/e2e: accept RESTORE in checkpoint tcp error match
   # https://github.com/containers/podman/pull/29381 - test/e2e/healthcheck: skip ignore-result test on non-amd64
+  # https://github.com/containers/podman/pull/29690 - test/system: Update test to handle new error message from runc 1.5.0
   21875:
     merged: "5.0.0"
   24068:
@@ -200,6 +201,8 @@ podman:
   29380:
     min: "6.0"
   29381:
+    min: "6.0"
+  29690:
     min: "6.0"
 
 podman-py:

--- a/data/containers/patches/podman/29690.patch
+++ b/data/containers/patches/podman/29690.patch
@@ -1,0 +1,34 @@
+From 7e8002dd08f1899a165242a643d1c299a9484d29 Mon Sep 17 00:00:00 2001
+From: Ricardo Branco <rbranco@suse.de>
+Date: Tue, 1 Sep 2026 11:01:36 +0200
+Subject: [PATCH] test/system: Update test to handle new error message from
+ runc 1.5.0
+
+runc 1.5.0 switched to a safe procfs API for setting SELinux labels,
+so reopened handles no longer carry a /proc/self path in error
+messages, e.g. "write /1/attr/keycreate: invalid argument" instead of
+"write /proc/self/attr/keycreate: invalid argument". Relax the regex
+to match on "attr/keycreate" without requiring the proc/self prefix.
+
+Signed-off-by: Ricardo Branco <rbranco@suse.de>
+---
+ test/system/410-selinux.bats | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/test/system/410-selinux.bats b/test/system/410-selinux.bats
+index 956525ed9e4..458ca02d9dd 100644
+--- a/test/system/410-selinux.bats
++++ b/test/system/410-selinux.bats
+@@ -258,7 +258,11 @@ function check_label() {
+         # runc 1.3.3 (temporarily?) changed the error message because of the fix to CVE-2025-52881, see
+         # https://github.com/opencontainers/runc/commit/2c5356e73f15b246729d03198bfb2c6c33454099
+         #   to   write fsmount:fscontext:proc/self/attr/keycreate: invalid argument
+-        runc) expect=".*: \(failed\|write\).*proc/self/attr/keycreate.*" ;;
++        # runc 1.5.0 changed the error message again because of the switch to a
++        # safe procfs API (reopened handles no longer carry a /proc/self path), see
++        # https://github.com/opencontainers/runc/commit/ed6b1693b8b3ae7eb0250a7e76fc888cdacf98c1
++        #   to   write /1/attr/keycreate: invalid argument
++        runc) expect=".*: \(failed\|write\).*attr/keycreate.*" ;;
+         *)    skip "Unknown runtime '$runtime'";;
+     esac
+ 


### PR DESCRIPTION
Backport https://github.com/podman-container-tools/podman/pull/29690 to fix issue with runc v1.5.x

Failed job: https://openqa.opensuse.org/tests/6196731
Verification run: https://openqa.opensuse.org/tests/6197069