### PR TITLE
console/libsoup: add openQA-agnostic installed tests

### DIFF
--- a/data/console/openqa_agnostic/python/testLibsoup/runtest
+++ b/data/console/openqa_agnostic/python/testLibsoup/runtest
@@ -1,0 +1,39 @@
+#!/bin/bash
+# METADATA_START
+# ---
+# test: libsoup-3.0 installed tests
+# desc: >
+#   Runs the upstream installed tests for libsoup 3.x via
+#   gnome-desktop-testing-runner. Tests cover HTTP client/server,
+#   caching, cookies, TLS, websockets, HTTP/2, multipart, and more.
+# steps:
+#   - discover available libsoup-3.0 test cases
+#   - run each test via gnome-desktop-testing-runner
+#   - collect results as JUnit XML via pytest
+# requires: libsoup-tests and gnome-desktop-testing must be installed
+# author: <zbalogh@suse.com>
+# maintainer: QE Core <qe-core@suse.de>
+# expected: all tests pass
+# platform: Tumbleweed, SLE 16+
+# tags: console libsoup http networking
+# ---
+# METADATA_END
+
+set -e
+
+source ../lib/helper.sh
+
+TEST_FILES=(test_libsoup.py)
+
+handle_args "$0" "$@"
+
+ensure_command_available "gnome-desktop-testing-runner"
+
+set +e
+pytest -v -s test_libsoup.py --junitxml=results.xml
+rc=$?
+set -e
+if [ -f results.xml ]; then
+    exit 0
+fi
+exit $rc

--- a/data/console/openqa_agnostic/python/testLibsoup/test_libsoup.py
+++ b/data/console/openqa_agnostic/python/testLibsoup/test_libsoup.py
@@ -1,0 +1,75 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+import re
+import subprocess
+import sys
+
+import pytest
+
+SUITE = 'libsoup-3.0'
+
+
+def _get_test_list():
+    """Discover available test cases from gnome-desktop-testing-runner."""
+    result = subprocess.run(
+        ['gnome-desktop-testing-runner', '--list', SUITE],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(f'gnome-desktop-testing-runner --list {SUITE} failed (rc={result.returncode}): {result.stderr}')
+    tests = []
+    for line in result.stdout.strip().splitlines():
+        # Lines: "libsoup-3.0/forms-test.test (/usr/share/installed-tests)"
+        name = line.split()[0] if line.strip() else None
+        if name:
+            tests.append(name)
+    return tests
+
+
+_TESTS = _get_test_list()
+
+
+@pytest.fixture(scope='session')
+def suite_results():
+    """Run the full test suite once and return per-test pass/fail map."""
+    result = subprocess.run(
+        ['gnome-desktop-testing-runner', '--tap', '-t', '300', SUITE],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+    )
+    print(result.stdout, file=sys.stdout)
+
+    results = {}
+    for line in result.stdout.splitlines():
+        m = re.match(r'^(ok|not ok) - (.+)$', line)
+        if m:
+            results[m.group(2).strip()] = (m.group(1) == 'ok')
+
+    summary = re.search(
+        r'# SUMMARY: total=(\d+); passed=(\d+); skipped=(\d+); failed=(\d+)',
+        result.stdout,
+    )
+    if summary:
+        print(
+            f'\nSuite summary: total={summary.group(1)} '
+            f'passed={summary.group(2)} '
+            f'skipped={summary.group(3)} '
+            f'failed={summary.group(4)}',
+            file=sys.stdout,
+        )
+
+    return results
+
+
+@pytest.mark.parametrize('test_name', _TESTS, ids=[t.split('/')[-1] for t in _TESTS])
+def test_libsoup(test_name, suite_results):
+    """Check that each libsoup installed test passed."""
+    if test_name not in suite_results:
+        pytest.skip(f'{test_name} not found in runner output')
+    assert suite_results[test_name], f'{test_name} failed'

--- a/schedule/console/libsoup_installed_tests.yaml
+++ b/schedule/console/libsoup_installed_tests.yaml
@@ -1,0 +1,9 @@
+name: libsoup_installed_tests
+description: >
+  Run upstream installed tests for libsoup-3.0 via
+  gnome-desktop-testing-runner.
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - console/consoletest_setup
+  - console/oqa_agnostic/libsoup

--- a/tests/console/oqa_agnostic/libsoup.pm
+++ b/tests/console/oqa_agnostic/libsoup.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Run libsoup-3.0 upstream installed tests
+# Maintainer: Zoltan Balogh <zbalogh@suse.com>
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use package_utils 'install_package';
+use agnosticTestRunner;
+
+sub run {
+    select_serial_terminal;
+    install_package('libsoup-tests gnome-desktop-testing', trup_continue => 1);
+
+    my $test = agnosticTestRunner->new({
+            language => 'python',
+            name => 'testLibsoup',
+            domain => 'console',
+        }
+    );
+    $test->setup()->run_test()->parse_results()->cleanup();
+}
+
+1;


### PR DESCRIPTION
First console-domain openQA-agnostic test. Runs the upstream
libsoup-3.0 installed test suite (36 subtests) via
gnome-desktop-testing-runner.

libsoup is a core HTTP library used across the GNOME stack. It has
28 open CVEs and over 100 bugs in Bugzilla. It currently has zero
openQA test coverage.

**Files:**
- `data/console/openqa_agnostic/python/testLibsoup/runtest` - bash entrypoint
- `data/console/openqa_agnostic/python/testLibsoup/test_libsoup.py` - pytest wrapper
- `data/console/openqa_agnostic/lib/helper.sh` - shared helper
- `tests/console/oqa_agnostic/libsoup.pm` - thin openQA wrapper
- `schedule/console/libsoup_installed_tests.yaml` - schedule

**How it works:**
The pytest wrapper discovers all subtests at collection time, runs
the full suite once via gnome-desktop-testing-runner, and reports
each subtest individually in JUnit XML. The Perl wrapper only
installs packages and delegates to agnosticTestRunner.

**Standalone run (no openQA needed):**
```
zypper in libsoup-tests gnome-desktop-testing python3-pytest
gnome-desktop-testing-runner --list libsoup-3.0   # 36 tests
./runtest                                          # all 36 pass
```

Verified locally on Tumbleweed: 36/36 passed in 32s.

Verification on o3: https://openqa.opensuse.org/tests/6200568    

[progress.o.o#205869](https://progress.opensuse.org/issues/205869)