### PR TITLE
Replace grub_test by using wait_serial for qemu backend

### DIFF
--- a/schedule/yam/agama.yaml
+++ b/schedule/yam/agama.yaml
@@ -6,8 +6,7 @@ schedule:
   - yam/agama/boot_agama
   - yam/agama/patch_agama_tests
   - yam/agama/agama
-  - installation/grub_test
-  - installation/first_boot
+  - yam/validate/first_boot
   - yam/validate/validate_selinux
   - yam/validate/validate_base_product
   - yam/validate/validate_product

--- a/schedule/yam/agama_extended.yaml
+++ b/schedule/yam/agama_extended.yaml
@@ -9,8 +9,7 @@ schedule:
   - yam/agama/patch_agama_tests
   - yam/validate/validate_self_update
   - yam/agama/agama
-  - installation/grub_test
-  - installation/first_boot
+  - yam/validate/first_boot
   - yam/validate/validate_hostname
   - yam/validate/validate_connectivity
   - yam/validate/validate_bootloader_timeout

--- a/schedule/yam/agama_immutable.yaml
+++ b/schedule/yam/agama_immutable.yaml
@@ -6,8 +6,7 @@ schedule:
   - yam/agama/boot_agama
   - yam/agama/patch_agama_tests
   - yam/agama/agama
-  - installation/grub_test
-  - installation/first_boot
+  - yam/validate/first_boot
   - yam/validate/validate_selinux
   - yam/validate/validate_base_product
   - yam/validate/validate_product

--- a/schedule/yam/agama_lvm_encrypted_unattended.yaml
+++ b/schedule/yam/agama_lvm_encrypted_unattended.yaml
@@ -5,8 +5,7 @@ description: >
 schedule:
   - yam/agama/boot_agama
   - yam/agama/agama_auto
-  - installation/grub_test
-  - installation/first_boot
+  - yam/validate/first_boot
   - console/validate_lvm
   - console/validate_encrypt
   - shutdown/shutdown

--- a/schedule/yam/agama_lvm_encrypted_unattended_ppc64le.yaml
+++ b/schedule/yam/agama_lvm_encrypted_unattended_ppc64le.yaml
@@ -6,8 +6,7 @@ schedule:
   - yam/agama/boot_agama
   - yam/agama/patch_agama_tests
   - yam/agama/agama
-  - installation/grub_test
-  - installation/first_boot
+  - yam/validate/first_boot
   - console/validate_lvm
   - console/validate_encrypt
   - shutdown/shutdown

--- a/schedule/yam/agama_unattended.yaml
+++ b/schedule/yam/agama_unattended.yaml
@@ -5,8 +5,7 @@ description: >
 schedule:
   - yam/agama/boot_agama
   - yam/agama/agama_auto
-  - installation/grub_test
-  - installation/first_boot
+  - yam/validate/first_boot
   - yam/validate/validate_selinux
   - yam/validate/validate_base_product
   - yam/validate/validate_product

--- a/tests/yam/validate/first_boot.pm
+++ b/tests/yam/validate/first_boot.pm
@@ -1,0 +1,61 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Validate system boot after agama reboot
+# - Validate that system can bootup to welcome banner
+#   with right product version and architecture.
+# - Validate that the system login prompt is ready.
+
+# Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+
+sub run {
+    my $product_id = get_var('AGAMA_PRODUCT_ID');
+    my $arch = get_var('ARCH');
+    my $version = get_var('VERSION');
+
+    my %grub_prompts = (
+        x86_64 => qr/Press enter to boot the selected OS/,
+        aarch64 => qr/Please press 't' to show the boot menu/,
+        ppc64le => qr/Trying to load:\s+from: .* \.\.\.\s+Successfully loaded/,
+    );
+
+    my %product_name = (
+        SLES => 'SUSE Linux Enterprise Server',
+        SLES_SAP => 'SUSE Linux Enterprise Server for SAP applications',
+    );
+
+    my $grub_found = wait_serial($grub_prompts{$arch}, timeout => 60);
+    unless ($grub_found) {
+        die "Failed to detect GRUB boot prompt on serial console for $arch within timeout";
+    }
+
+    send_key 'ret';
+
+    my $version_regex = $version;
+    $version_regex =~ s/\./\\./g;
+
+    my $banner_regex = qr/Welcome to $product_name{$product_id}\s+$version_regex.*\($arch\)/;
+
+    my $banner_match = wait_serial($banner_regex, timeout => 90);
+    unless ($banner_match) {
+        die "Failed to detect '$product_name{$product_id}' first boot welcome banner on serial console for $arch";
+    }
+
+    my $login_regex = qr/(\w+login:|login:)/i;
+
+    my $login_match = wait_serial($login_regex, timeout => 30);
+    unless ($login_match) {
+        die "System booted banner appeared, but failed to reach getty login prompt on $arch";
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
##
### Replace grub_test by using wait_serial for qemu backend
#### What's changed:
- Replace `grub_test` and `first_boot` to a single module by using wait_serial for GRUB prompt and Welcome banner to make sure the system can successfully bootup and ready for use.
- No need to maintain needles for GRUB and login prompt.
##
- Related ticket:
  - https://jira.suse.com/browse/QEIM-14
- Needles: N/A
- Verification run: 
  - [**first_boot**](https://openqa.suse.de/tests/overview?distri=sle&version=16.1&build=hjluo_sles_sap_default_immutable_888)

##