### PR TITLE
Revert "Recover from aarch64 GRUB serial-terminal hang" (#26588, #26580)

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -22,7 +22,6 @@ use testapi;
 use Utils::Architectures;
 use Utils::Backends;
 use version_utils qw(is_sle is_leap is_opensuse is_tumbleweed is_vmware is_jeos);
-use serial_terminal 'get_login_message';
 use Carp 'croak';
 
 our @EXPORT = qw(
@@ -33,7 +32,6 @@ our @EXPORT = qw(
   assert_shutdown_and_restore_system
   assert_shutdown_with_soft_timeout
   check_bsc1215132
-  wait_boot_serial
 );
 
 =head2 prepare_system_shutdown
@@ -382,46 +380,6 @@ sub power_action {
             select_console('sut');
         }
     }
-}
-
-=head2 wait_boot_serial
-
- wait_boot_serial();
-
-Confirm a reboot completed by watching the serial console for the login
-banner, recovering first if GRUB got stuck on its aarch64 serial-terminal
-bug (bsc#1140464: aarch64 has no legacy I/O ports, so GRUB's default
-C<com0> serial addressing can never resolve there; SUSE's grub2 config
-generation still doesn't use C<efi0> instead). Once grub.cfg gets
-regenerated (e.g. by a kernel/bootloader update or C<fips-mode-setup>),
-GRUB's C<terminal_output>/C<terminal_input serial> command aborts
-grub.cfg's script execution, parking GRUB at its hidden-menu hint
-("Please press 't' to show the boot menu") instead of ever reaching the
-auto-boot logic.
-
-Races that hint against the login banner for 60 seconds so an unaffected
-boot returns as soon as it's up. If neither appeared yet, keeps waiting
-for the login banner alone for another 240 seconds (300 seconds total,
-matching a plain boot-confirmation timeout). If the hint wins the race,
-presses 't' (reveal the menu) and 'ret' (confirm the default entry), then
-allows a fresh 300 seconds for the now-unstuck boot to actually complete.
-
-Returns the matched text (a true value) on success, or an empty/undef
-value if the login banner was never seen at all.
-
-=cut
-
-sub wait_boot_serial {
-    my $login_message = get_login_message();
-    my $hang = qr/Please press .t. to show the boot menu/;
-
-    my $matched = wait_serial(qr/$hang|$login_message/, 60);
-    if ($matched && $matched =~ $hang) {
-        send_key 't';
-        send_key 'ret';
-        return wait_serial($login_message, 300);
-    }
-    return $matched || wait_serial($login_message, 240);
 }
 
 =head2 assert_shutdown_and_restore_system

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -15,8 +15,8 @@ use bootloader_setup qw(add_grub_cmdline_settings change_grub_config);
 use power_action_utils 'power_action';
 use transactional qw(trup_call process_reboot);
 use utils qw(zypper_call reconnect_mgmt_console);
-use serial_terminal 'select_serial_terminal';
-use Utils::Backends 'is_pvm';
+use serial_terminal qw(get_login_message select_serial_terminal);
+use Utils::Backends qw(is_pvm is_qemu);
 use Utils::Architectures qw(is_aarch64 is_ppc64le is_s390x);
 use version_utils qw(is_jeos is_sle_micro is_sle is_tumbleweed is_transactional is_microos);
 use security::vendoraffirmation;
@@ -29,7 +29,17 @@ sub reboot_and_login {
 
     is_transactional ? process_reboot(trigger => 1) : power_action('reboot', textmode => 1, keepconsole => is_pvm);
     reconnect_mgmt_console if is_pvm;
-    $self->wait_boot if !is_transactional;
+    if (!is_transactional) {
+        if (is_qemu && is_sle('>=16')) {
+            # Same GRUB serial-terminal-init stall as containers/install_updates.pm:
+            # wait_boot's needle-based checks hit a "Stall detected" on this image
+            # rather than a missed match. Confirmed only on SLE 16+ qemu so far.
+            die 'System did not come back up after FIPS reboot' unless wait_serial(get_login_message(), 300);
+            reset_consoles;
+        } else {
+            $self->wait_boot;
+        }
+    }
     is_ppc64le() ? select_console('root-console') : select_serial_terminal();
     return;
 }

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -15,8 +15,8 @@ use bootloader_setup qw(add_grub_cmdline_settings change_grub_config);
 use power_action_utils 'power_action';
 use transactional qw(trup_call process_reboot);
 use utils qw(zypper_call reconnect_mgmt_console);
-use serial_terminal qw(get_login_message select_serial_terminal);
-use Utils::Backends qw(is_pvm is_qemu);
+use serial_terminal 'select_serial_terminal';
+use Utils::Backends 'is_pvm';
 use Utils::Architectures qw(is_aarch64 is_ppc64le is_s390x);
 use version_utils qw(is_jeos is_sle_micro is_sle is_tumbleweed is_transactional is_microos);
 use security::vendoraffirmation;
@@ -29,24 +29,7 @@ sub reboot_and_login {
 
     is_transactional ? process_reboot(trigger => 1) : power_action('reboot', textmode => 1, keepconsole => is_pvm);
     reconnect_mgmt_console if is_pvm;
-    if (!is_transactional) {
-        if (is_qemu && is_aarch64 && is_sle('=16.0')) {
-            # On this SLE 16.0 aarch64/qemu image GRUB fails to init its configured
-            # serial terminal ("serial port `com0' isn't found") and the video
-            # framebuffer then genuinely stalls instead of ever painting a screen,
-            # so wait_boot's needle-based checks hit a real "Stall detected" rather
-            # than a missed match (same root cause as containers/install_updates.pm).
-            # Confirmed only on SLE 16.0 aarch64 so far: other SLE 16+ qemu images
-            # (e.g. the SLE 16.1 Online flavor booted by docker/podman_fips_tests)
-            # render GRUB fine and instead rely on wait_boot's needle+keypress
-            # handling to get past a deliberately stopped boot menu, so keep this
-            # scoped narrowly rather than gating on qemu/version alone.
-            die 'System did not come back up after FIPS reboot' unless wait_serial(get_login_message(), 300);
-            reset_consoles;
-        } else {
-            $self->wait_boot;
-        }
-    }
+    $self->wait_boot if !is_transactional;
     is_ppc64le() ? select_console('root-console') : select_serial_terminal();
     return;
 }

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -15,8 +15,8 @@ use bootloader_setup qw(add_grub_cmdline_settings change_grub_config);
 use power_action_utils 'power_action';
 use transactional qw(trup_call process_reboot);
 use utils qw(zypper_call reconnect_mgmt_console);
-use serial_terminal qw(get_login_message select_serial_terminal);
-use Utils::Backends qw(is_pvm is_qemu);
+use serial_terminal 'select_serial_terminal';
+use Utils::Backends 'is_pvm';
 use Utils::Architectures qw(is_aarch64 is_ppc64le is_s390x);
 use version_utils qw(is_jeos is_sle_micro is_sle is_tumbleweed is_transactional is_microos);
 use security::vendoraffirmation;
@@ -29,18 +29,7 @@ sub reboot_and_login {
 
     is_transactional ? process_reboot(trigger => 1) : power_action('reboot', textmode => 1, keepconsole => is_pvm);
     reconnect_mgmt_console if is_pvm;
-    if (!is_transactional) {
-        if (is_qemu && is_sle('>=16')) {
-            # Same GRUB serial-terminal-init stall as containers/install_updates.pm:
-            # wait_boot's needle-based checks hit a "Stall detected" on this image
-            # rather than a missed match. Confirmed only on SLE 16+ qemu so far.
-            die 'System did not come back up after FIPS reboot' unless wait_serial(get_login_message(), 300);
-            $self->{in_wait_boot} = 0;
-            reset_consoles;
-        } else {
-            $self->wait_boot;
-        }
-    }
+    $self->wait_boot if !is_transactional;
     is_ppc64le() ? select_console('root-console') : select_serial_terminal();
     return;
 }

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -35,6 +35,7 @@ sub reboot_and_login {
             # wait_boot's needle-based checks hit a "Stall detected" on this image
             # rather than a missed match. Confirmed only on SLE 16+ qemu so far.
             die 'System did not come back up after FIPS reboot' unless wait_serial(get_login_message(), 300);
+            $self->{in_wait_boot} = 0;
             reset_consoles;
         } else {
             $self->wait_boot;

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -12,10 +12,10 @@
 use Mojo::Base 'consoletest';
 use testapi;
 use bootloader_setup qw(add_grub_cmdline_settings change_grub_config);
-use power_action_utils qw(power_action wait_boot_serial);
+use power_action_utils 'power_action';
 use transactional qw(trup_call process_reboot);
 use utils qw(zypper_call reconnect_mgmt_console);
-use serial_terminal 'select_serial_terminal';
+use serial_terminal qw(get_login_message select_serial_terminal);
 use Utils::Backends qw(is_pvm is_qemu);
 use Utils::Architectures qw(is_aarch64 is_ppc64le is_s390x);
 use version_utils qw(is_jeos is_sle_micro is_sle is_tumbleweed is_transactional is_microos);
@@ -31,16 +31,17 @@ sub reboot_and_login {
     reconnect_mgmt_console if is_pvm;
     if (!is_transactional) {
         if (is_qemu && is_aarch64 && is_sle('=16.0')) {
-            # On SLE 16.0 aarch64/qemu, GRUB can hit its serial-terminal bug
-            # (bsc#1140464) and hang at a hidden-menu prompt; wait_boot_serial
-            # recovers from that and confirms the login banner over serial.
-            # Confirmed only on SLE 16.0 aarch64 so far: other SLE 16+ qemu
-            # images (e.g. the SLE 16.1 Online flavor booted by docker/
-            # podman_fips_tests) render GRUB fine and instead rely on
-            # wait_boot's needle+keypress handling for a deliberately stopped
-            # boot menu, so keep this scoped narrowly rather than gating on
-            # qemu/version alone.
-            die 'System did not come back up after FIPS reboot' unless wait_boot_serial;
+            # On this SLE 16.0 aarch64/qemu image GRUB fails to init its configured
+            # serial terminal ("serial port `com0' isn't found") and the video
+            # framebuffer then genuinely stalls instead of ever painting a screen,
+            # so wait_boot's needle-based checks hit a real "Stall detected" rather
+            # than a missed match (same root cause as containers/install_updates.pm).
+            # Confirmed only on SLE 16.0 aarch64 so far: other SLE 16+ qemu images
+            # (e.g. the SLE 16.1 Online flavor booted by docker/podman_fips_tests)
+            # render GRUB fine and instead rely on wait_boot's needle+keypress
+            # handling to get past a deliberately stopped boot menu, so keep this
+            # scoped narrowly rather than gating on qemu/version alone.
+            die 'System did not come back up after FIPS reboot' unless wait_serial(get_login_message(), 300);
             reset_consoles;
         } else {
             $self->wait_boot;

--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -70,16 +70,12 @@ sub run {
     # DESKTOP can be gnome, but patch is happening in shell, thus always force reboot in shell
     power_action('reboot', textmode => 1);
     reconnect_mgmt_console if is_pvm;
-    if (is_qemu && is_aarch64 && is_sle('=16.0')) {
-        # On SLE 16.0 aarch64/qemu, patching the kernel/bootloader can
-        # regenerate grub.cfg and trigger GRUB's serial-terminal bug
-        # (bsc#1140464), hanging wait_boot's needle checks with "Stall
-        # detected". wait_boot_serial already confirms the login banner
-        # itself, so it replaces wait_boot here rather than preceding it.
-        die 'System did not come back up after patching' unless wait_boot_serial;
-    } else {
-        $self->wait_boot(ready_time => 600, bootloader_time => get_var('BOOTLOADER_TIMEOUT', 300));
-    }
+    # On SLE 16.0 aarch64/qemu, patching the kernel/bootloader can regenerate
+    # grub.cfg and trigger GRUB's serial-terminal bug (bsc#1140464), hanging
+    # wait_boot's needle checks with "Stall detected". Recover over serial
+    # first; wait_boot then proceeds normally either way.
+    wait_boot_serial if is_qemu && is_aarch64 && is_sle('=16.0');
+    $self->wait_boot(ready_time => 600, bootloader_time => get_var('BOOTLOADER_TIMEOUT', 300));
 }
 
 sub test_flags {

--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -22,8 +22,8 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 use Utils::Architectures;
 use qam;
-use Utils::Backends qw(use_ssh_serial_console is_pvm is_qemu);
-use power_action_utils qw(power_action wait_boot_serial);
+use Utils::Backends qw(use_ssh_serial_console is_pvm);
+use power_action_utils qw(power_action);
 use version_utils qw(is_sle);
 use serial_terminal qw(add_serial_console);
 use version_utils qw(is_jeos);
@@ -70,11 +70,6 @@ sub run {
     # DESKTOP can be gnome, but patch is happening in shell, thus always force reboot in shell
     power_action('reboot', textmode => 1);
     reconnect_mgmt_console if is_pvm;
-    # On SLE 16.0 aarch64/qemu, patching the kernel/bootloader can regenerate
-    # grub.cfg and trigger GRUB's serial-terminal bug (bsc#1140464), hanging
-    # wait_boot's needle checks with "Stall detected". Recover over serial
-    # first; wait_boot then proceeds normally either way.
-    wait_boot_serial if is_qemu && is_aarch64 && is_sle('=16.0');
     $self->wait_boot(ready_time => 600, bootloader_time => get_var('BOOTLOADER_TIMEOUT', 300));
 }
 


### PR DESCRIPTION
Reverts #26539, #26580, and #26588, in reverse-chronological order of their commits:

- Revert "fix(fips): Replace wait_boot with wait_boot_serial, not precede it" (26208f651a, from #26588)
- Revert "fix(fips): Recover from aarch64 GRUB serial-terminal hang (bsc#1140464)" (eb488f21f5, from #26588)
- Revert "fix(fips): Scope FIPS reboot's serial confirmation to SLE 16.0 aarch64" (16dfdef29e, from #26580)
- Revert "fix(fips): Revert to needle-based wait_boot for FIPS reboot" (db9b0e521d, from #26580)
- Revert "fix(containers): Drop redundant in_wait_boot reset" (917bdec91f, fips_setup.pm hunk only, from #26539)
- Revert "fix(fips): Confirm FIPS-mode reboot via serial console on SLE 16+ qemu" (8f6edab8d9, from #26539)

Removes `power_action_utils::wait_boot_serial` and its call sites in `tests/fips/fips_setup.pm` and `tests/qa_automation/patch_and_reboot.pm`, restoring `fips_setup.pm`'s `reboot_and_login` to a plain `$self->wait_boot if !is_transactional;` and `patch_and_reboot.pm`'s reboot to a plain `$self->wait_boot(...)`, matching their state before any of this work started. `tests/containers/install_updates.pm`'s serial-based reboot confirmation is untouched: unaffected by this saga and still needed for its own confirmed video-framebuffer stall.

Details in [Slack thread](https://suse.slack.com/archives/C02CGKBCGT1/p1788790948178789).