### PR TITLE
Ensure hacluster::script_output_retry_check actually retries

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -1251,7 +1251,7 @@ sub script_output_retry_check {
     }
 
     foreach (1 .. $retry) {
-        $result = script_output($cmd, %args);
+        $result = script_output($cmd, %args, proceed_on_failure => 1);
         return $result if $result =~ /$regex/;
         sleep $sleep;
         record_info('CMD RETRY', "Retry $_/$retry.\nScript output did not match pattern '$regex'\nOutput: $result");


### PR DESCRIPTION
The function `hacluster::script_output_retry_check()` has an internal call to `testapi::script_output()` which is done without `proceed_on_failure => 1`. This means, that if the command supplied to `script_output_retry_check` fails with a non-zero retval, then the retry mechanism inside the code of `script_output_retry_check` is useless, as the failure will fail the whole test module[1] instead of trying again.

This commit adds the missing argument to the `script_output` call.

[1] https://open.qa/api/testapi/#script_output

- Related ticket: N/A
- Needles: N/A
- Verification run: skipping VRs as most tests are working currently with a single try.
