### PR TITLE
publiccloud: Keep track of the time taken by aws/az command

### DIFF
--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -46,7 +46,8 @@ sub init {
         # CAVEAT: Use the bash environment variables to prevent credential leaks.
         assert_script_run('printf "[default]\naws_access_key_id=$AWS_ACCESS_KEY_ID\naws_secret_access_key=$AWS_SECRET_ACCESS_KEY\nregion=$AWS_DEFAULT_REGION\n" > ~/.aws/credentials');
         my $debug = "aws-cli-debug.txt";
-        script_run("PILOT_DEBUG=1 aws %silent --help &> $debug");
+        script_run("PILOT_DEBUG=1 time -p aws %silent --help &> $debug");
+        record_info("aws cli time", script_output("tail -n 3 $debug", proceed_on_failure => 1));
         upload_logs($debug, failok => 1);
         script_run("rpm -qi aws-cli-cmd");
     }

--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -44,7 +44,8 @@ sub init {
           . '}');
     if (is_sle(">=16")) {
         my $debug = "az-cli-debug.txt";
-        script_run("PILOT_DEBUG=1 az %silent --help &> $debug");
+        script_run("PILOT_DEBUG=1 time -p az %silent --help &> $debug");
+        record_info("az cli time", script_output("tail -n 3 $debug", proceed_on_failure => 1));
         upload_logs($debug, failok => 1);
         script_run("rpm -qi az-cli-cmd");
     }


### PR DESCRIPTION
On a test VM, `az help` took 49s while `aws help` takes 6s.

Let's keep track of this time in case we notice weird timeouts, etc.

Tested locally.
