### PR TITLE
io_uring: Temporarily disable SELinux enforcement for liburing tests

### DIFF
--- a/tests/kernel/io_uring.pm
+++ b/tests/kernel/io_uring.pm
@@ -11,7 +11,7 @@ use Mojo::Base 'opensusebasetest';
 use testapi;
 use serial_terminal 'select_serial_terminal';
 use utils;
-use version_utils 'is_transactional';
+use version_utils qw(is_transactional has_selinux);
 use LTP::WhiteList;
 use repo_tools 'add_qa_head_repo';
 use package_utils 'install_package';
@@ -20,6 +20,10 @@ sub run {
     my $self = shift;
 
     select_serial_terminal;
+
+    # liburing tests (like zcrx.t) can trigger AVC denials on SELinux-enabled systems
+    # due to operations such as mapping memory at address 0 (NULL)
+    script_run('setenforce 0') if has_selinux;
 
     my $install = get_var('LIBURING_INSTALL', 'from_repo');
     my $timeout = get_var('LIBURING_TIMEOUT', 1800);


### PR DESCRIPTION
On SELinux-enabled systems, security policies can prohibit memory mapping at address 0 (NULL). Some tests in the liburing suite (such as zcrx.t) perform memory mapping at address 0, which triggers permission denied and fails the test suite.

Temporarily disable SELinux enforcement when has_selinux is true to allow liburing test suite execution to proceed.

- Related ticket: https://progress.opensuse.org/issues/206370
- Verification run: https://openqa.opensuse.org/tests/6211924#step/io_uring/24
