### PR TITLE
console/glib-networking: add openQA-agnostic installed tests

### DIFF
--- a/data/console/openqa_agnostic/python/testGlibNetworking/runtest
+++ b/data/console/openqa_agnostic/python/testGlibNetworking/runtest
@@ -1,0 +1,42 @@
+#!/bin/bash
+# METADATA_START
+# ---
+# test: glib-networking installed tests
+# desc: >
+#   Runs the upstream installed tests for glib-networking via
+#   gnome-desktop-testing-runner. Tests cover TLS/HTTPS connections,
+#   certificates, file database, and proxy resolution (GnuTLS, libproxy, GNOME).
+# steps:
+#   - discover available glib-networking test cases
+#   - run each test via gnome-desktop-testing-runner
+#   - collect results as JUnit XML via pytest
+# requires: glib-networking-tests and gnome-desktop-testing must be installed
+# author: <zbalogh@suse.com>
+# maintainer: Zoltan Balogh <zbalogh@suse.com>
+# expected: all tests pass
+# platform: Tumbleweed, SLE 16+
+# tags: console glib-networking tls gnutls proxy networking
+# ---
+# METADATA_END
+
+set -e
+
+source ../lib/helper.sh
+
+TEST_FILES=(test_glib_networking.py)
+
+handle_args "$0" "$@"
+
+ensure_command_available "gnome-desktop-testing-runner"
+
+# Avoid OpenSC pkcs11-spy wrapper intercepting mock-pkcs11 provider on systems with opensc installed
+export PKCS11SPY_PATH="/usr/libexec/installed-tests/glib-networking/mock-pkcs11.so"
+
+set +e
+pytest -v -s test_glib_networking.py --junitxml=results.xml
+rc=$?
+set -e
+if [ -f results.xml ]; then
+    exit 0
+fi
+exit $rc

--- a/data/console/openqa_agnostic/python/testGlibNetworking/test_glib_networking.py
+++ b/data/console/openqa_agnostic/python/testGlibNetworking/test_glib_networking.py
@@ -1,0 +1,97 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+import os
+import re
+import subprocess
+import sys
+
+import pytest
+
+SUITE = 'glib-networking'
+
+
+def _get_test_list():
+    """Discover available test cases from gnome-desktop-testing-runner."""
+    result = subprocess.run(
+        ['gnome-desktop-testing-runner', '--list', SUITE],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(f'gnome-desktop-testing-runner --list {SUITE} failed (rc={result.returncode}): {result.stderr}')
+    tests = []
+    for line in result.stdout.strip().splitlines():
+        # Lines: "glib-networking/certificate-gnutls.test (/usr/share/installed-tests)"
+        name = line.split()[0] if line.strip() else None
+        if name:
+            tests.append(name)
+    return tests
+
+
+_TESTS = _get_test_list()
+
+
+@pytest.fixture(scope='session')
+def suite_results():
+    """Run the full test suite once and return per-test pass/fail map with output."""
+    env = os.environ.copy()
+    env.setdefault('PKCS11SPY_PATH', '/usr/libexec/installed-tests/glib-networking/mock-pkcs11.so')
+    result = subprocess.run(
+        ['gnome-desktop-testing-runner', '--tap', '-t', '300', SUITE],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+        env=env,
+    )
+    print(result.stdout, file=sys.stdout)
+
+    results = {}
+    current_test = None
+    current_output = []
+
+    for line in result.stdout.splitlines():
+        m_start = re.match(r'^# Running test:\s+(.+)$', line)
+        if m_start:
+            current_test = m_start.group(1).strip()
+            current_output = [line]
+            continue
+
+        if current_test:
+            current_output.append(line)
+
+        m_end = re.match(r'^(ok|not ok) - (.+)$', line)
+        if m_end:
+            test_name = m_end.group(2).strip()
+            passed = (m_end.group(1) == 'ok')
+            results[test_name] = {
+                'passed': passed,
+                'output': '\n'.join(current_output),
+            }
+
+    summary = re.search(
+        r'# SUMMARY: total=(\d+); passed=(\d+); skipped=(\d+); failed=(\d+)',
+        result.stdout,
+    )
+    if summary:
+        print(
+            f'\nSuite summary: total={summary.group(1)} '
+            f'passed={summary.group(2)} '
+            f'skipped={summary.group(3)} '
+            f'failed={summary.group(4)}',
+            file=sys.stdout,
+        )
+
+    return results
+
+
+@pytest.mark.parametrize('test_name', _TESTS, ids=[t.split('/')[-1] for t in _TESTS])
+def test_glib_networking(test_name, suite_results):
+    """Check that each glib-networking installed test passed."""
+    if test_name not in suite_results:
+        pytest.skip(f'{test_name} not found in runner output')
+    entry = suite_results[test_name]
+    assert entry['passed'], f"{test_name} failed:\n{entry['output']}"

--- a/schedule/console/glib_networking_installed_tests.yaml
+++ b/schedule/console/glib_networking_installed_tests.yaml
@@ -1,0 +1,9 @@
+name: glib_networking_installed_tests
+description: >
+  Run upstream installed tests for glib-networking via
+  gnome-desktop-testing-runner.
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - console/consoletest_setup
+  - console/oqa_agnostic/glib_networking

--- a/tests/console/oqa_agnostic/glib_networking.pm
+++ b/tests/console/oqa_agnostic/glib_networking.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Run glib-networking upstream installed tests
+# Maintainer: Zoltan Balogh <zbalogh@suse.com>
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use package_utils 'install_package';
+use agnosticTestRunner;
+
+sub run {
+    select_serial_terminal;
+    install_package('glib-networking-tests gnome-desktop-testing', trup_continue => 1);
+
+    my $test = agnosticTestRunner->new({
+            language => 'python',
+            name => 'testGlibNetworking',
+            domain => 'console',
+        }
+    );
+    $test->setup()->run_test()->parse_results()->cleanup();
+}
+
+1;


### PR DESCRIPTION
Runs the upstream glib-networking installed test suite (5 subtests) via
gnome-desktop-testing-runner.

glib-networking provides network-related GIO modules for GLib (TLS/HTTPS, proxy).
It currently has zero openQA test coverage.

**Files:**
- `data/console/openqa_agnostic/python/testGlibNetworking/runtest` - bash entrypoint
- `data/console/openqa_agnostic/python/testGlibNetworking/test_glib_networking.py` - pytest wrapper
- `tests/console/oqa_agnostic/glib_networking.pm` - thin openQA wrapper
- `schedule/console/glib_networking_installed_tests.yaml` - schedule

**How it works:**
The pytest wrapper discovers all subtests at collection time, runs
the full suite once via gnome-desktop-testing-runner, and reports
each subtest individually in JUnit XML. The Perl wrapper only
installs packages and delegates to agnosticTestRunner.

**Standalone run (no openQA needed):**
```bash
# Install dependencies
sudo zypper in glib-networking-tests gnome-desktop-testing python3-pytest

# Discover available installed tests
gnome-desktop-testing-runner --list glib-networking

# Run via entrypoint script
cd data/console/openqa_agnostic/python/testGlibNetworking && ./runtest
```

Verified locally on Tumbleweed: 5/5 passed in 3s.

Verification on o3: https://openqa.opensuse.org/tests/6205515