### PR TITLE
Revert all commits related to wait_for_serial in tests/containers/install_updates.pm

### DIFF
--- a/tests/containers/install_updates.pm
+++ b/tests/containers/install_updates.pm
@@ -51,6 +51,7 @@ sub run {
         # svirt) already have their own proven serial-based handling inside
         # wait_boot, so they keep using it.
         die 'System did not come back up after update reboot' unless wait_serial(get_login_message(), 300);
+        $self->{in_wait_boot} = 0;
         reset_consoles;
     } else {
         $self->wait_boot(bootloader_time => 300);

--- a/tests/containers/install_updates.pm
+++ b/tests/containers/install_updates.pm
@@ -12,7 +12,6 @@ use testapi;
 use utils;
 use power_action_utils;
 use serial_terminal qw(get_login_message);
-use Utils::Backends 'is_qemu';
 use version_utils qw(check_os_release get_os_release is_sle);
 
 sub run {
@@ -41,21 +40,15 @@ sub run {
     # Perform system reboot to ensure the system is still ok
     my $prev_console = current_console();
     power_action('reboot', textmode => 1);
-    if (is_qemu) {
-        # On this SLE 16.0 aarch64/qemu image GRUB fails to init its configured
-        # serial terminal ("serial port `com0' isn't found") and the video
-        # framebuffer then genuinely stalls instead of ever painting a screen,
-        # so wait_boot's needle-based checks hit a real "Stall detected" rather
-        # than a missed match. Confirm boot completion over the serial console
-        # instead, which stays live throughout. Non-qemu backends (e.g. s390x
-        # svirt) already have their own proven serial-based handling inside
-        # wait_boot, so they keep using it.
-        die 'System did not come back up after update reboot' unless wait_serial(get_login_message(), 300);
-        $self->{in_wait_boot} = 0;
-        reset_consoles;
-    } else {
-        $self->wait_boot(bootloader_time => 300);
-    }
+    # On this SLE 16.0 aarch64/qemu image GRUB fails to init its configured
+    # serial terminal ("serial port `com0' isn't found") and the video
+    # framebuffer then genuinely stalls instead of ever painting a screen,
+    # so wait_boot's needle-based checks hit a real "Stall detected" rather
+    # than a missed match. Confirm boot completion over the serial console
+    # instead, which stays live throughout.
+    die 'System did not come back up after update reboot' unless wait_serial(get_login_message(), 300);
+    $self->{in_wait_boot} = 0;
+    reset_consoles;
     select_console($prev_console);
 }
 

--- a/tests/containers/install_updates.pm
+++ b/tests/containers/install_updates.pm
@@ -11,7 +11,6 @@ use Mojo::Base 'consoletest';
 use testapi;
 use utils;
 use power_action_utils;
-use serial_terminal qw(get_login_message);
 use version_utils qw(check_os_release get_os_release is_sle);
 
 sub run {
@@ -40,15 +39,7 @@ sub run {
     # Perform system reboot to ensure the system is still ok
     my $prev_console = current_console();
     power_action('reboot', textmode => 1);
-    # On this SLE 16.0 aarch64/qemu image GRUB fails to init its configured
-    # serial terminal ("serial port `com0' isn't found") and the video
-    # framebuffer then genuinely stalls instead of ever painting a screen,
-    # so wait_boot's needle-based checks hit a real "Stall detected" rather
-    # than a missed match. Confirm boot completion over the serial console
-    # instead, which stays live throughout.
-    die 'System did not come back up after update reboot' unless wait_serial(get_login_message(), 300);
-    $self->{in_wait_boot} = 0;
-    reset_consoles;
+    $self->wait_boot(bootloader_time => 300);
     select_console($prev_console);
 }
 


### PR DESCRIPTION
Revert all commits related to fix the "Recover from aarch64 GRUB serial-terminal hang", as in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26603, but applied to `tests/containers/install_updates.pm` which was forgotten.

- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26603
- Verification run: https://openqa.suse.de/tests/24279625
