### PR TITLE
HBA kernel: Inital step for storage tests using FC switch and QNAP storage

### DIFF
--- a/lib/Kernel/hba.pm
+++ b/lib/Kernel/hba.pm
@@ -123,23 +123,17 @@ sub list_fc_hosts {
 
  check_fc_hosts();
 
-Checks that at least C<REQUIRED_FC_PORTS_ONLINE> Fibre Channel ports are
-C<Online>, per C<list_fc_hosts()>. Does nothing if the job setting is not
-set. Records a failure if fewer are found than required.
+Checks that at least one Fibre Channel port is C<Online>, per
+C<list_fc_hosts()>. Records a failure if none are found.
 
 Returns the number of C<Online> ports found.
 
 =cut
 
 sub check_fc_hosts {
-    my $required = get_var('REQUIRED_FC_PORTS_ONLINE');
-    return unless defined $required;
-
     my @online = grep { $_->{port_state} eq 'Online' } list_fc_hosts();
-    if (@online < $required) {
-        record_info('FC ports missing',
-            "Expected $required Online FC port(s), found " . scalar(@online),
-            result => 'fail');
+    unless (@online) {
+        record_info('FC port not online', 'No Online Fibre Channel port found', result => 'fail');
     }
     return scalar(@online);
 }

--- a/lib/Kernel/hba.pm
+++ b/lib/Kernel/hba.pm
@@ -1,0 +1,147 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+# Summary: Host Bus Adapter (HBA) detection helpers for kernel tests.
+# Maintainer: Kernel QE <kernel-qa@suse.de>
+
+package Kernel::hba;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use warnings;
+use testapi;
+
+our @EXPORT_OK = qw(
+  detect_fc_hba
+  list_scsi_hosts
+  list_fc_hosts
+  check_fc_hosts
+);
+
+=head1 SYNOPSIS
+
+Utils for working with Host Bus Adapters.
+
+=cut
+
+=head2 detect_fc_hba
+
+ detect_fc_hba();
+
+Checks whether at least one Fibre Channel HBA port is registered in sysfs.
+Returns true/false.
+
+=cut
+
+sub detect_fc_hba {
+    return scalar(list_fc_hosts()) > 0;
+}
+
+=head2 list_scsi_hosts
+
+ my @hosts = list_scsi_hosts();
+
+Lists the SCSI/SAS host adapters (initiators), via C<lsscsi -H -t> (list
+hosts, not devices/LUNs, with transport info), as an array of hashes:
+- C<host>: sysfs host name, e.g. C<host0>
+- C<driver>: kernel driver bound to the host, e.g. C<ahci>, C<virtio_scsi>,
+  C<qla2xxx>
+- C<transport>: raw transport string as reported by lsscsi, e.g.
+  C<fc:0x50060b00741cc28e,0x0b1900>, C<sata:>, C<usb: 7-1:1.0>; undef if
+  lsscsi reports none.
+
+Returns an empty list if none are found.
+
+=cut
+
+sub list_scsi_hosts {
+    my @errors;
+    my @ret;
+    my $lsscsi = script_output('lsscsi -H -t', proceed_on_failure => 1);
+
+    for my $line (split /\n/, $lsscsi) {
+        # lsscsi also lists NVMe controllers, tagged '[N:...]' instead of a
+        # numeric host; NVMe isn't a SCSI host, so skip it rather than
+        # treating it as unrecognized data
+        # https://lwn.net/Articles/760545/
+        next if $line =~ m/^\[N:/;
+
+        if ($line !~ m/^\[(\d+)\]\s+(\S+)(?:\s+(.*\S))?\s*$/) {
+            push @errors, $line;
+            next;
+        }
+
+        push @ret, {
+            host => "host$1",
+            driver => $2,
+            transport => $3
+        };
+    }
+
+    if (@errors) {
+        record_info('lsscsi -H -t error', "Unrecognized data in lsscsi -H -t output:\n" . join("\n", @errors), result => 'fail');
+    }
+
+    return @ret;
+}
+
+=head2 list_fc_hosts
+
+ my @hosts = list_fc_hosts();
+
+Lists the Fibre Channel host ports registered in sysfs
+(C</sys/class/fc_host>), as an array of hashes:
+- C<host>: sysfs host name, e.g. C<host6>
+- C<port_state>: link state, e.g. C<Online>, C<Linkdown>, C<Offline>
+- C<port_type>: topology, e.g. C<NPort> (fabric via switch), C<NLPort>
+  (loop), C<Point-To-Point>
+- C<speed>: negotiated link speed, e.g. C<16 Gbit>
+
+Returns an empty list if none are found.
+
+=cut
+
+sub list_fc_hosts {
+    my %hosts;
+    my $output = script_output(
+        'grep -H . /sys/class/fc_host/*/port_state /sys/class/fc_host/*/port_type /sys/class/fc_host/*/speed 2>/dev/null',
+        proceed_on_failure => 1
+    );
+
+    for my $line (split /\n/, $output) {
+        next unless $line =~ m{^/sys/class/fc_host/(host\d+)/(port_state|port_type|speed):(.*)$};
+        $hosts{$1}{$2} = $3;
+    }
+
+    return map { {host => $_, %{$hosts{$_}}} } sort keys %hosts;
+}
+
+=head2 check_fc_hosts
+
+ check_fc_hosts();
+
+Checks that at least C<REQUIRED_FC_PORTS_ONLINE> Fibre Channel ports are
+C<Online>, per C<list_fc_hosts()>. Does nothing if the job setting is not
+set. Records a failure if fewer are found than required.
+
+Returns the number of C<Online> ports found.
+
+=cut
+
+sub check_fc_hosts {
+    my $required = get_var('REQUIRED_FC_PORTS_ONLINE');
+    return unless defined $required;
+
+    my @online = grep { $_->{port_state} eq 'Online' } list_fc_hosts();
+    if (@online < $required) {
+        record_info('FC ports missing',
+            "Expected $required Online FC port(s), found " . scalar(@online),
+            result => 'fail');
+    }
+    return scalar(@online);
+}
+
+1;

--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -17,6 +17,7 @@ use LTP::utils 'prepare_whitelist_environment';
 use package_utils 'install_package';
 use Utils::Logging qw(export_logs_basic save_and_upload_log);
 use Kernel::block_dev qw(is_block_device record_storage_info);
+use Kernel::hba qw(detect_fc_hba list_scsi_hosts list_fc_hosts);
 use Kernel::utils qw(is_debugfs_mounted enable_debugfs get_kernel_config);
 
 sub prepare_blktests_config {
@@ -35,6 +36,14 @@ sub prepare_blktests_config {
 
 sub run {
     select_serial_terminal;
+
+    if (detect_fc_hba()) {
+        my @scsi_hosts = list_scsi_hosts();
+        record_info('SCSI hosts', @scsi_hosts ? join(', ', map { "$_->{host} ($_->{driver}" . ($_->{transport} ? ", $_->{transport}" : '') . ')' } @scsi_hosts) : 'No SCSI/SAS Host Bus Adapter found (lsscsi -H -t)');
+
+        my @fc_hosts = list_fc_hosts();
+        record_info('FC hosts', @fc_hosts ? join(', ', map { "$_->{host} ($_->{port_state}, $_->{port_type}, $_->{speed})" } @fc_hosts) : 'No Fibre Channel HBA found in /sys/class/fc_host');
+    }
 
     #below variable exposes blktests options to the openQA testsuite
     #definition, so that it allows flexible ways of re-runing the tests
@@ -150,6 +159,10 @@ sub post_fail_hook {
 
 Run the upstream blktests suite either from the C<blktests> package (default)
 or from a git checkout.
+
+If a Fibre Channel HBA is detected, SCSI/SAS host adapters (via
+C<lsscsi>) and Fibre Channel host adapters (C</sys/class/fc_host>) are
+recorded via C<record_info()>.
 
 The test groups to execute are selected with C<BLKTESTS>. Individual tests can
 be skipped either directly with C<BLKTESTS_EXCLUDE> (mostly for debugging purposes)

--- a/tests/kernel/blktests.pm
+++ b/tests/kernel/blktests.pm
@@ -17,7 +17,7 @@ use LTP::utils 'prepare_whitelist_environment';
 use package_utils 'install_package';
 use Utils::Logging qw(export_logs_basic save_and_upload_log);
 use Kernel::block_dev qw(is_block_device record_storage_info);
-use Kernel::hba qw(detect_fc_hba list_scsi_hosts list_fc_hosts);
+use Kernel::hba qw(check_fc_hosts list_scsi_hosts list_fc_hosts);
 use Kernel::utils qw(is_debugfs_mounted enable_debugfs get_kernel_config);
 
 sub prepare_blktests_config {
@@ -37,7 +37,9 @@ sub prepare_blktests_config {
 sub run {
     select_serial_terminal;
 
-    if (detect_fc_hba()) {
+    # initial FC tests - simple check if the port is online. This checks if
+    # fabric login was successful
+    if (check_fc_hosts()) {
         my @scsi_hosts = list_scsi_hosts();
         record_info('SCSI hosts', @scsi_hosts ? join(', ', map { "$_->{host} ($_->{driver}" . ($_->{transport} ? ", $_->{transport}" : '') . ')' } @scsi_hosts) : 'No SCSI/SAS Host Bus Adapter found (lsscsi -H -t)');
 
@@ -160,9 +162,9 @@ sub post_fail_hook {
 Run the upstream blktests suite either from the C<blktests> package (default)
 or from a git checkout.
 
-If a Fibre Channel HBA is detected, SCSI/SAS host adapters (via
+If at least one Fibre Channel port is online, SCSI/SAS host adapters (via
 C<lsscsi>) and Fibre Channel host adapters (C</sys/class/fc_host>) are
-recorded via C<record_info()>.
+recorded via C<record_info()>; otherwise a failure is recorded.
 
 The test groups to execute are selected with C<BLKTESTS>. Individual tests can
 be skipped either directly with C<BLKTESTS_EXCLUDE> (mostly for debugging purposes)


### PR DESCRIPTION
Initial step for running real, storage tests using hardware (servers with HBAs, FC switch and eventually storage system).

The idea is to provide `Kernel:hba` lib to handle typical utilities (similar in spirit as the `usb`) and then use this in the testing.
Since the full hardware setup is not in place, the initial tests are limited to `blktests` basically checking if `HBA` is there and if the port is `Online` which is a test on its own albeit very basic one - this does flogi/fabric login.

- Related ticket: https://progress.opensuse.org/issues/205932
- Verification run:
  - HBA hardware in: https://openqa.suse.de/tests/24155921;
  on a server with HBA one can see the following:
    - https://openqa.suse.de/tests/24155921#step/blktests/4 note: `host18 (qla2xxx, fc:0x210034800d7a8790,0x010000), host19 (qla2xxx, fc:0x210034800d7a8791,0x000000)`
    - https://openqa.suse.de/tests/24155921#step/blktests/6 `host18 (Online, NPort (fabric via point-to-point), 16 Gbit), host19 (Linkdown, Unknown, unknown)`
  - No HBA hardware: https://openqa.suse.de/tests/24156078