### PR TITLE
Enable FIPS before k3s/helm on sle-micro container host HDDs

### DIFF
--- a/lib/main_micro_alp.pm
+++ b/lib/main_micro_alp.pm
@@ -56,6 +56,9 @@ sub load_config_tests {
     loadtest 'transactional/enable_selinux' if (get_var('ENABLE_SELINUX') && is_image);
     loadtest 'console/suseconnect_scc' if (get_var('SCC_REGISTER') && !is_dvd);
     loadtest 'transactional/install_updates' if (is_sle_micro && is_released);
+    # Enable FIPS before installing k3s/helm so the container host HDD is FIPS-ready, see poo#206766
+    # Limited to sle-micro to avoid AutoYAST-installed systems, which already get FIPS via their own install-time flow
+    loadtest 'fips/fips_setup' if (get_var('CONTAINER_UPDATE_HOST') && get_var('FIPS_ENABLED') && is_sle_micro);
     loadtest 'containers/k3s_helm_install' if (get_var('CONTAINER_UPDATE_HOST') && is_sle_micro('6.0+') && (is_x86_64 || is_aarch64));
     loadtest 'containers/bci_prepare' if (get_var('CONTAINER_UPDATE_HOST') && get_var('BCI_PREPARE'));
     loadtest 'microos/services_enabled' if (is_transactional && !(check_var("FLAVOR", "Container-Image-Updates")));


### PR DESCRIPTION
Schedules `fips/fips_setup` before `containers/k3s_helm_install` when `CONTAINER_UPDATE_HOST` and `FIPS_ENABLED` are set for sle-micro, so a FIPS-enabled sle-micro 6.2 container host HDD has k3s/helm installed on top of an already-FIPS system instead of before FIPS is enabled.

* Related ticket: [poo#206766](https://progress.opensuse.org/issues/206766)
* Related merge requests: [qac/qac-openqa-yaml!2967](https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2967)
* Related merge requests: [qac/aceto-magico!42](https://gitlab.suse.de/qac/aceto-magico/-/merge_requests/42)
* Verification runs: In comment below
