### PR TITLE
fix(cit): 12sp5 images contain gce substring before arch

### DIFF
--- a/tests/publiccloud/run_cit.pm
+++ b/tests/publiccloud/run_cit.pm
@@ -145,8 +145,8 @@ sub find_sut_image {
     $arch =~ s/_//;
     my $version = get_var('VERSION');
     $version =~ s/\./-/;
-    my $img_regex = lc(sprintf("%ss?-?%s-%s", get_var('DISTRI'), $version, $arch));
-    my $image = script_output(qq[gcloud compute images list --project="$project" --filter="name ~ '(?i)^$img_regex' AND name \!~ '(chost|byos)'" --format="value(name)" --no-standard-images]);
+    my $img_regex = lc(sprintf("%ss?-?%s(-gce)?-%s", get_var('DISTRI'), $version, $arch));
+    my $image = script_output(qq[gcloud compute images list --project="$project" --filter="name ~ '(?i)^$img_regex' AND name \!~ '(chost|byos|sap)'" --format="value(name)" --no-standard-images]);
 
     die "Missing SUT image, no image match '$img_regex' in test project ($project)" unless (!!$image);
 


### PR DESCRIPTION
- ticket: https://progress.opensuse.org/issues/202821
- sle-12-SP5-GCE-On-Demand-Maintenance-Images-x86_64-Build0502-publiccloud_cit_tests@gce_n1_standard_2 -> https://openqa.suse.de/tests/24253979#