### PR TITLE
console/evolution-data-server: add openQA-agnostic installed tests

### DIFF
--- a/data/console/openqa_agnostic/python/testEvolutionDataServer/runtest
+++ b/data/console/openqa_agnostic/python/testEvolutionDataServer/runtest
@@ -1,0 +1,59 @@
+#!/bin/bash
+# METADATA_START
+# ---
+# test: evolution-data-server installed tests
+# desc: >
+#   Runs the upstream installed tests for evolution-data-server via
+#   gnome-desktop-testing-runner. Tests cover address book, calendar,
+#   contacts, SQLite cache, and D-Bus registry services.
+# steps:
+#   - discover available evolution-data-server test cases
+#   - run each test via gnome-desktop-testing-runner inside dbus-run-session
+#   - collect results as JUnit XML via pytest
+# requires: evolution-data-server-tests, gnome-desktop-testing, and dbus-1-daemon must be installed
+# author: <zbalogh@suse.com>
+# maintainer: Zoltan Balogh <zbalogh@suse.com>
+# expected: all tests pass
+# platform: Tumbleweed, SLE 16+
+# tags: console evolution-data-server eds calendar addressbook
+# ---
+# METADATA_END
+
+set -e
+
+source ../lib/helper.sh
+
+TEST_FILES=(test_evolution_data_server.py)
+
+handle_args "$0" "$@"
+
+ensure_command_available "gnome-desktop-testing-runner"
+
+# Ensure machine-id exists for D-Bus message bus
+dbus-uuidgen --ensure 2>/dev/null || true
+
+# Set UTF-8 locale for character set conversion tests
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
+# Symlink camel test binaries if installed with short names
+EDS_TEST_DIR="/usr/libexec/evolution-data-server/evolution-data-server/installed-tests"
+if [ -d "$EDS_TEST_DIR" ]; then
+    ln -sf test-camel-db "$EDS_TEST_DIR/cameltest-misc-test-camel-db" 2>/dev/null || true
+    ln -sf test-folder-thread "$EDS_TEST_DIR/cameltest-misc-test-folder-thread" 2>/dev/null || true
+    ln -sf test-store-search "$EDS_TEST_DIR/cameltest-misc-test-store-search" 2>/dev/null || true
+    ln -sf test-vee-folder "$EDS_TEST_DIR/cameltest-misc-test-vee-folder" 2>/dev/null || true
+fi
+
+set +e
+if command -v dbus-run-session &>/dev/null; then
+    dbus-run-session -- pytest -v -s test_evolution_data_server.py --junitxml=results.xml
+else
+    pytest -v -s test_evolution_data_server.py --junitxml=results.xml
+fi
+rc=$?
+set -e
+if [ -f results.xml ]; then
+    exit 0
+fi
+exit $rc

--- a/data/console/openqa_agnostic/python/testEvolutionDataServer/test_evolution_data_server.py
+++ b/data/console/openqa_agnostic/python/testEvolutionDataServer/test_evolution_data_server.py
@@ -1,0 +1,93 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+import re
+import subprocess
+import sys
+
+import pytest
+
+SUITE = 'evolution-data-server'
+
+
+def _get_test_list():
+    """Discover available test cases from gnome-desktop-testing-runner."""
+    result = subprocess.run(
+        ['gnome-desktop-testing-runner', '--list', SUITE],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(f'gnome-desktop-testing-runner --list {SUITE} failed (rc={result.returncode}): {result.stderr}')
+    tests = []
+    for line in result.stdout.strip().splitlines():
+        # Lines: "evolution-data-server/test-vcard.test (/usr/share/installed-tests)"
+        name = line.split()[0] if line.strip() else None
+        if name:
+            tests.append(name)
+    return tests
+
+
+_TESTS = _get_test_list()
+
+
+@pytest.fixture(scope='session')
+def suite_results():
+    """Run the full test suite once and return per-test pass/fail map with output."""
+    result = subprocess.run(
+        ['gnome-desktop-testing-runner', '--tap', '-t', '300', SUITE],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+    )
+    print(result.stdout, file=sys.stdout)
+
+    results = {}
+    current_test = None
+    current_output = []
+
+    for line in result.stdout.splitlines():
+        m_start = re.match(r'^# Running test:\s+(.+)$', line)
+        if m_start:
+            current_test = m_start.group(1).strip()
+            current_output = [line]
+            continue
+
+        if current_test:
+            current_output.append(line)
+
+        m_end = re.match(r'^(ok|not ok) - (.+)$', line)
+        if m_end:
+            test_name = m_end.group(2).strip()
+            passed = (m_end.group(1) == 'ok')
+            results[test_name] = {
+                'passed': passed,
+                'output': '\n'.join(current_output),
+            }
+
+    summary = re.search(
+        r'# SUMMARY: total=(\d+); passed=(\d+); skipped=(\d+); failed=(\d+)',
+        result.stdout,
+    )
+    if summary:
+        print(
+            f'\nSuite summary: total={summary.group(1)} '
+            f'passed={summary.group(2)} '
+            f'skipped={summary.group(3)} '
+            f'failed={summary.group(4)}',
+            file=sys.stdout,
+        )
+
+    return results
+
+
+@pytest.mark.parametrize('test_name', _TESTS, ids=[t.split('/')[-1] for t in _TESTS])
+def test_evolution_data_server(test_name, suite_results):
+    """Check that each evolution-data-server installed test passed."""
+    if test_name not in suite_results:
+        pytest.skip(f'{test_name} not found in runner output')
+    entry = suite_results[test_name]
+    assert entry['passed'], f"{test_name} failed:\n{entry['output']}"

--- a/schedule/console/evolution_data_server_installed_tests.yaml
+++ b/schedule/console/evolution_data_server_installed_tests.yaml
@@ -1,0 +1,9 @@
+name: evolution_data_server_installed_tests
+description: >
+  Run upstream installed tests for evolution-data-server via
+  gnome-desktop-testing-runner.
+schedule:
+  - installation/bootloader_start
+  - boot/boot_to_desktop
+  - console/consoletest_setup
+  - console/oqa_agnostic/evolution_data_server

--- a/tests/console/oqa_agnostic/evolution_data_server.pm
+++ b/tests/console/oqa_agnostic/evolution_data_server.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright SUSE LLC
+# SPDX-License-Identifier: FSFAP
+#
+# Summary: Run evolution-data-server upstream installed tests
+# Maintainer: Zoltan Balogh <zbalogh@suse.com>
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use serial_terminal 'select_serial_terminal';
+use package_utils 'install_package';
+use agnosticTestRunner;
+
+sub run {
+    select_serial_terminal;
+    # glibc-gconv-modules-extra is needed for vCard character set conversion tests (e.g. KOI8-R)
+    # dbus-1-daemon provides dbus-run-session for isolated D-Bus registry test services
+    install_package('evolution-data-server-tests gnome-desktop-testing dbus-1-daemon glibc-gconv-modules-extra', trup_continue => 1);
+
+    my $test = agnosticTestRunner->new({
+            language => 'python',
+            name => 'testEvolutionDataServer',
+            domain => 'console',
+        }
+    );
+    $test->setup()->run_test()->parse_results()->cleanup();
+}
+
+1;


### PR DESCRIPTION
Runs the upstream evolution-data-server installed test suite (100 subtests) via
gnome-desktop-testing-runner.

evolution-data-server provides address book, calendar, and contacts
backends for the GNOME stack.

**Files:**
- `data/console/openqa_agnostic/python/testEvolutionDataServer/runtest` - bash entrypoint
- `data/console/openqa_agnostic/python/testEvolutionDataServer/test_evolution_data_server.py` - pytest wrapper
- `tests/console/oqa_agnostic/evolution_data_server.pm` - thin openQA wrapper
- `schedule/console/evolution_data_server_installed_tests.yaml` - schedule

**How it works:**
The pytest wrapper discovers all subtests at collection time, runs
the full suite once inside a D-Bus session via gnome-desktop-testing-runner,
and reports each subtest individually in JUnit XML. The Perl wrapper only
installs packages and delegates to agnosticTestRunner.

**Standalone run (no openQA needed):**
```bash
# Install dependencies
sudo zypper in evolution-data-server-tests gnome-desktop-testing dbus-1-daemon glibc-gconv-modules-extra python3-pytest

# Discover available installed tests
gnome-desktop-testing-runner --list evolution-data-server   # 100 tests

# Run via entrypoint script
cd data/console/openqa_agnostic/python/testEvolutionDataServer && ./runtest
```

Verified locally on Tumbleweed: 100/100 passed in 35s.

Verification on o3: https://openqa.opensuse.org/tests/6205629