### PR TITLE
agnosticTestRunner: handle upload_logs typing timeout

### DIFF
--- a/lib/agnosticTestRunner.pm
+++ b/lib/agnosticTestRunner.pm
@@ -90,8 +90,8 @@ sub run_test {
       . ' && ( set -o pipefail; ' . $run_script . " 2>&1 | tee $output_log )"
       . ' && mv ' . $result_src . ' ' . $self->{result_file};
     assert_script_run($command, quiet => 1);
-    upload_logs($output_log, failok => 1);
     enter_cmd('reset');
+    eval { upload_logs($output_log, failok => 1) };
     return $self;
 }
 


### PR DESCRIPTION
Wrap upload_logs for the output log in eval so a typing timeout
on the serial console does not kill the test. The output log
upload was added in PR #26618 and broke polkit_rules which was
passing before.

Before PR #26618 the runner did not upload an output log.
The upload_logs call we added causes a typing timeout on tests
that leave the terminal slow (polkit_rules Go test). This is
a regression introduced by the runner, so it is fixed in the
runner. The eval makes the output log upload best-effort.

parse_extra_log and script_output are not wrapped in eval.
If those fail, the test dies with a clear error.

Failing job (regression from PR #26618):
https://openqa.opensuse.org/tests/6211210#step/polkit_rules/13

Previous passing job (before PR #26618):
https://openqa.opensuse.org/tests/6208858

Verification job:
- TW x86_64 (security_misc_o3): https://openqa.opensuse.org/tests/6212516