### PR TITLE
Add generic prefs.js path for Firefox changesaving test

### DIFF
--- a/tests/x11/firefox/firefox_changesaving.pm
+++ b/tests/x11/firefox/firefox_changesaving.pm
@@ -28,7 +28,7 @@ use version_utils 'is_sle';
 sub run {
 
     my ($self) = @_;
-    my $changesaving_checktimestamp = "ll --time-style=full-iso .mozilla/firefox/*default*/prefs.js | cut -d' ' -f7";
+    my $changesaving_checktimestamp = "ll --time-style=full-iso \$(find  ~/.config/mozilla ~/.mozilla  -type f -name prefs.js | grep '/firefox/' | head -n1) | cut -d' ' -f7";
 
     $self->start_firefox_with_profile;
 

--- a/tests/x11/firefox/firefox_pagesaving.pm
+++ b/tests/x11/firefox/firefox_pagesaving.pm
@@ -30,7 +30,8 @@ sub run {
     assert_screen 'firefox-pagesaving-saveas';
     wait_still_screen 3;
     # on sle15 just one alt-s does not work
-    send_key_until_needlematch 'firefox-downloading-saving_dialog', 'alt-s', 4, 3;
+    assert_and_click 'firefox-downloading-saveas_click';
+    wait_still_screen 3;
 
     # Exit
     $self->exit_firefox;


### PR DESCRIPTION
Replace the hard-coded Firefox prefs.js path with a dynamic lookup to support different Firefox profile locations.

- Related ticket: https://progress.opensuse.org/issues/206484
- Needles: NO
- Verification run: https://openqa.suse.de/tests/24208672#
 