### PR TITLE
ha/pacemaker_cts_regression.pm: Sanitize log output to console

### DIFF
--- a/tests/ha/pacemaker_cts_regression.pm
+++ b/tests/ha/pacemaker_cts_regression.pm
@@ -36,7 +36,8 @@ sub run {
     foreach my $cts_tests (@tests_to_run) {
         record_info("$cts_tests", "Starting $cts_tests");
         assert_script_run("echo ==== Starting $cts_tests ==== >> $log");
-        assert_script_run "$cts_path/$cts_tests -V | tee -a $log 2>&1 ; ( exit \${PIPESTATUS[0]} )", timeout => $timeout;
+        # Use "cat -v" to escape control characters that are in the log due to bsc#1279543
+        assert_script_run "$cts_path/$cts_tests -V | tee -a $log 2>&1 | cat -v; ( exit \${PIPESTATUS[0]} )", timeout => $timeout;
         save_screenshot;
     }
 


### PR DESCRIPTION
Due to a use-after-free in pacemaker-fenced (bsc#1279543), the log file contains random garbage, which if printed to a terminal can break further input and output. Use cat -v which converts them into printable sequences.

- Related ticket: https://progress.opensuse.org/issues/206241
- Verification run: http://10.168.5.231/tests/2152
