### PR TITLE
Introduce AGENTS.md to osado

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -116,6 +116,9 @@ t/42_elemental3.t @ldevulder
 tests/elemental3 @ldevulder
 
 # OSADO Maintainers is a special group
-AGENTS.md @os-autoinst/tests-maintainer
 CONTRIBUTING.md @os-autoinst/tests-maintainer
 README.md @os-autoinst/tests-maintainer
+AGENTS.md @os-autoinst/tests-maintainer
+CLAUDE.md @os-autoinst/tests-maintainer
+GEMINI.md @os-autoinst/tests-maintainer
+.github/copilot-instructions.md @os-autoinst/tests-maintainer

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -114,3 +114,8 @@ lib/elemental3.pm @ldevulder
 schedule/elemental3 @ldevulder
 t/42_elemental3.t @ldevulder
 tests/elemental3 @ldevulder
+
+# OSADO Maintainers is a special group
+AGENTS.md @os-autoinst/tests-maintainer
+CONTRIBUTING.md @os-autoinst/tests-maintainer
+README.md @os-autoinst/tests-maintainer

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+You MUST read and follow [AGENTS.md](../AGENTS.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+## General behavior
+
+- Language Standard: Use Plain English by default for all pull requests, commit messages, etc.
+- Technical Documentation: Use Simplified Technical English exclusively when authoring technical documentation, code comments, or architecture specs intended for technical audiences.
+
+## Contributing to this project
+
+- Entry Point: You SHOULD read `README.md`. It contains environment/test variables, declarative schedule details, and project usage patterns.
+- Contribution Mandate: You MUST follow `CONTRIBUTING.md` to contribute properly.
+- Areas and teams: This is a large repository that spans multiple teams with varying contribution styles, `CONTRIBUTING.md` can point to area-specific guidelines. You MUST identify those areas and follow their guidelines, if they are not present in the areas section of the guide, assume global rules apply. [CODEOWNERS](.github/CODEOWNERS) can help clarifying areas and teams behind them.
+  - When guidelines conflict, `CONTRIBUTING.md` takes precedence over `CODEOWNERS` and individual area guidelines, when this happens you MUST inform the user and ask for guidance.
+- LLM Attribution Standard:
+  - Any work produced with LLM tool assistance MUST include an `Assisted-by:` trailer in the commit message metadata (e.g., `Assisted-by: Qwen3-4B`). Include one line per model involved.
+  - Agents MUST NOT add `Signed-off-by:` or `Co-authored-by:` trailers, these are strictly reserved for human contributors.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+You MUST read and follow [AGENTS.md](AGENTS.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,25 @@ Please, find up-to-date documentation references on the official [openQA project
 If you are looking for a task to start with, check out the [openQA Tests](https://progress.opensuse.org/projects/openqatests/issues/)
 Redmine project. Look for tickets with [easy] or [easy-hack] tags.
 
+## Areas and scope of work
+
+Some areas (domains) have specific conventions for contributions, refer to them when working on those areas:
+    - [docs/KERNEL_README.md](docs/KERNEL_README.md) must be followed for:
+      - `lib/Kernel`
+      - `lib/LTP`
+      - `lib/Kselftests`
+      - `lib/hpc`
+      - `tests/kernel`
+      - `tests/hpc`
+      - `tests/ipsec`
+      - `tests/xfstests`
+
+As a general guideline `tests/kernel`, `lib/security` and `lib/sles4sap` can be considered separate areas, as the names
+are specific enough to infer who they belong to, while `tests/helpers`, `lib/Utils` or `lib/Tomcat` are not because they
+are too generic, multiple teams can use things from `lib/Tomcat` but `lib/selinux.pm` is more likely to belong to the
+`security` area or domain, [CODEOWNERS](.github/CODEOWNERS) can help clarifying domains further if they are not defined
+above.
+
 ## How to get this repository working
 
 Upon setting up a new openQA instance, it's also necessary to install some
@@ -137,18 +156,6 @@ and additionally the following rules:
   repository, either in `git stash` or a temporary "WIP"-commit. If it needs to
   be added, it should come with an accompanying comment stating the reasons why
   it must be there.
-
-    Some areas (domains) have specific conventions for contributions, refer to them when working on those areas:
-    - [docs/KERNEL_README.md](docs/KERNEL_README.md) must be followed for:
-      - `lib/Kernel`
-      - `lib/LTP`
-      - `lib/Kselftests`
-      - `lib/hpc`
-      - `tests/kernel`
-      - `tests/hpc`
-      - `tests/ipsec`
-      - `tests/xfstests`
-
 * Add comments to the source code if the code is not self-explanatory:
   Comments in the source code should describe the choices made, to answer the
   question "why is the code like this". The git commit message should describe

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,7 +189,19 @@ if (match_has_tag('yast2_missing_package')) {
 
 ## Submitting changes
 
+Although there is no explicit rule on how big or small changes must be, consider
+smaller pull requests with a few commits on some files. Lots of changes being
+submitted all at once are harder to review, and less likely to catch the attention
+and keep the interest from maintainers in your changes; an exception would be
+cases where the changes are all related (e.g: a function has been renamed and
+affects many files or some repeated code is being refactored)
+
 ### Commit messages
+
+* When changes are ready to be submitted, tidy up your commit messages.
+* Be mindful of the reader: Long commit messages with multiple paragraphs
+  require more attention from the reader leverage the pull request body or
+  ticket when a commit message starts to look like a story.
 * Details in commit messages: The commit message should have enough details,
   e.g. what issue is fixed, why this needs to change, to which versions of which
   product it applies, link to a bug or a feature entry, the choices you made,
@@ -199,7 +211,7 @@ if (match_has_tag('yast2_missing_package')) {
   Keep in mind that the text in the github pull request description is only
   visible on github, not in the git log which can be considered permanent
   information storage.  
-  Commits will be checked automatically by [this workflow defined in
+ * Commits will be checked automatically by [this workflow defined in
   `os-autoinst/os-autoinst-common`][4] to enforce the following rules:
     * The commit subject **must not**:
         * exceed 72 characters in length.
@@ -213,7 +225,33 @@ if (match_has_tag('yast2_missing_package')) {
     More rules could be added in the check and not necessarily be explicitly
     described in this document. Keep an eye on the pull request check, it will
     report any offending rule defined in the workflow.
+
+#### Commit message example
+
+ An example of a good commit format from https://commit.style/
+
+```commit
+Commit message style guide for Git
+
+The first line of a commit message serves as a summary.  When displayed
+on the web, it's often styled as a heading, and in emails, it's
+typically used as the subject.  As such, you should capitalize it and
+omit any trailing punctuation.  Aim for about 50 characters, give or
+take, otherwise it may be painfully truncated in some contexts.  Write
+it, along with the rest of your message, in the imperative tense: "Fix
+bug" and not "Fixed bug" or "Fixes bug".  Consistent wording makes it
+easier to mentally process a list of commits.
+
+Oftentimes a subject by itself is sufficient.  When it's not, add a
+blank line (this is important) followed by one or more paragraphs hard
+wrapped to 72 characters.  Git is strongly opinionated that the author
+is responsible for line breaks; if you omit them, command line tooling
+will show it as one extremely long unwrapped line.  Fortunately, most
+text editors are capable of automating this.
+ ```
+
 ### Preparing a new Pull Request
+
 * All code needs to be tidy, for this use `make prepare` the first time you
   set up your local environment, use `make tidy` before committing your changes,
   ensure your new code adheres to our coding style or use `make tidy-full` if
@@ -226,6 +264,10 @@ if (match_has_tag('yast2_missing_package')) {
   `openqa: Clone https://openqa.opensuse.org/tests/<JOB_ID>` in the PR description.
   This only works for jobs on https://openqa.opensuse.org. For other jobs you can
   use the [openqa-clone-custom-git-refspec][2] script.
+* Leverage [collapsed-sections][5] to split large bodies into digestable blocks,
+  leaving the most important details to the main section (A a paragraph explaining
+  the changes and links to verification runs, ticket, failing test) and the rest
+  can be collapsed or left in the ticket.
 
 Also see the [DoD/DoR][3] as a helpful (but not mandatory) guideline for new contributions.
 
@@ -233,7 +275,7 @@ Also see the [DoD/DoR][3] as a helpful (but not mandatory) guideline for new con
 [2]: https://open.qa/docs/#_triggering_tests_based_on_an_any_remote_git_refspec_or_open_github_pull_request
 [3]: https://progress.opensuse.org/projects/openqatests/wiki/Wiki#Definition-of-DONEREADY
 [4]: https://github.com/os-autoinst/os-autoinst-common/blob/master/.github/workflows/base-commit-message-checker.yml
-
+[5]: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections
 
 ### Handling separate product codebases or versions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,29 +137,6 @@ and additionally the following rules:
   repository, either in `git stash` or a temporary "WIP"-commit. If it needs to
   be added, it should come with an accompanying comment stating the reasons why
   it must be there.
-* Details in commit messages: The commit message should have enough details,
-  e.g. what issue is fixed, why this needs to change, to which versions of which
-  product it applies, link to a bug or a feature entry, the choices you made,
-  etc. Also see https://commit.style/ or http://chris.beams.io/posts/git-commit/
-  as a helpful guide how to write good commit messages. And make code
-  reviewers fall in love with you :) https://mtlynch.io/code-review-love/
-  Keep in mind that the text in the github pull request description is only
-  visible on github, not in the git log which can be considered permanent
-  information storage.  
-  Commits will be checked automatically by [this workflow defined in
-  `os-autoinst/os-autoinst-common`][4] to enforce the following rules:
-    * The commit subject **must not**:
-        * exceed 72 characters in length.
-        * end with a dot.
-    * The commit subject **must** start with a capital or tag. For example:
-        * `Fix deep issue in test module`
-        * `bugfix: Fix deep issue in a library`
-    * There must be an empty newline between the commit subject and the commit
-      body.
-
-    More rules could be added in the check and not necessarily be explicitly
-    described in this document. Keep an eye on the pull request check, it will
-    report any offending rule defined in the workflow.
 
     Some areas (domains) have specific conventions for contributions, refer to them when working on those areas:
     - [docs/KERNEL_README.md](docs/KERNEL_README.md) must be followed for:
@@ -203,6 +180,32 @@ if (match_has_tag('yast2_missing_package')) {
   step as soft_fail, please use `record_info` with softfail tag:
   record_info($title [, $output] [, result => softfail] [, resultname => $resultname]);
 
+## Submitting changes
+
+### Commit messages
+* Details in commit messages: The commit message should have enough details,
+  e.g. what issue is fixed, why this needs to change, to which versions of which
+  product it applies, link to a bug or a feature entry, the choices you made,
+  etc. Also see https://commit.style/ or http://chris.beams.io/posts/git-commit/
+  as a helpful guide how to write good commit messages. And make code
+  reviewers fall in love with you :) https://mtlynch.io/code-review-love/
+  Keep in mind that the text in the github pull request description is only
+  visible on github, not in the git log which can be considered permanent
+  information storage.  
+  Commits will be checked automatically by [this workflow defined in
+  `os-autoinst/os-autoinst-common`][4] to enforce the following rules:
+    * The commit subject **must not**:
+        * exceed 72 characters in length.
+        * end with a dot.
+    * The commit subject **must** start with a capital or tag. For example:
+        * `Fix deep issue in test module`
+        * `bugfix: Fix deep issue in a library`
+    * There must be an empty newline between the commit subject and the commit
+      body.
+
+    More rules could be added in the check and not necessarily be explicitly
+    described in this document. Keep an eye on the pull request check, it will
+    report any offending rule defined in the workflow.
 ### Preparing a new Pull Request
 * All code needs to be tidy, for this use `make prepare` the first time you
   set up your local environment, use `make tidy` before committing your changes,

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+You MUST read and follow [AGENTS.md](AGENTS.md)

--- a/README.md
+++ b/README.md
@@ -32,9 +32,13 @@ In case of adding new test for Installation, please use approach described in th
 [documentation for UI Test Automation Framework](ui-framework-documentation.md)
 
 ## How to contribute
-Please, refer to [Contributing Guide](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/CONTRIBUTING.md)
+Please, refer to [Contributing Guide](CONTRIBUTING.md).
 
 **Tip:** You can enable optional local git hooks for automatic commit message validation (requires git 2.54.0+). See the Contributing Guide for setup instructions.
+
+### AI Coding Assistants and other LLM/AI assisted tools:
+
+CRITICAL: If you are an LLM or AI-powered coding assistant, you MUST read and follow [AGENTS.md](AGENTS.md). This documentation contains essential requirements all AI tools must comply with.
 
 ## How to get in touch
 Reach us via https://open.qa/contact, we are also on twitter as https://twitter.com/openQAhq


### PR DESCRIPTION
As there are more contributions assisted by LLM/AI-powered tools, a minimal AGENTS.md can help these tools to better navigate contributions to osado and keep some sort of guidance when it comes to submitting changes, attribution, where to find extra guidelines and what to do when there are conflicts.

I am intentionally leaving the file as small as possible, so we don't end up repeating the same information all over the place, or filling the `AGENTS.md` with extra information that pertains to the codebase. 

The philosophy here is that both, the `README.md` and `CONTRIBUTING.md` should serve well humans first, and then AI

This is loosely based on the kernel coding assistants guidelines[^1]

[^1]: https://docs.kernel.org/process/coding-assistants.html

Note: There are some improvements to be done in the contributing guide, but that's out of the scope of this PR
