### PR TITLE
publiccloud: Fix "System management is locked" during registration

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -245,7 +245,8 @@ sub registercloudguest {
 
 sub register_addons_in_pc {
     my ($instance, %args) = @_;
-    my $timeout = $args{timeout} // 90;
+    # pc_refresh() below can take several minutes on many aggregated repos.
+    my $timeout = $args{timeout} // 900;
     my @addons = split(/,/, get_var('SCC_ADDONS', ''));
     my $remote = $instance->username . '@' . $instance->public_ip;
     # Refresh repos. publiccloud::zypper::pc_refresh always uses plain zypper

--- a/lib/publiccloud/zypper.pm
+++ b/lib/publiccloud/zypper.pm
@@ -92,6 +92,13 @@ use constant {
     DEFAULT_DELAY => 5,
     ZYPPER_LOG => '/var/log/zypper.log',
     TRANSACTIONAL_LOG => '/var/log/transactional-update.log',
+
+    # Bounded budget for actively waiting out an EXIT_LOCKED holder in
+    # _retry_loop(), instead of blindly sleep()ing DEFAULT_DELAY and
+    # retrying straight back into the same lock (~120s ceiling).
+    LOCK_WAIT_TIMEOUT => 10,
+    LOCK_WAIT_DELAY => 10,
+    LOCK_WAIT_RETRY => 6,
 };
 
 # Process names pc_wait_quit()/pc_wait_quit_local() poll for (poo#204534).
@@ -526,7 +533,18 @@ sub _retry_loop {
     for my $attempt (1 .. $retry) {
         $ret = $instance->ssh_script_run(cmd => $cmd, %$ssh_args);
         return $ret if $ret == EXIT_OK;
-        sleep($delay) if defined $ret;
+
+        if (defined $ret && $ret == EXIT_LOCKED) {
+            # A previous attempt may have been orphaned (e.g. left running
+            # server-side by a client-side SSH timeout) and still hold the
+            # zypp lock. Actively wait it out instead of blindly retrying
+            # straight back into the same lock; best-effort, so swallow a
+            # timeout here and fall through to the normal retry/backoff.
+            eval { pc_wait_quit($instance, timeout => LOCK_WAIT_TIMEOUT, delay => LOCK_WAIT_DELAY, retry => LOCK_WAIT_RETRY) };
+        }
+        else {
+            sleep($delay) if defined $ret;
+        }
 
         my $action = _handle_transient_failure($instance, $ret, $attempt, $retry, $kind);
         return $ret if $action eq 'stop';

--- a/tests/publiccloud/registration.pm
+++ b/tests/publiccloud/registration.pm
@@ -40,7 +40,7 @@ sub run {
     }
 
     pc_wait_quit($args->{my_instance});
-    register_addons_in_pc($args->{my_instance}, timeout => 240);
+    register_addons_in_pc($args->{my_instance});
     pc_wait_quit($args->{my_instance});
     # Double confirm system is correctly registered, and quit earlier if anything wrong
     # see bsc#1253777, we may need have to rerun the failed job in this case


### PR DESCRIPTION
Raises `register_addons_in_pc`'s `zypper ref` timeout from 90s/240s to 900s, so it has enough headroom on jobs with a large number of aggregated Maintenance-incident repos in `SCC_ADDONS`.

Makes the zypper retry loop actively wait out an `EXIT_LOCKED` holder via `pc_wait_quit()` (bounded ~120s) instead of blindly sleeping a fixed delay and retrying straight back into the same lock.

* Related failure: [openqa.suse.de/t24175868](https://openqa.suse.de/tests/24175868)
* Verification runs: In comment below

## Commits

- b38f3911d7 fix(publiccloud): Raise register_addons_in_pc zypper ref timeout to 900s
- 3c26b1eaae fix(publiccloud): Wait for zypp lock holder before retrying

Both commits fix the same underlying failure: the first removes the undersized timeout that caused it, the second makes the shared retry loop more robust against the same class of issue in general.
