### PR TITLE
Automate self_update enablement based on product version detection

### DIFF
--- a/test_data/yam/agama_sle_extended.yaml
+++ b/test_data/yam/agama_sle_extended.yaml
@@ -12,6 +12,5 @@ repos:
     enabled: 'Yes'
     filter: name
 bootloader_timeout: '8'
-self_update_enabled: 1
 ntp_servers:
   - 2.suse.pool.ntp.org

--- a/test_data/yam/agama_sle_extended_qu.yaml
+++ b/test_data/yam/agama_sle_extended_qu.yaml
@@ -12,4 +12,3 @@ repos:
     enabled: 'Yes'
     filter: name
 bootloader_timeout: '8'
-self_update_enabled: 0

--- a/test_data/yam/agama_sle_extended_s390x.yaml
+++ b/test_data/yam/agama_sle_extended_s390x.yaml
@@ -12,6 +12,5 @@ repos:
     enabled: 'Yes'
     filter: name
 bootloader_timeout: '30'
-self_update_enabled: 1
 ntp_servers:
   - 2.suse.pool.ntp.org

--- a/test_data/yam/agama_sle_self_update.yaml
+++ b/test_data/yam/agama_sle_self_update.yaml
@@ -40,4 +40,3 @@ selinux:
   mode: enforcing
 products:
   - SLES
-self_update_enabled: 1

--- a/test_data/yam/agama_sle_self_update_s390x_ppc64le.yaml
+++ b/test_data/yam/agama_sle_self_update_s390x_ppc64le.yaml
@@ -30,4 +30,3 @@ selinux:
   mode: enforcing
 products:
   - SLES
-self_update_enabled: 1

--- a/tests/yam/validate/validate_self_update.pm
+++ b/tests/yam/validate/validate_self_update.pm
@@ -10,11 +10,16 @@ use Mojo::Base 'consoletest';
 use testapi;
 use utils qw(systemctl);
 use scheduler qw(get_test_suite_data);
+use version_utils qw(is_sle);
+
+sub is_16_0_qu0 {
+    return is_sle('=16.0') && get_var('ISO') =~ /160.4/;
+}
 
 sub run {
     select_console 'install-shell';
-    my $self_update_enabled = get_test_suite_data()->{self_update_enabled};
-    if ($self_update_enabled) {
+    # Assuming extended testing is only performed using Full medium in QU
+    if (is_16_0_qu0() || !check_var('FLAVOR', 'Full')) {
         my $systemctl_output = script_output('systemctl status live-self-update.service', proceed_on_failure => 1);
         unless ($systemctl_output =~ /status=0\/SUCCESS/) {
             die "Self update did not end successfully";


### PR DESCRIPTION
Added support for QU, PI builds and production ones (16.1+).

- Related ticket: https://jira.suse.com/browse/QEIM-6
- Related PR: https://github.com/qe-installation-and-migration/agama-integration-test-webpack/pull/304
- Needles: N/A
- Verification run:
  - PI: https://openqa.suse.de/tests/24250814#
  - QU: https://openqa.suse.de/tests/24250815#
  - Prod: https://openqa.suse.de/tests/24250817#
