### PR TITLE
publiccloud: Upload tofu output on failure, fix undeclared use_user_data on EC2/GCE

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -340,9 +340,10 @@ sub terraform_cmd {
 Run a single tofu/terraform step (C<init>, C<plan> or C<apply>) via
 C<script_retry()>, capturing its combined stdout/stderr to C<tf_<step>_output>
 so the output survives even on a timeout (unlike letting C<script_retry> die
-internally with no diagnostics). Always returns the exit code and the
-captured output rather than dying itself, so the caller decides how to react
-to a failure.
+internally with no diagnostics). On failure, C<tf_<step>_output> is uploaded
+as a job log so the real error stays visible after the job ends. Always
+returns the exit code and the captured output rather than dying itself, so
+the caller decides how to react to a failure.
 
 =cut
 
@@ -353,6 +354,7 @@ sub _tofu_run_step {
         timeout => $args{timeout}, delay => $args{delay}, retry => $args{retry}, die => 0);
     my $output = script_output("cat $output_file", proceed_on_failure => 1);
     record_info("TFM $args{step} output", "exit code: $ret", result => ($ret) ? 'fail' : 'ok');
+    upload_logs($output_file, failok => 1) if $ret;
     return ($ret, $output);
 }
 
@@ -442,7 +444,7 @@ sub terraform_apply {
     $vars{project} = $args{project} if ($args{project});
     if (get_var('PUBLIC_CLOUD_CLOUD_INIT')) {
         $vars{cloud_init} = TERRAFORM_DIR . "/cloud-init.yaml";
-        $vars{use_user_data} = get_var('PUBLIC_CLOUD_USER_DATA') if defined get_var('PUBLIC_CLOUD_USER_DATA');
+        $vars{use_user_data} = get_var('PUBLIC_CLOUD_USER_DATA') if (is_azure && defined get_var('PUBLIC_CLOUD_USER_DATA'));
     }
     $vars{vm_create_timeout} = $terraform_vm_create_timeout;
     my $root_size = get_var('PUBLIC_CLOUD_ROOT_DISK_SIZE');
@@ -597,7 +599,7 @@ sub terraform_destroy {
     $vars{region} = $self->provider_client->region;
     if (get_var('PUBLIC_CLOUD_CLOUD_INIT')) {
         $vars{cloud_init} = TERRAFORM_DIR . '/cloud-init.yaml';
-        $vars{use_user_data} = get_var('PUBLIC_CLOUD_USER_DATA') if defined get_var('PUBLIC_CLOUD_USER_DATA');
+        $vars{use_user_data} = get_var('PUBLIC_CLOUD_USER_DATA') if (is_azure && defined get_var('PUBLIC_CLOUD_USER_DATA'));
     }
     $vars{ssh_public_key} = $self->ssh_key . '.pub';
 

--- a/t/45_publiccloud_provider.t
+++ b/t/45_publiccloud_provider.t
@@ -200,6 +200,49 @@ subtest '[terraform_apply] vars' => sub {
     _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_REGION PUBLIC_CLOUD_INSTANCE_TYPE FLAVOR OPENQA_URL/);
 };
 
+subtest '[terraform_apply] use_user_data is only passed on Azure' => sub {
+    # ec2.tf and gce.tf never declare a "use_user_data" variable (only
+    # azure.tf does, since PR#26367). Passing it on EC2/GCE makes tofu plan
+    # die with "Value for undeclared variable" (poo#206739).
+    set_var('PUBLIC_CLOUD', 1);
+    set_var('PUBLIC_CLOUD_REGION', 'Ferengi');
+    set_var('PUBLIC_CLOUD_INSTANCE_TYPE', 'Romulan');
+    set_var('FLAVOR', 'Talaxian');
+    set_var('OPENQA_URL', 'Xindi');
+    set_var('PUBLIC_CLOUD_CLOUD_INIT', 1);
+    set_var('PUBLIC_CLOUD_USER_DATA', 0);
+
+    for my $case (
+        {provider => 'EC2', client => 'publiccloud::aws_client', wants_var => 0},
+        {provider => 'AZURE', client => 'publiccloud::azure_client', wants_var => 1},
+      )
+    {
+        set_var('PUBLIC_CLOUD_PROVIDER', $case->{provider});
+        my $mock = Test::MockModule->new('publiccloud::provider', no_auto => 1);
+        $mock->redefine(get_image_id => sub { '' });
+        $mock->noop("$_") for qw(get_image_uri data_url file_content_replace);
+        $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+        $mock->redefine(get_current_job_id => sub { return 42; });
+        my @calls;
+        $mock->redefine($_ => sub { push @calls, $_[0]; return 0; }) for qw(assert_script_run script_run script_retry);
+        $mock->redefine(script_output => sub {
+                push @calls, $_[0];
+                return '{"vm_name":{"value":[]},"public_ip":{"value":[]}}' if ($_[0] =~ /output -json/);
+                return '';
+        });
+        Test::MockModule->new('publiccloud::instances', no_auto => 1)->redefine(set_instances => sub { });
+
+        my $provider = publiccloud::provider->new(provider_client => $case->{client}->new());
+        $provider->terraform_apply();
+
+        my ($plan_cmd) = grep { /tofu.*plan/ } @calls;
+        is(scalar(() = ($plan_cmd =~ /-var 'use_user_data=/g)), $case->{wants_var},
+            "$case->{provider} plan " . ($case->{wants_var} ? 'passes' : 'omits') . " use_user_data");
+    }
+
+    _unset(qw/PUBLIC_CLOUD PUBLIC_CLOUD_PROVIDER PUBLIC_CLOUD_REGION PUBLIC_CLOUD_INSTANCE_TYPE FLAVOR OPENQA_URL PUBLIC_CLOUD_CLOUD_INIT PUBLIC_CLOUD_USER_DATA/);
+};
+
 subtest '[terraform_apply] query csp at each region loop' => sub {
     set_var('PUBLIC_CLOUD', 1);
     set_var('PUBLIC_CLOUD_REGION', 'Ferengi');
@@ -322,6 +365,7 @@ sub _mock_terraform_apply {
     $mock->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
     $mock->redefine(get_current_job_id => sub { 42 });
     $mock->redefine(assert_script_run => sub { push @{$args{calls}}, $_[0]; return 0; });
+    $mock->redefine(upload_logs => sub { return; });
 
     # It consumes each regexp's list in order and dies if list of response is exhausted. Returns undef when no regexp matches at all.
     my %cursor;
@@ -694,6 +738,7 @@ subtest '[terraform_apply] init/plan failures die with captured output, no regio
             return $case->{garbage} if ($_[0] =~ /cat /);
             return '';
     });
+    $mock->redefine(upload_logs => sub { push @calls, "upload_logs $_[0]"; return; });
     my $provider = publiccloud::provider->new(provider_client => publiccloud::azure_client->new());
 
     for my $c (
@@ -711,6 +756,8 @@ subtest '[terraform_apply] init/plan failures die with captured output, no regio
         # (instead of `my ($ret) = ...`) silently captured the captured
         # output text instead of the numeric exit code from script_retry.
         like($died, qr/exit code 1\b/, "$case->{step} die message reports the numeric exit code, not the captured output");
+        ok((grep { /^upload_logs tf_$case->{step}_output/ } @calls),
+            "$case->{step} failure uploads the captured tofu output as a job log");
 
         my ($retry_call) = grep { $_->[0] =~ $case->{fail_cmd} } @retry_calls;
         ok($retry_call, "$case->{step} is retried via script_retry");


### PR DESCRIPTION
## Summary
- `_tofu_run_step()` in `lib/publiccloud/provider.pm` now uploads the captured `tf_<step>_output` as a job log via `upload_logs(..., failok => 1)` whenever an init/plan/apply step fails, instead of only recording the exit code. Without this, the real OpenTofu error text was unrecoverable once a job finished.
- That upload immediately surfaced a real bug: [PR#26367](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26367) added the `use_user_data` terraform variable to `azure.tf` only, but `provider.pm` set `$vars{use_user_data}` for every provider whenever `PUBLIC_CLOUD_CLOUD_INIT` and `PUBLIC_CLOUD_USER_DATA` are both set. `ec2.tf` and `gce.tf` never declared this variable, so `tofu plan` died with `Error: Value for undeclared variable` on EC2/GCE jobs using those settings. This is now gated behind `is_azure`.

## Root cause reference
Originally seen at https://openqa.suse.de/tests/24252524#step/prepare_instance/42 (`tofu plan` failing with only "exit code: 1" visible, no diagnostics).

Tracked as [poo#206739](https://progress.opensuse.org/issues/206739).

## Test plan
- [x] `t/45_publiccloud_provider.t` updated: mocks `upload_logs`, asserts it is called with the right file on init/plan failure, and asserts `use_user_data` is only passed to `tofu plan` on Azure, not EC2.
- [x] `prove -l t/45_publiccloud_provider.t` passes (18/18).
- [x] `perl -c lib/publiccloud/provider.pm`.
- [x] Verification run on real infra: https://openqa.suse.de/tests/24256451 (upload confirmed working, surfaced the `use_user_data` bug) then https://openqa.suse.de/tests/24256795 (passed, with the `use_user_data` fix applied).