### PR TITLE
bci_prepare: Use script_retry for git-clone to mitigate github issues

### DIFF
--- a/tests/containers/bci_prepare.pm
+++ b/tests/containers/bci_prepare.pm
@@ -127,7 +127,7 @@ sub update_test_repos {
     record_info('Clone', "Cloning BCI tests repository: $bci_tests_repo\nBranch: $bci_tests_branch");
     my $branch = $bci_tests_branch ? "-b $bci_tests_branch" : '';
     assert_script_run('rm -rf /root/BCI-tests');
-    assert_script_run("git clone $branch -q --depth 1 $bci_tests_repo /root/BCI-tests", timeout => 300);
+    script_retry("git clone $branch -q --depth 1 $bci_tests_repo /root/BCI-tests", retry => 5, delay => 60, timeout => 300);
 }
 
 sub run {


### PR DESCRIPTION
Failed job: https://openqa.opensuse.org/tests/6199634#step/bci_prepare/17