### PR TITLE
Poll with short retries in wait_quit_zypper

### DIFF
--- a/lib/zypper.pm
+++ b/lib/zypper.pm
@@ -16,6 +16,12 @@ our @EXPORT = qw(
   wait_quit_zypper
 );
 
+# Process names to poll for (poo#206742, poo#204534); pgrep truncates comm
+# to 15 chars, so "transactional-u" stands in for "transactional-update".
+use constant BUSY_PROCESS_PATTERN => join('|',
+    qw(zypper packagekit purge-kernels rpm snapper transactional-u),
+);
+
 =head2 wait_quit_zypper
 
     wait_quit_zypper();
@@ -30,9 +36,9 @@ lock so that we can run a new zypper for our test.
 =cut
 
 sub wait_quit_zypper {
-    # sometimes the zypper processes already in quit process but can't pgrep, we
-    # need wait several seconds for them to finish deactivate.
-    assert_script_run('for ((i=60; i>0; i--)) do if (! pgrep \'zypper|purge-kernels|rpm\' > /dev/null); then sleep 20; break; else sleep 10; continue; fi done', 600);
+    # Short polling commands avoid the serial terminal typing-echo timeout
+    # a single long assert_script_run() can hit (poo#206742, poo#204534).
+    utils::script_retry('! pgrep \'' . BUSY_PROCESS_PATTERN . '\'', timeout => 20, delay => 10, retry => 120);
 }
 
 1;


### PR DESCRIPTION
`wait_quit_zypper()` now polls with short `pgrep` retries via `utils::script_retry` instead of one long `assert_script_run()` with an embedded shell loop, matching `publiccloud::zypper::pc_wait_quit_local`. Also widens the watched process list to include `packagekit`, `snapper`, and `transactional-update`.

* Related ticket: [poo#206742](https://progress.opensuse.org/issues/206742)
* Related failure: [openqa.suse.de/t24252484](https://openqa.suse.de/tests/24252484)
* Verification runs: In comment below
