### PR TITLE
systemd_resolved: Fix file checks

### DIFF
--- a/tests/console/systemd_resolved.pm
+++ b/tests/console/systemd_resolved.pm
@@ -20,7 +20,7 @@ sub clean_up {
     assert_script_run("rm /etc/systemd/resolved.conf.d/dnssec.conf");
     assert_script_run("rm /etc/systemd/resolved.conf.d/dns_over_tls.conf");
     assert_script_run("mv /etc/resolv.conf{.bak,}");
-    assert_script_run("rm /etc/nsswitch.conf");
+    assert_script_run("mv /etc/nsswitch.conf{.bak,}");
     systemctl 'disable --now systemd-resolved', timeout => 30;
     zypper_call 'rm systemd-resolved nss-mdns';
     systemctl 'restart NetworkManager' if is_nm_used();
@@ -35,12 +35,12 @@ sub run {
     systemctl 'stop NetworkManager' if is_nm_used();
     systemctl 'stop wicked.service' if is_wicked_used();
     assert_script_run("mv /etc/resolv.conf{,.bak}");
+    assert_script_run("cp -a /etc/nsswitch.conf{,.bak}");
     # Add workaround for bsc#1248501
     my $file = '/usr/share/dbus-1/system.d/org.freedesktop.resolve1.conf';
-    assert_script_run("touch $file") if (!-f $file);
+    assert_script_run("touch $file") if script_run("test ! -f $file");
     systemctl 'enable --now systemd-resolved';
     assert_script_run 'ln -s /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf';
-    assert_script_run "cp /usr/etc/nsswitch.conf /etc/nsswitch.conf" if (!-f '/etc/nsswitch.conf');
     assert_script_run "sed -i 's/^hosts:.*files/hosts: files resolve [!UNAVAIL=return]/' /etc/nsswitch.conf";
     script_run 'cat /etc/nsswitch.conf';
     systemctl 'start NetworkManager' if (script_run('rpm -q NetworkManager') == 0);


### PR DESCRIPTION
Remove cp /usr/etc/nsswitch.conf /etc/nsswitch.conf, condition was wrong anyway, not checking file on tested VM

- Related ticket: https://progress.opensuse.org/issues/206784
- Verification run:
https://openqa.suse.de/tests/overview?build=jpupava_systemd_resolved&distri=sle osd
https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=jpupava_systemd_resolved o3