### PR TITLE
Add configuration for terraform runner

### DIFF
--- a/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure.yaml
@@ -9,6 +9,7 @@
 provider: 'azure'
 apiver: 4
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     # GENERAL VARIABLES
     vnet_address_range: '%MAIN_ADDRESS_RANGE%'

--- a/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_azure_uri.yaml
@@ -9,6 +9,7 @@
 provider: 'azure'
 apiver: 4
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     # GENERAL VARIABLES #
     az_region: '%PUBLIC_CLOUD_REGION%'

--- a/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_ec2.yaml
@@ -9,6 +9,7 @@
 provider: 'aws'
 apiver: 4
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     # GENERAL VARIABLES #
     aws_region: '%PUBLIC_CLOUD_REGION%'

--- a/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
+++ b/data/sles4sap/qe_sap_deployment/mr_test_gcp.yaml
@@ -9,6 +9,7 @@
 provider: 'gcp'
 apiver: 4
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     # GENERAL VARIABLES #
     project: '%SLES4SAP_GOOGLE_PROJECT%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_aws_generic.yaml
@@ -9,6 +9,7 @@
 provider: 'aws'
 apiver: 4
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     # GENERAL VARIABLES #
     aws_region: '%PUBLIC_CLOUD_REGION%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic.yaml
@@ -9,6 +9,7 @@
 provider: 'azure'
 apiver: 4
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     # GENERAL VARIABLES #
     az_region: '%PUBLIC_CLOUD_REGION%'

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_maintenance.yaml
@@ -9,6 +9,7 @@
 provider: 'azure'
 apiver: 4
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     # GENERAL VARIABLES #
     vnet_address_range: "%MAIN_ADDRESS_RANGE%"

--- a/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_azure_generic_uri.yaml
@@ -9,6 +9,7 @@
 provider: 'azure'
 apiver: 4
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     # GENERAL VARIABLES #
     vnet_address_range: "%MAIN_ADDRESS_RANGE%"

--- a/data/sles4sap/qe_sap_deployment/sles4sap_gcp_generic.yaml
+++ b/data/sles4sap/qe_sap_deployment/sles4sap_gcp_generic.yaml
@@ -9,6 +9,7 @@
 provider: 'gcp'
 apiver: 4
 terraform:
+  bin: '%TERRAFORM_RUNNER%'
   variables:
     # GENERAL VARIABLES #
     project: '%SLES4SAP_GOOGLE_PROJECT%'

--- a/tests/sles4sap/publiccloud/qesap_configure.pm
+++ b/tests/sles4sap/publiccloud/qesap_configure.pm
@@ -200,6 +200,7 @@ sub run {
     set_var('FENCING_MECHANISM', 'native') unless ($ha_enabled);
     set_var('ISCSI_ENABLED', check_var('FENCING_MECHANISM', 'sbd') ? 'true' : 'false');
     set_var_output('ANSIBLE_REMOTE_PYTHON', '/usr/bin/python3');
+    set_var_output('TERRAFORM_RUNNER', 'terraform');
 
     # Within the qe-sap-deployment terraform code, in each different CSP implementation,
     # an empty string means no peering.


### PR DESCRIPTION
This PR enables choice between terraform and tofu for mr_test and hanasr, defaulting to terraform unless otherwise specified.

- Related ticket: https://jira.suse.com/browse/TEAM-11109
- Verification run: without setting TERRAFORM_RUNNER= "tofu" (uses terraform): https://openqa.suse.de/tests/24167052/logfile?filename=serial_terminal.txt#line-1050
with setting (uses tofu): https://openqa.suse.de/tests/24167053/logfile?filename=serial_terminal.txt#line-1050 
