### PR TITLE
Record soft-failure for openssl_pqc on SLE 16.0

### DIFF
--- a/tests/security/oqa_agnostic/openssl_pqc.pm
+++ b/tests/security/oqa_agnostic/openssl_pqc.pm
@@ -27,18 +27,14 @@ sub run {
             domain => 'security',
         }
     );
-    if (is_sle('=15-SP7')) {
+    if (is_sle('=15-SP7') || is_sle('=16.0')) {
         eval { $test->setup()->run_test()->parse_results()->cleanup() };
         if ($@) {
-            record_soft_failure("poo#200579 OpenSSL PQ not yet ready for SLE15-SP7: $@");
+            record_soft_failure("poo#200579, bsc#1266010: OpenSSL Post-quantum not yet ready for SLES 15-SP7/16.0: $@");
         }
     } else {
         $test->setup()->run_test()->parse_results()->cleanup();
     }
-}
-
-sub test_flags {
-    return {always_rollback => 1};
 }
 
 1;


### PR DESCRIPTION
 Also remove autorollback, as it is not supported on s390x

- Related ticket: https://progress.opensuse.org/issues/205884
- Needles: n/a
- Verification run:
  - SLE16.0 staging: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=%3Agit%3A7611%3Aapache2&groupid=680
  - SLE16.0 prodinc: https://openqa.suse.de/tests/overview?distri=sle&version=16.0&build=PI-277.29&groupid=680