### PR TITLE
Delete destroy_orphaned_resources to use c7n

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/basetest.pm
@@ -98,7 +98,6 @@ sub full_cleanup {
     # Clean up orphaned resources inside permanent deployer job group
     # Resource retention time can be controlled by OpenQA parameter: SDAF_DEPLOYER_VM_RETENTION_SEC
     record_info('Remove orphans', 'Cleaning up orphaned resources');
-    destroy_orphaned_resources();
     if (my $ret = destroy_orphaned_peerings()) {
         record_info('Retry', 'Delete orphaned peerings failed and retry');
         $ret = destroy_orphaned_peerings();


### PR DESCRIPTION
Delete destroy_orphaned_resources as we have custodian now


- Related ticket: 
[TEAM-11533](https://jira.suse.com/browse/TEAM-11533) - [timeboxed][SDAF][Incidents][sporadic] cleanup_ENSA2_sbd failed on test execution exceeded MAX_JOB_TIME (6 hours) due to deployer was powered off
- Verification run:
Just deleting no need VRs.