### PR TITLE
Recover from aarch64 GRUB serial-terminal hang (bsc#1140464)

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -22,6 +22,7 @@ use testapi;
 use Utils::Architectures;
 use Utils::Backends;
 use version_utils qw(is_sle is_leap is_opensuse is_tumbleweed is_vmware is_jeos);
+use serial_terminal 'get_login_message';
 use Carp 'croak';
 
 our @EXPORT = qw(
@@ -32,6 +33,7 @@ our @EXPORT = qw(
   assert_shutdown_and_restore_system
   assert_shutdown_with_soft_timeout
   check_bsc1215132
+  wait_boot_serial
 );
 
 =head2 prepare_system_shutdown
@@ -380,6 +382,46 @@ sub power_action {
             select_console('sut');
         }
     }
+}
+
+=head2 wait_boot_serial
+
+ wait_boot_serial();
+
+Confirm a reboot completed by watching the serial console for the login
+banner, recovering first if GRUB got stuck on its aarch64 serial-terminal
+bug (bsc#1140464: aarch64 has no legacy I/O ports, so GRUB's default
+C<com0> serial addressing can never resolve there; SUSE's grub2 config
+generation still doesn't use C<efi0> instead). Once grub.cfg gets
+regenerated (e.g. by a kernel/bootloader update or C<fips-mode-setup>),
+GRUB's C<terminal_output>/C<terminal_input serial> command aborts
+grub.cfg's script execution, parking GRUB at its hidden-menu hint
+("Please press 't' to show the boot menu") instead of ever reaching the
+auto-boot logic.
+
+Races that hint against the login banner for 60 seconds so an unaffected
+boot returns as soon as it's up. If neither appeared yet, keeps waiting
+for the login banner alone for another 240 seconds (300 seconds total,
+matching a plain boot-confirmation timeout). If the hint wins the race,
+presses 't' (reveal the menu) and 'ret' (confirm the default entry), then
+allows a fresh 300 seconds for the now-unstuck boot to actually complete.
+
+Returns the matched text (a true value) on success, or an empty/undef
+value if the login banner was never seen at all.
+
+=cut
+
+sub wait_boot_serial {
+    my $login_message = get_login_message();
+    my $hang = qr/Please press .t. to show the boot menu/;
+
+    my $matched = wait_serial(qr/$hang|$login_message/, 60);
+    if ($matched && $matched =~ $hang) {
+        send_key 't';
+        send_key 'ret';
+        return wait_serial($login_message, 300);
+    }
+    return $matched || wait_serial($login_message, 240);
 }
 
 =head2 assert_shutdown_and_restore_system

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -12,10 +12,10 @@
 use Mojo::Base 'consoletest';
 use testapi;
 use bootloader_setup qw(add_grub_cmdline_settings change_grub_config);
-use power_action_utils 'power_action';
+use power_action_utils qw(power_action wait_boot_serial);
 use transactional qw(trup_call process_reboot);
 use utils qw(zypper_call reconnect_mgmt_console);
-use serial_terminal qw(get_login_message select_serial_terminal);
+use serial_terminal 'select_serial_terminal';
 use Utils::Backends qw(is_pvm is_qemu);
 use Utils::Architectures qw(is_aarch64 is_ppc64le is_s390x);
 use version_utils qw(is_jeos is_sle_micro is_sle is_tumbleweed is_transactional is_microos);
@@ -31,17 +31,16 @@ sub reboot_and_login {
     reconnect_mgmt_console if is_pvm;
     if (!is_transactional) {
         if (is_qemu && is_aarch64 && is_sle('=16.0')) {
-            # On this SLE 16.0 aarch64/qemu image GRUB fails to init its configured
-            # serial terminal ("serial port `com0' isn't found") and the video
-            # framebuffer then genuinely stalls instead of ever painting a screen,
-            # so wait_boot's needle-based checks hit a real "Stall detected" rather
-            # than a missed match (same root cause as containers/install_updates.pm).
-            # Confirmed only on SLE 16.0 aarch64 so far: other SLE 16+ qemu images
-            # (e.g. the SLE 16.1 Online flavor booted by docker/podman_fips_tests)
-            # render GRUB fine and instead rely on wait_boot's needle+keypress
-            # handling to get past a deliberately stopped boot menu, so keep this
-            # scoped narrowly rather than gating on qemu/version alone.
-            die 'System did not come back up after FIPS reboot' unless wait_serial(get_login_message(), 300);
+            # On SLE 16.0 aarch64/qemu, GRUB can hit its serial-terminal bug
+            # (bsc#1140464) and hang at a hidden-menu prompt; wait_boot_serial
+            # recovers from that and confirms the login banner over serial.
+            # Confirmed only on SLE 16.0 aarch64 so far: other SLE 16+ qemu
+            # images (e.g. the SLE 16.1 Online flavor booted by docker/
+            # podman_fips_tests) render GRUB fine and instead rely on
+            # wait_boot's needle+keypress handling for a deliberately stopped
+            # boot menu, so keep this scoped narrowly rather than gating on
+            # qemu/version alone.
+            die 'System did not come back up after FIPS reboot' unless wait_boot_serial;
             reset_consoles;
         } else {
             $self->wait_boot;

--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -22,8 +22,8 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use Utils::Architectures;
 use qam;
-use Utils::Backends qw(use_ssh_serial_console is_pvm);
-use power_action_utils qw(power_action);
+use Utils::Backends qw(use_ssh_serial_console is_pvm is_qemu);
+use power_action_utils qw(power_action wait_boot_serial);
 use version_utils qw(is_sle);
 use serial_terminal qw(add_serial_console);
 use version_utils qw(is_jeos);
@@ -70,6 +70,11 @@ sub run {
     # DESKTOP can be gnome, but patch is happening in shell, thus always force reboot in shell
     power_action('reboot', textmode => 1);
     reconnect_mgmt_console if is_pvm;
+    # On SLE 16.0 aarch64/qemu, patching the kernel/bootloader can regenerate
+    # grub.cfg and trigger GRUB's serial-terminal bug (bsc#1140464), hanging
+    # wait_boot's needle checks with "Stall detected". Recover over serial
+    # first; wait_boot then proceeds normally either way.
+    wait_boot_serial if is_qemu && is_aarch64 && is_sle('=16.0');
     $self->wait_boot(ready_time => 600, bootloader_time => get_var('BOOTLOADER_TIMEOUT', 300));
 }
 

--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -70,12 +70,16 @@ sub run {
     # DESKTOP can be gnome, but patch is happening in shell, thus always force reboot in shell
     power_action('reboot', textmode => 1);
     reconnect_mgmt_console if is_pvm;
-    # On SLE 16.0 aarch64/qemu, patching the kernel/bootloader can regenerate
-    # grub.cfg and trigger GRUB's serial-terminal bug (bsc#1140464), hanging
-    # wait_boot's needle checks with "Stall detected". Recover over serial
-    # first; wait_boot then proceeds normally either way.
-    wait_boot_serial if is_qemu && is_aarch64 && is_sle('=16.0');
-    $self->wait_boot(ready_time => 600, bootloader_time => get_var('BOOTLOADER_TIMEOUT', 300));
+    if (is_qemu && is_aarch64 && is_sle('=16.0')) {
+        # On SLE 16.0 aarch64/qemu, patching the kernel/bootloader can
+        # regenerate grub.cfg and trigger GRUB's serial-terminal bug
+        # (bsc#1140464), hanging wait_boot's needle checks with "Stall
+        # detected". wait_boot_serial already confirms the login banner
+        # itself, so it replaces wait_boot here rather than preceding it.
+        die 'System did not come back up after patching' unless wait_boot_serial;
+    } else {
+        $self->wait_boot(ready_time => 600, bootloader_time => get_var('BOOTLOADER_TIMEOUT', 300));
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
Adds `power_action_utils::wait_boot_serial`, a helper that races GRUB's aarch64 serial-terminal hang prompt ("Please press `t` to show the boot menu") against the login banner over serial, recovers with `t`+`ret` if the prompt wins, and otherwise just confirms the login banner. Root cause is [bsc#1140464](https://bugzilla.suse.com/show_bug.cgi?id=1140464): aarch64 has no legacy I/O ports, so GRUB's default `com0` serial addressing never resolves there, and SUSE's grub2 config generation still doesn't use `efi0` instead. Once grub.cfg gets regenerated (`fips-mode-setup`, a kernel/bootloader patch, ...), GRUB's `terminal_output`/`terminal_input serial` aborts grub.cfg's script execution and parks GRUB at that hidden-menu hint instead of reaching the auto-boot logic.

Wires the helper into `fips_setup.pm` (replacing its existing SLE 16.0 aarch64 `wait_serial` call) and into `qa_automation/patch_and_reboot.pm`, which had no protection at all and was failing on roughly half its aarch64 runs. Both call sites are gated on `is_qemu && is_aarch64 && is_sle('=16.0')`. `containers/install_updates.pm` already confirms over serial and is unaffected by this change.

* Related merge requests: #26580
* Failing jobs: [FIPS Build PI-277.29](https://openqa.suse.de/tests/overview?version=16.0&build=PI-277.29&groupid=675&distri=sle&result=failed)
* Verification runs: