### PR TITLE
Allow non-uefi systems to run this tests

### DIFF
--- a/schedule/security/sle16_transactional/fips_ker_mode_tests_crypt_core_qcow.yaml
+++ b/schedule/security/sle16_transactional/fips_ker_mode_tests_crypt_core_qcow.yaml
@@ -29,6 +29,4 @@ conditional_schedule:
       s390x:
         - installation/bootloader_start
       aarch64:
-        - installation/bootloader_uefi
-      x86_64:
-        - installation/bootloader_uefi
+        - boot/boot_to_desktop

--- a/schedule/security/sle16_transactional/selinux_qcow.yaml
+++ b/schedule/security/sle16_transactional/selinux_qcow.yaml
@@ -18,6 +18,4 @@ conditional_schedule:
       s390x:
         - installation/bootloader_start
       aarch64:
-        - installation/bootloader_uefi
-      x86_64:
-        - installation/bootloader_uefi
+        - boot/boot_to_desktop


### PR DESCRIPTION
Remove wrong/unnecessary step(s) in schedules.

- Related ticket: https://progress.opensuse.org/issues/204795
- Verification runs: 
  -  https://openqa.suse.de/tests/overview?distri=sle&version=16.1&build=13.21&groupid=611 (fde_tpm fails due to existing issue) 
  - https://openqa.suse.de/tests/24168273 (FLAVOR=Transactional-Base-qcow)