### PR TITLE
Recover from aarch64 GRUB serial hang in remaining container reboots (bsc#1140464)

### DIFF
--- a/lib/containers/bats.pm
+++ b/lib/containers/bats.pm
@@ -21,7 +21,8 @@ use version_utils qw(is_sle is_tumbleweed);
 use serial_terminal qw(select_user_serial_terminal select_serial_terminal);
 use registration qw(add_suseconnect_product get_addon_fullname);
 use bootloader_setup 'add_grub_cmdline_settings';
-use power_action_utils 'power_action';
+use power_action_utils qw(power_action wait_boot_serial);
+use Utils::Backends 'is_qemu';
 use List::MoreUtils qw(uniq);
 use YAML::PP;
 use File::Basename;
@@ -475,7 +476,13 @@ EOF
     add_grub_cmdline_settings("ignore_loglevel", update_grub => 1);
 
     power_action('reboot', textmode => 1);
-    $self->wait_boot();
+    if (is_qemu && is_aarch64 && is_sle('=16.0')) {
+        # Some aarch64 SUTs regenerate a bad grub.cfg (bsc#1140464) and hang
+        # at a hidden-menu prompt; wait_boot_serial recovers from that.
+        die 'System did not come back up after reboot' unless wait_boot_serial;
+    } else {
+        $self->wait_boot();
+    }
     push @commands, "reboot";
     $rebooted = 1;
 

--- a/lib/containers/common.pm
+++ b/lib/containers/common.pm
@@ -16,10 +16,11 @@ use containers::utils qw(registry_url container_ip container_route);
 use transactional qw(trup_call check_reboot_changes process_reboot);
 use bootloader_setup 'add_grub_cmdline_settings';
 use serial_terminal 'select_serial_terminal';
-use power_action_utils 'power_action';
+use power_action_utils qw(power_action wait_boot_serial);
 use Mojo::JSON;
 use version_utils qw(is_sle);
 use Utils::Architectures qw(is_aarch64);
+use Utils::Backends 'is_qemu';
 
 our @EXPORT = qw(is_unreleased_sle install_podman_when_needed install_docker_when_needed install_containerd_when_needed
   test_container_runtime test_container_image
@@ -289,7 +290,13 @@ sub switch_cgroup_version {
     } else {
         add_grub_cmdline_settings("systemd.unified_cgroup_hierarchy=$setting", update_grub => 1);
         power_action('reboot', textmode => 1);
-        $self->wait_boot(bootloader_time => 360);
+        if (is_qemu && is_aarch64 && is_sle('=16.0')) {
+            # Some aarch64 SUTs regenerate a bad grub.cfg (bsc#1140464) and
+            # hang at a hidden-menu prompt; wait_boot_serial recovers from that.
+            die 'System did not come back up after reboot' unless wait_boot_serial;
+        } else {
+            $self->wait_boot(bootloader_time => 360);
+        }
     }
     select_serial_terminal;
 

--- a/tests/containers/host_configuration.pm
+++ b/tests/containers/host_configuration.pm
@@ -19,9 +19,10 @@ use containers::common;
 use containers::utils qw(reset_container_network_if_needed);
 use containers::k8s qw(install_k3s);
 use bootloader_setup qw(add_grub_cmdline_settings);
-use power_action_utils qw(power_action);
+use power_action_utils qw(power_action wait_boot_serial);
 use zypper qw(wait_quit_zypper);
 use Utils::Architectures qw(is_x86_64 is_aarch64);
+use Utils::Backends 'is_qemu';
 
 # /tmp as tmpfs has multiple issues: it can't store SELinux labels, consumes RAM and doesn't have enough space
 # Bind-mount it to /var/tmp
@@ -65,7 +66,14 @@ sub run {
         if (is_bootloader_grub2 && script_run('grep -q quiet /proc/cmdline') != 0) {
             add_grub_cmdline_settings('quiet', update_grub => 1);
             power_action("reboot", textmode => 1);
-            $self->wait_boot(textmode => 1);
+            if (is_qemu && is_aarch64 && is_sle('=16.0')) {
+                # Some aarch64 SUTs regenerate a bad grub.cfg (bsc#1140464)
+                # and hang at a hidden-menu prompt; wait_boot_serial
+                # recovers from that.
+                die 'System did not come back up after reboot' unless wait_boot_serial;
+            } else {
+                $self->wait_boot(textmode => 1);
+            }
             select_serial_terminal;
         }
     }
@@ -107,7 +115,14 @@ sub run {
             script_run('systemctl disable SuSEfirewall2');
             add_grub_cmdline_settings('apparmor=0', update_grub => 1);
             power_action("reboot", textmode => 1);
-            $self->wait_boot(textmode => 1);
+            if (is_qemu && is_aarch64 && is_sle('=16.0')) {
+                # Some aarch64 SUTs regenerate a bad grub.cfg (bsc#1140464)
+                # and hang at a hidden-menu prompt; wait_boot_serial
+                # recovers from that.
+                die 'System did not come back up after reboot' unless wait_boot_serial;
+            } else {
+                $self->wait_boot(textmode => 1);
+            }
             select_serial_terminal;
         } else {
             script_run('systemctl disable --now firewalld');

--- a/tests/containers/kubectl.pm
+++ b/tests/containers/kubectl.pm
@@ -15,7 +15,9 @@ use version_utils;
 use publiccloud::utils;
 use containers::k8s;
 use bootloader_setup qw(add_grub_cmdline_settings);
-use power_action_utils qw(power_action);
+use power_action_utils qw(power_action wait_boot_serial);
+use Utils::Architectures 'is_aarch64';
+use Utils::Backends 'is_qemu';
 
 sub run {
     my ($self, $args) = @_;
@@ -27,7 +29,13 @@ sub run {
     if (script_run("test -f /sys/fs/cgroup/cgroup.controllers") != 0) {
         add_grub_cmdline_settings("systemd.unified_cgroup_hierarchy=1", update_grub => 1);
         power_action('reboot', textmode => 1);
-        $self->wait_boot();
+        if (is_qemu && is_aarch64 && is_sle('=16.0')) {
+            # Some aarch64 SUTs regenerate a bad grub.cfg (bsc#1140464) and
+            # hang at a hidden-menu prompt; wait_boot_serial recovers from that.
+            die 'System did not come back up after reboot' unless wait_boot_serial;
+        } else {
+            $self->wait_boot();
+        }
         select_serial_terminal;
     }
 

--- a/tests/containers/kubevirt_smoketest.pm
+++ b/tests/containers/kubevirt_smoketest.pm
@@ -21,6 +21,8 @@ use mmapi 'get_current_job_id';
 use power_action_utils;
 use version_utils;
 use containers::k8s;
+use Utils::Architectures 'is_aarch64';
+use Utils::Backends 'is_qemu';
 
 my $vmi_user = 'test';
 my $vmi_pubkey;
@@ -156,7 +158,13 @@ sub install_kernel_with_kvm_support {
     zypper_call('in kernel-default -' . current_kernel_flavor, timeout => 300);
 
     power_action('reboot', textmode => 1);
-    $self->wait_boot(bootloader_time => 300);
+    if (is_qemu && is_aarch64 && is_sle('=16.0')) {
+        # Some aarch64 SUTs regenerate a bad grub.cfg (bsc#1140464) and hang
+        # at a hidden-menu prompt; wait_boot_serial recovers from that.
+        die 'System did not come back up after reboot' unless wait_boot_serial;
+    } else {
+        $self->wait_boot(bootloader_time => 300);
+    }
     select_serial_terminal;
 }
 

--- a/tests/containers/run_container_in_k3s.pm
+++ b/tests/containers/run_container_in_k3s.pm
@@ -14,10 +14,11 @@ use serial_terminal 'select_serial_terminal';
 use utils;
 use version_utils;
 use publiccloud::utils;
-use Utils::Architectures qw(is_ppc64le);
+use Utils::Architectures qw(is_ppc64le is_aarch64);
+use Utils::Backends 'is_qemu';
 use containers::k8s qw(install_k3s uninstall_k3s apply_manifest wait_for_k8s_job_complete find_pods validate_pod_log dump_k3s_debug_info);
 use bootloader_setup qw(add_grub_cmdline_settings);
-use power_action_utils qw(power_action);
+use power_action_utils qw(power_action wait_boot_serial);
 
 sub prepare_pod_yaml {
     record_info('Prep', 'Generate the yaml from a pod');
@@ -39,7 +40,13 @@ sub run {
     if (script_run("test -f /sys/fs/cgroup/cgroup.controllers") != 0) {
         add_grub_cmdline_settings("systemd.unified_cgroup_hierarchy=1", update_grub => 1);
         power_action('reboot', textmode => 1);
-        $self->wait_boot();
+        if (is_qemu && is_aarch64 && is_sle('=16.0')) {
+            # Some aarch64 SUTs regenerate a bad grub.cfg (bsc#1140464) and
+            # hang at a hidden-menu prompt; wait_boot_serial recovers from that.
+            die 'System did not come back up after reboot' unless wait_boot_serial;
+        } else {
+            $self->wait_boot();
+        }
         select_serial_terminal;
     }
 

--- a/tests/containers/update_host.pm
+++ b/tests/containers/update_host.pm
@@ -13,10 +13,12 @@
 
 use Mojo::Base 'consoletest';
 use utils qw(zypper_call script_retry);
-use version_utils qw(get_os_release);
-use power_action_utils qw(power_action);
+use version_utils qw(get_os_release is_sle);
+use power_action_utils qw(power_action wait_boot_serial);
 use testapi;
 use serial_terminal 'select_serial_terminal';
+use Utils::Architectures 'is_aarch64';
+use Utils::Backends 'is_qemu';
 
 sub disable_selinux {
     if (script_run('selinuxenabled') == 0) {
@@ -56,7 +58,13 @@ sub run {
     power_action('reboot', textmode => 1);
     # For some reason, we need to wait for some time in RES8 before waiting for boot
     sleep 60 if ($host_distri eq 'rhel');
-    $self->wait_boot();
+    if (is_qemu && is_aarch64 && is_sle('=16.0')) {
+        # Some aarch64 SUTs regenerate a bad grub.cfg (bsc#1140464) and hang
+        # at a hidden-menu prompt; wait_boot_serial recovers from that.
+        die 'System did not come back up after reboot' unless wait_boot_serial;
+    } else {
+        $self->wait_boot();
+    }
     select_serial_terminal;
     record_info('uname', script_output('uname -a'));
     record_info('relaese', script_output('cat /etc/os-release'));

--- a/tests/containers/upgrade.pm
+++ b/tests/containers/upgrade.pm
@@ -12,9 +12,11 @@ use testapi;
 use serial_terminal;
 use utils;
 use version_utils;
-use power_action_utils 'power_action';
+use power_action_utils qw(power_action wait_boot_serial);
 use containers::bats;
 use containers::common;
+use Utils::Architectures 'is_aarch64';
+use Utils::Backends 'is_qemu';
 
 my $port = 8080;
 
@@ -143,7 +145,13 @@ sub run {
     if (get_var("TEST_REPOS")) {
         upgrade_via_testrepos;
         power_action('reboot', textmode => 1);
-        $self->wait_boot();
+        if (is_qemu && is_aarch64 && is_sle('=16.0')) {
+            # Some aarch64 SUTs regenerate a bad grub.cfg (bsc#1140464) and
+            # hang at a hidden-menu prompt; wait_boot_serial recovers from that.
+            die 'System did not come back up after reboot' unless wait_boot_serial;
+        } else {
+            $self->wait_boot();
+        }
         select_serial_terminal;
     }
 


### PR DESCRIPTION
Follow-up to #26588: every remaining plain `power_action`+`wait_boot` reboot in the containers test suites can hit the same aarch64 SLE 16.0 GRUB hidden-menu hang ([bsc#1140464](https://bugzilla.suse.com/show_bug.cgi?id=1140464)) that `fips_setup.pm`/`patch_and_reboot.pm` already had fixed. Applies the same `wait_boot_serial` fallback to the remaining sites:

- `lib/containers/bats.pm` (`setup_pkgs`) — shared reboot for every BATS/upstream-style suite (`containerd_testsuite`, `docker_testsuite`, `aardvark_testsuite`, `netavark_testsuite`, `runc_testsuite`, `podman`, `buildah`, `skopeo`, `umoci`, `conmon`, `docker-cli`, `docker-compose`, `docker-buildx`, `python_docker`, `python_podman`, `podman_e2e`)
- `lib/containers/common.pm` (`switch_cgroup_version`)
- `tests/containers/host_configuration.pm` (2 sites: `quiet` cmdline fixup, k3s apparmor disable on SLE 12)
- `tests/containers/upgrade.pm`
- `tests/containers/update_host.pm`
- `tests/containers/run_container_in_k3s.pm`
- `tests/containers/kubectl.pm`
- `tests/containers/kubevirt_smoketest.pm`

Reproduced this exact hang on `aardvark_testsuite`, `containerd_testsuite`, `netavark_testsuite`, `runc_testsuite`, and intermittently `docker_testsuite` while verifying #26588 — see [comment](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26588#issuecomment-5544005650).

* Related PR: #26588
* Related bug: bsc#1140464
* Verification runs: