### PR TITLE
feat: AWS S3 smoketest and S3 library

### DIFF
--- a/lib/main_publiccloud.pm
+++ b/lib/main_publiccloud.pm
@@ -223,10 +223,15 @@ sub load_create_publiccloud_tools_image {
 
 # Test CLI tools for each provider
 sub load_publiccloud_cli_tools {
+    my $args = OpenQA::Test::RunArgs->new();
     loadtest 'installation/bootloader_zkvm' if (is_s390x);
     loadtest 'boot/boot_to_desktop';
-    loadtest 'publiccloud/azure_cli' if (is_azure());
-    loadtest 'publiccloud/aws_cli' if (is_ec2());
+    if (is_azure()) {
+        loadtest 'publiccloud/azure_cli';
+    } elsif (is_ec2()) {
+        loadtest 'publiccloud/aws_cli';
+        loadtest 'publiccloud/s3', run_args => $args, name => 'aws_s3';
+    }
 }
 
 sub load_publiccloud_download_repos {
@@ -276,6 +281,7 @@ The rest of the scheduling is divided into two separate subroutines C<load_maint
 =cut
 
 sub load_publiccloud_tests {
+    my $args = OpenQA::Test::RunArgs->new();
     if (check_var('PUBLIC_CLOUD_PREPARE_TOOLS', 1)) {
         load_create_publiccloud_tools_image();
     }

--- a/lib/publiccloud/s3.pm
+++ b/lib/publiccloud/s3.pm
@@ -1,0 +1,376 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Utils for S3 storage operations across cloud providers
+#
+# Maintainer: QE-C team <qa-c@suse.de>
+
+package publiccloud::s3;
+use Mojo::Base -base;
+use testapi;
+use utils;
+use File::Basename;
+
+has 'provider';
+has region => sub { die 'region is required' };
+has azure_storage_account => undef;
+has azure_storage_account_key => undef;
+
+my %PROVIDER_CMDS = (
+    EC2 => {
+        bucket_uri => sub {
+            my (%args) = @_;
+            return $args{key} ? "s3://$args{bucket}/$args{key}" : "s3://$args{bucket}";
+        },
+        create_bucket => sub {
+            my (%args) = @_;
+            return "aws s3 mb '$args{uri}' --region '$args{region}'";
+        },
+        upload_file => sub {
+            my (%args) = @_;
+            # The cli flake container bind-mounts /root (no /tmp) on SLE 16
+            return "aws s3 cp '$args{file}' '$args{uri}'";
+        },
+        list_bucket => sub {
+            my (%args) = @_;
+            return "aws s3 ls '$args{uri}/'";
+        },
+        download_file => sub {
+            my (%args) = @_;
+            # The cli flake container bind-mounts /root (no /tmp) on SLE 16
+            return "aws s3 cp '$args{uri}' '$args{file}'";
+        },
+        delete_file => sub {
+            my (%args) = @_;
+            return "aws s3 rm '$args{uri}'";
+        },
+        delete_bucket => sub {
+            my (%args) = @_;
+            return "aws s3 rb '$args{uri}' --region '$args{region}'";
+        },
+        force_delete_bucket => sub {
+            my (%args) = @_;
+            return "aws s3 rb '$args{uri}' --force --region '$args{region}'";
+        },
+    },
+    AZURE => {
+        bucket_uri => sub {
+            my (%args) = @_;
+            return $args{bucket};
+        },
+        create_bucket => sub {
+            my (%args) = @_;
+            return "az storage container create --name '$args{bucket}' --account-name '$args{azure_storage_account}' --account-key '$args{azure_storage_account_key}'";
+        },
+        upload_file => sub {
+            my (%args) = @_;
+            return "az storage blob upload --file '$args{file}' --container-name '$args{bucket}' --name '$args{key}' --account-name '$args{azure_storage_account}' --account-key '$args{azure_storage_account_key}'";
+        },
+        list_bucket => sub {
+            my (%args) = @_;
+            return "az storage blob list --container-name '$args{bucket}' --output table --account-name '$args{azure_storage_account}' --account-key '$args{azure_storage_account_key}'";
+        },
+        download_file => sub {
+            my (%args) = @_;
+            return "az storage blob download --container-name '$args{bucket}' --name '$args{key}' --file '$args{file}' --account-name '$args{azure_storage_account}' --account-key '$args{azure_storage_account_key}'";
+        },
+        delete_file => sub {
+            my (%args) = @_;
+            return "az storage blob delete --container-name '$args{bucket}' --name '$args{key}' --account-name '$args{azure_storage_account}' --account-key '$args{azure_storage_account_key}'";
+        },
+        delete_bucket => sub {
+            my (%args) = @_;
+            return "az storage container delete --name '$args{bucket}' --account-name '$args{azure_storage_account}' --account-key '$args{azure_storage_account_key}'";
+        },
+        force_delete_bucket => sub {
+            my (%args) = @_;
+            # Azure container delete is recursive by design — removes container and all blobs.
+            return "az storage container delete --name '$args{bucket}' --account-name '$args{azure_storage_account}' --account-key '$args{azure_storage_account_key}'";
+        },
+    },
+);
+
+=head1 METHODS
+
+=head2 new
+
+Create a new storage helper instance
+
+    my $s3 = publiccloud::s3->new(provider => 'EC2', region => 'us-east-1');
+
+Supported providers: 'EC2' (AWS S3), 'AZURE' (Azure Blob Storage)
+
+=cut
+
+sub new {
+    my ($class, %args) = @_;
+    my $provider = $args{provider} // die 'provider is required (EC2, or AZURE)';
+    die("Unsupported provider: $provider") unless $PROVIDER_CMDS{$provider};
+    return $class->SUPER::new(%args);
+}
+
+sub _provider_cmd {
+    my ($self, $action, %args) = @_;
+    # For AZURE, automatically include storage_account and storage_account_key if set
+    if ($self->provider eq 'AZURE') {
+        $args{azure_storage_account} = $self->azure_storage_account if $self->azure_storage_account;
+        $args{azure_storage_account_key} = $self->azure_storage_account_key if $self->azure_storage_account_key;
+    }
+    return $PROVIDER_CMDS{$self->provider}{$action}->(%args);
+}
+
+=head2 get_bucket_uri
+
+Generate bucket URI for the provider
+
+    my $uri = $s3->get_bucket_uri($bucket_name);           # Returns: s3://bucket or gs://bucket
+    my $uri = $s3->get_bucket_uri($bucket_name, $key);     # Returns: s3://bucket/key or gs://bucket/key
+
+Returns the provider-specific URI format. For Azure, returns just the bucket name.
+
+=cut
+
+sub get_bucket_uri {
+    my ($self, $bucket_name, $key) = @_;
+    return $self->_provider_cmd('bucket_uri', bucket => $bucket_name, key => $key);
+}
+
+=head2 create_bucket
+
+Create a storage bucket/container
+
+    $s3->create_bucket($bucket_name);
+
+=cut
+
+sub create_bucket {
+    my ($self, $bucket_name) = @_;
+    die('bucket_name is required') unless $bucket_name;
+    record_info('Create Bucket', "Creating bucket: $bucket_name");
+    my $uri = $self->get_bucket_uri($bucket_name);
+    my $cmd = $self->_provider_cmd('create_bucket', uri => $uri, bucket => $bucket_name, region => $self->region);
+    assert_script_run($cmd, timeout => 120);
+}
+
+=head2 upload_file
+
+Upload a file to a storage bucket
+
+    $s3->upload_file(bucket => $bucket_name, file => $local_file, [key => $remote_key]);
+
+If key is not specified, the basename of the file is used.
+
+=cut
+
+sub upload_file {
+    my ($self, %args) = @_;
+
+    die('bucket is required') unless $args{bucket};
+    die('file is required') unless $args{file};
+
+    my $bucket = $args{bucket};
+    my $file = $args{file};
+    my $key = $args{key} // basename($file);
+
+    record_info('Upload File', "Uploading $file to $bucket/$key");
+
+    my $uri = $self->get_bucket_uri($bucket, $key);
+    my $cmd = $self->_provider_cmd('upload_file', file => $file, uri => $uri, bucket => $bucket, key => $key);
+    assert_script_run($cmd, timeout => 120);
+    return $key;
+}
+
+=head2 list_bucket
+
+List contents of a storage bucket
+
+    my $contents = $s3->list_bucket($bucket_name);
+
+Returns the output of the list command
+
+=cut
+
+sub list_bucket {
+    my ($self, $bucket_name) = @_;
+    die('bucket_name is required') unless $bucket_name;
+    record_info('List Bucket', "Listing contents of $bucket_name");
+    my $uri = $self->get_bucket_uri($bucket_name);
+    my $cmd = $self->_provider_cmd('list_bucket', uri => $uri, bucket => $bucket_name);
+    my $contents = script_output($cmd, timeout => 120);
+    return $contents;
+}
+
+=head2 download_file
+
+Download a file from a storage bucket
+
+    $s3->download_file(bucket => $bucket_name, key => $remote_key, file => $local_file);
+
+=cut
+
+sub download_file {
+    my ($self, %args) = @_;
+
+    die('bucket is required') unless $args{bucket};
+    die('key is required') unless $args{key};
+    die('file is required') unless $args{file};
+
+    my $bucket = $args{bucket};
+    my $key = $args{key};
+    my $file = $args{file};
+
+    record_info('Download File', "Downloading $bucket/$key to $file");
+
+    my $uri = $self->get_bucket_uri($bucket, $key);
+    my $cmd = $self->_provider_cmd('download_file', uri => $uri, bucket => $bucket, key => $key, file => $file);
+    assert_script_run($cmd, timeout => 120);
+}
+
+=head2 delete_file
+
+Delete a file from a storage bucket and verify deletion
+
+    $s3->delete_file(bucket => $bucket_name, key => $file_key);
+
+=cut
+
+sub delete_file {
+    my ($self, %args) = @_;
+
+    die('bucket is required') unless $args{bucket};
+    die('key is required') unless $args{key};
+
+    my $bucket = $args{bucket};
+    my $key = $args{key};
+
+    record_info('Delete File', "Deleting $bucket/$key");
+
+    my $uri = $self->get_bucket_uri($bucket, $key);
+    my $cmd = $self->_provider_cmd('delete_file', uri => $uri, bucket => $bucket, key => $key);
+    assert_script_run($cmd, timeout => 120);
+
+    my $bucket_uri = $self->get_bucket_uri($bucket);
+    my $list_cmd = $self->_provider_cmd('list_bucket', uri => $bucket_uri, bucket => $bucket);
+    my $contents = script_output($list_cmd, timeout => 120);
+    die("File $key still present in bucket $bucket after deletion") if ($contents =~ /\Q$key\E/);
+
+    record_info('File Deleted', "Verified $key deleted from bucket $bucket");
+}
+
+=head2 delete_bucket
+
+Delete a storage bucket (bucket must be empty)
+
+    $s3->delete_bucket($bucket_name);
+
+=cut
+
+sub delete_bucket {
+    my ($self, $bucket_name) = @_;
+    die('bucket_name is required') unless $bucket_name;
+    record_info('Delete Bucket', "Deleting bucket: $bucket_name");
+    my $uri = $self->get_bucket_uri($bucket_name);
+    my $cmd = $self->_provider_cmd('delete_bucket', uri => $uri, bucket => $bucket_name, region => $self->region);
+    assert_script_run($cmd, timeout => 120);
+}
+
+=head2 force_delete_bucket
+
+Delete a storage bucket along with any contents it still holds.
+
+    $s3->force_delete_bucket($bucket_name);
+
+Intended for cleanup paths where the bucket may not be empty (e.g. mid-test failure).
+
+=cut
+
+sub force_delete_bucket {
+    my ($self, $bucket_name) = @_;
+    die('bucket_name is required') unless $bucket_name;
+    record_info('Force Delete Bucket', "Recursively deleting bucket: $bucket_name");
+    my $uri = $self->get_bucket_uri($bucket_name);
+    my $cmd = $self->_provider_cmd('force_delete_bucket', uri => $uri, bucket => $bucket_name, region => $self->region);
+    assert_script_run($cmd, timeout => 240);
+}
+
+=head2 verify_file_exists
+
+Verify that a file exists in an S3 bucket
+
+    $s3->verify_file_exists(bucket => $bucket_name, key => $file_key);
+
+Dies if the file is not found in the bucket listing.
+
+=cut
+
+sub verify_file_exists {
+    my ($self, %args) = @_;
+
+    die('bucket is required') unless $args{bucket};
+    die('key is required') unless $args{key};
+
+    my $bucket = $args{bucket};
+    my $key = $args{key};
+
+    my $contents = $self->list_bucket($bucket);
+    die("File $key not found in bucket $bucket") unless ($contents =~ /\Q$key\E/);
+
+    record_info('File Exists', "Verified $key exists in bucket $bucket");
+}
+
+=head2 verify_checksum
+
+Verify that two files have the same SHA256 checksum
+
+    $s3->verify_checksum(file1 => $path1, file2 => $path2);
+
+Dies if checksums don't match.
+
+=cut
+
+sub verify_checksum {
+    my ($self, %args) = @_;
+
+    die('file1 is required') unless $args{file1};
+    die('file2 is required') unless $args{file2};
+
+    my $file1 = $args{file1};
+    my $file2 = $args{file2};
+
+    my ($checksum1) = split /\s+/, script_output("sha256sum '$file1'");
+    record_info('Checksum', "SHA256 of $file1: $checksum1");
+
+    my ($checksum2) = split /\s+/, script_output("sha256sum '$file2'");
+    record_info('Checksum', "SHA256 of $file2: $checksum2");
+
+    die("Checksum mismatch! File1: $checksum1, File2: $checksum2")
+      unless ($checksum1 eq $checksum2);
+
+    record_info('Checksum Match', 'File integrity verified successfully');
+}
+
+=head2 generate_unique_bucket_name
+
+Generate a unique S3 bucket name
+
+    my $bucket_name = $s3->generate_unique_bucket_name([$prefix]);
+
+Generates a globally unique bucket name using a prefix (default: 'openqa-s3-test')
+and timestamp. S3 bucket names must be globally unique and DNS-compliant.
+
+=cut
+
+sub generate_unique_bucket_name {
+    my ($self, $prefix) = @_;
+
+    $prefix //= 'openqa-s3-test';
+    my $timestamp = time();
+    my $bucket_name = "$prefix-$timestamp";
+
+    record_info('Bucket Name', "Generated bucket name: $bucket_name");
+    return $bucket_name;
+}
+
+1;

--- a/tests/publiccloud/s3.pm
+++ b/tests/publiccloud/s3.pm
@@ -1,0 +1,116 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Summary: Cloud storage S3-compatible API smoke test (AWS S3, Azure Blob)
+# Maintainer: QE-C team <qa-c@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use publiccloud::ssh_interactive 'select_host_console';
+use publiccloud::s3;
+use testapi;
+use utils;
+use mmapi 'get_current_job_id';
+use publiccloud::utils 'calculate_custodian_ttl';
+
+my $bucket_name;
+my $s3;
+my $azure_resource_group;
+my $azure_storage_account;
+my $azure_storage_account_key;
+
+sub run {
+    my ($self, $args) = @_;
+
+    select_host_console();
+
+    my $provider = $self->provider_factory();
+    my $cloud_provider = get_required_var('PUBLIC_CLOUD_PROVIDER');
+
+    my $job_id = get_current_job_id();
+    my $openqa_ttl = get_var('MAX_JOB_TIME', 7200) + get_var('PUBLIC_CLOUD_TTL_OFFSET', 300);
+    my $openqa_url = get_var('OPENQA_URL', get_var('OPENQA_HOSTNAME'));
+    my $custodian_ttl = calculate_custodian_ttl($openqa_ttl);
+    my $tags = "openqa_var_job_id=$job_id custodian_ttl=$custodian_ttl openqa_created_by=$openqa_url/t$job_id";
+
+    # Azure-specific: Create ResourceGroup and StorageAccount
+    if ($cloud_provider eq 'AZURE') {
+
+        $azure_resource_group = "openqa-s3-test-rg-$job_id";
+        $azure_storage_account = "openqas3test$job_id";
+
+        record_info('Create ResourceGroup', "Creating resource group: $azure_resource_group");
+        assert_script_run("az group create -n $azure_resource_group -l " . $provider->provider_client->region . " --tags $tags", timeout => 300);
+
+        # Azure S3 buckets (containers) can only be created inside a storage account
+        record_info('Create StorageAccount', "Creating storage account: $azure_storage_account");
+        assert_script_run("az storage account create --resource-group $azure_resource_group -l " . $provider->provider_client->region .
+              " --name $azure_storage_account --kind StorageV2 --sku Standard_LRS", timeout => 300);
+
+        # Get storage account key for authentication
+        # Suppress stderr to avoid Python warnings in the output
+        $azure_storage_account_key = script_output("az storage account keys list --resource-group $azure_resource_group --account-name $azure_storage_account 2>/dev/null | jq -r '.[0].value'");
+        die("Failed to retrieve Azure storage account key") unless $azure_storage_account_key;
+    }
+
+    # Initialize S3 helper
+    $s3 = publiccloud::s3->new(
+        provider => $cloud_provider,
+        region => $provider->provider_client->region,
+        ($cloud_provider eq 'AZURE' ? (
+                azure_storage_account => $azure_storage_account,
+                azure_storage_account_key => $azure_storage_account_key
+        ) : ())
+    );
+
+    # Generate unique bucket name
+    $bucket_name = $s3->generate_unique_bucket_name();
+
+    # Create test data file
+    # On SLE 16 the CLI is a flake container that only mounts /root
+    # so the files must be saved to /root
+    my $test_file = '/root/hello-suse.txt';
+    my $test_file_key = 'hello-suse.txt';    # Key as in S3 Object Key
+    assert_script_run("echo geeko123 > $test_file");
+
+    # Create bucket and upload file
+    $s3->create_bucket($bucket_name);
+    $s3->upload_file(bucket => $bucket_name, file => $test_file, key => $test_file_key);
+
+    # List bucket contents and verify file exists
+    $s3->verify_file_exists(bucket => $bucket_name, key => $test_file_key);
+
+    # Download file and verify checksum
+    my $downloaded_file = "$test_file-downloaded";
+    $s3->download_file(bucket => $bucket_name, key => $test_file_key, file => $downloaded_file);
+    $s3->verify_checksum(file1 => $test_file, file2 => $downloaded_file);
+
+    # Delete file and bucket
+    $s3->delete_file(bucket => $bucket_name, key => $test_file_key);
+    $s3->delete_bucket($bucket_name);
+
+    # Clean up downloaded files
+    assert_script_run("rm -f $downloaded_file $test_file");
+
+    record_info('Test Complete', "$cloud_provider S3-compatible storage smoke test completed successfully");
+}
+
+sub cleanup {
+    # For Azure, delete the entire resource group (removes storage account, containers, and blobs)
+    if ($azure_resource_group) {
+        eval { script_run("az group delete --resource-group $azure_resource_group --yes", timeout => 360) };
+        record_info('Azure cleanup failed', $@, result => 'softfail') if $@;
+        return;
+    }
+
+    # For EC2, delete individual bucket
+    return unless $s3 && $bucket_name;
+    eval { $s3->force_delete_bucket($bucket_name) };
+    record_info('Cleanup failed', $@, result => 'softfail') if $@;
+}
+
+sub post_run_hook { cleanup() }
+sub post_fail_hook { cleanup() }
+
+1;


### PR DESCRIPTION
This PR:

1. Creates a new `publiccloud` library - `s3.pm`. This library implements generic functions for S3 usage. It intended to unify how we test S3 across CSPs, so that if we add Azure and/or Google somewhere down the line, it is reusable. I have tried to keep the functions and logic readable.
1. Creates a new test, `s3.pm` - It The test can be re-used across CSPs and does the following:
    - creates a bucket
    - uploads a file
    - lists the files in the bucket
    - downloads the file
    - verifies the checksum of the uploaded and downloaded files
    - deletes the file
    - deletes the bucket
    - performs cleanup (method varies by CSP)
1. Updates the scheduling in `main_publiccloud.pm` to add the new S3 test to run after the `aws_cli` tests.
1. Tiny refactor on the scheduling in `sub load_publiccloud_cli_tools` as It was a bit confusing.

- Related ticket: https://progress.opensuse.org/issues/205128
- Verification run: 
  - AWS: http://dirtman.qe.prg2.suse.org/tests/186#step/aws_s3/148 
  - AWS (after feedback): http://dirtman.qe.prg2.suse.org/tests/190
  - Azure (just for POC of library usage): http://dirtman.qe.prg2.suse.org/tests/187#step/azure_s3/166


Claude Sonnet 4.6 and Opus 4.6 used for troubleshooting and to extend my initial AWS test and library for other CSPs and make them more readable.