### PR TITLE
Enforce AITL poll-loop timeout in azure_aitl

### DIFF
--- a/tests/publiccloud/azure_aitl.pm
+++ b/tests/publiccloud/azure_aitl.pm
@@ -116,7 +116,10 @@ sub run {
     # AITL Jobs run in parallel so it's possible to have Jobs in all kind of states.
     # The goal of the loop is to check there are no Jobs Queued or currently Running.
     my $status_data;
+    my $poll_start = time();
     while (1) {
+        die "AITL jobs did not complete within PUBLIC_CLOUD_AITL_TIMEOUT (${timeout}s)" if (time() - $poll_start > $timeout);
+
         # # poo#200979: If the AITL resource was already deleted by Azure don't overwrite last known results
         my $results_rc = script_run("$aitl_job get $aitl_get_options -q 'properties.results[]' > /tmp/aitl_results.out 2>&1", timeout => 300);
         my $results_current = script_output("cat /tmp/aitl_results.out");

--- a/variables.md
+++ b/variables.md
@@ -323,6 +323,7 @@ PUBLIC_AZURE_CLI_TEST | string | "vmss" | Azure CLI test names. This variable sh
 PUBLIC_CLOUD | boolean | false | All Public Cloud tests have this variable set to true. Contact: qa-c@suse.de
 PUBLIC_CLOUD_ACCNET | boolean | false | If set, az_accelerated_net test module is added to the job.
 PUBLIC_CLOUD_AHB_LT | string | "SLES_BYOS" | For Azure, it specifies the license type to change to (and test).
+PUBLIC_CLOUD_AITL_TIMEOUT | integer | 5400 | Timeout in seconds for the AITL job poll loop in `azure_aitl.pm` to wait for job completion before failing the test.
 PUBLIC_CLOUD_ARCH | string | "x86_64" | The architecture of created VM.
 PUBLIC_CLOUD_AVAILABILITY_ZONE | string | "" | The availability zone to use. Depends on `PUBLIC_CLOUD_REGION`. Only for GCE.
 PUBLIC_CLOUD_AZURE_IMAGE_DEFINITION | string | "" | Defines the image definition for uploading Arm64 images to the image gallery.


### PR DESCRIPTION
Adds a `PUBLIC_CLOUD_AITL_TIMEOUT` check to the AITL job-status poll loop, which previously declared the variable but never used it and could loop forever.

* Related failure: [openqa.suse.de/t24166507](https://openqa.suse.de/tests/24166507)
* Verification runs: In comment below

