### PR TITLE
Schedule bootloader_uefi on UEFI systems for SLE16 transactional qcow

### DIFF
--- a/schedule/security/sle16_transactional/fips_ker_mode_tests_crypt_core_qcow.yaml
+++ b/schedule/security/sle16_transactional/fips_ker_mode_tests_crypt_core_qcow.yaml
@@ -28,5 +28,11 @@ conditional_schedule:
     ARCH:
       s390x:
         - installation/bootloader_start
-      aarch64:
-        - boot/boot_to_desktop
+    # The image boots with "console=ttyAMA0" only, so /dev/console is the
+    # serial port and jeos-firstboot renders there instead of on the
+    # graphical console. bootloader_uefi appends "console=tty", which the
+    # needle based modules that follow need. Non-UEFI systems boot the
+    # image directly and need no bootloader module.
+    UEFI:
+      '1':
+        - installation/bootloader_uefi

--- a/schedule/security/sle16_transactional/selinux_qcow.yaml
+++ b/schedule/security/sle16_transactional/selinux_qcow.yaml
@@ -17,5 +17,11 @@ conditional_schedule:
     ARCH:
       s390x:
         - installation/bootloader_start
-      aarch64:
-        - boot/boot_to_desktop
+    # The image boots with "console=ttyAMA0" only, so /dev/console is the
+    # serial port and jeos-firstboot renders there instead of on the
+    # graphical console. bootloader_uefi appends "console=tty", which the
+    # needle based modules that follow need. Non-UEFI systems boot the
+    # image directly and need no bootloader module.
+    UEFI:
+      '1':
+        - installation/bootloader_uefi


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/206886
- Verification run: https://openqa.suse.de/tests/overview?distri=sle&version=16.1&build=paolostivanin%2Fos-autoinst-distri-opensuse%23poo-aarch64-bootloader-uefi-sle16-transactional&groupid=431
