### PR TITLE
fips_setup: scope FIPS reboot's serial confirmation instead of gating on qemu/SLE 16+

### DIFF
--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -15,8 +15,8 @@ use bootloader_setup qw(add_grub_cmdline_settings change_grub_config);
 use power_action_utils 'power_action';
 use transactional qw(trup_call process_reboot);
 use utils qw(zypper_call reconnect_mgmt_console);
-use serial_terminal qw(get_login_message select_serial_terminal);
-use Utils::Backends qw(is_pvm is_qemu);
+use serial_terminal 'select_serial_terminal';
+use Utils::Backends 'is_pvm';
 use Utils::Architectures qw(is_aarch64 is_ppc64le is_s390x);
 use version_utils qw(is_jeos is_sle_micro is_sle is_tumbleweed is_transactional is_microos);
 use security::vendoraffirmation;
@@ -29,17 +29,7 @@ sub reboot_and_login {
 
     is_transactional ? process_reboot(trigger => 1) : power_action('reboot', textmode => 1, keepconsole => is_pvm);
     reconnect_mgmt_console if is_pvm;
-    if (!is_transactional) {
-        if (is_qemu && is_sle('>=16')) {
-            # Same GRUB serial-terminal-init stall as containers/install_updates.pm:
-            # wait_boot's needle-based checks hit a "Stall detected" on this image
-            # rather than a missed match. Confirmed only on SLE 16+ qemu so far.
-            die 'System did not come back up after FIPS reboot' unless wait_serial(get_login_message(), 300);
-            reset_consoles;
-        } else {
-            $self->wait_boot;
-        }
-    }
+    $self->wait_boot if !is_transactional;
     is_ppc64le() ? select_console('root-console') : select_serial_terminal();
     return;
 }

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -15,8 +15,8 @@ use bootloader_setup qw(add_grub_cmdline_settings change_grub_config);
 use power_action_utils 'power_action';
 use transactional qw(trup_call process_reboot);
 use utils qw(zypper_call reconnect_mgmt_console);
-use serial_terminal 'select_serial_terminal';
-use Utils::Backends 'is_pvm';
+use serial_terminal qw(get_login_message select_serial_terminal);
+use Utils::Backends qw(is_pvm is_qemu);
 use Utils::Architectures qw(is_aarch64 is_ppc64le is_s390x);
 use version_utils qw(is_jeos is_sle_micro is_sle is_tumbleweed is_transactional is_microos);
 use security::vendoraffirmation;
@@ -29,7 +29,24 @@ sub reboot_and_login {
 
     is_transactional ? process_reboot(trigger => 1) : power_action('reboot', textmode => 1, keepconsole => is_pvm);
     reconnect_mgmt_console if is_pvm;
-    $self->wait_boot if !is_transactional;
+    if (!is_transactional) {
+        if (is_qemu && is_aarch64 && is_sle('=16.0')) {
+            # On this SLE 16.0 aarch64/qemu image GRUB fails to init its configured
+            # serial terminal ("serial port `com0' isn't found") and the video
+            # framebuffer then genuinely stalls instead of ever painting a screen,
+            # so wait_boot's needle-based checks hit a real "Stall detected" rather
+            # than a missed match (same root cause as containers/install_updates.pm).
+            # Confirmed only on SLE 16.0 aarch64 so far: other SLE 16+ qemu images
+            # (e.g. the SLE 16.1 Online flavor booted by docker/podman_fips_tests)
+            # render GRUB fine and instead rely on wait_boot's needle+keypress
+            # handling to get past a deliberately stopped boot menu, so keep this
+            # scoped narrowly rather than gating on qemu/version alone.
+            die 'System did not come back up after FIPS reboot' unless wait_serial(get_login_message(), 300);
+            reset_consoles;
+        } else {
+            $self->wait_boot;
+        }
+    }
     is_ppc64le() ? select_console('root-console') : select_serial_terminal();
     return;
 }


### PR DESCRIPTION
`tests/fips/fips_setup.pm`'s `reboot_and_login` no longer takes the FIPS-triggered reboot through `wait_serial(get_login_message())` unconditionally on `is_qemu && is_sle('>=16')` (from #26539). The Container Host group's `docker_fips_tests`/`podman_fips_tests` jobs boot from `create_hdd_textmode`, whose Agama profile sets `stopOnBootMenu: true`, so GRUB stops at the boot menu on every reboot and needs an Enter press that `wait_serial` never sends. `wait_boot` already handles this correctly via `handle_grub`/`grub_select`'s `send_key('ret')`, so it's used by default again.

The `wait_serial` path is kept, but scoped to `is_aarch64 && is_sle('=16.0')` instead of the previous `is_qemu && is_sle('>=16')`. VRs against a plain revert showed `create_hdd_fips_containers` on SLE 16.0 aarch64 still hits the real video-framebuffer stall `containers/install_updates.pm` was fixed for (GRUB fails to init its serial terminal there) — that image needs `wait_serial`, while the SLE 16.1 Online flavor used by `docker_fips_tests`/`podman_fips_tests` renders GRUB fine and needs `wait_boot`'s keypress handling instead. The previous gate caught both cases; this one is scoped to only the confirmed one.

`containers/install_updates.pm` is untouched throughout — it addresses a different, still-needed fix and is unaffected by either commit here.

## Commits

- db9b0e5 fix(fips): Revert to needle-based wait_boot for FIPS reboot
- 16dfdef fix(fips): Scope FIPS reboot's serial confirmation to SLE 16.0 aarch64

The second commit refines the first after VR results showed the plain revert reintroduced the original SLE 16.0 aarch64 stall; both are needed together, and the end state is a narrower gate rather than a straight revert.

* Related failure: [openqa.suse.de/t24186224](https://openqa.suse.de/tests/24186224)
* Related merge requests: #26539
* Verification runs: In comment below
