### PR TITLE
Fix write_sut_file to avoid AppArmor curl restriction

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -3086,7 +3086,12 @@ sub write_sut_file {
 
     save_tmp_file($path, $contents);
     my $url = join('/', (autoinst_url, 'files', $path));
-    assert_script_run("curl -v -o $path $url");
+    # AppArmor's curl profile only allows curl to write within $HOME, /tmp,
+    # /var/tmp, etc. so fetch into /tmp first and move it into place
+    # afterwards, since mv is not confined by that profile.
+    my $tmp_path = '/tmp/' . basename($path);
+    assert_script_run("curl -v -o $tmp_path $url");
+    assert_script_run("mv -Zf $tmp_path $path") unless $tmp_path eq $path;
 }
 
 =head2 is_ipxe_boot


### PR DESCRIPTION
curl's AppArmor profile only allows writing within $HOME, /tmp, /var/tmp, etc., so write_sut_file failed when writing to other paths such as /etc/containers/registries.conf.d/. Download to /tmp first and move the file into place with mv, which is not confined by that profile.

Failed job: https://openqa.opensuse.org/tests/6208281#step/podman/136
