### PR TITLE
Increase azure cli timeout

### DIFF
--- a/lib/sles4sap/azure_cli.pm
+++ b/lib/sles4sap/azure_cli.pm
@@ -118,7 +118,9 @@ Example:
 =cut
 
 sub az(%args) {
-    $args{timeout} //= $bmwqemu::default_timeout;
+    # azure cli needs sometimes even 50s to start the container (bsc#1271390)
+    # 2min should be enough for an average azure cli command to finish
+    $args{timeout} //= 120;
     croak 'Command `az` is not needed in $args{az_args}'
       if $args{az_args} =~ /az/;
     croak 'Missing mandatory argument: <az_args>' unless $args{az_args};


### PR DESCRIPTION
Podman based azure cli can take up to 50s to just bring the container up
 without any cloud API call. This PR increases execution timeout to 2min
  which should be plenty for most of the commands to complete.

Ticket: https://jira.suse.com/browse/TEAM-11534
VRs:
- sle-15-SP4-Azure-SDAF-PAYG-x86_64-Build15-SP4_2026-09-03T01:03:17Z-SDAF_LAB_deploy_HanaSR@64bit -> https://openqaworker15.qe.prg2.suse.org/tests/384930#step/deploy_workload_zone/201
- sle-15-SP5-Azure-SDAF-PAYG-x86_64-Build15-SP5_2026-09-03T01:03:17Z-SDAF_LAB_deploy_ENSA2@64bit -> https://openqaworker15.qe.prg2.suse.org/tests/384934#step/deploy_workload_zone/241
- sle-15-SP5-Azure-SDAF-PAYG-x86_64-Build15-SP5_2026-09-03T01:03:17Z-SDAF_LAB_deploy_HanaSR@64bit -> https://openqaworker15.qe.prg2.suse.org/tests/384937#step/deploy_workload_zone/201
- sle-15-SP5-Azure-SDAF-PAYG-x86_64-Build15-SP5_2026-09-03T01:03:17Z-SDAF_LAB_deploy_HanaSR_sbd@64bit -> https://openqaworker15.qe.prg2.suse.org/tests/384942#step/deploy_workload_zone/201
- sle-15-SP6-Azure-SDAF-PAYG-x86_64-Build15-SP6_2026-09-03T01:03:17Z-SDAF_LAB_deploy_ENSA2_sbd@64bit -> https://openqaworker15.qe.prg2.suse.org/tests/384943#step/deploy_workload_zone/241
- sle-15-SP6-Azure-SDAF-PAYG-x86_64-Build15-SP6_2026-09-03T01:03:17Z-SDAF_LAB_deploy_HanaSR_sbd@64bit -> https://openqaworker15.qe.prg2.suse.org/tests/384947#step/deploy_workload_zone/201
- sle-15-SP7-Azure-SDAF-PAYG-x86_64-Build15-SP7_2026-09-03T01:03:17Z-SDAF_LAB_deploy_HanaSR_sbd@64bit -> https://openqaworker15.qe.prg2.suse.org/tests/384951#step/deploy_workload_zone/241