### PR TITLE
kernel: NVIDIA: Bump CUDA Samples version

### DIFF
--- a/lib/nvidia_utils.pm
+++ b/lib/nvidia_utils.pm
@@ -163,7 +163,7 @@ sub validate_cuda
     record_info('CUDA Sample', script_output('./hello_world'));
 
     # Build NVIDIA/cuda-samples
-    my $cuda_samples_branch = get_var('NVIDIA_CUDA_SAMPLES_BRANCH', 'v13.3');
+    my $cuda_samples_branch = get_var('NVIDIA_CUDA_SAMPLES_BRANCH', 'v13.4');
     assert_script_run("git clone --depth 1 --single-branch --branch $cuda_samples_branch https://github.com/NVIDIA/cuda-samples.git");
     assert_script_run('mkdir cuda-samples/build; cd $_');
     my $cmake_compiler_args = $gcc_ver ? "-DCMAKE_C_COMPILER=gcc-$gcc_ver -DCMAKE_CXX_COMPILER=g++-$gcc_ver -DCMAKE_CUDA_HOST_COMPILER=g++-$gcc_ver" : "";


### PR DESCRIPTION
SLE15 repository is now shipping CUDA v13.4.1, let's bump the samples to v13.4 aswell.

VR (15.6): https://openqa.suse.de/tests/24323002#step/nvidia/41

Note that this is currently failing in 15.4 until Mesa-libEGL-devel gets bumped (bsc#1279959), however the old v13.2update samples version is also failing due to CUDA v13.4 being incompatible with that version. Therefore we must bump the version in all 15.X products.

Related ticket: https://progress.opensuse.org/issues/201828