### PR TITLE
Add suseconnect_keepalive module for SLES-HA/SAP Install tests

### DIFF
--- a/schedule/qam/common/qam-incidentinstall-HA-SAP.yaml
+++ b/schedule/qam/common/qam-incidentinstall-HA-SAP.yaml
@@ -1,0 +1,13 @@
+name: qam-incidentinstall-HA-SAP
+description:    >
+    Maintainer: qe-sap <qe-sap@suse.de>
+schedule:
+    - '{{boot}}'
+    - boot/boot_to_desktop
+    - qam-updinstall/suseconnect_keepalive
+    - qam-updinstall/SLFO_update_install
+conditional_schedule:
+    boot:
+        ARCH:
+            s390x:
+                - installation/bootloader_zkvm

--- a/tests/qam-updinstall/suseconnect_keepalive.pm
+++ b/tests/qam-updinstall/suseconnect_keepalive.pm
@@ -1,0 +1,42 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Prevent SUT de-registration from SCC by sending keepalive
+# Maintainer: Wang Jun <jgwang@suse.com>
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use version_utils qw(is_sle is_sles4sap);
+use serial_terminal qw(select_serial_terminal);
+
+sub run {
+    my $self = shift;
+
+    my $flavor = get_var('FLAVOR') // '';
+    unless (is_sle('>=16.0') && (is_sles4sap() || $flavor =~ /-(SAP|HA)-/i)) {
+        record_info('Keepalive Skip', 'SUSEConnect keepalive is only triggered on SLES 16.0 HA/SAP tests');
+        return;
+    }
+
+    select_serial_terminal;
+    if (script_run('which SUSEConnect') == 0) {
+        my $exit_code = script_run('SUSEConnect --keepalive', timeout => 120);
+        if ($exit_code != 0) {
+            die "SUSEConnect --keepalive returned exit code: $exit_code. System might not be registered or SCC is unreachable.";
+        }
+        else {
+            record_info('SCC Info', 'Successfully executed SUSEConnect --keepalive.');
+        }
+    }
+    else {
+        record_info('SCC Info', 'SUSEConnect command is not available. Skipping keepalive.', result => 'info');
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Add a new module `suseconnect_keepalive.pm`  to `run suseconnect --keepalive` to avoid SUT removing from SCC, and the module is only applied in **16.0** Install Tests.  please read the details in the ticket.

- Related ticket: https://jira.suse.com/browse/TEAM-11505
- Verification run:
    https://openqa.suse.de/tests/24204165#step/suseconnect_keepalive/1   (SKIP in Core Team test)
    https://openqa.suse.de/tests/24204168#step/suseconnect_keepalive/11 (Enable keepalive)