### PR TITLE
change_password: Wait before and after typing of pw

### DIFF
--- a/lib/services/users.pm
+++ b/lib/services/users.pm
@@ -163,7 +163,6 @@ sub full_users_check {
     if ($stage eq 'before') {
         # change pwd for current user and add new user for switch scenario
         x11test::unlock_user_settings;
-        wait_still_screen(1, 2);
         change_pwd;
         add_user;
         # verify changed password work well in the following scenario:

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -790,7 +790,9 @@ sub unlock_user_settings {
     assert_screen "users-settings";
     assert_and_click "Unlock-user-settings";
     assert_screen "authentication-required-user-settings";
+    wait_still_screen(1, 2);
     type_password;
+    wait_still_screen(1, 2);
     assert_and_click "authenticate";
 }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/204285
- Verification run: 
https://openqa.suse.de/tests/overview?build=jpupava_pw&distri=sle&version=15-SP7