### PR TITLE
Fix SDAF script run timed out issue

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -117,7 +117,8 @@ Example:
 =back
 =cut
 
-sub az(%args) {
+sub az {
+    my (%args) = @_;
     $args{timeout} //= $bmwqemu::default_timeout;
     croak 'Command `az` is not needed in $args{az_args}'
       if $args{az_args} =~ /az/;
@@ -277,9 +278,10 @@ Returns non-empty value if resource group exists, otherwise B<undef>
 =cut
 
 sub az_group_exists(%args) {
+    $args{timeout} //= 90;
     croak "Missing mandatory argument: 'name'" unless $args{name};
     my $out = az(az_args => "group exists --resource-group $args{name}",
-        quiet => $args{quiet});
+        quiet => $args{quiet}, timeout => $args{timeout});
     die "Command failed.\nCommand didn't return a boolean value: $out->{output}"
       unless JSON::PP::is_bool($out->{output});
     return $out->{output};
@@ -414,9 +416,10 @@ some query result in the function to die on decode_json.
 sub az_network_vnet_get(%args) {
     croak("Argument < resource_group > missing") unless $args{resource_group};
     $args{query} //= '[].name';
+    $args{timeout} //= 90;
 
     my $az_args = "network vnet list -g $args{resource_group}";
-    my $az_out = az(az_args => $az_args, query => $args{query});
+    my $az_out = az(az_args => $az_args, query => $args{query}, timeout => $args{timeout});
     return $az_out->{output};
 }
 
@@ -1714,12 +1717,13 @@ sub az_network_peering_list(%args) {
     foreach (qw(resource_group vnet)) {
         croak("Argument < $_ > missing") unless $args{$_}; }
     $args{query} //= '[].name';
+    $args{timeout} //= 90;
 
     my $az_args = join(' ', 'network vnet peering list',
         '--resource-group', $args{resource_group},
         '--vnet-name', $args{vnet}
     );
-    my $az_out = az(az_args => $az_args, query => $args{query});
+    my $az_out = az(az_args => $az_args, query => $args{query}, timeout => $args{timeout});
     return $az_out->{output};
 }
 
@@ -2311,13 +2315,14 @@ Creates private DNS zone within specified B<resource_group>.
 
 sub az_network_dns_zone_create {
     my (%args) = @_;
+    $args{timeout} //= 90;
     foreach ('resource_group', 'name') { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
     my @az_args = ('network private-dns zone create',
         "--resource-group $args{resource_group}",
         "--name $args{name}",
     );
     push @az_args, '--tags', $args{tags} if $args{tags};
-    my $az_out = az(az_args => join(' ', @az_args));
+    my $az_out = az(az_args => join(' ', @az_args), timeout => $args{timeout});
     return $az_out->{rc};
 }
 
@@ -2338,6 +2343,7 @@ Deletes private DNS zone within B<resource_group> specified by B<zone_name>.
 
 sub az_network_dns_zone_delete {
     my (%args) = @_;
+    $args{timeout} //= 90;
     foreach ('resource_group', 'zone_name') { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
     my @az_args = ('network private-dns zone delete',
         "--resource-group $args{resource_group}",
@@ -2345,7 +2351,7 @@ sub az_network_dns_zone_delete {
         '--yes'
     );
 
-    my $az_out = az(az_args => (join(' ', @az_args)));
+    my $az_out = az(az_args => (join(' ', @az_args)), timeout => $args{timeout});
     return $az_out->{rc};
 }
 
@@ -2366,9 +2372,10 @@ Returns private DNS zone list as an B<ARRAYREF> existing within specified B<reso
 
 sub az_network_dns_zone_list {
     my (%args) = @_;
+    $args{timeout} //= 90;
     croak "Missing mandatory argument: 'resource_group'" unless $args{resource_group};
     $args{query} //= '[].name';
-    my $az_out = az(az_args => "network private-dns zone list --resource-group $args{resource_group}", query => $args{query});
+    my $az_out = az(az_args => "network private-dns zone list --resource-group $args{resource_group}", query => $args{query}, timeout => $args{timeout});
     return $az_out->{output};
 }
 
@@ -2441,6 +2448,7 @@ Setting it to false (Common Use Cases) means Auto-Registration is disabled.
 
 sub az_network_dns_link_create {
     my (%args) = @_;
+    $args{timeout} //= 90;
     my @mandatory_args = qw(resource_group zone_name vnet name);
     foreach (@mandatory_args) { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
     my @az_args = (' ',
@@ -2452,7 +2460,7 @@ sub az_network_dns_link_create {
         '--registration-enabled false'
     );
 
-    my $az_out = az(az_args => join(' ', @az_args));
+    my $az_out = az(az_args => join(' ', @az_args), timeout => $args{timeout});
     return $az_out->{rc};
 }
 
@@ -2479,6 +2487,7 @@ Deletes private DNS link between VNET and DNS zone.
 
 sub az_network_dns_link_delete {
     my (%args) = @_;
+    $args{timeout} //= 90;
     my @mandatory_args = qw(resource_group zone_name link_name);
     foreach (@mandatory_args) { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
     my @az_args = (' ',
@@ -2489,7 +2498,7 @@ sub az_network_dns_link_delete {
         '--yes'
     );
 
-    my $az_out = az(az_args => join(' ', @az_args));
+    my $az_out = az(az_args => join(' ', @az_args), timeout => $args{timeout});
     return $az_out->{rc};
 }
 
@@ -2512,6 +2521,7 @@ Lists private DNS links withing specified B<resource_group> and B<zone_name>. Re
 
 sub az_network_dns_link_list {
     my (%args) = @_;
+    $args{timeout} //= 90;
     $args{query} //= '[].name';
     my @mandatory_args = qw(resource_group zone_name);
     foreach (@mandatory_args) { croak "Missing mandatory argument: '$_'" unless $args{$_}; }
@@ -2521,7 +2531,7 @@ sub az_network_dns_link_list {
         "--zone-name $args{zone_name}"
     );
 
-    my $az_out = az(az_args => join(' ', @az_args), query => $args{query});
+    my $az_out = az(az_args => join(' ', @az_args), query => $args{query}, timeout => $args{timeout});
     return $az_out->{output};
 }
 

--- a/lib/sles4sap/sap_deployment_automation_framework/inventory_tools.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/inventory_tools.pm
@@ -237,7 +237,7 @@ sub verify_ssh_proxy_connection {
             my $max_retries = 10;
             my $hostname_output = '';
             for my $attempt (1 .. $max_retries) {
-                $hostname_output = script_output("ssh $hostname hostname", timeout => 15, quiet => 1, proceed_on_failure => 1);
+                $hostname_output = script_output("ssh $hostname hostname", timeout => 60, quiet => 1, proceed_on_failure => 1);
                 last if defined $hostname_output && $hostname_output ne '';
 
                 if ($attempt < $max_retries) {

--- a/schedule/sles4sap/sap_deployment_automation_framework/sdaf_deployment.yml
+++ b/schedule/sles4sap/sap_deployment_automation_framework/sdaf_deployment.yml
@@ -16,10 +16,12 @@ schedule:
   - '{{iscsi_workaround}}'
   - sles4sap/sap_deployment_automation_framework/os_preparation
   - '{{maintenance_update}}'
-  - sles4sap/sap_deployment_automation_framework/app_deployment
-  - sles4sap/redirection_tests/check_hana_database
-  - sles4sap/redirection_tests/check_ensa2_cluster
-  - sles4sap/redirection_tests/check_netweaver
+  #- sles4sap/sap_deployment_automation_framework/app_deployment
+  #- sles4sap/redirection_tests/check_hana_database
+  #- sles4sap/redirection_tests/check_ensa2_cluster
+  #- sles4sap/redirection_tests/check_netweaver
+  - sles4sap/sap_deployment_automation_framework/cleanup
+
 
 conditional_schedule:
   maintenance_update:

--- a/tests/sles4sap/sap_deployment_automation_framework/ibsm_configure.pm
+++ b/tests/sles4sap/sap_deployment_automation_framework/ibsm_configure.pm
@@ -122,7 +122,7 @@ record_info
 
     record_info(
         'IBSm DNS', "Private DNS zone: $zone_name\nDNS record: $ibsm_ip -> " . get_required_var('REPO_MIRROR_HOST'));
-    az_network_dns_zone_create(resource_group => $workload_resource_group, name => $zone_name);
+    az_network_dns_zone_create(resource_group => $workload_resource_group, name => $zone_name, timeout => 90);
     az_network_dns_add_record(
         resource_group => $workload_resource_group, zone_name => $zone_name, record_name => $subdomain, ip_addr => $ibsm_ip);
     az_network_dns_link_create(


### PR DESCRIPTION
TEAM-11533 - [timeboxed][SDAF][Incidents][sporadic] cleanup_ENSA2_sbd failed on
  test execution exceeded MAX_JOB_TIME (6 hours) due to deployer was powered off

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
