### PR TITLE
agnosticTestRunner: use install_package for immutable systems

### DIFF
--- a/lib/agnosticTestRunner.pm
+++ b/lib/agnosticTestRunner.pm
@@ -16,7 +16,7 @@ use warnings;
 use testapi qw(assert_script_run data_url parse_extra_log script_output enter_cmd upload_logs record_info);
 use Mojo::DOM;
 use registration 'add_suseconnect_product', 'get_addon_fullname';
-use utils 'zypper_call';
+use package_utils 'install_package';
 use version_utils 'is_sle';
 
 sub new {
@@ -56,7 +56,7 @@ sub setup {
 
     my %lang_deps = (go => 'go gotestsum', python => 'python3-pytest');
     my $packages = $self->{language} eq 'java' ? latest_java_devel() : $lang_deps{$self->{language}};
-    zypper_call "in $packages";
+    install_package($packages, trup_reboot => 1);
 
     # Create test_dir and sibling lib/ for shared helpers in one shot
     my $test_dir = $self->{test_dir};


### PR DESCRIPTION
Replace zypper_call with install_package(trup_reboot => 1) so
the runner works on transactional/immutable systems where the
filesystem is read-only and packages must be installed via
transactional-update.

On immutable systems, trup_reboot installs into a new snapshot
and reboots into it so the package is available. It also applies
any pending packages stacked by the .pm wrapper's trup_continue
calls. On non-transactional systems, trup_reboot has no effect
and zypper install works directly.

Reference failing job on SLE 16.1 Immutable:
https://openqa.suse.de/tests/24299740

Verification job:
- SLE 16.1 Immutable x86_64: https://openqa.suse.de/tests/24302579