### PR TITLE
Install TW kvm server on baremetal machine with Agama

### DIFF
--- a/data/virt_autotest/host_unattended_installation_files/agama/tw_virt_host.jsonnet
+++ b/data/virt_autotest/host_unattended_installation_files/agama/tw_virt_host.jsonnet
@@ -1,0 +1,115 @@
+{
+  product: {
+    id: 'Tumbleweed',
+  },
+  user: {
+    userName: 'bernhard',
+    fullName: "Bernhard M. Wiedemann",
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true
+  },
+  root: {
+    password: '$6$vYbbuJ9WMriFxGHY$gQ7shLw9ZBsRcPgo6/8KmfDvQ/lCqxW8/WnMoLCoWGdHO6Touush1nhegYfdBbXRpsQuy/FTZZeg7gQL50IbA/',
+    hashedPassword: true,
+    sshPublicKey: '{{_SECRET_ED25519_PUB_KEY}}'
+  },
+  storage: {
+    drives: [
+      {
+        partitions: [
+          {
+            filesystem: { path: 'swap' },
+            size: '4 GiB'
+          },
+          {
+            filesystem: { path: '/' },
+          }
+        ]
+      }
+    ]
+  },
+  software: {
+      patterns: {
+        add: [
+          'kvm_server',
+          'kvm_tools'
+        ],
+      },
+      packages: [
+        'openssh-server-config-rootlogin',
+        'virt-bridge-setup',
+      ]
+  },
+  scripts: {
+    pre: [
+      {
+        name: 'wipefs',
+        content: |||
+          #!/usr/bin/env bash
+          for i in `lsblk -n -l -o NAME -d -e 7,11,254`
+              do wipefs -af /dev/$i
+              # The following 4 lines work around Agama race condition on NVMe devices.
+              # See bsc#1269730 and PR#25926
+              partprobe /dev/$i 2>/dev/null
+              blockdev --rereadpt /dev/$i 2>/dev/null
+          done
+          udevadm settle --timeout=30
+          sync
+          sleep 2
+        |||
+      }
+    ],
+    post: [
+      {
+        name: "config_sshd",
+        chroot: true,
+        content: |||
+          #!/usr/bin/env bash
+          sshd_config_file="/etc/ssh/sshd_config.d/01-virt-test.conf"
+          echo -e "TCPKeepAlive yes\nClientAliveInterval 60\nClientAliveCountMax 60" > $sshd_config_file
+        |||
+      },
+      {
+        name: "enable_persistent_journal_logging",
+        content: |||
+          #!/usr/bin/env bash
+          echo -e "[Journal]\nStorage=persistent" > /etc/systemd/journald.conf.d/01-virt-test.conf
+        |||
+      },
+      {
+        name: "Configure_ssh_client",
+        content: |||
+          #!/usr/bin/env bash
+          ssh_config_dir="/etc/ssh/ssh_config.d"
+          mkdir -p $ssh_config_dir
+          ssh_config_file="$ssh_config_dir/01-virt-test.conf"
+          echo -e "StrictHostKeyChecking no\nUserKnownHostsFile /dev/null\nLogLevel ERROR" > $ssh_config_file
+          chmod 644 "$ssh_config_file"
+        |||
+      },
+      {
+        name: 'turn_on_modular_libvirt_debug_logging',
+        chroot: true,
+        content: |||
+          for daemon in qemu storage network nodedev secret ; do
+            config_file=/etc/libvirt/virt${daemon}d.conf
+            log_file=/var/log/libvirt/virt${daemon}d.log
+            sed -i "/^[# ]*log_outputs *=/{h;s%^[# ]*log_outputs *=.*[0-9].*\$%log_outputs = \"1:file:${log_file}\"%};\${x;/^\$/{s%%log_outputs = \"1:file:${log_file}\"%;H};x}" $config_file
+            sed -i "/^[# ]*log_filters *=/{h;s%^[# ]*log_filters *=.*[0-9].*\$%log_filters = \"1:qemu 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci\"%};\${x;/^\$/{s%%log_filters = \"1:qemu 1:libvirt 4:object 4:json 4:event 3:util 1:util.pci\"%;H};x}" $config_file
+          done
+        |||
+      },
+      {
+        name: "disable_nm_for_sriov_vfs",
+        chroot: true,
+        content: |||
+          #!/usr/bin/env bash
+          # Make a udev rule to force NM to skip SR-IOV VFs
+          rules_file="/etc/udev/rules.d/99-sriov-vfs-unmanaged.rules"
+          echo 'SUBSYSTEM=="net", ACTION=="add|change", TEST=="device/physfn", ENV{NM_UNMANAGED}="1"' > "$rules_file"
+          chmod 644 "$rules_file"
+        |||
+      }
+    ]
+  }
+}

--- a/lib/concurrent_guest_installations.pm
+++ b/lib/concurrent_guest_installations.pm
@@ -70,6 +70,11 @@ sub instantiate_guests_and_profiles {
         my $_geturl = data_url("virt_autotest/guest_params_xml_files/$_store_of_guests{$_element}{PROFILE}.xml");
         my $_req = HTTP::Request->new(GET => "$_geturl");
         my $_res = $_ua->request($_req);
+
+        # Check if the request actually succeeded before parsing
+        unless ($_res->is_success) {
+            die "Failed to fetch profile from $_geturl: " . $_res->status_line;
+        }
         my $_guest_profile = (XML::Simple->new)->XMLin($_res->content, SuppressEmpty => '');
         $_guest_profile->{guest_name} = $_element;
         $_guest_profile->{guest_installation_media} = $_store_of_guests{$_element}{INSTALL_MEDIA} if ($_store_of_guests{$_element}{INSTALL_MEDIA} ne '');

--- a/schedule/virt_autotest/tumbleweed-virt-guest-install.yaml
+++ b/schedule/virt_autotest/tumbleweed-virt-guest-install.yaml
@@ -3,24 +3,24 @@ description:    >
     Maintainer: jcao@suse.com
     Virtualization guest installation tests including extended feature tests schedule
 schedule:
-    - '{{install_and_bootup}}'
+    - '{{host_installation}}'
+    - virt_autotest/login_console
     - '{{install_guest}}'
-    - virt_autotest/set_config_as_glue
     - '{{virtual_network_test}}'
     - '{{sriov_network_card_pci_passthrough_test}}'
     - '{{hotplugging_test}}'
     - '{{storage_test}}'
 conditional_schedule:
-    install_and_bootup:
+    host_installation:
         DO_NOT_INSTALL_HOST:
             0:
                 - installation/ipxe_install
-                - autoyast/installation
-                - virt_autotest/login_console
+                - installation/agama_reboot
     install_guest:
         SKIP_GUEST_INSTALL:
             0:
                 - virt_autotest/unified_guest_installation
+                - virt_autotest/set_config_as_glue
     virtual_network_test:
         ENABLE_VIR_NET:
             1:

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -163,18 +163,26 @@ END_BOOTSCRIPT
 }
 
 sub enter_o3_ipxe_boot_entry {
-    ipmitool('chassis power reset') unless check_screen([qw(o3-ipxe-menu ipxe-boot-failure)], 180);
-    assert_screen('o3-ipxe-menu', 210);
-    my $key = get_var('HOST_INSTALL_AUTOYAST') ? (is_kvm_host ? 'k' : 'z') : 't';
+
+    my $key = get_var('AGAMA') ? 'g' : (get_var('HOST_INSTALL_AUTOYAST') ? 'y' : 't');
+
+    assert_screen('o3-ipxe-menu', 120);
+
     send_key "$key";
-    # try one more time as sometimes sending key does not take effect
-    send_key "$key" if check_screen('o3-ipxe-menu');
-    # confirm the dialog asking for user modifications to kernel, cmdline and initrd
-    # set limit to 10 in case some keys don't go through
-    for (1 .. 10) {
-        last if check_screen([qw(load-linux-kernel load-initrd)], 3);
-        send_key "ret";
+    # Give the SOL buffer 1s to process the hotkey and transition to the 'read
+    # kernel' prompt. Without this, 'g' gets swallowed and 'ret' accidentally
+    # executes the default 'exit' option.
+    sleep 1;
+
+    # Rapidly press 'Enter' to clear the three 'read' prompts (read kernel,
+    # read cmdline, read initrd) in menu.ipxe before SOL noise pollutes the URLs
+    for (1 .. 4) {
+        send_key 'ret';
+        sleep 0.5;
     }
+
+    # Confirm installation system is loading
+    assert_screen([qw(load-linux-kernel load-initrd)], 120);
 }
 
 
@@ -367,18 +375,24 @@ sub run {
         send_key "ret";
     }
 
+    #On O3, TW uses a static ipxe menu to start installation
+    enter_o3_ipxe_boot_entry if get_var('IPXE_STATIC');
+
     if (is_agama) {
         record_info('Loading kernel&initrd and starting installation');
         check_screen([qw(load-linux-kernel load-initrd)], 240);
         assert_screen('agama-installer-live-root', 400);
-        set_bootscript_hdd if get_var('IPXE_SET_HDD_BOOTSCRIPT');
+        if (get_var('IPXE_STATIC', '')) {
+            # A runtime bootscript is not supported on O3 static iPXE menu
+            ipmitool("chassis bootdev disk");
+        } else {
+            set_bootscript_hdd if get_var('IPXE_SET_HDD_BOOTSCRIPT');
+        }
         return;
     }
 
     # Print screenshots for ipxe boot process
     if (get_var('VIRT_AUTOTEST')) {
-        #it is static menu and choose the TW entry to start installation
-        enter_o3_ipxe_boot_entry if get_var('IPXE_STATIC');
         check_screen([qw(load-linux-kernel load-initrd)], 80);
         assert_screen([qw(network-config-created loading-installation-system sshd-server-started autoyast-installation)], 300);
         set_bootscript_hdd if get_var('IPXE_SET_HDD_BOOTSCRIPT');


### PR DESCRIPTION
Support host installation with auto-Agama on a baremetal machine on O3.

- Related ticket: https://progress.opensuse.org/issues/202614
- Needles: created on O3 web UI directly.
- Verification run: 
[TW host installation](https://openqa.opensuse.org/tests/6212857)
[sle16.1 on x86](https://openqa.suse.de/tests/24346125)
