### PR TITLE
Wait more time for login after migration on s390x

### DIFF
--- a/tests/yam/validate/validate_migration_logs.pm
+++ b/tests/yam/validate/validate_migration_logs.pm
@@ -14,7 +14,7 @@ use Utils::Architectures;
 sub run {
     if (is_s390x()) {
         record_soft_failure('bsc#1259353 - Failed to log in root after migration from 15sp{5-7} to sles16.1 on s390x kvm');
-        sleep 120;
+        sleep 240;
     }
     select_console 'root-console';
 


### PR DESCRIPTION


- Related ticket: N/A
- Needles: 
- Verification run: https://openqa.suse.de/tests/overview?build=lemon-suse%2Fos-autoinst-distri-opensuse%23wait_more_time_for_login_s390x&distri=sle&version=16.1