### PR TITLE
fix(kernel): Raise make test compilation timeout in io_uring to 300s

### DIFF
--- a/tests/kernel/io_uring.pm
+++ b/tests/kernel/io_uring.pm
@@ -50,7 +50,7 @@ sub run {
         record_info("test version", script_output("git log -1 --oneline"));
         assert_script_run("./configure");
         assert_script_run("make -C src");
-        assert_script_run("make -C test");
+        assert_script_run("make -C test", timeout => 300);
         $test_dir = 'liburing';
     } else {
         my $default_test_dir = '/usr/lib/liburing-tests';


### PR DESCRIPTION
Compiling the liburing tests from git on slow/emulated architectures (such as aarch64 under QEMU) times out after the default 90 seconds during assert_script_run('make -C test').

Extend the timeout to 300s to ensure compilation completes successfully on all platforms.

- Related ticket: https://progress.opensuse.org/issues/203859
- Verification run: https://openqa.opensuse.org/tests/6202788#step/io_uring/23 

Timestamps from the Log
   * Command started: 2026-09-04T06:17:44.160765Z
   * Command completed: 2026-09-04T06:20:58.966058Z
 
Make test  duration = 06:20:58.966 - 06:17:44.160 = 3 minutes and  14.8 seconds = 194.8 seconds


