### PR TITLE
[PoC] Build the Public Cloud tools image on a SLE 16.0 MinimalVM

### DIFF
--- a/lib/publiccloud/utils.pm
+++ b/lib/publiccloud/utils.pm
@@ -540,12 +540,17 @@ sub ssh_update_transactional_system {
 
 get_python_exec()
 
-Returns the Python executable name for public cloud purposes. As of now, it returns "python3.11" by default.
+Returns the Python executable name for public cloud purposes. Defaults to
+"python3.11", the interpreter of the SLE 15-SP7 tools image. Set
+PUBLIC_CLOUD_PYTHON_VERSION to override it, e.g. to 3.13 on SLE 16.
+
+The version cannot be derived from VERSION: in a publiccloud_ltp job that is
+the version of the instance under test, not of the tools image this runs on.
 
 =cut
 
 sub get_python_exec {
-    my $version = '3.11';
+    my $version = get_var('PUBLIC_CLOUD_PYTHON_VERSION', '3.11');
     return "python$version";
 }
 

--- a/schedule/publiccloud/create_tools_hdd_minimalvm.yaml
+++ b/schedule/publiccloud/create_tools_hdd_minimalvm.yaml
@@ -1,0 +1,30 @@
+---
+name: create_tools_hdd_minimalvm
+description: >
+  Build the Public Cloud tools image on top of a SLE 16.0 MinimalVM qcow2
+  instead of installing it. Replaces the autoyast/prepare_profile +
+  installation/bootloader + autoyast/installation sequence of
+  load_create_publiccloud_tools_image() with a plain boot of the published
+  Minimal-VM image.
+conditional_schedule:
+  bootloader:
+    MACHINE:
+      uefi-virtio-vga:
+        - installation/bootloader_uefi
+      64bit-virtio-vga:
+        - installation/bootloader_uefi
+  wizard:
+    FIRST_BOOT_CONFIG:
+      wizard:
+        - jeos/firstrun
+      cloud-init:
+        - installation/first_boot
+schedule:
+  - '{{bootloader}}'
+  - '{{wizard}}'
+  - jeos/host_config
+  - console/suseconnect_scc
+  - publiccloud/prepare_minimalvm
+  - publiccloud/prepare_tools
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/tests/publiccloud/prepare_minimalvm.pm
+++ b/tests/publiccloud/prepare_minimalvm.pm
@@ -1,0 +1,60 @@
+# SUSE's openQA tests
+#
+# Copyright 2026 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Close the gap between a bare SLE 16.0 MinimalVM image and what
+# publiccloud/prepare_tools expects to find on the tools image. On 15-SP7 that
+# baseline comes from the AutoYaST profile data/autoyast_sle15/pc_tools.xml,
+# which a MinimalVM qcow2 obviously never ran. PoC for poo#206526.
+#
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use utils qw(zypper_call systemctl);
+use publiccloud::utils qw(get_python_exec);
+
+# The pc_tools.xml package list, translated to SLE 16 names. python311-* became
+# python313-*, and ntp is chrony now. Kept in the profile's order so the two can
+# be diffed by eye.
+my @packages = qw(
+  netcat-openbsd git-core chrony gcc sudo wget haveged
+  python313-pip python313-devel python313-pytest
+  podman docker jq rsync unzip
+);
+
+sub run {
+    select_serial_terminal;
+
+    # A MinimalVM image is unregistered and has no repos, so everything below
+    # depends on this being set.
+    if (my $repos = get_var('PUBLIC_CLOUD_BASE_REPO')) {
+        zypper_call("ar --refresh $_") for (split(/\s+/, $repos));
+    }
+    zypper_call('--gpg-auto-import-keys ref');
+
+    # Install one by one: on a PoC the interesting output is *which* of these
+    # the 16.0 repos cannot give us, and a single zypper call would stop at the
+    # first one.
+    my @missing;
+    for my $pkg (@packages) {
+        push @missing, $pkg if zypper_call("in $pkg", exitcode => [0, 104], timeout => 600) == 104;
+    }
+    record_info('missing', join("\n", @missing) || 'none', result => @missing ? 'fail' : 'ok');
+
+    my $python_exec = get_python_exec();
+    record_info('python', script_output("$python_exec --version; $python_exec -m pip --version"));
+
+    # prepare_tools asserts on both of these straight after the img-proof step.
+    systemctl('enable --now docker');
+    assert_script_run('podman ps');
+    assert_script_run('docker ps');
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;


### PR DESCRIPTION
Reference material for [poo#206526](https://progress.opensuse.org/issues/206526), not a merge candidate. It is a draft so the branch is readable outside a personal fork; the implementation belongs to [poo#206361](https://progress.opensuse.org/issues/206361) and [poo#206367](https://progress.opensuse.org/issues/206367).

### Problem

The Public Cloud tools image is built by installing SLE 15-SP7 from an AutoYaST profile. SLE 16 has no AutoYaST, so the assumed port was an Agama profile. A published Minimal-VM qcow2 is already a booted SLE 16 system, which would remove the installation step rather than port it.

### What the runs showed

The Minimal-VM image boots through `installation/bootloader_uefi`, `jeos/firstrun`, `jeos/host_config` and `console/suseconnect_scc`, and reaches `publiccloud/prepare_tools` with no installation step at all.

Of the packages `data/autoyast_sle15/pc_tools.xml` installs, only `haveged` was unavailable, and it is obsolete on kernels that have their own entropy source. `python3.13` and pip 25.0.1 are present, so `get_python_exec()` only needs to stop hardcoding an interpreter.

The build then stops on packaging rather than on anything about the image: `python-img-proof` cannot be installed from `Cloud:Tools:CI/16.0`, because `python313-google-cloud-compute` requires a protobuf that only `devel:languages:python:backports` carries. That is tracked in [poo#206694](https://progress.opensuse.org/issues/206694) and no change in test code works around it.

### What the branch contains

`schedule/publiccloud/create_tools_hdd_minimalvm.yaml` boots the published image instead of installing one.

`tests/publiccloud/prepare_minimalvm.pm` installs what the AutoYaST profile used to, one package at a time, and reports every package it cannot find instead of stopping at the first.

`get_python_exec()` reads `PUBLIC_CLOUD_PYTHON_VERSION` and still defaults to 3.11, so 15-SP7 is unchanged. It cannot detect the interpreter on the SUT because `prepare_tools.pm` calls it at file scope, and it cannot use `is_sle()` because `VERSION` belongs to the instance under test in a `publiccloud_ltp` job.

Only that last change is ready to stand on its own.

### Verification runs

Four runs against source job [24188961](https://openqa.suse.de/tests/24188961), a passing SLE 16.0 Minimal-VM job. Each failed later than the one before, and the last failure is external:

- [24189329](https://openqa.suse.de/tests/24189329#step/prepare_minimalvm/14): no repositories on the SUT, fixed by scheduling `console/suseconnect_scc`
- [24192442](https://openqa.suse.de/tests/24192442#step/prepare_minimalvm/17): reaches `prepare_tools`, and the linked step is the missing-package list
- [24192530](https://openqa.suse.de/tests/24192530#step/prepare_tools/9): `nothing provides 'python313-boto3'`
- [24195026](https://openqa.suse.de/tests/24195026#step/prepare_tools/9): `nothing provides 'python313-protobuf >= 6.33.5'`, [poo#206694](https://progress.opensuse.org/issues/206694)

No run has published a tools image, so nothing downstream of `prepare_tools` has been exercised: the venv installs, the CSP clients and `check_booting` are all untested on 16.0. Only x86_64 and only the `uefi-virtio-vga` machine were covered.
