### PR TITLE
Automate support preview feature for Systemd-boot

### DIFF
--- a/schedule/functional/systemd_boot.yaml
+++ b/schedule/functional/systemd_boot.yaml
@@ -1,0 +1,8 @@
+---
+name: systemd_boot
+description: >
+  Check if the system is systemd boot.
+schedule:
+  - boot/boot_to_desktop
+  - yam/validate/validate_systemd_boot
+  - shutdown/shutdown

--- a/schedule/yam/agama_systemd_boot.yaml
+++ b/schedule/yam/agama_systemd_boot.yaml
@@ -1,0 +1,10 @@
+---
+name: sles_systemd_boot
+description: >
+  Perform unattended installation with systemd boot.
+schedule:
+  - yam/agama/boot_agama
+  - yam/agama/agama_auto
+  - installation/grub_test
+  - installation/first_boot
+  - yam/validate/validate_systemd_boot

--- a/tests/yam/validate/validate_systemd_boot.pm
+++ b/tests/yam/validate/validate_systemd_boot.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Verify the system is booted with systemd-boot
+# Maintainer: QE Installation and Migration (QE Iam) <none@suse.de>
+
+use Mojo::Base 'consoletest';
+use testapi;
+use utils;
+
+sub run {
+
+    select_console 'root-console';
+
+    my $output = script_output('bootctl status');
+
+    die "Validation failed: Current Boot Loader Product is not 'systemd-boot'!\n"
+      unless $output =~ /Current Boot Loader:[\s\S]*?Product:\s+systemd-boot/;
+}
+
+sub post_fail_hook {
+    script_run('efibootmgr -v > /tmp/efibootmgr.log');
+    script_run('bootctl status > /tmp/bootctl_status.log');
+    upload_logs('/tmp/efibootmgr.log');
+    upload_logs('/tmp/bootctl_status.log');
+    shift->SUPER::post_fail_hook();
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Automate support preview feature for Systemd-boot: add the bootloader parameter inst.systemd_boot_preview=1 before installation; adapt bootloader to boot using the new menu; and create validation for systemd boot.

- Related ticket: https://jira.suse.com/browse/QEIM-23
- Verification run: [x86_64](https://openqa.suse.de/tests/24204540#) || [aarch64](https://openqa.suse.de/tests/24204996) || [opensuse tumbleweed](https://openqa.opensuse.org/tests/6206398) 
- Related MR: https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/899
- Related PR: https://github.com/os-autoinst/opensuse-jobgroups/pull/914
