### PR TITLE
Changed release strategy to overwrite release files

### DIFF
--- a/tests/yam/agama/patch_agama_tests.pm
+++ b/tests/yam/agama/patch_agama_tests.pm
@@ -6,17 +6,20 @@
 # Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
 
 use Mojo::Base 'Yam::Agama::patch_agama_base';
-use testapi qw(assert_script_run get_required_var select_console script_run assert_script_run script_output);
+use testapi qw(assert_script_run get_required_var select_console script_run assert_script_run script_output record_info);
 
 sub run {
     select_console 'install-shell';
     my ($repo, $branch) = split /#/, get_required_var('YUPDATE_GIT');
     my $agama_test = get_required_var("AGAMA_TEST");
     my $destination = "/usr/share/agama/system-tests";
-    my $latest_commit_sha = script_output("curl -s 'https://api.github.com/repos/$repo/commits/$branch' | jq -r '.sha'");
+    my $url = "https://github.com/$repo/releases/download/tag-$branch/agama-integration-tests.tar.gz";
+
     script_run("mkdir -p $destination");
-    assert_script_run("curl -sfL https://github.com/$repo/releases/download/tag-$branch/$latest_commit_sha.tar.gz | tar -xz",
-        fail_message => "Error: CI build artifact (tarball) for $repo/$branch is not available yet. The CI run may still be in progress.");
+    assert_script_run("curl -sfL $url | tar -xz",
+        fail_message => "No CI build artifact at $url. Either the CI run for $repo#$branch has not finished, or the
+          branch predates the ci.yml change that publishes agama-integration-tests.tar.gz - rebase it on main.");
+    record_info("SHA", script_output("cat dist/BUILD_SHA"));
     script_run("cp dist/vendor.js dist/${agama_test}* $destination");
 }
 


### PR DESCRIPTION
We have changed the way to release the files instead of using commits We added the SHA inside the compiled files
Then we overwrite the last uploaded compilation

- Related ticket: https://progress.opensuse.org/issues/189948
- Related PR: https://github.com/qe-installation-and-migration/agama-integration-test-webpack/pull/301
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/24152270#
