### PR TITLE
Add workaround for bsc#1259353

### DIFF
--- a/tests/yam/validate/validate_migration_logs.pm
+++ b/tests/yam/validate/validate_migration_logs.pm
@@ -9,8 +9,13 @@
 use Mojo::Base 'consoletest';
 use testapi;
 use utils 'upload_folders';
+use Utils::Architectures;
 
 sub run {
+    if (is_s390x()) {
+        record_soft_failure('bsc#1259353 - Failed to log in root after migration from 15sp{5-7} to sles16.1 on s390x kvm');
+        sleep 120;
+    }
     select_console 'root-console';
 
     upload_logs("/var/log/distro_migration.log", failok => 1);


### PR DESCRIPTION
It seems system is not ready for login after migration on s390x, we need add workaround to wait some time. 

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/24276751#step/validate_migration_logs/3
