### PR TITLE
Fix SDAF script run timed out issue

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/inventory_tools.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/inventory_tools.pm
@@ -237,7 +237,7 @@ sub verify_ssh_proxy_connection {
             my $max_retries = 10;
             my $hostname_output = '';
             for my $attempt (1 .. $max_retries) {
-                $hostname_output = script_output("ssh $hostname hostname", timeout => 15, quiet => 1, proceed_on_failure => 1);
+                $hostname_output = script_output("ssh $hostname hostname", timeout => 60, quiet => 1, proceed_on_failure => 1);
                 last if defined $hostname_output && $hostname_output ne '';
 
                 if ($attempt < $max_retries) {


### PR DESCRIPTION
1. Increase timeout value
2. Fix `sub az(%args)` did not pass `timeout` value to `script_run()`:
For example: https://openqaworker15.qe.prg2.suse.org/tests/384819#step/ibsm_configure/269
Set `timedout = > 180` in `az_network_dns_zone_create()` but `script_run()` still uses `30` (`$args{timeout} //= $bmwqemu::default_timeout;` see https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26630/changes).
```
	testapi::script_run("az network private-dns zone create --resource-group SDAF-Open"..., "quiet", undef, "timeout", 30) called at /var/lib/openqa/pool/41/os-autoinst-distri-opensuse/lib/sles4sap/azure_cli.pm line 147
	sles4sap::azure_cli::az("az_args", "network private-dns zone create --resource-group SDAF-OpenQA-"...) called at /var/lib/openqa/pool/41/os-autoinst-distri-opensuse/lib/sles4sap/azure_cli.pm line 2320
	sles4sap::azure_cli::az_network_dns_zone_create("resource_group", "SDAF-OpenQA-workload_zone-384819", "name", "suse.de", "timeout", 180)
``` 



- Related ticket:
[TEAM-11533](https://jira.suse.com/browse/TEAM-11533) - [timeboxed][SDAF][Incidents][sporadic] cleanup_ENSA2_sbd failed on test execution exceeded MAX_JOB_TIME (6 hours) due to deployer was powered off
- Verification run:
sle-15-SP7 ENSA2 https://openqaworker15.qe.prg2.suse.org/tests/385201#dependencies (passed)
sle-15-SP7 HanaSR http://openqaworker15.qe.prg2.suse.org/tests/385212#dependencies (passed)