### PR TITLE
publiccloud: Use Bash's time builtin instead of external time command

### DIFF
--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -46,7 +46,7 @@ sub init {
         # CAVEAT: Use the bash environment variables to prevent credential leaks.
         assert_script_run('printf "[default]\naws_access_key_id=$AWS_ACCESS_KEY_ID\naws_secret_access_key=$AWS_SECRET_ACCESS_KEY\nregion=$AWS_DEFAULT_REGION\n" > ~/.aws/credentials');
         my $debug = "aws-cli-debug.txt";
-        script_run("PILOT_DEBUG=1 time -p aws %silent --help &> $debug");
+        script_run("PILOT_DEBUG=1 bash -c 'time -p aws %silent --help' &> $debug");
         record_info("aws cli time", script_output("tail -n 3 $debug", proceed_on_failure => 1));
         upload_logs($debug, failok => 1);
         script_run("rpm -qi aws-cli-cmd");

--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -44,7 +44,7 @@ sub init {
           . '}');
     if (is_sle(">=16")) {
         my $debug = "az-cli-debug.txt";
-        script_run("PILOT_DEBUG=1 time -p az %silent --help &> $debug");
+        script_run("PILOT_DEBUG=1 bash -c 'time -p az %silent --help' &> $debug");
         record_info("az cli time", script_output("tail -n 3 $debug", proceed_on_failure => 1));
         upload_logs($debug, failok => 1);
         script_run("rpm -qi az-cli-cmd");


### PR DESCRIPTION
time(1)  may not be available as an external binary on minimal images, so run the command through `bash -c` to use Bash's time reserved word instead.

Related ticket: https://progress.opensuse.org/issues/206796
Verification run: https://openqa.suse.de/tests/24297408 (failing due to https://bugzilla.suse.com/show_bug.cgi?id=1275516)
