### PR TITLE
Add GCP spoke cleanup

### DIFF
--- a/lib/sles4sap/qesap/qesapdeployment.pm
+++ b/lib/sles4sap/qesap/qesapdeployment.pm
@@ -90,6 +90,7 @@ our @EXPORT = qw(
   qesap_terraform_ansible_deploy_retry
   qesap_create_cidr_from_ip
   qesap_ssh_intrusion_detection
+  qesap_gcp_delete_leftover_ncc_spokes
 );
 
 =head1 DESCRIPTION
@@ -2014,6 +2015,141 @@ sub qesap_ssh_intrusion_detection {
                 "Found $report{$host}{attempts} login attempts. Users: @{$report{$host}{users}}. IPs: @{$report{$host}{ips}}");
         }
     }
+}
+
+=head3 qesap_gcp_get_ncc_spokes
+
+    qesap_gcp_get_ncc_spokes( [hub => $hub], [name => $name] )
+
+    Queries GCP for Network Connectivity Center (NCC) spokes matching the given
+    hub or spoke name.
+    Return:
+     - Array ref of spoke HASH references
+     - Empty array ref on failure or if no spokes are found
+
+=over
+
+=item B<hub> - Optional NCC hub name to filter spokes by
+
+=item B<name> - Optional spoke name to filter by
+
+=back
+=cut
+
+sub qesap_gcp_get_ncc_spokes {
+    my (%args) = @_;
+    my $filter = '';
+    if ($args{name}) {
+        $filter = "--filter='name:$args{name}'";
+    }
+    elsif ($args{hub}) {
+        $filter = "--filter='hub:$args{hub}'";
+    }
+
+    my $cmd = join(' ', 'gcloud network-connectivity spokes list',
+        '--global',
+        $filter,
+        '--format=json');
+
+    my $output = script_output($cmd, proceed_on_failure => 1);
+    return [] unless $output;
+
+    my $spokes = eval { decode_json($output) };
+    return ref($spokes) eq 'ARRAY' ? $spokes : [];
+}
+
+
+=head3 qesap_gcp_delete_ncc_spoke
+
+    qesap_gcp_delete_ncc_spoke( name => $name, [wait => 1], [timeout => 300] )
+
+    Deletes a GCP NCC spoke by name and optionally waits until deletion completes.
+    Return:
+     - 1 if deletion succeeded or wait flag is 0
+     - 0 if wait timed out before deletion completed
+
+=over
+
+=item B<name> - Mandatory spoke name to delete
+
+=item B<wait> - Optional boolean flag to wait for deletion completion (default: 1)
+
+=item B<timeout> - Optional max seconds to wait in seconds (default: 300)
+
+=back
+=cut
+
+sub qesap_gcp_delete_ncc_spoke {
+    my (%args) = @_;
+    croak 'Must provide spoke name' unless $args{name};
+    $args{timeout} //= bmwqemu::scale_timeout(300);
+    $args{wait} = $args{wait} // 1;
+
+    my $cmd = join(' ', 'gcloud network-connectivity spokes delete', $args{name}, '--global', '--quiet');
+    script_run($cmd);
+
+    return 1 unless $args{wait};
+
+    my $duration;
+    my $start_time = time();
+    my $res;
+    while (($duration = time() - $start_time) < $args{timeout}) {
+        sleep 5;
+        $res = qesap_gcp_get_ncc_spokes(name => $args{name});
+        last unless ref($res) eq 'ARRAY' && @$res;
+    }
+    return $duration < $args{timeout} ? 1 : 0;
+}
+
+
+=head3 qesap_gcp_delete_leftover_ncc_spokes
+
+    qesap_gcp_delete_leftover_ncc_spokes( hub => $hub )
+
+    Scans GCP NCC spokes attached to the given hub, identifies edge spokes left over
+    from finished openQA jobs, and initiates deletion. Ignores the center spoke.
+    Return:
+     - 0 if mandatory arguments are missing
+     - 1 on successful scan and cleanup execution
+
+=over
+
+=item B<hub> - Mandatory NCC hub name to inspect
+
+=back
+=cut
+
+sub qesap_gcp_delete_leftover_ncc_spokes {
+    my (%args) = @_;
+    return 0 unless $args{hub};
+
+    my $available_spokes = qesap_gcp_get_ncc_spokes(hub => $args{hub});
+
+    return 1 unless ref($available_spokes) eq 'ARRAY' && @$available_spokes;
+    record_info('GCP PEERING CLEANUP', 'Starting leftover NCC spoke cleanup (GCP)');
+
+    foreach my $spoke (@$available_spokes) {
+        my $spoke_name = $spoke->{name} // next;
+        $spoke_name =~ s{.*/}{};
+
+        # Ignore non-edge spokes and the permanent center spoke
+        next if $spoke_name eq 'ibsm-center-spoke' || ($spoke->{group} // '') eq 'center';
+
+        # Extract job ID appended at the end of the spoke name (e.g. edge-hanasr24276142)
+        next unless $spoke_name =~ /(\d+)$/;
+        my $job_id = $1;
+
+        # Delete spoke if the associated job is finished
+        next unless qesap_is_job_finished(job_id => $job_id);
+
+        record_info('LEFTOVER GCP SPOKE', "Spoke ${spoke_name}'s job $job_id has finished, deleting");
+
+        qesap_gcp_delete_ncc_spoke(
+            name => $spoke_name,
+            wait => 0
+        );
+    }
+    return 1;
 }
 
 1;

--- a/t/09_qesapdeployment.t
+++ b/t/09_qesapdeployment.t
@@ -1401,4 +1401,52 @@ LOG
     ok(scalar @cat_calls == 2, 'Log files read for both hosts');
 };
 
+subtest '[qesap_gcp_delete_leftover_ncc_spokes] missing hub argument' => sub {
+    my $ret = qesap_gcp_delete_leftover_ncc_spokes();
+    is $ret, 0, 'Returns 0 when hub argument is missing';
+};
+
+subtest '[qesap_gcp_delete_leftover_ncc_spokes] cleanup logic' => sub {
+    my $qesap = Test::MockModule->new('sles4sap::qesap::qesapdeployment', no_auto => 1);
+    my @deleted_spokes;
+
+    $qesap->redefine(record_info => sub { note(join(' ', 'RECORD_INFO -->', @_)); });
+
+    # Mock GCP spoke listing returning various test cases
+    $qesap->redefine(qesap_gcp_get_ncc_spokes => sub {
+            return [
+                # 1. Permanent center spoke by name -> SKIP
+                {name => 'projects/FF8/locations/global/spokes/ibsm-center-spoke', group => 'center'},
+                # 2. Spoke assigned to center group -> SKIP
+                {name => 'projects/FF8/locations/global/spokes/custom-center-spoke', group => 'center'},
+                # 3. Spoke without trailing digits -> SKIP
+                {name => 'projects/FF8/locations/global/spokes/edge-spoke-squall', group => 'edge'},
+                # 4. Spoke from an active/running openQA job -> SKIP
+                {name => 'projects/FF8/locations/global/spokes/edge-running-100001', group => 'edge'},
+                # 5. Spoke from a finished openQA job -> DELETE
+                {name => 'projects/FF8/locations/global/spokes/edge-finished-200002', group => 'edge'},
+            ];
+    });
+
+    # Mock job status check
+    $qesap->redefine(qesap_is_job_finished => sub {
+            my (%args) = @_;
+            return 1 if $args{job_id} eq '200002';
+            return 0;
+    });
+
+    # Record which spokes get triggered for deletion
+    $qesap->redefine(qesap_gcp_delete_ncc_spoke => sub {
+            my (%args) = @_;
+            push @deleted_spokes, $args{name};
+            return 1;
+    });
+
+    my $res = qesap_gcp_delete_leftover_ncc_spokes(hub => 'ibsm-ncc-hub');
+
+    is $res, 1, 'Function returns 1 on successful execution';
+    is scalar @deleted_spokes, 1, 'Exactly 1 leftover spoke deleted';
+    is $deleted_spokes[0], 'edge-finished-200002', 'Target spoke matching finished job ID was selected for deletion';
+};
+
 done_testing;

--- a/tests/sles4sap/publiccloud/qesap_configure.pm
+++ b/tests/sles4sap/publiccloud/qesap_configure.pm
@@ -370,6 +370,9 @@ sub run {
     elsif (is_ec2 && get_var('IBSM_PRJ_TAG')) {
         qesap_aws_delete_leftover_tgw_attachments(mirror_tag => get_var('IBSM_PRJ_TAG'));
     }
+    elsif (is_gce && get_var('IBSM_NCC_HUB')) {
+        qesap_gcp_delete_leftover_ncc_spokes(hub => get_var('IBSM_NCC_HUB'));
+    }
 
     # Regenerate config files
     qesap_prepare_env(provider => $provider_setting, only_configure => 1, region => get_required_var('PUBLIC_CLOUD_REGION'));


### PR DESCRIPTION
This PR adds gcp edge spoke cleanup for finished OSD jobs in `qesap_configure`, in an attempt to minimize failed tests due to leftover spokes. The cleanup will only delete a spoke if a job ID exists as a suffix of an edge spoke name (center spokes do not get deleted), and only if the job exists in osd and is finished. In all other cases, cleanup will be skipped for that spoke.

- Related ticket: https://jira.suse.com/browse/TEAM-11504
- Verification run: https://openqa.suse.de/tests/24294977#step/qesap_configure/115 (see deleted jobs - they were leftovers, other jobs running at the same time did not have their spokes deleted, like https://openqa.suse.de/tests/24294775)
