### PR TITLE
io_uring: Raise liburing execution timeout in io_uring to 300s

### DIFF
--- a/tests/kernel/io_uring.pm
+++ b/tests/kernel/io_uring.pm
@@ -100,14 +100,14 @@ sub run {
     if ($install =~ /git/i) {
         assert_script_run("echo 'TEST_EXCLUDE=\"$test_exclude\"' > test/config.local") if $test_exclude;
         $out = script_output(
-            "make -C test runtests",
+            "TIMEOUT=300 make -C test runtests",
             timeout => $timeout,
             proceed_on_failure => 1
         );
     } else {
         my $env = $test_exclude ? "TEST_EXCLUDE=\"$test_exclude\" " : '';
         $out = script_output(
-            "cd $test_dir && ${env}./runtests.sh *.t",
+            "cd $test_dir && TIMEOUT=300 ${env}./runtests.sh *.t",
             timeout => $timeout,
             proceed_on_failure => 1
         );


### PR DESCRIPTION
io_uring: Raise liburing execution timeout in io_uring to 300s

- Related ticket: https://progress.opensuse.org/issues/203859 
- Verification run: https://openqa.opensuse.org/tests/6206287#next_previous  (50runs)

Average time spent on aarch64:
Running test cbpf_filter.t                  90 sec
send-zerocopy.t                                 112 sec