### PR TITLE
Elemental3 use totest lcm

### DIFF
--- a/data/elemental3/cluster.yaml
+++ b/data/elemental3/cluster.yaml
@@ -14,7 +14,7 @@ network:
 helm:
   charts:
     - name: "cert-manager"
-      version: "v1.20.3"
+      version: "%CERTMANAGER_VERSION%"
       targetNamespace: "cert-manager"
       repositoryName: "jetstack-charts"
       valuesFile: cert-manager.yaml
@@ -23,11 +23,11 @@ helm:
       targetNamespace: "cattle-system"
       repositoryName: "rancher-charts"
     - name: "elemental-lifecycle-manager-crds"
-      version: "0.1.0"
+      version: "%LCM_VERSION%"
       targetNamespace: "elemental-system"
       repositoryName: "elemental-charts"
     - name: "elemental-lifecycle-manager"
-      version: "0.1.0"
+      version: "%LCM_VERSION%"
       targetNamespace: "elemental-system"
       repositoryName: "elemental-charts"
       valuesFile: lcm-internal-suse-ca.yaml
@@ -37,4 +37,4 @@ helm:
     - name: "rancher-charts"
       url: "https://charts.rancher.io"
     - name: "elemental-charts"
-      url: "oci://registry.suse.com/elemental/charts"
+      url: "%LCM_REGISTRY%"

--- a/tests/elemental3/generate_image.pm
+++ b/tests/elemental3/generate_image.pm
@@ -131,9 +131,11 @@ sub customize_cmd {
         );
     } else {
         if (get_var('CLUSTER_TYPE', '') =~ /(singlenode|multinode)/) {
+            my $cluster_yaml = "$args{config_dir}/kubernetes/cluster.yaml";
+
             # K8s configuration file
             assert_script_run(
-                "curl -sf -o $args{config_dir}/kubernetes/cluster.yaml "
+                "curl -sf -o $cluster_yaml "
                   . data_url('elemental3/cluster.yaml')
             );
 
@@ -141,9 +143,17 @@ sub customize_cmd {
             if (check_var('CLUSTER_TYPE', 'singlenode')) {
                 # Keep configuration for first node only
                 assert_script_run(
-                    "sed -i -e '/^nodes:/,/^network:/d' -e '/apiVIP:.*/i network:' $args{config_dir}/kubernetes/cluster.yaml"
+                    "sed -i -e '/^nodes:/,/^network:/d' -e '/apiVIP:.*/i network:' $cluster_yaml"
                 );
             }
+
+            # Set CertManager version and LCM registry/version
+            file_content_replace(
+                $cluster_yaml,
+                '%CERTMANAGER_VERSION%' => get_required_var('CERTMANAGER_VERSION'),
+                '%LCM_REGISTRY%' => get_required_var('LCM_REGISTRY'),
+                '%LCM_VERSION%' => get_required_var('LCM_VERSION')
+            );
         } else {
             # Remove k8s-preinstall service, as this is only useful
             # for the single-node and multi-node tests

--- a/tests/elemental3/start_k8s.pm
+++ b/tests/elemental3/start_k8s.pm
@@ -100,6 +100,9 @@ sub run {
         return;
     }
 
+    # No GUI, easier and quicker to use the serial console
+    select_serial_terminal();
+
     # Cannot be defined with the other variables, as we need terminal access
     my $hostname = get_var('HOSTNAME', script_output('hostnamectl hostname'));
 
@@ -146,6 +149,9 @@ sub post_fail_hook {
     my ($self) = @_;
 
     record_info(__PACKAGE__ . ':' . 'post_fail_hook');
+
+    # No GUI, easier and quicker to use the serial console
+    select_serial_terminal();
 
     # Useful to debug K8s starting issues
     foreach my $svc ('k8s-resource-installer', 'k3s', 'rke2-server') {

--- a/tests/elemental3/upgrade_manifest.pm
+++ b/tests/elemental3/upgrade_manifest.pm
@@ -9,7 +9,7 @@ use Mojo::Base 'opensusebasetest';
 use testapi;
 use elemental3;
 use serial_terminal qw(select_serial_terminal);
-use utils qw(file_content_replace);
+use utils qw(file_content_replace validate_script_output_retry);
 
 sub run {
     my ($self) = @_;
@@ -72,6 +72,15 @@ sub run {
     # Apply upgrade plan
     kubectl_cmd(cmd => "apply -f ${upgrade_file}");
     record_info('Upgrade Plan status', script_output('kubectl get release upgrade-manifest -o yaml 2>&1'));
+
+    # Wait for upgrade to complete
+    validate_script_output_retry(
+        'kubectl get release upgrade-manifest -o jsonpath={.status.version}',
+        qr/.+/,
+        delay => bmwqemu::scale_timeout(30),
+        retry => 10,
+        fail_message => "Manifest upgrade failed!"
+    );
 
     # Select SUT for bootloader
     select_console('sut');

--- a/tests/elemental3/upgrade_manifest.pm
+++ b/tests/elemental3/upgrade_manifest.pm
@@ -17,6 +17,8 @@ sub run {
     my $k8s = get_required_var('K8S');
     my $k8s_version_prefix = get_required_var('K8S_VERSION_PREFIX');
     my $totest_path = get_required_var('TOTEST_PATH');
+    my $timeout = bmwqemu::scale_timeout(300);
+    my $long_timeout = bmwqemu::scale_timeout(900);
 
     # Add static hosts if needed
     # TODO: use a support-server to add a DNS server with internal LAN access?
@@ -42,7 +44,7 @@ sub run {
         # NOTE: kubectl_cmd cannot be used for the 'rollout status' command!
         kubectl_cmd(cmd => "${ns} apply -f ${yaml_file}");
         kubectl_cmd(cmd => "${ns} rollout restart deployment -l k8s-app=kube-dns");
-        assert_script_run("kubectl ${ns} rollout status deployment -l k8s-app=kube-dns", timeout => bmwqemu::scale_timeout('300'));
+        assert_script_run("kubectl ${ns} rollout status deployment -l k8s-app=kube-dns", timeout => $timeout);
     }
 
     my $uri = get_container_uri(
@@ -76,7 +78,7 @@ sub run {
 
     # OS upgrade is done automatically as well as the reboot after upgrade
     # We just have to wait for the VM to reboot
-    $self->wait_boot(bootloader_time => bmwqemu::scale_timeout(900), textmode => 1, nologin => 1);
+    $self->wait_boot(bootloader_time => $long_timeout, textmode => 1, nologin => 1);
 
     # Set default root password
     $testapi::password = get_required_var('TEST_PASSWORD');
@@ -85,10 +87,10 @@ sub run {
     select_serial_terminal();
 
     # Check K8s status
-    wait_k8s_state(regex => 'status.*restarts|(1/1|2/2|3/3|4.4).*running|0/1.*completed', timeout => bmwqemu::scale_timeout('1200'));
+    wait_k8s_state(regex => 'status.*restarts|(1/1|2/2|3/3|4.4).*running|0/1.*completed', timeout => $long_timeout);
 
     # Check upgrade status after reboot
-    my $upgrade_version = wait_script_output(cmd => 'kubectl get release upgrade-manifest -o jsonpath={.spec.version}', timeout => 300);
+    my $upgrade_version = wait_script_output(cmd => 'kubectl get release upgrade-manifest -o jsonpath={.status.version}', timeout => $timeout);
 
     # Record upgrade status
     record_info('Upgrade done', "Upgrade to version '${upgrade_version}' done successfully!");


### PR DESCRIPTION
- Related ticket: N/A
- Needles: N/A
- Failing test: this is mainly to help in  this [failing test](https://openqa.suse.de/tests/24191146), to have some error messages in the upgrade pod logs
- Verification runs: http://10.168.203.107/tests/overview?distri=sle&distri=sle-micro&version=16.1&build=97.1_rke2-manifest-image&groupid=1

**NOTE:** the `upgrade` test is failing for a [valid reason](http://openqa-webui/tests/608#step/upgrade_manifest/40) not due to these changes. In fact some of these changes were added to be able to catch this issue. This is an upstream problem that is already discussed with the Devs.
&nbsp;

This PR adds/fixes the following:
- remove hardcoded LCM path/version
- add missing serial console selection
- fix some timeout in upgrade test
- add a better way to wait for upgrade