### PR TITLE
bci_version_check: Record stale build as failed instead of dying

### DIFF
--- a/tests/containers/bci_version_check.pm
+++ b/tests/containers/bci_version_check.pm
@@ -19,6 +19,7 @@ use testapi;
 use serial_terminal 'select_serial_terminal';
 
 sub run {
+    my $self = shift;
     select_serial_terminal;
 
     return unless (get_var('CONTAINER_IMAGE_TO_TEST') && get_var('CONTAINER_IMAGE_BUILD'));
@@ -55,7 +56,11 @@ sub run {
         my $reference = script_output(qq($engine inspect --type image $image | jq -r '.[0].Config.Labels."org.opensuse.reference"'));
         # Note: Both lines are aligned, thus the additional space
         record_info('builds', "CONTAINER_IMAGE_BUILD:  $build\norg.opensuse.reference: $reference");
-        die('Missmatch in image build number. The image build number is different than the one triggered by the container bot!') if ($reference !~ /$buildrelease$/);
+        if ($reference !~ /$buildrelease$/) {
+            record_info('Stale build', "CONTAINER_IMAGE_BUILD=$build does not match image label org.opensuse.reference=$reference.\nA newer build has already replaced this one in the registry, so container-release-bot will (correctly) not release it.\nA new job for the newer build should already be scheduled or running in openQA. This build can be ignored.", result => 'fail', resultname => 'build_superseded');
+            $self->result('fail');
+            return;
+        }
     }
 }
 

--- a/tests/containers/bci_version_check.pm
+++ b/tests/containers/bci_version_check.pm
@@ -57,7 +57,7 @@ sub run {
         # Note: Both lines are aligned, thus the additional space
         record_info('builds', "CONTAINER_IMAGE_BUILD:  $build\norg.opensuse.reference: $reference");
         if ($reference !~ /$buildrelease$/) {
-            record_info('Stale build', "CONTAINER_IMAGE_BUILD=$build does not match image label org.opensuse.reference=$reference.\nA newer build has already replaced this one in the registry, so container-release-bot will (correctly) not release it.\nA new job for the newer build should already be scheduled or running in openQA. This build can be ignored.", result => 'fail', resultname => 'build_superseded');
+            record_info('Stale build', "CONTAINER_IMAGE_BUILD=$build does not match image label org.opensuse.reference=$reference.\nA newer build has already replaced this one.\nThis jobs is obsolete and can be ignored.", result => 'fail', resultname => 'build_superseded');
             $self->result('fail');
             return;
         }


### PR DESCRIPTION
Replace `die()` with `record_info(..., result => 'fail')` in `containers/bci_version_check` for the build-number mismatch check, so the job still fails but shows a clear, descriptive box instead of a raw Perl death trace.

* Related ticket: [poo#206697](https://progress.opensuse.org/issues/206697)
* Related failure: [openqa.suse.de/t24195860](https://openqa.suse.de/tests/24195860)
* Verification runs: In comment below
