### PR TITLE
Add coredump collection to minimalvm-toolchains

### DIFF
--- a/schedule/jeos/sle/minimalvm-toolchains.yaml
+++ b/schedule/jeos/sle/minimalvm-toolchains.yaml
@@ -41,4 +41,5 @@ schedule:
     - toolchain/gcc_compilation
     - toolchain/gcc_fortran_compilation
     - console/orphaned_packages_check
+    - console/coredump_collect
     - console/consoletest_finish


### PR DESCRIPTION
Ideally we should have these on all MinimalVM schedules.

Verification run: https://openqa.suse.de/tests/24279585/logfile?filename=core.perf.0.22c0758e5f9e482cae6c55c08dc32dc7.15123.1788867390000000.zst_backtrace.txt