### PR TITLE
Increase SDAF playbook timeout

### DIFF
--- a/lib/sles4sap/sap_deployment_automation_framework/ansible.pm
+++ b/lib/sles4sap/sap_deployment_automation_framework/ansible.pm
@@ -83,7 +83,7 @@ sub set {
     # DB installation pulls in SAP specific configuration
     if (grep /db_install/, @$components) {
         # SAP-specific operating system configuration
-        push @playbook_list, {playbook_filename => 'playbook_02_os_sap_specific_config.yaml'};
+        push @playbook_list, {playbook_filename => 'playbook_02_os_sap_specific_config.yaml', timeout => 5400};
         # SAP Bill of Materials processing - this also mounts install media storage
         push @playbook_list, {playbook_filename => 'playbook_03_bom_processing.yaml', timeout => 7200};
         # SAP HANA database installation


### PR DESCRIPTION
Playbook `playbook_02_os_sap_specific_config` timeout is nearly hitting its ceiling with each run and causing failures on SLE16. This PR increases it with additional 30 min.

Ticket: https://jira.suse.com/browse/TEAM-11536

VRs:
- sle-16.0-Azure-SDAF-PAYG-x86_64-Build16.0_2026-09-10T01:03:18Z-SDAF_LAB_deploy_HanaSR@64bit -> https://openqaworker15.qe.prg2.suse.org/tests/385215#step/os_preparation/91
- sle-16.0-Azure-SDAF-PAYG-x86_64-Build16.0_2026-09-10T01:03:18Z-SDAF_LAB_deploy_HanaSR_sbd@64bit -> https://openqaworker15.qe.prg2.suse.org/tests/385222#step/os_preparation/81

