### PR TITLE
bats: Increase internal test timeout for buildah & podman by 15m

### DIFF
--- a/tests/containers/bats/buildah.pm
+++ b/tests/containers/bats/buildah.pm
@@ -69,7 +69,7 @@ sub run_tests {
         "copy.bats::copy-preserving-extended-attributes",
     ) if (is_ppc64le);
 
-    my $ret = bats_tests($log_file, \%env, \@xfails, 6000);
+    my $ret = bats_tests($log_file, \%env, \@xfails, 6900);
 
     run_command "STORAGE_DRIVER=$storage_driver buildah prune -a -f";
     cleanup_podman;

--- a/tests/containers/bats/podman.pm
+++ b/tests/containers/bats/podman.pm
@@ -69,7 +69,7 @@ sub run_tests {
         "090-events.bats::events - died event contains OOMKilled attribute",
     ) if (version->parse(numeric_version($version)) >= version->parse("6.0.0"));
 
-    my $ret = bats_tests($log_file, \%env, \@xfails, 6000);
+    my $ret = bats_tests($log_file, \%env, \@xfails, 6900);
 
     run_command 'kill %1; kill -9 %1 || true' if ($remote);
 


### PR DESCRIPTION
Otherwise tests timeout in aarch64 on Tumbleweed maybe due to the Glibc 4.44 upgrade.

Failed jobs:
- buildah: https://openqa.opensuse.org/tests/6200350/logfile?filename=serial_terminal.txt (terminated almost when it was finishing)
- podman: https://openqa.opensuse.org/tests/6199870/logfile?filename=serial_terminal_user.txt 