### PR TITLE
Fixed Flavor reference in s390x Full

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -786,7 +786,7 @@ sub registration_bootloader_params {
     my ($max_interval) = @_;    # see 'type_string'
     $max_interval //= 13;
     my @params;
-    if (check_var('AGAMA_FORCE_REGISTER', '1') || !(is_agama && check_var('FLAVOR', 'Full'))) {
+    if (check_var('AGAMA_FORCE_REGISTER', '1') || !(is_agama && get_var('FLAVOR') =~ /^(Full(-Immutable)?)$/)) {
         push @params, split ' ', registration_bootloader_cmdline;
     }
     type_string "@params", $max_interval;

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -53,7 +53,7 @@ sub prepare_parmfile {
     else {
         if (get_var('AGAMA')) {
             my $host = "ftp://" . get_var('REPO_HOST', 'openqa');
-            my $root_line = " root=live:" . ((get_var('FLAVOR') =~ /^(Full|agama-installer|offline-installer|online-installer)$/) ?
+            my $root_line = " root=live:" . ((get_var('FLAVOR') =~ /^(Full(-Immutable)?|agama-installer|offline-installer|online-installer)$/) ?
                   $host . '/' . get_required_var('REPO_0') . "/LiveOS/squashfs.img" :
                   $host . '/' . get_var('REPO_999'));
             $params .= $root_line;
@@ -79,7 +79,7 @@ sub prepare_parmfile {
     }
 
     $params .= specific_bootmenu_params;
-    if (!(is_agama && check_var('FLAVOR', 'Full'))) {
+    if (!(is_agama && get_var('FLAVOR') =~ /^(Full(-Immutable)?)$/)) {
         $params .= registration_bootloader_cmdline if check_var('SCC_REGISTER', 'installation') || get_var('FLAVOR') =~ 'Online';
     }
 

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -56,7 +56,7 @@ sub set_svirt_domain_elements {
         $cmdline .= ' ' . get_var("EXTRABOOTPARAMS") if get_var("EXTRABOOTPARAMS");
         # inst.auto and inst.install_url are defined in 'specific_bootmenu_params'
         $cmdline .= specific_bootmenu_params;
-        if (check_var('AGAMA_FORCE_REGISTER', '1') || !(is_agama && check_var('FLAVOR', 'Full'))) {
+        if (check_var('AGAMA_FORCE_REGISTER', '1') || !(is_agama && get_var('FLAVOR') =~ /^(Full(-Immutable)?)$/)) {
             $cmdline .= registration_bootloader_cmdline if check_var('SCC_REGISTER', 'installation') && !get_var('NTLM_AUTH_INSTALL');
         }
 


### PR DESCRIPTION
We have modified the references to Full to match Full or Full-Immutable

- Related ticket: https://jira.suse.com/browse/QEIM-33
- Needles: N/A
- Verification run:
  - https://openqa.suse.de/tests/24346138
  - https://openqa.suse.de/tests/24340499
