### PR TITLE
sshd: Avoid typing timeouts during post_fail_hook exection

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -122,13 +122,12 @@ sub post_run_hook {
 sub post_fail_hook {
     my $self = shift;
 
-    # If the test fails inside the subshell, many commands can fail
+    # If the test fails in interactive mode (via script_start_io), we need to make sure to close it here
     if (get_var('SUBSHELL_NOT_AS_ROOT', 0)) {
         script_run "ps -aux";
         script_run "env";
         enter_cmd('exit');
-        # For some reason the serial guard seems to fail
-        $testapi::distri->pretty_serial_marker_guard(1);
+        script_finish_io(timeout => 300, exitcodes => [0]);
     }
 
     $self->cleanup();


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26433/changes#r3814724255 is the starting point...

When the test fails inside the codeblock for sshboy's session from
services::sshd and reaches the post_fail_hook of sshd test, the SUT is still in
the interactive session, and that causes openqa to die when typing commands, as
the serial marker has been restored via scope_guard.

A longer explanation is in: https://progress.opensuse.org/issues/206256#note-5

VR with (forced failure): https://openqa.opensuse.org/tests/6197063#step/sshd/36

openqa: clone https://openqa.opensuse.org/tests/6194803 EXCLUDE_MODULES=vsftpd,wpa_supplicant
