### PR TITLE
Remove %silent from aws/az calls

### DIFF
--- a/lib/publiccloud/aws_client.pm
+++ b/lib/publiccloud/aws_client.pm
@@ -46,7 +46,7 @@ sub init {
         # CAVEAT: Use the bash environment variables to prevent credential leaks.
         assert_script_run('printf "[default]\naws_access_key_id=$AWS_ACCESS_KEY_ID\naws_secret_access_key=$AWS_SECRET_ACCESS_KEY\nregion=$AWS_DEFAULT_REGION\n" > ~/.aws/credentials');
         my $debug = "aws-cli-debug.txt";
-        script_run("PILOT_DEBUG=1 bash -c 'time -p aws %silent --help' &> $debug");
+        script_run("PILOT_DEBUG=1 bash -c 'time -p aws --help' &> $debug");
         record_info("aws cli time", script_output("tail -n 3 $debug", proceed_on_failure => 1));
         upload_logs($debug, failok => 1);
         script_run("rpm -qi aws-cli-cmd");

--- a/lib/publiccloud/azure_client.pm
+++ b/lib/publiccloud/azure_client.pm
@@ -44,7 +44,7 @@ sub init {
           . '}');
     if (is_sle(">=16")) {
         my $debug = "az-cli-debug.txt";
-        script_run("PILOT_DEBUG=1 bash -c 'time -p az %silent --help' &> $debug");
+        script_run("PILOT_DEBUG=1 bash -c 'time -p az --help' &> $debug");
         record_info("az cli time", script_output("tail -n 3 $debug", proceed_on_failure => 1));
         upload_logs($debug, failok => 1);
         script_run("rpm -qi az-cli-cmd");

--- a/tests/containers/helm.pm
+++ b/tests/containers/helm.pm
@@ -54,13 +54,6 @@ sub run {
             add_suseconnect_product(get_addon_fullname('pcm')) if is_sle("<16");
             my $aws_cli_pkg = is_sle(">16.0") ? 'aws-cli-cmd' : 'aws-cli';
             zypper_call("in jq $aws_cli_pkg", timeout => 300);
-            if (is_sle(">16.0")) {
-                # Wrap aws to suppress flake-pilot stderr noise
-                # https://github.com/OSInside/flake-pilot/issues/80
-                my $aws_bin = script_output("command -v aws");
-                assert_script_run("printf '#!/bin/sh\\nexec $aws_bin %%silent \"\$\@\"\\n' > /usr/local/bin/aws && chmod +x /usr/local/bin/aws");
-                assert_script_run('export PATH=/usr/local/bin:$PATH');
-            }
 
             # publiccloud::aws_client needs to demand PUBLIC_CLOUD_REGION due to other places where
             # we don't want to have defaults and want tests to fail when region is not defined
@@ -78,13 +71,6 @@ sub run {
             add_suseconnect_product(get_addon_fullname('phub')) if is_sle('=12-sp5');
             my $az_cli_pkg = is_sle(">16.0") ? 'az-cli-cmd' : 'azure-cli';
             zypper_call("in jq $az_cli_pkg", timeout => 300);
-            if (is_sle(">16.0")) {
-                # Wrap az to suppress flake-pilot stderr noise
-                # https://github.com/OSInside/flake-pilot/issues/80
-                my $az_bin = script_output("command -v az");
-                assert_script_run("printf '#!/bin/sh\\nexec $az_bin %%silent \"\$\@\"\\n' > /usr/local/bin/az && chmod +x /usr/local/bin/az");
-                assert_script_run('export PATH=/usr/local/bin:$PATH');
-            }
 
             # publiccloud::aws_client needs to demand PUBLIC_CLOUD_REGION due to other places where
 

--- a/tests/publiccloud/aws_cli.pm
+++ b/tests/publiccloud/aws_cli.pm
@@ -20,8 +20,6 @@ use publiccloud::utils 'detect_worker_ip';
 use registration qw(add_suseconnect_product get_addon_fullname);
 use publiccloud::utils qw(calculate_custodian_ttl);
 
-my $silent = (is_sle('>=16')) ? '%silent' : '';
-
 sub run {
     my ($self, $args) = @_;
     select_serial_terminal;
@@ -39,7 +37,7 @@ sub run {
 
     # 013907871322 is the official SUSE account ID
     my $ownerId = get_var('PUBLIC_CLOUD_EC2_ACCOUNT_ID', '013907871322');
-    my $image_id = script_output("aws $silent ec2 describe-images --filters 'Name=name,Values=suse-sles-15-sp6-v*-x86_64' 'Name=state,Values=available' --owners '$ownerId' --query 'Images[?Name != `ecs`]|[0].ImageId' --output=text", 240);
+    my $image_id = script_output("aws ec2 describe-images --filters 'Name=name,Values=suse-sles-15-sp6-v*-x86_64' 'Name=state,Values=available' --owners '$ownerId' --query 'Images[?Name != `ecs`]|[0].ImageId' --output=text", 240);
     record_info("EC2 AMI", "EC2 AMI query: " . $image_id);
 
     my $ssh_key = "openqa-cli-test-key-$job_id";
@@ -57,7 +55,7 @@ sub run {
     my $create_security_group = "aws ec2 create-security-group --group-name $security_group_name --description 'aws_cli openqa test security group'";
     $create_security_group .= " --tag-specifications 'ResourceType=security-group,Tags=[$tag]'";
     assert_script_run($create_security_group, 180);
-    my $security_group_id = script_output("aws $silent ec2 describe-security-groups --filters Name=group-name,Values=$security_group_name --query 'SecurityGroups[*].GroupId' --output=text", 180);
+    my $security_group_id = script_output("aws ec2 describe-security-groups --filters Name=group-name,Values=$security_group_name --query 'SecurityGroups[*].GroupId' --output=text", 180);
     my $worker_public_ip = detect_worker_ip();
     assert_script_run("aws ec2 authorize-security-group-ingress --group-id $security_group_id --protocol tcp --port 22 --cidr $worker_public_ip/32");
 
@@ -65,13 +63,13 @@ sub run {
     $run_instances .= " --tag-specifications 'ResourceType=instance,Tags=[$tag]' 'ResourceType=volume,Tags=[$tag]'";
     assert_script_run($run_instances, 240);
     assert_script_run("aws ec2 describe-instances --filters 'Name=tag:openqa-cli-test-tag,Values=$job_id'", 90);
-    my $instance_id = script_output("aws $silent ec2 describe-instances --filters 'Name=tag:openqa-cli-test-tag,Values=$job_id' --output=text --query 'Reservations[*].Instances[*].InstanceId'", 90);
+    my $instance_id = script_output("aws ec2 describe-instances --filters 'Name=tag:openqa-cli-test-tag,Values=$job_id' --output=text --query 'Reservations[*].Instances[*].InstanceId'", 90);
 
     # Wait until the instance is really running
     script_retry("aws ec2 describe-instances --instance-ids $instance_id --query 'Reservations[*].Instances[*].State.Name' --output text | grep 'running'", 90, delay => 15, retry => 12);
 
     # Check that the machine is reachable via ssh
-    my $ip_address = script_output("aws $silent ec2 describe-instances --instance-ids $instance_id --query 'Reservations[*].Instances[*].PublicIpAddress' --output text", 90);
+    my $ip_address = script_output("aws ec2 describe-instances --instance-ids $instance_id --query 'Reservations[*].Instances[*].PublicIpAddress' --output text", 90);
     script_retry("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ec2-user\@$ip_address hostnamectl", 90, delay => 15, retry => 12);
 }
 
@@ -83,7 +81,7 @@ sub cleanup {
     my $security_group_name = "openqa-cli-test-sg-$job_id";
     my $ssh_key = "openqa-cli-test-key-$job_id";
 
-    my $instance_id = script_output("aws $silent ec2 describe-instances --filters 'Name=tag:openqa-cli-test-tag,Values=$job_id' --output=text --query 'Reservations[*].Instances[*].InstanceId'", timeout => 90, proceed_on_failure => 1);
+    my $instance_id = script_output("aws ec2 describe-instances --filters 'Name=tag:openqa-cli-test-tag,Values=$job_id' --output=text --query 'Reservations[*].Instances[*].InstanceId'", timeout => 90, proceed_on_failure => 1);
     record_info("InstanceId", "InstanceId: " . $instance_id);
 
     if ($assert) {

--- a/tests/publiccloud/azure_cli.pm
+++ b/tests/publiccloud/azure_cli.pm
@@ -19,8 +19,6 @@ use version_utils 'is_sle';
 use registration qw(add_suseconnect_product get_addon_fullname);
 use publiccloud::utils qw(calculate_custodian_ttl);
 
-my $silent = (is_sle('>=16')) ? '%silent' : '';
-
 sub run {
     my ($self, $args) = @_;
     select_serial_terminal;
@@ -64,7 +62,7 @@ sub run {
     record_info("PINT", "Pint query: " . $image_name);
 
     # VM creation
-    my $vm_create = "az $silent vm create --resource-group $resource_group --name $machine_name --public-ip-sku Standard --tags $tags";
+    my $vm_create = "az vm create --resource-group $resource_group --name $machine_name --public-ip-sku Standard --tags $tags";
     $vm_create .= " --image $image_name --size Standard_B1ms --admin-username azureuser --ssh-key-values ~/.ssh/id_rsa.pub";
     my $output = script_output($vm_create, timeout => 600);
     die('Failed to start/stop vms with azure cli') if ($output =~ /ValidationError.*object has no attribute/);
@@ -73,7 +71,7 @@ sub run {
     assert_script_run("az vm list-ip-addresses -g $resource_group -n $machine_name");
 
     # Check that the machine is reachable via ssh
-    my $ip_address = script_output("az $silent vm list-ip-addresses -g $resource_group -n $machine_name --query '[].virtualMachine.network.publicIpAddresses[0].ipAddress' --output tsv", 90);
+    my $ip_address = script_output("az vm list-ip-addresses -g $resource_group -n $machine_name --query '[].virtualMachine.network.publicIpAddresses[0].ipAddress' --output tsv", 90);
     die "IP address not found in output!" unless $ip_address;
     script_retry("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no azureuser\@$ip_address hostnamectl", 90, delay => 15, retry => 12);
 }


### PR DESCRIPTION
https://github.com/OSinside/flake-pilot/issues/80 was fixed.

Otherwise we get  `aws: [ERROR]: argument command: Found invalid choice '%silent'` in
https://openqa.suse.de/tests/24297408/logfile?filename=prepare_instance-aws-cli-debug.txt