### PR TITLE
wsl/enable_systemd.pm: Avoid delay due to wait_serial mismatch

### DIFF
--- a/tests/wsl/enable_systemd.pm
+++ b/tests/wsl/enable_systemd.pm
@@ -31,7 +31,8 @@ sub run {
     $self->run_in_powershell(
         cmd => '$port.WriteLine($(wsl /bin/bash -c "systemctl is-system-running"))',
         code => sub {
-            $systemd_on_by_default = 0 if wait_serial("offline", timeout => 90);
+            my $systemd_status = wait_serial(qr/running|offline/, timeout => 90);
+            $systemd_on_by_default = 0 if $systemd_status eq "offline";
         }
     );
     record_info('systemd', $systemd_on_by_default ?


### PR DESCRIPTION
It's expected that systemd may already be running, so let wait_serial accept both offline and running as options to avoid waiting 90s.

- Before: https://openqa.opensuse.org/tests/6212572#step/enable_systemd/3
- Verification run: https://openqa.opensuse.org/tests/6212577
