### PR TITLE
set_hostname: skip network restart by default

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1289,7 +1289,11 @@ sub check_nm_connectivity {
 
   restart_network();
 
-helper function to restart network
+Restart the network stack to propagate hostname changes to DHCP/DNS.
+
+On QEMU systems with NetworkManager, disconnects and reconnects each
+network device to trigger a DHCP lease renewal. On wicked systems,
+reloads or restarts the network service.
 
 =cut
 
@@ -1309,12 +1313,8 @@ sub restart_network {
             next if ($indx == 0 && $dev eq 'DEVICE');
             next if ($dev eq 'lo');
 
-            script_run("nmcli general logging level DEBUG");
-
-            # poo#169726 Increasing timeout to 120s and adding DEBUG logs for future investigation
+            # poo#169726: 120s timeout needed for slow VMs (ARM qemu, nested virt)
             script_run('nmcli -w 120 device disconnect ' . $dev, timeout => 120);
-            script_run("journalctl -u NetworkManager -b >> /var/log/nmcli_logs");
-            record_info("Logs", script_output("cat /var/log/nmcli_logs"));
             script_run('nmcli device connect ' . $dev, timeout => 120);
         }
 
@@ -1328,32 +1328,37 @@ sub restart_network {
 =head2 set_hostname
 
  set_hostname($hostname);
+ set_hostname($hostname, restart_network => 1);
 
-Setting hostname according input parameter using hostnamectl.
-Calling I<reload-or-restart> to make sure that network stack will propogate
-hostname into DHCP/DNS.
+Set the system hostname using hostnamectl and verify it took effect.
 
-If you change hostname using C<hostnamectl set-hostname>, then C<hostname -f>
-will fail with I<hostname: Name or service not known> also DHCP/DNS don't know
-about the changed hostname, you need to send a new DHCP request to update
-dynamic DNS yast2-network module does
-C<NetworkService.ReloadOrRestart if Stage.normal || !Linuxrc.usessh>
-if hostname is changed via C<yast2 lan>.
+By default, no network restart is performed because all existing
+callers use C</etc/hosts> for name resolution and do not depend on
+DHCP/DNS propagation of the hostname.
+
+Pass C<restart_network =E<gt> 1> to force a network restart after
+setting the hostname (disconnects and reconnects all NM devices to
+trigger DHCP lease renewal). This is only needed if downstream code
+resolves the hostname via DHCP-registered dynamic DNS rather than
+C</etc/hosts>.
 
 =cut
 
 sub set_hostname {
-    my ($hostname) = @_;
+    my ($hostname, %args) = @_;
+    my $do_restart = $args{restart_network} // 0;
+
     assert_script_run "hostnamectl set-hostname $hostname";
     assert_script_run "hostnamectl status|grep $hostname";
     assert_script_run "uname -n|grep $hostname";
-    systemctl 'status network.service';
     save_screenshot;
 
-    restart_network();
-
-    print_ip_info;
-    script_run("dig +short $hostname.openqa.test");
+    if ($do_restart) {
+        systemctl 'status network.service';
+        restart_network();
+        print_ip_info;
+        script_run("dig +short $hostname.openqa.test");
+    }
 }
 
 =head2 assert_and_click_until_screen_change

--- a/tests/console/hostname.pm
+++ b/tests/console/hostname.pm
@@ -4,23 +4,14 @@
 # Copyright 2012-2020 SUSE LLC
 # SPDX-License-Identifier: FSFAP
 
-# Summary: server hostname setup and check
-# - Set hostname as "susetest"
-# - If network is down (using ip command)
-#   - Reload network
-#   - Check network status
-#   - Save screenshot
-#   - Restart network
-#   - Check status
-#   - Save screenshot
-# - Check network status (using ip command)
-# - Save screenshot
+# Summary: Set system hostname for test environment
+# - Prevent DHCP from resetting hostname
+# - Set hostname via hostnamectl
 # Maintainer: QE Core <qe-core@suse.de>
 
 use Mojo::Base 'consoletest';
 use testapi;
 use utils;
-use version_utils "is_sle";
 
 sub run {
     select_console 'root-console';


### PR DESCRIPTION
`set_hostname()` unconditionally restarts the network after setting the
hostname. On NetworkManager systems this disconnects and reconnects
every device with 120s timeouts, taking 60-120s per call. None of the
9 callers need this -- they all use `/etc/hosts` for name resolution,
not DHCP/DNS.

Changes:
- `set_hostname`: add optional `restart_network => 1` (default 0)
- `restart_network`: remove NM debug logging added in poo#169726,
  keep 120s nmcli timeouts (needed for slow VMs)
- `hostname.pm`: clean up comment header, drop unused `is_sle` import

<details>
<summary>Verification runs (75 passed, 5 infra failures, 0 test-code failures)</summary>

Verified across 12-SP3, 12-SP5, SP4, SP5, SP6, SP7, 16.0, and
Tumbleweed on x86_64, s390x, ppc64le, and aarch64.

All 5 non-passing jobs are infrastructure failures (AutoYaST install
errors or worker restarts). The hostname module passed in every job
that reached it.

Passed (osd):
- https://openqa.suse.de/tests/24340472
- https://openqa.suse.de/tests/24340473
- https://openqa.suse.de/tests/24340474
- https://openqa.suse.de/tests/24340475
- https://openqa.suse.de/tests/24340476
- https://openqa.suse.de/tests/24340477
- https://openqa.suse.de/tests/24340478
- https://openqa.suse.de/tests/24340479
- https://openqa.suse.de/tests/24340480
- https://openqa.suse.de/tests/24340481
- https://openqa.suse.de/tests/24340482
- https://openqa.suse.de/tests/24340483
- https://openqa.suse.de/tests/24340486
- https://openqa.suse.de/tests/24340487
- https://openqa.suse.de/tests/24340488
- https://openqa.suse.de/tests/24340489
- https://openqa.suse.de/tests/24340490
- https://openqa.suse.de/tests/24340492
- https://openqa.suse.de/tests/24340493
- https://openqa.suse.de/tests/24340494
- https://openqa.suse.de/tests/24340495
- https://openqa.suse.de/tests/24340496

Passed (o3):
- https://openqa.opensuse.org/tests/6212933
- https://openqa.opensuse.org/tests/6212934

Failed -- AutoYaST install error, hostname not reached:
- https://openqa.suse.de/tests/24340470 SP7/x86_64/qam-allpatterns
- https://openqa.suse.de/tests/24340471 SP7/x86_64/qam-gnome
- https://openqa.suse.de/tests/24340484 SP6/aarch64/qam-gnome (auto-clone https://openqa.suse.de/tests/24340562 passed)

Incomplete -- worker restart:
- https://openqa.suse.de/tests/24340485 SP7/s390x (auto-clone ran, hostname passed, unrelated gnome_control_center needle mismatch)
- https://openqa.suse.de/tests/24340497 SP7/x86_64/jeos (auto-clone https://openqa.suse.de/tests/24340574 passed)

</details>